### PR TITLE
fix: adyen shoppername to none for bankredirect, repeatpayment

### DIFF
--- a/backend/connector-integration/src/connectors/adyen/transformers.rs
+++ b/backend/connector-integration/src/connectors/adyen/transformers.rs
@@ -1764,9 +1764,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             additional_data,
             mpi_data: None,
             telephone_number,
-            shopper_name: get_shopper_name(
-                item.router_data.resource_common_data.get_optional_billing(),
-            ),
+            shopper_name: None,
             shopper_email: item
                 .router_data
                 .resource_common_data
@@ -4441,10 +4439,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             additional_data,
             shopper_reference: shopper_reference.clone(),
             store_payment_method,
-            shopper_name: get_shopper_name(
-                item.router_data.resource_common_data.get_optional_billing(),
-            ),
             shopper_ip: item.router_data.request.get_ip_address_as_optional(),
+            shopper_name: None,
             shopper_locale: item.router_data.request.locale.clone(),
             shopper_email: item
                 .router_data


### PR DESCRIPTION


## Description
adyen diff fix: setting shoppername to none for bankredirect, repeatpayment

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
