### PR TITLE
fix: adyen url on non test mode for authorize,void,etc

### DIFF
--- a/backend/connector-integration/src/connectors/adyen.rs
+++ b/backend/connector-integration/src/connectors/adyen.rs
@@ -527,14 +527,10 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>,
         ) -> CustomResult<String, errors::ConnectorError> {
+            // TODO: Add build_env_specific_endpoint when DisputeFlowData has test_mode and connector_meta_data fields
             let dispute_url = self.connector_base_url_disputes(req)
                 .ok_or(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
-            let endpoint = build_env_specific_endpoint(
-                dispute_url,
-                req.resource_common_data.test_mode,
-                &req.resource_common_data.connector_meta_data,
-            )?;
-            Ok(format!("{endpoint}ca/services/DisputeService/v30/defendDispute"))
+            Ok(format!("{dispute_url}ca/services/DisputeService/v30/defendDispute"))
         }
     }
 );
@@ -1051,14 +1047,10 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>,
         ) -> CustomResult<String, errors::ConnectorError> {
+            // TODO: Add build_env_specific_endpoint when DisputeFlowData has test_mode and connector_meta_data fields
             let dispute_url = self.connector_base_url_disputes(req)
                 .ok_or(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
-            let endpoint = build_env_specific_endpoint(
-                dispute_url,
-                req.resource_common_data.test_mode,
-                &req.resource_common_data.connector_meta_data,
-            )?;
-            Ok(format!("{endpoint}ca/services/DisputeService/v30/acceptDispute"))
+            Ok(format!("{dispute_url}ca/services/DisputeService/v30/acceptDispute"))
         }
     }
 );
@@ -1086,14 +1078,10 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>,
         ) -> CustomResult<String, errors::ConnectorError> {
+            // TODO: Add build_env_specific_endpoint when DisputeFlowData has test_mode and connector_meta_data fields
             let dispute_url = self.connector_base_url_disputes(req)
                 .ok_or(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
-            let endpoint = build_env_specific_endpoint(
-                dispute_url,
-                req.resource_common_data.test_mode,
-                &req.resource_common_data.connector_meta_data,
-            )?;
-            Ok(format!("{endpoint}ca/services/DisputeService/v30/supplyDefenseDocument"))
+            Ok(format!("{dispute_url}ca/services/DisputeService/v30/supplyDefenseDocument"))
         }
     }
 );


### PR DESCRIPTION
## Description
fix adyen url on non test mode for authorize,void,etc

## Motivation and Context

UCS uses direct base_url from env for authorize, void, etc flow
(previously, only fixed for refund)

```
   pub fn connector_base_url_refunds<'a, F, Req, Res>(
            &self,
            req: &'a RouterDataV2<F, RefundFlowData, Req, Res>,
        ) -> &'a str {
            &req.resource_common_data.connectors.adyen.base_url
        }
```
But adyen prod url need special substitution from metadata.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
