### PR TITLE
chore: Implemented Webhook Flow For Composite Service

### DIFF
--- a/backend/composite-service/src/payments.rs
+++ b/backend/composite-service/src/payments.rs
@@ -8,7 +8,9 @@ use grpc_api_types::payments::{
     customer_service_server::CustomerService,
     merchant_authentication_service_server::MerchantAuthenticationService,
     payment_service_server::PaymentService, CompositeAuthorizeRequest, CompositeAuthorizeResponse,
-    CompositeGetRequest, CompositeGetResponse, ConnectorState, CustomerServiceCreateResponse,
+    CompositeGetRequest, CompositeGetResponse, CompositeHandleEventRequest,
+    CompositeHandleEventResponse, ConnectorState, CustomerServiceCreateResponse,
+    EventServiceHandleRequest, EventServiceHandleResponse,
     MerchantAuthenticationServiceCreateAccessTokenRequest,
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentMethod,
     PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse, PaymentServiceGetResponse,
@@ -287,6 +289,44 @@ where
             get_response: Some(get_response),
         }))
     }
+
+    async fn handle_event(
+        &self,
+        payload: &CompositeHandleEventRequest,
+        metadata: &tonic::metadata::MetadataMap,
+        extensions: &tonic::Extensions,
+    ) -> Result<EventServiceHandleResponse, tonic::Status> {
+        let handle_event_payload = EventServiceHandleRequest::foreign_from(payload);
+
+        let mut handle_event_request = tonic::Request::new(handle_event_payload);
+        *handle_event_request.metadata_mut() = metadata.clone();
+        *handle_event_request.extensions_mut() = extensions.clone();
+
+        let handle_event_response = self
+            .payment_service
+            .handle_event(handle_event_request)
+            .await?
+            .into_inner();
+
+        Ok(handle_event_response)
+    }
+
+    async fn process_composite_handle_event(
+        &self,
+        request: tonic::Request<CompositeHandleEventRequest>,
+    ) -> Result<tonic::Response<CompositeHandleEventResponse>, tonic::Status> {
+        let (metadata, extensions, payload) = request.into_parts();
+
+        let handle_event_response = self.handle_event(&payload, &metadata, &extensions).await?;
+
+        Ok(tonic::Response::new(CompositeHandleEventResponse {
+            event_type: handle_event_response.event_type,
+            event_response: handle_event_response.event_response,
+            source_verified: handle_event_response.source_verified,
+            merchant_event_id: handle_event_response.merchant_event_id,
+            event_status: handle_event_response.event_status,
+        }))
+    }
 }
 
 #[tonic::async_trait]
@@ -308,5 +348,12 @@ where
         request: tonic::Request<CompositeGetRequest>,
     ) -> Result<tonic::Response<CompositeGetResponse>, tonic::Status> {
         self.process_composite_get(request).await
+    }
+
+    async fn composite_handle_event(
+        &self,
+        request: tonic::Request<CompositeHandleEventRequest>,
+    ) -> Result<tonic::Response<CompositeHandleEventResponse>, tonic::Status> {
+        self.process_composite_handle_event(request).await
     }
 }

--- a/backend/composite-service/src/transformers.rs
+++ b/backend/composite-service/src/transformers.rs
@@ -1,7 +1,8 @@
 use domain_types::connector_types::ConnectorEnum;
 use grpc_api_types::payments::{
-    CompositeAuthorizeRequest, CompositeGetRequest, ConnectorState, CustomerServiceCreateRequest,
-    CustomerServiceCreateResponse, MerchantAuthenticationServiceCreateAccessTokenRequest,
+    CompositeAuthorizeRequest, CompositeGetRequest, CompositeHandleEventRequest, ConnectorState,
+    CustomerServiceCreateRequest, CustomerServiceCreateResponse, EventServiceHandleRequest,
+    MerchantAuthenticationServiceCreateAccessTokenRequest,
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentServiceAuthorizeRequest,
     PaymentServiceGetRequest,
 };
@@ -198,6 +199,17 @@ impl
             connector_order_reference_id: item.connector_order_reference_id.clone(),
             test_mode: item.test_mode,
             payment_experience: item.payment_experience,
+        }
+    }
+}
+
+impl ForeignFrom<&CompositeHandleEventRequest> for EventServiceHandleRequest {
+    fn foreign_from(item: &CompositeHandleEventRequest) -> Self {
+        Self {
+            merchant_event_id: item.merchant_event_id.clone(),
+            request_details: item.request_details.clone(),
+            webhook_secrets: item.webhook_secrets.clone(),
+            state: item.state.clone(),
         }
     }
 }

--- a/backend/composite-service/tests/composite_request_schema_check.rs
+++ b/backend/composite-service/tests/composite_request_schema_check.rs
@@ -46,6 +46,13 @@ const COMPOSITE_FLOW_SPECS: &[CompositeFlowSpec] = &[
         ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
         ignore_composite_only_fields: IGNORE_COMPOSITE_ONLY_FIELDS,
     },
+    CompositeFlowSpec {
+        name: "handle_event",
+        composite_request_message: "CompositeHandleEventRequest",
+        granular_request_messages: &["EventServiceHandleRequest"],
+        ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
+        ignore_composite_only_fields: DEFAULT_IGNORE_COMPOSITE_ONLY_FIELDS,
+    },
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/backend/grpc-api-types/proto/composite_payment.proto
+++ b/backend/grpc-api-types/proto/composite_payment.proto
@@ -155,3 +155,36 @@ message CompositeGetResponse {
   optional MerchantAuthenticationServiceCreateAccessTokenResponse access_token_response = 1; // Access token flow response
   optional PaymentServiceGetResponse get_response = 2; // Get flow response
 }
