### PR TITLE
refactor(connector): [redsys] skip serializing fields that are `none` and sort fields in alphabetical order

### DIFF
--- a/backend/connector-integration/src/connectors/redsys/responses.rs
+++ b/backend/connector-integration/src/connectors/redsys/responses.rs
@@ -23,38 +23,38 @@ pub enum RedsysResponse {
 /// Payment response containing order details and 3DS data
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RedsysPaymentsResponse {
-    #[serde(rename = "Ds_Order")]
-    pub ds_order: String,
-    #[serde(rename = "Ds_EMV3DS")]
-    pub ds_emv3ds: Option<RedsysEmv3DSResponseData>,
+    #[serde(rename = "Ds_AuthorisationCode")]
+    pub ds_authorisation_code: Option<Secret<String>>,
     #[serde(rename = "Ds_Card_PSD2")]
     pub ds_card_psd2: Option<CardPSD2>,
+    #[serde(rename = "Ds_EMV3DS")]
+    pub ds_emv3ds: Option<RedsysEmv3DSResponseData>,
+    #[serde(rename = "Ds_Order")]
+    pub ds_order: String,
     #[serde(rename = "Ds_Response")]
     pub ds_response: Option<DsResponse>,
     #[serde(rename = "Ds_Response_Description")]
     pub ds_response_description: Option<String>,
-    #[serde(rename = "Ds_AuthorisationCode")]
-    pub ds_authorisation_code: Option<Secret<String>>,
 }
 
 /// PSD2 compliance indicator
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CardPSD2 {
-    Y,
     N,
+    Y,
 }
 
 /// EMV 3DS response data from authentication
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedsysEmv3DSResponseData {
-    pub protocol_version: String,
-    pub three_d_s_server_trans_i_d: Option<String>,
-    pub three_d_s_info: Option<RedsysThreeDsInfo>,
-    pub three_d_s_method_u_r_l: Option<String>,
     pub acs_u_r_l: Option<String>,
     pub creq: Option<String>,
+    pub protocol_version: String,
+    pub three_d_s_info: Option<RedsysThreeDsInfo>,
+    pub three_d_s_method_u_r_l: Option<String>,
+    pub three_d_s_server_trans_i_d: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -64,10 +64,10 @@ pub struct RedsysThreedsChallengeResponse {
 
 /// Result type for pre-authenticate response building
 pub struct PreAuthenticateResponseData {
-    pub redirection_data: Option<Box<router_response_types::RedirectForm>>,
-    pub connector_meta_data: Option<Secret<serde_json::Value>>,
-    pub response_ref_id: Option<String>,
     pub authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
+    pub connector_meta_data: Option<Secret<serde_json::Value>>,
+    pub redirection_data: Option<Box<router_response_types::RedirectForm>>,
+    pub response_ref_id: Option<String>,
 }
 
 /// Response code from Redsys (4-digit code)
@@ -77,12 +77,12 @@ pub struct DsResponse(pub String);
 /// Response for operation requests (capture, void, refund)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RedsysOperationsResponse {
+    #[serde(rename = "Ds_AuthorisationCode")]
+    pub ds_authorisation_code: Option<String>,
     #[serde(rename = "Ds_Order")]
     pub ds_order: String,
     #[serde(rename = "Ds_Response")]
     pub ds_response: DsResponse,
-    #[serde(rename = "Ds_AuthorisationCode")]
-    pub ds_authorisation_code: Option<String>,
 }
 
 /// Error response structure from Redsys
@@ -110,9 +110,9 @@ pub struct RedsysSyncResponseBody {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub struct ConsultaOperacionesResponse {
+    pub consultaoperacionesreturn: ConsultaOperacionesReturn,
     #[serde(rename = "@xmlns:p259", default)]
     pub xmlns_p259: String,
-    pub consultaoperacionesreturn: ConsultaOperacionesReturn,
 }
 
 /// Return data from consulta operaciones
@@ -126,8 +126,8 @@ pub struct ConsultaOperacionesReturn {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub struct MessagesResponseData {
-    pub version: VersionResponseData,
     pub signature: Option<String>,
+    pub version: VersionResponseData,
 }
 
 /// Version wrapper containing message data
@@ -144,8 +144,8 @@ pub struct VersionResponseData {
 // If both are present or both are absent, an error is thrown.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MessageResponseType {
-    pub response: Option<Vec<RedsysSyncResponseData>>,
     pub errormsg: Option<SyncErrorCode>,
+    pub response: Option<Vec<RedsysSyncResponseData>>,
 }
 
 /// Error code from sync response
@@ -157,44 +157,44 @@ pub struct SyncErrorCode {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DsState {
-    /// Requested
-    S,
-    /// Authorizing
-    P,
     /// Authenticating
     A,
-    /// Completed
-    F,
-    /// No response / Technical Error
-    T,
-    /// Transfer, direct debit, or PayPal in progress
-    E,
     /// Direct debit downloaded.
     D,
+    /// Transfer, direct debit, or PayPal in progress
+    E,
+    /// Completed
+    F,
     /// Online transfer
     L,
-    /// Redirected to a wallet
-    W,
     /// Redirected to Iupay
     O,
+    /// Authorizing
+    P,
+    /// Requested
+    S,
+    /// No response / Technical Error
+    T,
+    /// Redirected to a wallet
+    W,
 }
 
 /// Sync response transaction data
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RedsysSyncResponseData {
-    pub ds_merchantcode: Option<String>,
-    pub ds_terminal: Option<String>,
-    pub ds_order: String,
-    pub ds_transactiontype: String,
-    pub ds_date: Option<String>,
-    pub ds_hour: Option<String>,
+    pub ds_authorisationcode: Option<String>,
     pub ds_amount: Option<StringMinorUnit>,
     // Redsys uses numeric ISO 4217 currency codes (e.g., "978" for EUR)
     // not 3-letter codes, so we use String here
     pub ds_currency: Option<String>,
+    pub ds_date: Option<String>,
+    pub ds_hour: Option<String>,
+    pub ds_merchantcode: Option<String>,
+    pub ds_order: String,
+    pub ds_response: Option<DsResponse>,
     pub ds_securepayment: Option<String>,
     pub ds_state: Option<DsState>,
-    pub ds_response: Option<DsResponse>,
-    pub ds_authorisationcode: Option<String>,
+    pub ds_terminal: Option<String>,
+    pub ds_transactiontype: String,
 }

--- a/backend/connector-integration/src/connectors/redsys/transformers.rs
+++ b/backend/connector-integration/src/connectors/redsys/transformers.rs
@@ -225,8 +225,8 @@ where
                 let expiry_date = Secret::new(format!("{year}{month}"));
                 Ok(Self {
                     card_number: card.card_number.clone(),
-                    expiry_date,
                     cvv2: card.card_cvc.clone(),
+                    expiry_date,
                 })
             }
             Some(PaymentMethodData::Wallet(..))
@@ -520,8 +520,8 @@ fn build_threeds_invoke_response(
     )?;
 
     let threeds_invoke_request = requests::RedsysThreedsInvokeRequest {
-        three_d_s_server_trans_i_d: three_d_s_server_trans_i_d.to_string(),
         three_d_s_method_notification_u_r_l: notification_url,
+        three_d_s_server_trans_i_d: three_d_s_server_trans_i_d.to_string(),
     };
 
     let three_ds_data_string = threeds_invoke_request
@@ -531,11 +531,11 @@ fn build_threeds_invoke_response(
     let three_ds_method_data = BASE64_ENGINE.encode(&three_ds_data_string);
 
     let three_ds_invoke_data = requests::RedsysThreeDsInvokeData {
-        three_ds_method_url: three_ds_method_url.to_string(),
-        three_ds_method_data: three_ds_method_data.clone(),
         message_version: protocol_version,
-        three_d_s_server_trans_i_d: three_d_s_server_trans_i_d.to_string(),
+        three_ds_method_data: three_ds_method_data.clone(),
         three_ds_method_data_submission: true.to_string(),
+        three_ds_method_url: three_ds_method_url.to_string(),
+        three_d_s_server_trans_i_d: three_d_s_server_trans_i_d.to_string(),
     };
 
     // Serialize to JSON, then deserialize to HashMap<String, String>
@@ -769,8 +769,7 @@ where
         }?;
 
         let payment_request = requests::RedsysPaymentRequest {
-            ds_merchant_emv3ds,
-            ds_merchant_transactiontype,
+            ds_merchant_amount: amount,
             ds_merchant_currency: router_data
                 .request
                 .currency
@@ -779,15 +778,16 @@ where
                 })?
                 .iso_4217()
                 .to_owned(),
+            ds_merchant_cvv2: card_data.cvv2,
+            ds_merchant_emv3ds,
+            ds_merchant_expirydate: card_data.expiry_date,
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order,
             ds_merchant_pan: cards::CardNumber::try_from(card_data.card_number.peek().to_string())
                 .change_context(errors::ConnectorError::RequestEncodingFailed)
                 .attach_printable("Invalid card number")?,
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
             ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_order,
-            ds_merchant_amount: amount,
-            ds_merchant_expirydate: card_data.expiry_date,
-            ds_merchant_cvv2: card_data.cvv2,
+            ds_merchant_transactiontype,
         };
 
         let transaction = Self::try_from((&payment_request, &auth))?;
@@ -944,22 +944,6 @@ where
         .set_shipping_data(router_data.resource_common_data.get_optional_shipping())?;
 
         let payment_request = requests::RedsysPaymentRequest {
-            ds_merchant_emv3ds: Some(emv3ds_data),
-            ds_merchant_transactiontype,
-            ds_merchant_currency: router_data
-                .request
-                .currency
-                .ok_or(errors::ConnectorError::MissingRequiredField {
-                    field_name: "currency",
-                })?
-                .iso_4217()
-                .to_owned(),
-            ds_merchant_pan: cards::CardNumber::try_from(card_data.card_number.peek().to_string())
-                .change_context(errors::ConnectorError::RequestEncodingFailed)
-                .attach_printable("Invalid card number")?,
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
-            ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_order,
             ds_merchant_amount: RedsysAmountConvertor::convert(
                 router_data.request.amount,
                 router_data.request.currency.ok_or(
@@ -968,8 +952,24 @@ where
                     },
                 )?,
             )?,
-            ds_merchant_expirydate: card_data.expiry_date,
+            ds_merchant_currency: router_data
+                .request
+                .currency
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "currency",
+                })?
+                .iso_4217()
+                .to_owned(),
             ds_merchant_cvv2: card_data.cvv2,
