### PR TITLE
feat(connector): implement GooglePay for shift4

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -12,7 +12,7 @@ use domain_types::{
         ResponseId,
     },
     payment_method_data::{
-        BankRedirectData, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber,
+        BankRedirectData, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber, WalletData,
     },
     router_data::ConnectorSpecificConfig,
     router_data_v2::RouterDataV2,
@@ -147,6 +147,7 @@ pub struct Shift4PaymentsRequest<T: PaymentMethodDataTypes> {
 pub enum Shift4PaymentMethod<T: PaymentMethodDataTypes> {
     Card(Shift4CardPayment<T>),
     BankRedirect(Shift4BankRedirectPayment),
+    GooglePay(Shift4GooglePayPayment),
 }
 
 #[derive(Debug, Serialize)]
@@ -162,6 +163,26 @@ pub struct Shift4CardData<T: PaymentMethodDataTypes> {
     pub exp_month: Secret<String>,
     pub exp_year: Secret<String>,
     pub cardholder_name: Secret<String>,
+}
+
+// GooglePay Payment Structures
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Shift4GooglePayPayment {
+    pub payment_method: Shift4GooglePayMethod,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Shift4GooglePayMethod {
+    #[serde(rename = "type")]
+    pub payment_type: String,
+    pub google_pay: Shift4GooglePayToken,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Shift4GooglePayToken {
+    pub token: Secret<String>,
 }
 
 // BankRedirect Payment Structures
@@ -344,6 +365,33 @@ impl<T: PaymentMethodDataTypes>
                     flow: Some(Shift4FlowRequest { return_url }),
                 })
             }
+            PaymentMethodData::Wallet(wallet_data) => match wallet_data {
+                WalletData::GooglePay(google_pay_data) => {
+                    let token = google_pay_data
+                        .tokenization_data
+                        .get_encrypted_google_pay_token()
+                        .change_context(IntegrationError::MissingRequiredField {
+                            field_name: "google_pay.tokenization_data.token",
+                            context: Default::default(),
+                        })?;
+
+                    Shift4PaymentMethod::GooglePay(Shift4GooglePayPayment {
+                        payment_method: Shift4GooglePayMethod {
+                            payment_type: "google_pay".to_string(),
+                            google_pay: Shift4GooglePayToken {
+                                token: Secret::new(token),
+                            },
+                        },
+                    })
+                }
+                _ => {
+                    return Err(error_stack::report!(IntegrationError::NotSupported {
+                        message: "Wallet payment method".to_string(),
+                        connector: "Shift4",
+                        context: Default::default()
+                    }))
+                }
+            },
             _ => {
                 return Err(error_stack::report!(IntegrationError::NotSupported {
                     message: "Payment method".to_string(),


### PR DESCRIPTION
## Summary

- Adds **GooglePay** wallet payment support to the **shift4** connector
- Sends GooglePay token via Shift4's `paymentMethod` API with the correct nested structure: `{ "paymentMethod": { "type": "google_pay", "googlePay": { "token": "..." } } }`
- Fixes the previous implementation that incorrectly used a flat structure, causing Shift4 to reject with "invalid value for field: type"

## Files Modified

`crates/integrations/connector-integration/src/connectors/shift4/transformers.rs`

## Changes

1. Added `WalletData` import
2. Added `GooglePay(Shift4GooglePayPayment)` variant to `Shift4PaymentMethod` enum
3. Created `Shift4GooglePayPayment`, `Shift4GooglePayMethod`, and `Shift4GooglePayToken` structs matching the Shift4 API specification
4. Added `PaymentMethodData::Wallet(WalletData::GooglePay(...))` handling in the Authorize request transformation

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl request (credentials redacted)</summary>

```
grpcurl -plaintext \
  -H "x-connector: shift4" \
  -H "x-auth: header-key" \
  -H "x-api-key: sk_test_****" \
  -d '{
    "amount": {"minor_amount": 1000, "currency": "USD"},
    "payment_method": {
      "google_pay": {
        "type": "CARD",
        "description": "Visa ending in 1234",
        "info": {
          "card_network": "VISA",
          "card_details": "1234"
        },
        "tokenization_data": {
          "encrypted_data": {
            "token_type": "PAYMENT_GATEWAY",
            "token": "CRYPTOGRAM_3DS"
          }
        }
      }
    },
    "capture_method": "AUTOMATIC",
    "auth_type": "NO_THREE_DS",
    "address": {
      "billing_address": {
        "first_name": {"value": "John"},
        "last_name": {"value": "Doe"},
        "line1": {"value": "123 Test St"},
        "city": {"value": "Test City"},
        "state": {"value": "CA"},
        "zip_code": {"value": "12345"},
        "country_alpha2_code": "US"
      }
    },
    "customer": {
      "email": {"value": "test@example.com"},
      "name": "John Doe"
    },
    "return_url": "https://example.com/return"
  }' \
  localhost:8000 \
  types.PaymentService/Authorize
```

</details>

<details>
<summary>grpcurl response (credentials redacted)</summary>

```json
{
  "merchantTransactionId": "char_****",
  "connectorTransactionId": "char_****",
  "status": "CHARGED",
  "statusCode": 200,
  "rawConnectorResponse": {
    "value": "{\"id\":\"char_****\",\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"refunded\":false,\"status\":\"successful\",\"paymentMethod\":{\"type\":\"google_pay\",\"status\":\"chargeable\",\"googlePay\":{\"cardBrand\":\"Visa\",\"cardType\":\"Credit Card\",\"first6\":\"411111\",\"last4\":\"1111\",\"authMethod\":\"cryptogram_3ds\"}}}"
  },
  "rawConnectorRequest": {
    "value": "{\"url\":\"https://api.shift4.com/charges\",\"method\":\"POST\",\"headers\":{\"Content-Type\":\"application/json\",\"Authorization\":\"Basic ****\"},\"body\":{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"paymentMethod\":{\"type\":\"google_pay\",\"googlePay\":{\"token\":\"CRYPTOGRAM_3DS\"}}}}"
  }
}
```

</details>

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [x] grpcurl Authorize returned success status (200 CHARGED)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified