### PR TITLE
feat: emitting lineage id an reference id to kafka metadata in events

### DIFF
--- a/backend/common_utils/src/event_publisher.rs
+++ b/backend/common_utils/src/event_publisher.rs
@@ -77,13 +77,25 @@ impl EventPublisher {
         topic: &str,
         partition_key_field: &str,
     ) -> CustomResult<(), EventPublisherError> {
+        let metadata = OwnedHeaders::new();
+        self.publish_event_with_metadata(event, topic, partition_key_field, metadata)
+    }
+
+    /// Publishes a single event to Kafka with custom metadata.
+    pub fn publish_event_with_metadata(
+        &self,
+        event: serde_json::Value,
+        topic: &str,
+        partition_key_field: &str,
+        metadata: OwnedHeaders,
+    ) -> CustomResult<(), EventPublisherError> {
         tracing::debug!(
             topic = %topic,
             partition_key_field = %partition_key_field,
             "Starting event publication to Kafka"
         );
 
-        let mut headers: OwnedHeaders = OwnedHeaders::new();
+        let mut headers = metadata;
 
         let key = if let Some(partition_key_value) =
             event.get(partition_key_field).and_then(|v| v.as_str())
@@ -134,9 +146,42 @@ impl EventPublisher {
         base_event: Event,
         config: &EventConfig,
     ) -> CustomResult<(), EventPublisherError> {
+        let metadata = self.build_kafka_metadata(&base_event);
         let processed_event = self.process_event(&base_event)?;
 
-        self.publish_event(processed_event, &config.topic, &config.partition_key_field)
+        self.publish_event_with_metadata(
+            processed_event,
+            &config.topic,
+            &config.partition_key_field,
+            metadata,
+        )
+    }
+
+    fn build_kafka_metadata(&self, event: &Event) -> OwnedHeaders {
+        let mut headers = OwnedHeaders::new();
+
+        // Add lineage headers from Event.lineage_ids
+        for (key, value) in event.lineage_ids.inner() {
+            headers = headers.insert(Header {
+                key: &key,
+                value: Some(value.as_bytes()),
+            });
+        }
+
+        let ref_id_option = event
+            .additional_fields
+            .get("reference_id")
+            .and_then(|ref_id_value| ref_id_value.inner().as_str());
+
+        // Add reference_id from Event.additional_fields
+        if let Some(ref_id_str) = ref_id_option {
+            headers = headers.insert(Header {
+                key: "reference_id",
+                value: Some(ref_id_str.as_bytes()),
+            });
+        }
+
+        headers
     }
 
     fn process_event(&self, event: &Event) -> CustomResult<serde_json::Value, EventPublisherError> {

--- a/backend/common_utils/src/events.rs
+++ b/backend/common_utils/src/events.rs
@@ -44,6 +44,10 @@ impl MaskedSerdeValue {
             })
             .ok()
     }
+
+    pub fn inner(&self) -> &serde_json::Value {
+        &self.inner
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
 Add lineage ID and reference ID emission to Kafka event metadata headers. This enables downstream
  services to track event lineage and correlate requests across the system.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
Received reference id and lineage id in kafka headers, as verified by local kafka for grpcurl

**request:**

```bash
 grpcurl -plaintext \
    -proto backend/grpc-api-types/proto/services.proto \
    -import-path backend/grpc-api-types/proto \
    -d '{"transaction_id":{"id":"txn_1234567890"},"request_ref_id":{"id":"payment_1234567890"}}' \
    -H "x-tenant-id: public" \
    -H "x-request-id: req1234" \
    -H "x-connector: razorpay" \
    -H "x-merchant-id: test_merchant" \
    -H "x-auth: body-key" \
    -H "x-api-key: test_key" \
    -H "x-key1: 32d46916-4bc9-423b-88d5-35558b59a1b3" \
    -H "x-reference-id: fallback_merchant_order_ref_12345" \
    -H "x-resource-id: fallback_resource_98765" \
    -H "x-lineage-ids: 
  merchant_id=test_merchant&tenant_id=public&environment=sandbox&region=in-west-1&version=v2.1" \
    localhost:8000 ucs.v2.PaymentService/Get
```

<img width="937" height="338" alt="image" src="https://github.com/user-attachments/assets/6823022f-763b-4ea3-9a2e-b5cf55712269" />
