### PR TITLE
fix: adyen brand name lower case to match hyperswitch diff

### DIFF
--- a/backend/connector-integration/src/connectors/adyen/transformers.rs
+++ b/backend/connector-integration/src/connectors/adyen/transformers.rs
@@ -56,6 +56,7 @@ pub struct Amount {
 type Error = error_stack::Report<domain_types::errors::ConnectorError>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum CardBrand {
     Visa,
     MC,


### PR DESCRIPTION
## Description
Diff check fix, brand name in adyen should be lower_case as per existing hyperswitch adyen brandname

## Motivation and Context
Diff check fix, brand name in adyen should be lower_case as per existing hyperswitch adyen brandname

https://github.com/juspay/hyperswitch-cloud/issues/13070

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
