### PR TITLE
fix(connector): Rapyd amount type in request

### DIFF
--- a/backend/connector-integration/src/connectors/rapyd.rs
+++ b/backend/connector-integration/src/connectors/rapyd.rs
@@ -1,7 +1,7 @@
 pub mod transformers;
 
 use base64::Engine;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMajorUnit};
 use domain_types::{
     connector_flow::{
         Accept, Authenticate, Authorize, Capture, CreateAccessToken, CreateConnectorCustomer,
@@ -349,7 +349,7 @@ macros::create_all_prerequisites!(
         )
     ],
     amount_converters: [
-        amount_converter: FloatMajorUnit
+        amount_converter: StringMajorUnit
     ],
     member_functions: {
         pub fn build_headers<F, FCD, Req, Res>(

--- a/backend/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/backend/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1,4 +1,4 @@
-use common_utils::{ext_traits::OptionExt, request::Method, FloatMajorUnit};
+use common_utils::{ext_traits::OptionExt, request::Method, FloatMajorUnit, StringMajorUnit};
 use domain_types::{
     connector_flow::{Authorize, Capture},
     connector_types::{
@@ -138,7 +138,7 @@ impl TryFrom<&ConnectorAuthType> for RapydAuthType {
 pub struct RapydPaymentsRequest<
     T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
 > {
-    pub amount: FloatMajorUnit,
+    pub amount: StringMajorUnit,
     pub currency: common_enums::Currency,
     pub payment_method: PaymentMethod<T>,
     pub payment_method_options: Option<PaymentMethodOptions>,
@@ -417,7 +417,7 @@ pub struct ResponseData {
 // Capture Request
 #[derive(Debug, Serialize, Clone)]
 pub struct CaptureRequest {
-    amount: Option<FloatMajorUnit>,
+    amount: Option<StringMajorUnit>,
     receipt_email: Option<Secret<String>>,
     statement_descriptor: Option<String>,
 }
@@ -457,7 +457,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 #[derive(Default, Debug, Serialize)]
 pub struct RapydRefundRequest {
     pub payment: String,
-    pub amount: Option<FloatMajorUnit>,
+    pub amount: Option<StringMajorUnit>,
     pub currency: Option<common_enums::Currency>,
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changed amount type to StringMajorunit so that both 45.00 and 45.12 amount type can get success.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested using Diff checker:-
<img width="1689" height="838" alt="Screenshot 2026-01-30 at 4 28 42 PM" src="https://github.com/user-attachments/assets/fd96eae9-f89d-4d5b-bb1e-6e8c863ca4ee" />
