### PR TITLE
chore: add trigger to push image to ghcr when tag is created

### DIFF
--- a/.github/workflows/docker-to-ghcr-publish.yml
+++ b/.github/workflows/docker-to-ghcr-publish.yml
@@ -2,6 +2,12 @@ name: Docker Build and Push to GHCR
 
 on:
   workflow_dispatch:
+  
+  # Automatically run when nightly tags are created.
+  # Accepts formats like: 2025.12.03.0 or 2025.01.09.12
+  push:
+    tags:
+      - "20[0-9][0-9].[0-1][0-9].[0-3][0-9].*"
 
 jobs:
   build-and-push-dockerfile:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR makes changes in the docker to ghcr workflow, where if a tag is created matching the nightly release regex, the docker-to-ghcr-publish workflow will get triggered, pushing the nightly release automatically to ghcr.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Main purpose is to automatically run this workflow after every nightly release tag is created without human intervention.

### Additional Changes
- [ ] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->
1. .github/workflows/docker-to-ghcr-publish.yml

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
NA