### PR TITLE
chore(connector): add warning comment about dtd validation to redsys soap api

### DIFF
--- a/backend/connector-integration/src/connectors/redsys/requests.rs
+++ b/backend/connector-integration/src/connectors/redsys/requests.rs
@@ -197,6 +197,12 @@ pub struct RedsysVersionData {
 }
 
 /// Message wrapper containing the actual message type
+///
+/// Note: Uses Transaction or Monitor based on transaction_type parameter in construct_sync_request()
+/// - Transaction: Filters by Ds_TransactionType
+/// - Monitor: Returns all transaction types
+///
+/// Both use same field ordering as simple variants (not Masiva).
 #[derive(Debug, Serialize)]
 #[serde(rename = "Message")]
 pub struct Message {
@@ -213,7 +219,14 @@ pub enum MessageContent {
     Monitor(RedsysMonitorRequest),
 }
 
-/// Transaction request for querying transaction status
+/// SOAP XML Transaction request for querying transaction status
+///
+/// CRITICAL: Field ordering must match Redsys DTD exactly.
+/// Alphabetical sorting will cause XML0001 error (DTD validation failure).
+///
+/// Required DTD order: Ds_MerchantCode → Ds_Terminal → Ds_Order → Ds_TransactionType
+///
+/// Ref: RS.TE.CEL.MAN.0021 v1.4, Section 3.2.1 (Transaction simple)
 #[derive(Debug, Serialize)]
 pub struct RedsysTransactionRequest {
     #[serde(rename = "Ds_MerchantCode")]
@@ -226,7 +239,16 @@ pub struct RedsysTransactionRequest {
     pub ds_transaction_type: String,
 }
 
-/// Monitor request (simpler - no transaction type needed)
+/// SOAP XML Monitor request for querying all transaction types
+///
+/// CRITICAL: Field ordering must match Redsys DTD exactly.
+/// Alphabetical sorting will cause XML0001 error (DTD validation failure).
+///
+/// Required DTD order: Ds_MerchantCode → Ds_Terminal → Ds_Order
+///
+/// Note: Monitor (simple) does NOT include Ds_TransactionType
+///
+/// Ref: RS.TE.CEL.MAN.0021 v1.4, Section 3.2.1 (Monitor simple)
 #[derive(Debug, Serialize)]
 pub struct RedsysMonitorRequest {
     #[serde(rename = "Ds_MerchantCode")]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds warning comments to Redsys SOAP API (PSync and RSync) giving a heads up about the DTD validation.

Below is a summary of the SOAP API documentation regarding the DTD validation:

- The documentation states (p.6): "El XML enviando será validado por un DTD que evaluará la estructura y sintaxis del mismo" - the XML is validated against a DTD that evaluates structure and syntax.
- Error XML0001 specifically indicates: "Error en la generación del DOM a partir del XML-String recibido y la DTD definida" - DOM generation failed due to DTD validation.

Required Field Ordering by Message Type:

1. Transaction (simple)
Order: Ds_MerchantCode → Ds_Terminal → Ds_Order → Ds_TransactionType

2. TransactionMasiva (masivo)
Order: Ds_Order → Ds_MerchantCode → Ds_Terminal → Ds_TransactionType → Ds_Fecha_inicio → Ds_Fecha_fin

3. Monitor (simple)
Order: Ds_MerchantCode → Ds_Terminal → Ds_Order

4. MonitorMasiva (masivo)
Order: Ds_Order → Ds_MerchantCode → Ds_Terminal → Ds_Fecha_inicio → Ds_Fecha_fin

5. Detail
Order: Ds_MerchantCode → Ds_Terminal → Ds_Order → Ds_TransactionType

XML Schema Reference (Anexo 1)
The XSD schema uses <sequence> elements which enforce strict ordering. Example from documentation (p.22):

```xml
<element name="Transaction">
  <complexType>
    <sequence>
      <element ref="t:Ds_MerchantCode"/>
      <element ref="t:Ds_Terminal"/>
      <element ref="t:Ds_Order"/>
      <element ref="t:Ds_TransactionType"/>
    </sequence>
  </complexType>
</element>
```

> [!NOTE]
> `TransactionMasiva` and `MonitorMasiva` use a DIFFERENT field order than their simple counterparts (starting with `Ds_Order` instead of `Ds_MerchantCode`). Redsys implementation done here is `simple` and not `masivo`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This is done to give a heads up to other developers who might work on this in the future.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

It is just a comment addition. Does not touch the code. Clippy lints should not fail.