### PR TITLE
fix: Populate connector response for Repeat Everything Flow's Err response

### DIFF
--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -8568,7 +8568,13 @@ pub fn generate_repeat_payment_response<T: PaymentMethodDataTypes>(
         .connector_response
         .clone()
         .and_then(|data| {
-            grpc_api_types::payments::ConnectorResponseData::foreign_try_from(data).ok()
+            match grpc_api_types::payments::ConnectorResponseData::foreign_try_from(data) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    tracing::error!("Failed to convert ConnectorResponseData: {err:?}");
+                    None
+                }
+            }
         });
 
     match transaction_response {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
populating the field connector response in error response of repeat everything/ repeat payment flow.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
