### PR TITLE
fix: initliazing event publisher only if config.event is enabled

### DIFF
--- a/backend/grpc-server/src/app.rs
+++ b/backend/grpc-server/src/app.rs
@@ -103,9 +103,13 @@ impl Service {
     #[allow(clippy::expect_used)]
     pub async fn new(config: Arc<configs::Config>) -> Self {
         // Initialize the global EventPublisher - fail fast on startup
-        common_utils::init_event_publisher(&config.events)
-            .expect("Failed to initialize global EventPublisher during startup");
-        logger::info!("Global EventPublisher initialized successfully");
+        if config.events.enabled {
+            common_utils::init_event_publisher(&config.events)
+                .expect("Failed to initialize global EventPublisher during startup");
+            logger::info!("Global EventPublisher initialized successfully");
+        } else {
+            logger::info!("EventPublisher disabled in configuration");
+        }
 
         Self {
             health_check_service: crate::server::health_check::HealthCheck,


### PR DESCRIPTION
## Description

This change prevents the application from attempting to initialize the global `EventPublisher` when event publishing is disabled in the configuration (`events.enabled = false`).

Previously, the application would unconditionally try to establish a connection to Kafka during startup, causing it to panic and crash if the connection failed. This occurred even if the intention was to run without event publishing enabled.

With this fix, the `EventPublisher` is only initialized if `config.events.enabled` is explicitly set to `true`. Otherwise, the application logs that the publisher is disabled and continues to start up normally.

## Motivation and Context

This change is required to prevent unnecessary application crashes during startup. In environments where Kafka is not available or not needed, the application should not be forced to connect to it.

This fix aligns the application's startup behavior with its configuration, making it more robust and flexible. It solves the problem of the application crashing when `events.enabled` is `false` but the Kafka brokers are unreachable.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

This change was tested manually by modifying the `development.toml` configuration file:

1.  **Events Disabled**: Set `events.enabled = false`. Started the application and verified that it launched successfully without attempting to connect to Kafka. The log message "EventPublisher disabled in configuration" was confirmed.
2.  **Events Enabled**: Set `events.enabled = true`. Started the application and confirmed that it successfully initialized the `EventPublisher` and connected to Kafka as expected.

This ensures that the fix correctly handles the disabled case while preserving the existing behavior for the enabled case.

<img width="1062" height="352" alt="image" src="https://github.com/user-attachments/assets/6674a872-1c09-49bf-b260-249085ad6067" />
