### PR TITLE
ci(docs): Update workflow to use CONNECTOR_SERVICE_DOCS_CI secret

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: juspay/hyperswitch-docs
-          token: ${{ secrets.CONNECTOR_SERVICE_CI_PAT }}
+          token: ${{ secrets.CONNECTOR_SERVICE_DOCS_CI }}
           path: hyperswitch-docs
 
       - name: Sync documentation
@@ -70,9 +70,9 @@ jobs:
 
           git add connector-service/
 
-          # Check if there are any staged changes (new files or modifications)
+          # Check if there are any staged changes
           if git diff --cached --quiet; then
-            echo "No changes to sync"
+            echo "No changes to commit"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow to use the new `CONNECTOR_SERVICE_DOCS_CI` secret for authentication with hyperswitch-docs repository.

## Changes

- Changed PAT secret from `CONNECTOR_SERVICE_CI_PAT` to `CONNECTOR_SERVICE_DOCS_CI`
- Minor comment and message cleanup

## Why this change

The previous PAT (`CONNECTOR_SERVICE_CI_PAT`) had insufficient permissions to push to `juspay/hyperswitch-docs`. The new fine-grained PAT (`CONNECTOR_SERVICE_DOCS_CI`) has specific read/write access to the hyperswitch-docs repository.

## Required Setup

Ensure `CONNECTOR_SERVICE_DOCS_CI` secret is set in repository settings with:
- Repository access: `juspay/hyperswitch-docs`
- Permissions: `Contents: Read and Write`

## Testing

- [x] Tested workflow on separate branch
- [x] Successfully synced 54 files to hyperswitch-docs
- [x] Verified PAT authentication works

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
