### PR TITLE
fix(Braintree): Refund diff check for connector Braintree

### DIFF
--- a/backend/connector-integration/src/connectors/braintree/transformers.rs
+++ b/backend/connector-integration/src/connectors/braintree/transformers.rs
@@ -878,11 +878,7 @@ impl<
             }
         } else {
             utils::to_connector_meta_from_secret(
-                item.router_data
-                    .request
-                    .connector_metadata
-                    .clone()
-                    .map(Secret::new),
+                item.router_data.request.merchant_account_metadata.clone(),
             )
             .change_context(errors::ConnectorError::InvalidConnectorConfig { config: "metadata" })?
         };
@@ -1077,7 +1073,7 @@ impl<
             }
         } else {
             utils::to_connector_meta_from_secret(
-                item.router_data.request.refund_connector_metadata.clone(),
+                item.router_data.request.merchant_account_metadata.clone(),
             )
             .change_context(errors::ConnectorError::InvalidConnectorConfig { config: "metadata" })?
         };

--- a/backend/domain_types/src/connector_types.rs
+++ b/backend/domain_types/src/connector_types.rs
@@ -1371,6 +1371,7 @@ pub struct RefundSyncData {
     pub browser_info: Option<BrowserInformation>,
     /// Charges associated with the payment
     pub split_refunds: Option<SplitRefundsRequest>,
+    pub merchant_account_metadata: Option<common_utils::pii::SecretSerdeValue>,
 }
 
 impl RefundSyncData {
@@ -1896,6 +1897,7 @@ pub struct RefundsData {
     pub browser_info: Option<BrowserInformation>,
     /// Charges associated with the payment
     pub split_refunds: Option<SplitRefundsRequest>,
+    pub merchant_account_metadata: Option<common_utils::pii::SecretSerdeValue>,
 }
 
 impl RefundsData {

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -3631,6 +3631,23 @@ impl ForeignTryFrom<grpc_api_types::payments::RefundServiceGetRequest> for Refun
             all_keys_required: None, // Field not available in new proto structure
             integrity_object: None,
             split_refunds: None,
+            merchant_account_metadata: (!value.merchant_account_metadata.is_empty())
+                .then(|| {
+                    serde_json::to_value(&value.merchant_account_metadata)
+                        .map(common_utils::pii::SecretSerdeValue::new)
+                        .map_err(|_| {
+                            error_stack::Report::new(ApplicationErrorResponse::InternalServerError(
+                                crate::errors::ApiError {
+                                    sub_code: "SERDE_JSON_ERROR".to_owned(),
+                                    error_identifier: 500,
+                                    error_message: "Failed to serialize merchant_account_metadata"
+                                        .to_owned(),
+                                    error_object: None,
+                                },
+                            ))
+                        })
+                })
+                .transpose()?,
         })
     }
 }
@@ -4517,6 +4534,23 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceRefundRequest> for R
                 .transpose()?,
             integrity_object: None,
             split_refunds: None,
+            merchant_account_metadata: (!value.merchant_account_metadata.is_empty())
+                .then(|| {
+                    serde_json::to_value(&value.merchant_account_metadata)
+                        .map(common_utils::pii::SecretSerdeValue::new)
+                        .map_err(|_| {
+                            error_stack::Report::new(ApplicationErrorResponse::InternalServerError(
+                                crate::errors::ApiError {
+                                    sub_code: "SERDE_JSON_ERROR".to_owned(),
+                                    error_identifier: 500,
+                                    error_message: "Failed to serialize merchant_account_metadata"
+                                        .to_owned(),
+                                    error_object: None,
+                                },
+                            ))
+                        })
+                })
+                .transpose()?,
         })
     }
 }

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -1738,6 +1738,9 @@ message PaymentServiceRefundRequest {
 
   // State Information
   optional ConnectorState state = 17; // State data for access token storage and other connector-specific state
+
+  // Account-Specific Configuration
+  map<string, string> merchant_account_metadata = 18; // Account-level configuration metadata (e.g., merchant_name, brand_id)
 }
 
 // Response message for a refund operation (unified for both Create and Get).
@@ -2337,6 +2340,9 @@ message RefundServiceGetRequest {
 
 // State Information
   optional ConnectorState state = 8; // State data for access token storage and other connector-specific state
+
+// Account-Specific Configuration
+  map<string, string> merchant_account_metadata = 9; // Account-level configuration metadata (e.g., merchant_name, brand_id)
 }
 
 // Legacy alias for backward compatibility - use RefundResponse instead

--- a/backend/grpc-server/tests/authorizedotnet_payment_flows_test.rs
+++ b/backend/grpc-server/tests/authorizedotnet_payment_flows_test.rs
@@ -492,6 +492,7 @@ fn create_refund_request(transaction_id: &str) -> PaymentServiceRefundRequest {
         refund_metadata,
         browser_info: None,
         state: None,
+        merchant_account_metadata: HashMap::new(),
     }
 }
 
@@ -513,6 +514,7 @@ fn create_refund_get_request(transaction_id: &str, refund_id: &str) -> RefundSer
         refund_reason: None,
         refund_metadata: HashMap::new(),
         state: None,
+        merchant_account_metadata: HashMap::new(),
     }
 }
 

--- a/backend/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/backend/grpc-server/tests/braintree_payment_flows_test.rs
@@ -255,6 +255,7 @@ fn create_refund_sync_request(transaction_id: &str, refund_id: &str) -> RefundSe
         browser_info: None,
         refund_metadata,
         state: None,
+        merchant_account_metadata: HashMap::new(),
     }
 }
 

--- a/backend/grpc-server/tests/fiuu_payment_flows_test.rs
+++ b/backend/grpc-server/tests/fiuu_payment_flows_test.rs
@@ -243,6 +243,7 @@ fn create_refund_sync_request(transaction_id: &str, refund_id: &str) -> RefundSe
         browser_info: None,
         refund_metadata: std::collections::HashMap::new(),
         state: None,
+        merchant_account_metadata: std::collections::HashMap::new(),
     }
 }
 

--- a/backend/grpc-server/tests/xendit_payment_flows_test.rs
+++ b/backend/grpc-server/tests/xendit_payment_flows_test.rs
@@ -210,6 +210,7 @@ fn create_refund_sync_request(transaction_id: &str, refund_id: &str) -> RefundSe
         browser_info: None,
         refund_metadata: std::collections::HashMap::new(),
         state: None,
+        merchant_account_metadata: std::collections::HashMap::new(),
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added merchant_account_metadata field in proto to extract the MCA and use that in Refund & RSync request
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Getting merchant_account_meta_data from hyperswitch request
<img width="1443" height="451" alt="Screenshot 2025-11-20 at 1 49 50 PM" src="https://github.com/user-attachments/assets/483d3b1f-c939-4f23-8b74-0a6321e7467d" />
