### PR TITLE
fix(razorpay): Change payment_capture field type from boolean to integer

### DIFF
--- a/backend/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/backend/connector-integration/src/connectors/razorpay/transformers.rs
@@ -935,7 +935,7 @@ pub struct RazorpayOrderRequest {
     pub partial_payment: Option<bool>,
     pub first_payment_min_amount: Option<MinorUnit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_capture: Option<bool>,
+    pub payment_capture: Option<i8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1022,7 +1022,7 @@ impl
                 .clone(),
             partial_payment: None,
             first_payment_min_amount: None,
-            payment_capture: Some(true),
+            payment_capture: Some(1),
             method: metadata_map.get("method").cloned(),
             discount: metadata_map
                 .get("discount")


### PR DESCRIPTION
## Summary

Fix Razorpay Order API integration by changing `payment_capture` field type from boolean to integer. Razorpay's API expects an integer value (1 for auto-capture, 0 for manual capture) rather than a boolean, which was causing API compatibility issues.

## Changes

- **Modified `RazorpayOrderRequest` struct** (`backend/connector-integration/src/connectors/razorpay/transformers.rs:938`)
  - Changed `payment_capture` field type from `Option<bool>` to `Option<i8>`
  
- **Updated default value assignment** (`backend/connector-integration/src/connectors/razorpay/transformers.rs:1025`)
  - Changed from `Some(true)` to `Some(1)` to match Razorpay API specification

## Related Issues

This fix ensures compatibility with Razorpay's Order API specification which requires integer values for the `payment_capture` parameter.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## Root Cause

Razorpay's API documentation specifies that the `payment_capture` field should be an integer:
- `1` = Auto-capture payment after authorization
- `0` = Manual capture (authorization only)

Using a boolean value was causing type mismatch issues with Razorpay's API.

## Testing

- Verified the field type matches Razorpay API specification
- Ensured backward compatibility with existing payment flows
- Validated serialization produces correct integer values in API requests

## Impact

- **Scope**: Razorpay connector integration
- **Risk**: Low - simple type correction aligned with vendor API spec
- **Compatibility**: No breaking changes to internal interfaces

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Change is minimal and focused on the specific issue
- [x] Type safety maintained with Option<i8>
- [x] No impact on other connectors or payment flows
