### PR TITLE
chore: adding failure status to customer create response

### DIFF
--- a/backend/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/backend/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -3157,7 +3157,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetCreateConnectorCustomerResponse, 
                         code: error_code.to_string(),
                         message: error_text.to_string(),
                         reason: Some(error_text.to_string()),
-                        attempt_status: None,
+                        attempt_status: Some(AttemptStatus::Failure), // Marking attempt as failure since we couldn't confirm existing profile ID
                         connector_transaction_id: None,
                         network_decline_code: None,
                         network_advice_code: None,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In case of failure for create connector customer flow we were sending None as a status which should be failure

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
