### PR TITLE
fix: Adyen webhook fix

### DIFF
--- a/backend/connector-integration/src/connectors/adyen.rs
+++ b/backend/connector-integration/src/connectors/adyen.rs
@@ -925,8 +925,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             })?;
 
         let (error_code, error_message, error_reason) =
-            if transformers::get_adyen_payment_webhook_event(notif.event_code.clone(), notif.success.clone())?
-                == AttemptStatus::Failure
+            if transformers::get_adyen_payment_webhook_event(
+                notif.event_code.clone(),
+                notif.success.clone(),
+            )? == AttemptStatus::Failure
             {
                 (
                     notif.reason.clone(),
@@ -970,14 +972,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     .attach_printable(format!("error while decoding webhook body {err}"))
             })?;
 
-        let (error_code, error_message) =
-            if transformers::get_adyen_refund_webhook_event(notif.event_code.clone(), notif.success.clone())?
-                == common_enums::RefundStatus::Failure
-            {
-                (notif.reason.clone(), notif.reason.clone())
-            } else {
-                (None, None)
-            };
+        let (error_code, error_message) = if transformers::get_adyen_refund_webhook_event(
+            notif.event_code.clone(),
+            notif.success.clone(),
+        )? == common_enums::RefundStatus::Failure
+        {
+            (notif.reason.clone(), notif.reason.clone())
+        } else {
+            (None, None)
+        };
 
         Ok(RefundWebhookDetailsResponse {
             connector_refund_id: Some(notif.psp_reference.clone()),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
wrong 
error_message is some 

<img width="3456" height="1626" alt="image" src="https://github.com/user-attachments/assets/f791e25b-8660-4bdf-9fbb-22f808871a3b" />


correct  success webhook
<img width="2560" height="1123" alt="Screenshot 2026-02-02 at 7 17 00 PM" src="https://github.com/user-attachments/assets/157405a7-ca74-4bca-927d-6b273269c8c5" />

correct failure webhook
<img width="2560" height="739" alt="Screenshot 2026-02-02 at 7 31 55 PM" src="https://github.com/user-attachments/assets/b29fecd4-f433-48ec-b0da-c3097844d089" />
