### PR TITLE
fix(cybersource): update error handling to use message instead of reason

### DIFF
--- a/backend/connector-integration/src/connectors/cybersource.rs
+++ b/backend/connector-integration/src/connectors/cybersource.rs
@@ -430,7 +430,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
                         });
                         (
                             error_info.reason.clone(),
-                            error_info.reason.clone(),
+                            error_info.message.clone(),
                             transformers::get_error_reason(
                                 Some(error_info.message.clone()),
                                 detailed_error_info,
@@ -452,8 +452,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
                                 .clone()
                                 .map_or(NO_ERROR_CODE.to_string(), |reason| reason.to_string()),
                             response
-                                .reason
-                                .map_or(error_message.to_string(), |reason| reason.to_string()),
+                                .message
+                                .clone()
+                                .map_or(error_message.to_string(), |msg| msg.to_string()),
                             transformers::get_error_reason(
                                 response.message,
                                 detailed_error_info,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The Cybersource connector was incorrectly storing reason (error code) in the error_message field instead of the actual error message. This affects GSM consistency
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Request:
```
{
    "amount": 60,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "{{customer_id}}",
    "description": "this is description",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4548814479727229",
            "card_exp_month": "09",
            "card_exp_year": "29",
            "card_holder_name": "joseph Doe",
            "card_cvc": "098"
        },
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washingtonr",
                "first_name": "One",
                "last_name": "Two"
            },
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        }
    },
    "setup_future_usage": "on_session",
    "billing": {
        "address": {
            "city": "sakilmostak",
            "country": "US",
            "line1": "here",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560090",
            "state": "Washingtonr",
            "first_name": "One",
            "last_name": "Two"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "Cantabria",
            "zip": "12345",
            "country": "ES",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "en-GB",
        "color_depth": 24,
        "screen_height": 1440,
        "screen_width": 2560,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "0.0.0.0"
    }
}
```
Response:
```
{
    "payment_id": "pay_t7syjOYPHVKiN0S9E1zc",
    "merchant_id": "merchant_1763032290",
    "status": "failed",
    "amount": 60,
    "net_amount": 60,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "cybersource",
    "client_secret": "pay_t7syjOYPHVKiN0S9E1zc_secret_YCHcHGqM6AMHb47smvd7",
    "created": "2025-11-13T11:12:33.676Z",
    "currency": "USD",
    "customer_id": "cus_fhgWlCTgGHZHedJt5FI0",
    "customer": {
        "id": "cus_fhgWlCTgGHZHedJt5FI0",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": "this is description",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "7229",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "454881",
            "card_extended_bin": null,
            "card_exp_month": "09",
            "card_exp_year": "29",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washingtonr",
                "first_name": "One",
                "last_name": "Two",
                "origin_zip": null
            },
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        }
    },
    "payment_token": "token_fBwxFD25xeO9GpefO7Mc",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "ES",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "12345",
            "state": "Cantabria",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "sakilmostak",
            "country": "US",
            "line1": "here",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560090",
            "state": "Washingtonr",
            "first_name": "One",
            "last_name": "Two",
            "origin_zip": null
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "INVALID_DATA",
    "error_message": "Declined - One or more fields in the request contains invalid data",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "cus_fhgWlCTgGHZHedJt5FI0",
        "created_at": 1763032353,
        "expires": 1763035953,
        "secret": "epk_1abc96756f444fa4bea484797e0fcf97"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        },
        "braintree": null,
        "adyen": null
    },
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "unified_connector_service"
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_XPdMbR5bVHNLtIAmgydD",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_bIUvLdbWYOwMv5hVPuh1",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-13T11:27:33.675Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "0.0.0.0",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 2560,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 1440,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "payment_method_status": null,
    "updated": "2025-11-13T11:12:35.523Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": "{\"id\":\"7630323552886586303812\",\"submitTimeUtc\":\"2025-11-13T11:12:35Z\",\"status\":\"INVALID_REQUEST\",\"reason\":\"INVALID_DATA\",\"message\":\"Declined - One or more fields in the request contains invalid data\",\"details\":[{\"field\":\"orderInformation.billTo.administrativeArea\",\"reason\":\"INVALID_DATA\"}]}",
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null
}
```
<img width="1424" height="978" alt="image" src="https://github.com/user-attachments/assets/189134b3-a6b1-4666-ac0d-76c6b7a80750" />