+            ds_merchant_emv3ds: Some(emv3ds_data),
+            ds_merchant_expirydate: card_data.expiry_date,
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order,
+            ds_merchant_pan: cards::CardNumber::try_from(card_data.card_number.peek().to_string())
+                .change_context(errors::ConnectorError::RequestEncodingFailed)
+                .attach_printable("Invalid card number")?,
+            ds_merchant_terminal: auth.terminal_id.clone(),
+            ds_merchant_transactiontype,
         };
 
         let transaction = Self::try_from((&payment_request, &auth))?;
@@ -1199,21 +1199,21 @@ where
         }?;
 
         let payment_request = requests::RedsysPaymentRequest {
-            ds_merchant_emv3ds: Some(emv3ds_data),
-            ds_merchant_transactiontype,
-            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
-            ds_merchant_pan: cards::CardNumber::try_from(card_data.card_number.peek().to_string())
-                .change_context(errors::ConnectorError::RequestEncodingFailed)
-                .attach_printable("Invalid card number")?,
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
-            ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_order,
             ds_merchant_amount: RedsysAmountConvertor::convert(
                 router_data.request.amount,
                 router_data.request.currency,
             )?,
-            ds_merchant_expirydate: card_data.expiry_date,
+            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
             ds_merchant_cvv2: card_data.cvv2,
+            ds_merchant_emv3ds: Some(emv3ds_data),
+            ds_merchant_expirydate: card_data.expiry_date,
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order,
+            ds_merchant_pan: cards::CardNumber::try_from(card_data.card_number.peek().to_string())
+                .change_context(errors::ConnectorError::RequestEncodingFailed)
+                .attach_printable("Invalid card number")?,
+            ds_merchant_terminal: auth.terminal_id.clone(),
+            ds_merchant_transactiontype,
         };
 
         let transaction = Self::try_from((&payment_request, &auth))?;
