### PR TITLE
refactor(connector): [PHONEPE] refactor status mapping

### DIFF
--- a/backend/connector-integration/src/connectors/phonepe/transformers.rs
+++ b/backend/connector-integration/src/connectors/phonepe/transformers.rs
@@ -818,7 +818,6 @@ impl
                         }
                         "PAYMENT_ERROR"
                         | "PAYMENT_DECLINED"
-                        | "TIMED_OUT"
                         | "BAD_REQUEST"
                         | "AUTHORIZATION_FAILED"
                         | "TRANSACTION_NOT_FOUND" => common_enums::AttemptStatus::Failure,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR refactors Phonepe Status mapping where INTERNAL_SERVER_ERROR and TIMED_OUT are considered as Pending according to Phonepe docs.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
