### PR TITLE
fix: populate payment method token for AuthorizeOnly request

### DIFF
--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -2265,7 +2265,9 @@ impl
             access_token,
             session_token: value.session_token,
             reference_id: value.order_id,
-            payment_method_token: None,
+            payment_method_token: value
+                .payment_method_token
+                .map(|pmt| router_data::PaymentMethodToken::Token(Secret::new(pmt))),
             preprocessing_id: None,
             connector_api_version: None,
             test_mode: value.test_mode,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
currently payment_method_token value send in the request is not being populated in PaymentFlowData in AuthorizeOnly grpc flow. Fixed that.


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
By making a payment for Braintree
