### PR TITLE
fix(payload): do not pass `content-type` header in sync calls

### DIFF
--- a/backend/connector-integration/src/connectors/payload.rs
+++ b/backend/connector-integration/src/connectors/payload.rs
@@ -379,7 +379,10 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<PSync, PaymentFlowData, PaymentsSyncData, PaymentsResponseData>,
         ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
-            self.build_headers(req)
+            let mut header = Vec::new();
+            let mut api_key = self.get_auth_header(&req.connector_auth_type)?;
+            header.append(&mut api_key);
+            Ok(header)
         }
         fn get_url(
             &self,
@@ -516,7 +519,10 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
         ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
-            self.build_headers(req)
+            let mut header = Vec::new();
+            let mut api_key = self.get_auth_header(&req.connector_auth_type)?;
+            header.append(&mut api_key);
+            Ok(header)
         }
         fn get_url(
             &self,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

At present, `content-type` headers are being passed in the request that is stopping the sync calls from working. This is unintentional and, is a bug. Instead, we shouldn't be passing the header at all!

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Sync calls are failing.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


<details>

<summary>Create Payment (should not be in terminal state since we want the PSync to actually trigger)</summary>

```bash
curl --location 'http://localhost:8080/payments/pay_XYa9aG9uv8OP1acQhhqa/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_1778ec59a4f24e828170b60a78b9b004' \
--data '{
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "30",
            "card_holder_name": "Joseph Doe",
            "card_cvc": "123"
        }
    },
    "client_secret": "pay_XYa9aG9uv8OP1acQhhqa_secret_ui3anADc2H61zDbpFCwH"
}'
```
```json
{
	"payment_id": "pay_XYa9aG9uv8OP1acQhhqa",
	"merchant_id": "postman_merchant_GHAction_1769768611",
	"status": "requires_capture",
	"amount": 35,
	"net_amount": 35,
	"shipping_cost": null,
	"amount_capturable": 35,
	"amount_received": null,
	"processor_merchant_id": "postman_merchant_GHAction_1769768611",
	"initiator": null,
	"connector": "payload",
	"client_secret": "pay_XYa9aG9uv8OP1acQhhqa_secret_ui3anADc2H61zDbpFCwH",
	"created": "2026-01-30T10:24:09.130Z",
	"modified_at": "2026-01-30T10:24:13.344Z",
	"currency": "USD",
	"customer_id": "customer",
	"customer": {
		"id": "customer",
		"name": null,
		"email": "guesjhvghht@example.com",
		"phone": "999999999",
		"phone_country_code": "+1"
	},
	"description": "Its my first payment request",
	"refunds": null,
	"disputes": null,
	"mandate_id": null,
	"mandate_data": null,
	"setup_future_usage": null,
	"off_session": null,
	"capture_on": null,
	"capture_method": "manual",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "4242",
			"card_type": "CREDIT",
			"card_network": "Visa",
			"card_issuer": "STRIPE PAYMENTS UK LIMITED",
			"card_issuing_country": "UNITEDKINGDOM",
			"card_isin": "424242",
			"card_extended_bin": null,
			"card_exp_month": "10",
			"card_exp_year": "30",
			"card_holder_name": "Joseph Doe",
			"payment_checks": {
				"avs_result": "street_and_zip"
			},
			"authentication_data": null,
			"auth_code": null
		},
		"billing": null
	},
	"payment_token": null,
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "PiX",
			"last_name": null,
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"billing": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "PiX",
			"last_name": "THE",
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"order_details": null,
	"email": "guesjhvghht@example.com",
	"name": null,
	"phone": "999999999",
	"return_url": "https://duck.com/",
	"authentication_type": "no_three_ds",
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"next_action": null,
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"error_details": null,
	"payment_experience": null,
	"payment_method_type": "credit",
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"manual_retry_allowed": null,
	"connector_transaction_id": "txn_3f7n20byTirbZmUgrkO0l",
	"frm_message": null,
	"metadata": {
		"udf1": "value1",
		"login_date": "2019-09-10T10:11:12Z",
		"new_customer": "true"
	},
	"connector_metadata": null,
	"feature_metadata": {
		"redirect_response": null,
		"search_tags": null,
		"apple_pay_recurring_details": null,
		"gateway_system": "unified_connector_service"
	},
	"reference_id": "PL-NLM-XUQ-9YN",
	"payment_link": null,
	"profile_id": "pro_QNHP3RPLzNf6RfkJAV4y",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_IEMEwetDTecjoNP1rbXs",
	"incremental_authorization_allowed": false,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2026-01-30T10:39:09.130Z",
	"fingerprint": null,
	"browser_info": {
		"os_type": null,
		"referer": null,
		"language": null,
		"time_zone": null,
		"ip_address": "::1",
		"os_version": null,
		"user_agent": null,
		"color_depth": null,
		"device_model": null,
		"java_enabled": null,
		"screen_width": null,
		"accept_header": null,
		"screen_height": null,
		"accept_language": "en",
		"java_script_enabled": null
	},
	"payment_channel": null,
	"payment_method_id": null,
	"network_transaction_id": null,
	"payment_method_status": null,
	"updated": "2026-01-30T10:24:13.344Z",
	"split_payments": null,
	"frm_metadata": null,
	"extended_authorization_applied": null,
	"extended_authorization_last_applied_at": null,
	"request_extended_authorization": null,
	"capture_before": null,
	"merchant_order_reference_id": null,
	"order_tax_amount": null,
	"connector_mandate_id": null,
	"card_discovery": "manual",
	"force_3ds_challenge": false,
	"force_3ds_challenge_trigger": false,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"is_iframe_redirection_enabled": null,
	"whole_connector_response": "<redacted>",
	"enable_partial_authorization": null,
	"enable_overcapture": null,
	"is_overcapture_enabled": null,
	"network_details": null,
	"is_stored_credential": null,
	"mit_category": null,
	"billing_descriptor": null,
	"tokenization": null,
	"partner_merchant_identifier_details": null,
	"payment_method_tokenization_details": null
}
```

</details>

<details>

<summary>Retrieve Payment (Error should be `null`)</summary>

```bash
curl --location 'http://localhost:8080/payments/pay_XYa9aG9uv8OP1acQhhqa?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_NtvQe6KGmpht0vhPEIBo2GMV0bKtGn5E0EjuxD71pSXl4YWriu5cf2eetX9Pm2UY'
```
```json
{
	"payment_id": "pay_XYa9aG9uv8OP1acQhhqa",
	"merchant_id": "postman_merchant_GHAction_1769768611",
	"status": "requires_capture",
	"amount": 35,
	"net_amount": 35,
	"shipping_cost": null,
	"amount_capturable": 35,
	"amount_received": null,
	"processor_merchant_id": "postman_merchant_GHAction_1769768611",
	"initiator": null,
	"connector": "payload",
	"client_secret": "pay_XYa9aG9uv8OP1acQhhqa_secret_ui3anADc2H61zDbpFCwH",
	"created": "2026-01-30T10:24:09.130Z",
	"modified_at": "2026-01-30T10:24:17.787Z",
	"currency": "USD",
	"customer_id": "customer",
	"customer": {
		"id": "customer",
		"name": null,
		"email": "guesjhvghht@example.com",
		"phone": "999999999",
		"phone_country_code": "+1"
	},
	"description": "Its my first payment request",
	"refunds": null,
	"disputes": null,
	"mandate_id": null,
	"mandate_data": null,
	"setup_future_usage": null,
	"off_session": null,
	"capture_on": null,
	"capture_method": "manual",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "4242",
			"card_type": "CREDIT",
			"card_network": "Visa",
			"card_issuer": "STRIPE PAYMENTS UK LIMITED",
			"card_issuing_country": "UNITEDKINGDOM",
			"card_isin": "424242",
			"card_extended_bin": null,
			"card_exp_month": "10",
			"card_exp_year": "30",
			"card_holder_name": "Joseph Doe",
			"payment_checks": {
				"avs_result": "street_and_zip"
			},
			"authentication_data": null,
			"auth_code": null
		},
		"billing": null
	},
	"payment_token": null,
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "PiX",
			"last_name": null,
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"billing": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "PiX",
			"last_name": "THE",
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"order_details": null,
	"email": "guesjhvghht@example.com",
	"name": null,
	"phone": "999999999",
	"return_url": "https://duck.com/",
	"authentication_type": "no_three_ds",
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"next_action": null,
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"error_details": null,
	"payment_experience": null,
	"payment_method_type": "credit",
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"manual_retry_allowed": null,
	"connector_transaction_id": "txn_3f7n20byTirbZmUgrkO0l",
	"frm_message": null,
	"metadata": {
		"udf1": "value1",
		"login_date": "2019-09-10T10:11:12Z",
		"new_customer": "true"
	},
	"connector_metadata": null,
	"feature_metadata": {
		"redirect_response": null,
		"search_tags": null,
		"apple_pay_recurring_details": null,
		"gateway_system": "unified_connector_service"
	},
	"reference_id": "PL-NLM-XUQ-9YN",
	"payment_link": null,
	"profile_id": "pro_QNHP3RPLzNf6RfkJAV4y",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_IEMEwetDTecjoNP1rbXs",
	"incremental_authorization_allowed": false,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2026-01-30T10:39:09.130Z",
	"fingerprint": null,
	"browser_info": {
		"os_type": null,
		"referer": null,
		"language": null,
		"time_zone": null,
		"ip_address": "::1",
		"os_version": null,
		"user_agent": null,
		"color_depth": null,
		"device_model": null,
		"java_enabled": null,
		"screen_width": null,
		"accept_header": null,
		"screen_height": null,
		"accept_language": "en",
		"java_script_enabled": null
	},
	"payment_channel": null,
	"payment_method_id": null,
	"network_transaction_id": null,
	"payment_method_status": null,
	"updated": "2026-01-30T10:24:17.787Z",
	"split_payments": null,
	"frm_metadata": null,
	"extended_authorization_applied": null,
	"extended_authorization_last_applied_at": null,
	"request_extended_authorization": null,
	"capture_before": null,
	"merchant_order_reference_id": null,
	"order_tax_amount": null,
	"connector_mandate_id": null,
	"card_discovery": "manual",
	"force_3ds_challenge": false,
	"force_3ds_challenge_trigger": false,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"is_iframe_redirection_enabled": null,
	"whole_connector_response": "<redacted>",
	"enable_partial_authorization": null,
	"enable_overcapture": null,
	"is_overcapture_enabled": null,
	"network_details": null,
	"is_stored_credential": null,
	"mit_category": null,
	"billing_descriptor": null,
	"tokenization": null,
	"partner_merchant_identifier_details": null,
	"payment_method_tokenization_details": null
}
```

</details>

<details>

<summary>Create Refund</summary>

```bash
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_NtvQe6KGmpht0vhPEIBo2GMV0bKtGn5E0EjuxD71pSXl4YWriu5cf2eetX9Pm2UY' \
--data '{
    "payment_id": "pay_XYa9aG9uv8OP1acQhhqa",
    "amount": 35,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
```json
{
	"refund_id": "ref_volWr625xS9X8AkbcNkj",
	"payment_id": "pay_XYa9aG9uv8OP1acQhhqa",
	"amount": 35,
	"currency": "USD",
	"status": "succeeded",
	"reason": "Customer returned product",
	"metadata": {
		"udf1": "value1",
		"new_customer": "true",
		"login_date": "2019-09-10T10:11:12Z"
	},
	"error_message": null,
	"error_code": null,
	"unified_code": null,
	"unified_message": null,
	"created_at": "2026-01-30T10:28:10.664Z",
	"updated_at": "2026-01-30T10:28:11.551Z",
	"connector": "payload",
	"profile_id": "pro_QNHP3RPLzNf6RfkJAV4y",
	"merchant_connector_id": "mca_IEMEwetDTecjoNP1rbXs",
	"split_refunds": null,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"raw_connector_response": null
}
```

</details>

<details>

<summary>Retrieve Refund (Error should be `null`)</summary>

```bash
curl --location 'http://localhost:8080/refunds/ref_volWr625xS9X8AkbcNkj?force_sync=true' \
--header 'api-key: dev_NtvQe6KGmpht0vhPEIBo2GMV0bKtGn5E0EjuxD71pSXl4YWriu5cf2eetX9Pm2UY'
```
```json
{
	"refund_id": "ref_volWr625xS9X8AkbcNkj",
	"payment_id": "pay_XYa9aG9uv8OP1acQhhqa",
	"amount": 35,
	"currency": "USD",
	"status": "succeeded",
	"reason": "Customer returned product",
	"metadata": {
		"udf1": "value1",
		"new_customer": "true",
		"login_date": "2019-09-10T10:11:12Z"
	},
	"error_message": null,
	"error_code": null,
	"unified_code": null,
	"unified_message": null,
	"created_at": "2026-01-30T10:28:10.664Z",
	"updated_at": "2026-01-30T10:28:27.829Z",
	"connector": "payload",
	"profile_id": "pro_QNHP3RPLzNf6RfkJAV4y",
	"merchant_connector_id": "mca_IEMEwetDTecjoNP1rbXs",
	"split_refunds": null,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"raw_connector_response": null
}
```

</details>