@@ -1313,15 +1313,15 @@ where
             common_utils::types::MinorUnit::new(router_data.request.amount_to_capture);
 
         let capture_request = requests::RedsysOperationRequest {
-            ds_merchant_order: connector_transaction_id,
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
-            ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
-            ds_merchant_transactiontype: requests::RedsysTransactionType::Confirmation,
             ds_merchant_amount: RedsysAmountConvertor::convert(
                 amount_to_capture,
                 router_data.request.currency,
             )?,
+            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order: connector_transaction_id,
+            ds_merchant_terminal: auth.terminal_id.clone(),
+            ds_merchant_transactiontype: requests::RedsysTransactionType::Confirmation,
         };
 
         let transaction = Self::try_from((&capture_request, &auth))?;
@@ -1430,12 +1430,12 @@ where
                 })?;
 
         let void_request = requests::RedsysOperationRequest {
-            ds_merchant_order: connector_transaction_id,
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
-            ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_currency: currency.iso_4217().to_owned(),
-            ds_merchant_transactiontype: requests::RedsysTransactionType::Cancellation,
             ds_merchant_amount: RedsysAmountConvertor::convert(amount, currency)?,
+            ds_merchant_currency: currency.iso_4217().to_owned(),
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order: connector_transaction_id,
+            ds_merchant_terminal: auth.terminal_id.clone(),
+            ds_merchant_transactiontype: requests::RedsysTransactionType::Cancellation,
         };
 
         let transaction = Self::try_from((&void_request, &auth))?;
