### PR TITLE
feat(connector): [Revolut] Rename RevolutAuth "api_key" field and add "signing_secret" for webhook source verification

### DIFF
--- a/backend/connector-integration/src/connectors/revolut.rs
+++ b/backend/connector-integration/src/connectors/revolut.rs
@@ -283,14 +283,33 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         &self,
         request: RequestDetails,
         connector_webhook_secret: Option<ConnectorWebhookSecrets>,
-        _connector_account_details: Option<ConnectorSpecificAuth>,
+        connector_account_details: Option<ConnectorSpecificAuth>,
     ) -> Result<bool, error_stack::Report<errors::ConnectorError>> {
         // Revolut uses HMAC-SHA256
         let algorithm = crypto::HmacSha256;
 
         let connector_webhook_secrets = match connector_webhook_secret {
             Some(secrets) => secrets,
-            None => Err(errors::ConnectorError::WebhookSourceVerificationFailed)?,
+            None => {
+                // If webhook secrets are not provided, take them from connector_account_details
+                let auth = revolut::RevolutAuthType::try_from(
+                    connector_account_details
+                        .as_ref()
+                        .ok_or(errors::ConnectorError::FailedToObtainAuthType)?,
+                )
+                .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
+
+                ConnectorWebhookSecrets {
+                    secret: auth
+                        .signing_secret
+                        .as_ref()
+                        .ok_or(errors::ConnectorError::WebhookSourceVerificationFailed)?
+                        .peek()
+                        .as_bytes()
+                        .to_vec(),
+                    additional_secret: None,
+                }
+            }
         };
 
         let signature =
@@ -547,7 +566,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(
             headers::AUTHORIZATION.to_string(),
-            format!("Bearer {}", auth.api_key.peek()).into(),
+            format!("Bearer {}", auth.secret_api_key.peek()).into(),
         )])
     }
 

--- a/backend/connector-integration/src/connectors/revolut/transformers.rs
+++ b/backend/connector-integration/src/connectors/revolut/transformers.rs
@@ -22,7 +22,8 @@ use std::fmt::Debug;
 use time::PrimitiveDateTime;
 
 pub struct RevolutAuthType {
-    pub api_key: Secret<String>,
+    pub secret_api_key: Secret<String>,
+    pub signing_secret: Option<Secret<String>>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -452,8 +453,12 @@ impl TryFrom<&ConnectorSpecificAuth> for RevolutAuthType {
 
     fn try_from(auth_type: &ConnectorSpecificAuth) -> Result<Self, Self::Error> {
         match auth_type {
-            ConnectorSpecificAuth::Revolut { api_key } => Ok(Self {
-                api_key: api_key.to_owned(),
+            ConnectorSpecificAuth::Revolut {
+                secret_api_key,
+                signing_secret,
+            } => Ok(Self {
+                secret_api_key: secret_api_key.to_owned(),
+                signing_secret: signing_secret.to_owned(),
             }),
             _ => Err(ConnectorError::FailedToObtainAuthType.into()),
         }

--- a/backend/domain_types/src/router_data.rs
+++ b/backend/domain_types/src/router_data.rs
@@ -167,7 +167,8 @@ pub enum ConnectorSpecificAuth {
         api_key: Secret<String>,
     },
     Revolut {
-        api_key: Secret<String>,
+        secret_api_key: Secret<String>,
+        signing_secret: Option<Secret<String>>,
     },
     Shift4 {
         api_key: Secret<String>,
@@ -758,7 +759,8 @@ impl ForeignTryFrom<grpc_api_types::payments::ConnectorAuth> for ConnectorSpecif
                 merchant_code: worldpayxml.merchant_code.ok_or_else(err)?,
             }),
             AuthType::Revolut(revolut) => Ok(Self::Revolut {
-                api_key: revolut.api_key.ok_or_else(err)?,
+                secret_api_key: revolut.secret_api_key.ok_or_else(err)?,
+                signing_secret: revolut.signing_secret,
             }),
             AuthType::Loonio(loonio) => Ok(Self::Loonio {
                 merchant_id: loonio.merchant_id.ok_or_else(err)?,
@@ -868,7 +870,8 @@ impl ForeignTryFrom<(&ConnectorAuthType, &connector_types::ConnectorEnum)>
             },
             ConnectorEnum::Revolut => match auth {
                 ConnectorAuthType::HeaderKey { api_key } => Ok(Self::Revolut {
-                    api_key: api_key.clone(),
+                    secret_api_key: api_key.clone(),
+                    signing_secret: None,
                 }),
                 _ => Err(err().into()),
             },

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -3491,7 +3491,8 @@ message NexixpayAuth {
 }
 
 message RevolutAuth {
-  SecretString api_key = 1;
+  SecretString secret_api_key = 1;
+  optional SecretString signing_secret = 2;
 }
 
 message Revolv3Auth {

--- a/backend/grpc-server/src/http/utils.rs
+++ b/backend/grpc-server/src/http/utils.rs
@@ -25,7 +25,6 @@ pub fn http_headers_to_grpc_metadata(
         consts::X_MERCHANT_ID,
         consts::X_REQUEST_ID,
         consts::X_TENANT_ID,
-        consts::X_AUTH,
     ];
 
     // Optional headers - these may or may not be present
@@ -37,6 +36,8 @@ pub fn http_headers_to_grpc_metadata(
         consts::X_KEY2,
         consts::X_AUTH_KEY_MAP,
         consts::X_SHADOW_MODE,
+        consts::X_AUTH,
+        consts::X_CONNECTOR_AUTH,
     ];
 
     // Process required headers - fail if missing


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

#### Changes:
- This PR updates the Revolut connector's authentication model to correctly name the `api_key` field and add support for an optional `signing_secret` used in webhook source verification.
#### Bug fixes: 
Fix ConnectorSpecificAuth handling in HTTP mode:
- Resolved an issue where ConnectorSpecificAuth was not functioning in the HTTP mode due to incorrect header classification.
- Moved X_AUTH from the required headers list to the optional headers list in backend/grpc-server/src/http/utils.rs.
- Added X_CONNECTOR_AUTH to the optional headers list to ensure connector-specific authentication headers are properly accepted.
- This prevents 400 - Missing required header: x-auth errors when ConnectorSpecificAuth is used.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [x] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?

Tested for Revolut with http curl
Webhooks
Request
```sh
curl --location 'http://localhost:8000/payments/transform' \
--header 'x-connector: revolut' \
--header 'x-connector-auth: {"auth_type":{"Revolut":{"signing_secret":"sdfsfds", "secret_api_key":"dfsafds"}}}' \
--header 'x-merchant-id: merchant_id' \
--header 'x-tenant-id: tenant1' \
--header 'content-Type: application/json' \
--data '{
    "request_details": {
        "method": "POST",
        "uri": "www.google.com",
        "headers": {
            "revolut-signature": "v1=121313",
            "revolut-request-timestamp": "123131"
        },
        "body": [
            123,
            34,
            102,
            49,
            34,
            125
        ]
    }
}'
```

Response
```sh
{"event_type":"PAYMENT_INTENT_SUCCESS","content":{"content":{"PaymentsResponse":{"transaction_id":{"id_type":{"Id":"1234"}},"status":"CHARGED","status_code":200,"response_headers":{}}}},"source_verified":true,"transformation_status":"COMPLETE"}%
```

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