+
+// Request message for composite handle event (webhook) flow.
+message CompositeHandleEventRequest {
+  // Identification
+  Identifier merchant_event_id = 1; // Merchant's event ID for tracking
+
+  // Request Details
+  RequestDetails request_details = 2; // The raw HTTP request from the connector
+
+  // Security
+  optional WebhookSecrets webhook_secrets = 3; // Secrets for webhook source verification
+
+  // State Information
+  optional ConnectorState state = 4; // State data for access token storage and other connector-specific state
+}
+
+// Response message for composite handle event (webhook) flow.
+message CompositeHandleEventResponse {
+  // Event type
+  WebhookEventType event_type = 1;
+
+  // Content
+  EventResponse event_response = 2;
+
+  // Verification
+  bool source_verified = 3;
+
+  // Reference
+  optional Identifier merchant_event_id = 4;
+
+  // Event Status
+  WebhookEventStatus event_status = 5;
+}

--- a/backend/grpc-api-types/proto/composite_service.proto
+++ b/backend/grpc-api-types/proto/composite_service.proto
@@ -13,4 +13,7 @@ service CompositePaymentService {
 
   // Runs composite get flow.
   rpc CompositeGet(CompositeGetRequest) returns (CompositeGetResponse);
+
+  // Runs composite handle event (webhook) flow.
+  rpc CompositeHandleEvent(CompositeHandleEventRequest) returns (CompositeHandleEventResponse);
 }

--- a/backend/grpc-server/src/http/handlers/composite/payments.rs
+++ b/backend/grpc-server/src/http/handlers/composite/payments.rs
@@ -6,6 +6,7 @@ use axum::{
 use grpc_api_types::payments::{
     composite_payment_service_server::CompositePaymentService, CompositeAuthorizeRequest,
     CompositeAuthorizeResponse, CompositeGetRequest, CompositeGetResponse,
+    CompositeHandleEventRequest, CompositeHandleEventResponse,
 };
 use std::sync::Arc;
 
@@ -29,5 +30,13 @@ http_handler!(
     CompositeGetRequest,
     CompositeGetResponse,
     composite_get,
+    composite_payments_service
+);
+
+http_handler!(
+    handle_event,
+    CompositeHandleEventRequest,
+    CompositeHandleEventResponse,
+    composite_handle_event,
     composite_payments_service
 );

--- a/backend/grpc-server/src/http/router.rs
+++ b/backend/grpc-server/src/http/router.rs
@@ -16,6 +16,10 @@ pub fn create_router(state: AppState) -> Router {
             "/composite/payments/get",
             post(handlers::composite::payments::get),
         )
+        .route(
+            "/composite/payments/transform",
+            post(handlers::composite::payments::handle_event),
+        )
         .route("/payments/authorize", post(handlers::payments::authorize))
         // .route(
         //     "/payments/authorize_only",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds composite HandleEvent (webhook) flow to the composite service.
Unlike other composite flows (authorize, get, refund, refund_get), webhooks are a pure passthrough — no access token creation or customer creation is needed.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
**Request**
```
{"merchant_event_id": {"id_type": {"Id": "webhook_test_002"}},
    "request_details": {
      "method": "HTTP_METHOD_POST",
      "uri": "/webhooks/authorizedotnet",
      "headers": {},
      "body": [123,34,110,111,116,105,102,105,99,97,116,105,111,110,73,100,34,58,34,53,53,48,101,56,52,48,48,45,101,50,57,98,45,52,49,100,52,45,97,55,49,54,45,52,52,54,54,53,53,52,52,48,48,48,48,34,44,34,101,118,101,110,116,84,121,112,101,34,58,34,110,101,116,46,97,117,116,104,111,114,105,122,101,46,112,97,121,109,101,110,116,46,97,117,116,104,111,114,105,122,97,116,105,111,110,46,99,114,101,97,116,101,100,34,44,34,101,118,101,110,116,68,97,116,101,34,58,34,50,48,50,51,45,49,50,45,48,49,84,49,50,58,48,48,58,48,48,90,34,44,34,119,101,98,104,111,111,107,73,100,34,58,34,119,101,98,104,111,111,107,95,49,50,51,34,44,34,112,97,121,108,111,97,100,34,58,123,34,114,101,115,112,111,110,115,101,67,111,100,101,34,58,49,44,34,101,110,116,105,116,121,78,97,109,101,34,58,34,116,114,97,110,115,97,99,116,105,111,110,34,44,34,105,100,34,58,34,54,48,49,50,51,52,53,54,55,56,57,34,44,34,97,117,116,104,65,109,111,117,110,116,34,58,49,48,48,46,53,48,44,34,97,118,115,82,101,115,112,111,110,115,101,34,58,34,89,34,44,34,99,118,118,82,101,115,112,111,110,115,101,34,58,34,77,34,125,125]
    } 
    }
 ```
    
**Response**

```
{
    "event_type": "PAYMENT_INTENT_AUTHORIZATION_SUCCESS",
    "event_response": {
        "content": {
            "PaymentsResponse": {
                "connector_transaction_id": {
                    "id_type": {
                        "Id": "60123456789"
                    }
                },
                "status": "AUTHORIZED",
                "error": {
                    "connector_details": {}
                },
                "status_code": 200,
                "response_headers": {}
            }
        }
    },
    "source_verified": false,
    "event_status": "WEBHOOK_EVENT_STATUS_COMPLETE"
}
```
