### PR TITLE
chore: Populate connector response field in error response

### DIFF
--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -3830,7 +3830,7 @@ pub fn generate_payment_authorize_response<T: PaymentMethodDataTypes>(
                 minor_captured_amount: None,
                 minor_capturable_amount: None,
                 minor_authorized_amount: None,
-                connector_response: None,
+                connector_response,
             }
         }
     };
@@ -4661,7 +4661,7 @@ pub fn generate_payment_sync_response(
                     .get_connector_response_headers_as_map(),
                 state,
                 raw_connector_request,
-                connector_response: None,
+                connector_response,
             })
         }
     }
@@ -7128,7 +7128,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                     .get_connector_response_headers_as_map(),
                 state,
                 raw_connector_request,
-                connector_response: None,
+                connector_response,
                 connector_metadata: None,
                 captured_amount: None,
                 minor_captured_amount: None,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In case of error response despite of connector response present we where not adding in error response of UCS so just populated that field

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
I think no test is required as i am just populating a field 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
