### PR TITLE
fix: incremental_authorization_allowed and cybersource repeatpayment diff fix

### DIFF
--- a/backend/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/backend/connector-integration/src/connectors/cybersource/transformers.rs
@@ -4418,37 +4418,41 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        match &item.router_data.request.payment_method_data {
-            PaymentMethodData::MandatePayment => {
-                let connector_mandate_id = item.router_data.request.connector_mandate_id().ok_or(
-                    ConnectorError::MissingRequiredField {
-                        field_name: "connector_mandate_id",
-                    },
-                )?;
-                Self::try_from((&item, connector_mandate_id))
-            }
-            PaymentMethodData::CardDetailsForNetworkTransactionId(card) => {
-                Self::try_from((&item, card))
-            }
-            PaymentMethodData::NetworkToken(token_data) => Self::try_from((&item, token_data)),
-            PaymentMethodData::CardRedirect(_)
-            | PaymentMethodData::PayLater(_)
-            | PaymentMethodData::Wallet(_)
-            | PaymentMethodData::Card(_)
-            | PaymentMethodData::BankRedirect(_)
-            | PaymentMethodData::BankDebit(_)
-            | PaymentMethodData::BankTransfer(_)
-            | PaymentMethodData::Crypto(_)
-            | PaymentMethodData::Reward
-            | PaymentMethodData::RealTimePayment(_)
-            | PaymentMethodData::MobilePayment(_)
-            | PaymentMethodData::Upi(_)
-            | PaymentMethodData::Voucher(_)
-            | PaymentMethodData::GiftCard(_)
-            | PaymentMethodData::OpenBanking(_)
-            | PaymentMethodData::CardToken(_) => Err(ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("Cybersource"),
-            ))?,
+        match item.router_data.request.connector_mandate_id() {
+            Some(connector_mandate_id) => Self::try_from((&item, connector_mandate_id)),
+            None => match &item.router_data.request.payment_method_data {
+                PaymentMethodData::MandatePayment => {
+                    let connector_mandate_id =
+                        item.router_data.request.connector_mandate_id().ok_or(
+                            ConnectorError::MissingRequiredField {
+                                field_name: "connector_mandate_id",
+                            },
+                        )?;
+                    Self::try_from((&item, connector_mandate_id))
+                }
+                PaymentMethodData::CardDetailsForNetworkTransactionId(card) => {
+                    Self::try_from((&item, card))
+                }
+                PaymentMethodData::NetworkToken(token_data) => Self::try_from((&item, token_data)),
+                PaymentMethodData::CardRedirect(_)
+                | PaymentMethodData::PayLater(_)
+                | PaymentMethodData::Wallet(_)
+                | PaymentMethodData::Card(_)
+                | PaymentMethodData::BankRedirect(_)
+                | PaymentMethodData::BankDebit(_)
+                | PaymentMethodData::BankTransfer(_)
+                | PaymentMethodData::Crypto(_)
+                | PaymentMethodData::Reward
+                | PaymentMethodData::RealTimePayment(_)
+                | PaymentMethodData::MobilePayment(_)
+                | PaymentMethodData::Upi(_)
+                | PaymentMethodData::Voucher(_)
+                | PaymentMethodData::GiftCard(_)
+                | PaymentMethodData::OpenBanking(_)
+                | PaymentMethodData::CardToken(_) => Err(ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Cybersource"),
+                ))?,
+            },
         }
     }
 }

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -4600,7 +4600,7 @@ pub fn generate_payment_sync_response(
                 connector_metadata: _,
                 network_txn_id,
                 connector_response_reference_id,
-                incremental_authorization_allowed: _,
+                incremental_authorization_allowed,
                 mandate_reference,
                 status_code,
             } => {
@@ -4665,6 +4665,7 @@ pub fn generate_payment_sync_response(
                     state,
                     raw_connector_request,
                     connector_response,
+                    incremental_authorization_allowed,
                 })
             }
             _ => Err(report!(ApplicationErrorResponse::InternalServerError(
@@ -4730,6 +4731,7 @@ pub fn generate_payment_sync_response(
                 raw_connector_request,
                 connector_response,
                 redirection_data: None,
+                incremental_authorization_allowed: None,
             })
         }
     }
@@ -5479,6 +5481,7 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
             raw_connector_request: None,
             connector_response: None,
             redirection_data: None,
+            incremental_authorization_allowed: None,
         })
     }
 }

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -1885,6 +1885,9 @@ message PaymentServiceGetResponse {
 
   // Redirection and Transaction Details
   optional RedirectForm redirection_data = 35; // Data for redirecting the customer's browser
+
+  // Capability Flags
+  optional bool incremental_authorization_allowed = 36; // Whether incremental auth is allowed
 }
 
 // Request message for voiding a payment.


### PR DESCRIPTION
## Description

1. Some saved card payment sends both paymentmethoddata as card and connector_mandateid
In that case, hyperswitch takes mandateid try_from but ucs gets unimplemented error through repeatpayment.
https://github.com/juspay/hyperswitch-cloud/issues/14555
fixing the logic to first check if connector_mandate_id is present, if so use mandate try_from, same as hyperswitch.

2. UCS PaymentServiceGetResponse does not have incremental_authorization_allowed, and generate_payment_sync_response explicitly ignores it when building the gRPC response, so UCS return null for that field in PSync comparisons.
HS direct path sets incremental_authorization_allowed during Cybersource PSync based on status, so HS routerdata has a boolean.
https://github.com/juspay/hyperswitch-cloud/issues/14556


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?

https://github.com/juspay/hyperswitch-cloud/issues/14556