### PR TITLE
fix(connector): Paypal Capture & Void flow

### DIFF
--- a/backend/connector-integration/src/connectors/paypal.rs
+++ b/backend/connector-integration/src/connectors/paypal.rs
@@ -610,7 +610,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>,
         ) -> CustomResult<String, ConnectorError> {
-            let paypal_meta: paypal::PaypalMeta = utils::to_connector_meta(req.request.metadata.clone().map(|m| m.expose()))?;
+            let paypal_meta: paypal::PaypalMeta = utils::to_connector_meta(req.request.connector_metadata.clone().map(|m| m.expose()))?;
             let authorize_id = paypal_meta.authorize_id.ok_or(
                 ConnectorError::RequestEncodingFailedWithReason(
                     "Missing Authorize id".to_string(),
@@ -660,7 +660,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
         ) -> CustomResult<String, ConnectorError> {
-            let connector_metadata_value = req.request.metadata.clone().map(|secret| secret.expose());
+            let connector_metadata_value = req.request.connector_metadata.clone().map(|secret| secret.expose());
             let paypal_meta: paypal::PaypalMeta = utils::to_connector_meta(connector_metadata_value)?;
             let authorize_id = paypal_meta.authorize_id.ok_or(
                 ConnectorError::RequestEncodingFailedWithReason(

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -4762,7 +4762,7 @@ impl ForeignTryFrom<PaymentServiceVoidRequest> for PaymentVoidData {
             amount,
             currency,
             connector_metadata: (!value.connector_metadata.is_empty())
-                .then(|| Secret::new(convert_metadata_to_json(&value.connector_metadata))),
+                .then(|| Secret::new(convert_merchant_metadata_to_json(&value.connector_metadata))),
         })
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixed connector_metadat extraction logic for Paypal Capture and Void request.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Using Diff Checker:-
1. Capture flow:-
<img width="1208" height="541" alt="Screenshot 2025-12-15 at 8 06 24 PM" src="https://github.com/user-attachments/assets/15802298-b121-43d7-98e3-8e50b52d6a51" />

2. Void flow:-
<img width="1208" height="405" alt="Screenshot 2025-12-15 at 8 06 41 PM" src="https://github.com/user-attachments/assets/e858e6f0-20d2-4736-9338-2ad70e40399f" />
