### PR TITLE
fix(bluesnap): address `merchantTransactionId` being `IRRELEVANT_ATTEMPT_ID` instead of actual `attempt_id`

### DIFF
--- a/backend/connector-integration/src/connectors/bluesnap/transformers.rs
+++ b/backend/connector-integration/src/connectors/bluesnap/transformers.rs
@@ -273,7 +273,12 @@ impl<
             transaction_fraud_info: Some(TransactionFraudInfo {
                 fraud_session_id: router_data.resource_common_data.payment_id.clone(),
             }),
-            merchant_transaction_id: Some(router_data.resource_common_data.attempt_id.clone()),
+            merchant_transaction_id: Some(
+                router_data
+                    .resource_common_data
+                    .connector_request_reference_id
+                    .clone(),
+            ),
             transaction_meta_data,
         })
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

this pr address a bug in bluesnap integration where the `merchantTransactionId` is being returned as `IRRELEVANT_ATTEMPT_ID` instead of the actual value.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

bug fix.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

tested manually.

<img width="1705" height="176" alt="image" src="https://github.com/user-attachments/assets/3b12894b-ed76-40c8-a8b6-cbe07bfa7fe7" />