@@ -1542,21 +1542,21 @@ pub fn construct_sync_request(
         requests::Message {
             content: requests::MessageContent::Transaction(requests::RedsysTransactionRequest {
                 ds_merchant_code: auth.merchant_id,
+                ds_order: order_id.clone(),
                 ds_terminal: auth.terminal_id,
                 ds_transaction_type: transaction_type.ok_or(
                     errors::ConnectorError::MissingRequiredField {
                         field_name: "transaction_type",
                     },
                 )?,
-                ds_order: order_id.clone(),
             }),
         }
     } else {
         requests::Message {
             content: requests::MessageContent::Monitor(requests::RedsysMonitorRequest {
                 ds_merchant_code: auth.merchant_id,
-                ds_terminal: auth.terminal_id,
                 ds_order: order_id.clone(),
+                ds_terminal: auth.terminal_id,
             }),
         }
     };
@@ -1572,9 +1572,9 @@ pub fn construct_sync_request(
     let signature = get_signature(&order_id, &version_data, auth.sha256_pwd.peek())?;
 
     let messages = requests::Messages {
-        version,
         signature,
         signature_version: SIGNATURE_VERSION.to_owned(),
+        version,
     };
 
     let cdata = quick_xml::se::to_string(&messages)
@@ -1735,15 +1735,15 @@ where
         let refund_amount = common_utils::types::MinorUnit::new(router_data.request.refund_amount);
 
         let refund_request = requests::RedsysOperationRequest {
-            ds_merchant_order: router_data.request.connector_transaction_id.clone(),
-            ds_merchant_merchantcode: auth.merchant_id.clone(),
-            ds_merchant_terminal: auth.terminal_id.clone(),
-            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
-            ds_merchant_transactiontype: requests::RedsysTransactionType::Refund,
             ds_merchant_amount: RedsysAmountConvertor::convert(
                 refund_amount,
                 router_data.request.currency,
             )?,
+            ds_merchant_currency: router_data.request.currency.iso_4217().to_owned(),
+            ds_merchant_merchantcode: auth.merchant_id.clone(),
+            ds_merchant_order: router_data.request.connector_transaction_id.clone(),
+            ds_merchant_terminal: auth.terminal_id.clone(),
+            ds_merchant_transactiontype: requests::RedsysTransactionType::Refund,
         };
 
         let transaction = Self::try_from((&refund_request, &auth))?;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In UCS shadow mode, there exist a lot of diffs in the PreAuthenticate, Authenticate and Authorize flow. And it is all due to unordered structs and enums. This PR aims to address that.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Relevant Hyperswitch PR: https://github.com/juspay/hyperswitch/pull/11121

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Normal Redsys transactions should be unaffected. All cURLs available [here](https://github.com/juspay/hyperswitch/pull/10490)

In shadow mode, there should be no diffs between UCS and Hyperswitch.

We previously used to get diffs like below:

PreAuthenticate:

<img width="749" height="817" alt="image" src="https://github.com/user-attachments/assets/aa8afeed-b142-4001-8736-445d3aa4e8f4" />

Authenticate:

<img width="749" height="817" alt="image" src="https://github.com/user-attachments/assets/aa8afeed-b142-4001-8736-445d3aa4e8f4" />

After sorting the fields in alphabetical order and the skipping the serialization of `null` fields:

PreAuthenticate:

<img width="1710" height="826" alt="image" src="https://github.com/user-attachments/assets/92ce2312-758d-45d4-a784-43ffde5eb8a6" />

Authenticate:

<img width="1711" height="971" alt="image" src="https://github.com/user-attachments/assets/b5c8cb85-58cd-4b97-b1c5-046cd8e2c09a" />

