### PR TITLE
fix(connector): Fiserv RSync flow Diff fix

### DIFF
--- a/backend/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/backend/connector-integration/src/connectors/fiserv/transformers.rs
@@ -835,7 +835,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 terminal_id: None,
             },
             reference_transaction_details: ReferenceTransactionDetails {
-                reference_transaction_id: router_data.request.connector_transaction_id.clone(),
+                reference_transaction_id: router_data.request.connector_refund_id.clone(),
             },
         })
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In fiserv Rsync flow the refund id was mapped incorrectly. Fixed it by mapping with refund_id.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Using Diff Checker:-
<img width="1546" height="543" alt="Screenshot 2025-12-15 at 8 48 10 PM" src="https://github.com/user-attachments/assets/8ea59727-37b6-4287-ac03-9a4e967bc1bd" />
