### PR TITLE
fix(noon): Refund diff check for connector noon

### DIFF
--- a/backend/connector-integration/src/connectors/noon/transformers.rs
+++ b/backend/connector-integration/src/connectors/noon/transformers.rs
@@ -780,7 +780,7 @@ impl<
     ) -> Result<Self, Self::Error> {
         let item = &data.router_data;
         let refund_amount = data.connector.amount_converter.convert(
-            data.router_data.request.minor_payment_amount,
+            data.router_data.request.minor_refund_amount,
             data.router_data.request.currency,
         );
         let order = NoonActionOrder {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In refund flow insted of `minor_refund_amount`, `minor_payment_amount` was used.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested using diff checker:
<img width="1727" height="957" alt="Screenshot 2025-11-17 at 7 09 44 PM" src="https://github.com/user-attachments/assets/4fdde634-2be3-461b-9d06-2a3761294ffe" />
