### PR TITLE
fix: Removed the authorization_indicator_type field from Authdotnet Req

### DIFF
--- a/backend/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/backend/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -416,12 +416,6 @@ pub enum Reason {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AuthorizationIndicator {
-    authorization_indicator: AuthorizationType,
-}
-
-#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum ProfileDetails {
     CreateProfileDetails(CreateProfileDetails),
@@ -464,8 +458,6 @@ pub struct AuthorizedotnetTransactionRequest<T: PaymentMethodDataTypes> {
     user_fields: Option<UserFields>,
     processing_options: Option<ProcessingOptions>,
     subsequent_auth_information: Option<SubsequentAuthInformation>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    authorization_indicator_type: Option<AuthorizationIndicator>,
     ref_trans_id: Option<String>,
 }
 
@@ -708,7 +700,6 @@ fn create_regular_transaction_request<
         user_fields,
         processing_options: None,
         subsequent_auth_information: None,
-        authorization_indicator_type: None,
         ref_trans_id: None,
     })
 }
@@ -741,8 +732,6 @@ pub struct AuthorizedotnetRepeatPaymentTransactionRequest {
     user_fields: Option<UserFields>,
     processing_options: Option<ProcessingOptions>,
     subsequent_auth_information: Option<SubsequentAuthInformation>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    authorization_indicator_type: Option<AuthorizationIndicator>,
 }
 
 // Implementation for RepeatPayment request conversion
@@ -900,7 +889,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             user_fields,
             processing_options,
             subsequent_auth_information,
-            authorization_indicator_type: None,
         };
 
         Ok(Self {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
AuthorizeIndicatorType Field was removed to have parity with HS as this was not required

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
