### PR TITLE
chore: Implemented verify_redirect_response For Composite Service

### DIFF
--- a/crates/grpc-server/grpc-server/src/http/handlers/composite/payments.rs
+++ b/crates/grpc-server/grpc-server/src/http/handlers/composite/payments.rs
@@ -7,6 +7,7 @@ use grpc_api_types::payments::{
     composite_payment_service_server::CompositePaymentService, CompositeAuthorizeRequest,
     CompositeAuthorizeResponse, CompositeCaptureRequest, CompositeCaptureResponse,
     CompositeGetRequest, CompositeGetResponse, CompositeRefundRequest, CompositeRefundResponse,
+    CompositeVerifyRedirectResponseRequest, CompositeVerifyRedirectResponseResponse,
     CompositeVoidRequest, CompositeVoidResponse,
 };
 use std::sync::Arc;
@@ -39,6 +40,14 @@ http_handler!(
     CompositeRefundRequest,
     CompositeRefundResponse,
     refund,
+    composite_payments_service
+);
+
+http_handler!(
+    verify_redirect_response,
+    CompositeVerifyRedirectResponseRequest,
+    CompositeVerifyRedirectResponseResponse,
+    verify_redirect_response,
     composite_payments_service
 );
 

--- a/crates/grpc-server/grpc-server/src/http/router.rs
+++ b/crates/grpc-server/grpc-server/src/http/router.rs
@@ -25,6 +25,10 @@ pub fn create_router(state: AppState) -> Router {
             post(handlers::composite::refunds::refund_get),
         )
         .route(
+            "/composite/payments/verify_redirect_response",
+            post(handlers::composite::payments::verify_redirect_response),
+        )
+        .route(
             "/composite/payments/void",
             post(handlers::composite::payments::void),
         )

--- a/crates/internal/composite-service/src/payments.rs
+++ b/crates/internal/composite-service/src/payments.rs
@@ -12,11 +12,13 @@ use grpc_api_types::payments::{
     CompositeAuthorizeRequest, CompositeAuthorizeResponse, CompositeCaptureRequest,
     CompositeCaptureResponse, CompositeGetRequest, CompositeGetResponse, CompositeRefundGetRequest,
     CompositeRefundGetResponse, CompositeRefundRequest, CompositeRefundResponse,
+    CompositeVerifyRedirectResponseRequest, CompositeVerifyRedirectResponseResponse,
     CompositeVoidRequest, CompositeVoidResponse, ConnectorState, CustomerServiceCreateResponse,
     MerchantAuthenticationServiceCreateAccessTokenRequest,
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentMethod,
     PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse, PaymentServiceCaptureRequest,
     PaymentServiceCaptureResponse, PaymentServiceGetResponse, PaymentServiceRefundRequest,
+    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVerifyRedirectResponseResponse,
     PaymentServiceVoidRequest, PaymentServiceVoidResponse, RefundResponse, RefundServiceGetRequest,
 };
 
@@ -557,6 +559,44 @@ where
             capture_response: Some(capture_response),
         }))
     }
+
+    async fn verify_redirect_response(
+        &self,
+        payload: &CompositeVerifyRedirectResponseRequest,
+        metadata: &tonic::metadata::MetadataMap,
+        extensions: &tonic::Extensions,
+    ) -> Result<PaymentServiceVerifyRedirectResponseResponse, tonic::Status> {
+        let verify_payload = PaymentServiceVerifyRedirectResponseRequest::foreign_from(payload);
+
+        let mut verify_request = tonic::Request::new(verify_payload);
+        *verify_request.metadata_mut() = metadata.clone();
+        *verify_request.extensions_mut() = extensions.clone();
+
+        let verify_response = self
+            .payment_service
+            .verify_redirect_response(verify_request)
+            .await?
+            .into_inner();
+
+        Ok(verify_response)
+    }
+
+    async fn process_composite_verify_redirect_response(
+        &self,
+        request: tonic::Request<CompositeVerifyRedirectResponseRequest>,
+    ) -> Result<tonic::Response<CompositeVerifyRedirectResponseResponse>, tonic::Status> {
+        let (metadata, extensions, payload) = request.into_parts();
+
+        let verify_response = self
+            .verify_redirect_response(&payload, &metadata, &extensions)
+            .await?;
+
+        Ok(tonic::Response::new(
+            CompositeVerifyRedirectResponseResponse {
+                verify_redirect_response: Some(verify_response),
+            },
+        ))
+    }
 }
 
 #[tonic::async_trait]
@@ -600,6 +640,14 @@ where
         request: tonic::Request<CompositeCaptureRequest>,
     ) -> Result<tonic::Response<CompositeCaptureResponse>, tonic::Status> {
         self.process_composite_capture(request).await
+    }
+
+    async fn verify_redirect_response(
+        &self,
+        request: tonic::Request<CompositeVerifyRedirectResponseRequest>,
+    ) -> Result<tonic::Response<CompositeVerifyRedirectResponseResponse>, tonic::Status> {
+        self.process_composite_verify_redirect_response(request)
+            .await
     }
 }
 

--- a/crates/internal/composite-service/src/payments.rs
+++ b/crates/internal/composite-service/src/payments.rs
@@ -18,8 +18,7 @@ use grpc_api_types::payments::{
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentMethod,
     PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse, PaymentServiceCaptureRequest,
     PaymentServiceCaptureResponse, PaymentServiceGetResponse, PaymentServiceRefundRequest,
-    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVerifyRedirectResponseResponse,
-    PaymentServiceVoidRequest, PaymentServiceVoidResponse, RefundResponse, RefundServiceGetRequest,
+    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVoidRequest, PaymentServiceVoidResponse, RefundResponse, RefundServiceGetRequest,
 };
 
 use crate::transformers::ForeignFrom;
@@ -560,36 +559,23 @@ where
         }))
     }
 
-    async fn verify_redirect_response(
-        &self,
-        payload: &CompositeVerifyRedirectResponseRequest,
-        metadata: &tonic::metadata::MetadataMap,
-        extensions: &tonic::Extensions,
-    ) -> Result<PaymentServiceVerifyRedirectResponseResponse, tonic::Status> {
-        let verify_payload = PaymentServiceVerifyRedirectResponseRequest::foreign_from(payload);
-
-        let mut verify_request = tonic::Request::new(verify_payload);
-        *verify_request.metadata_mut() = metadata.clone();
-        *verify_request.extensions_mut() = extensions.clone();
-
-        let verify_response = self
-            .payment_service
-            .verify_redirect_response(verify_request)
-            .await?
-            .into_inner();
-
-        Ok(verify_response)
-    }
-
     async fn process_composite_verify_redirect_response(
         &self,
         request: tonic::Request<CompositeVerifyRedirectResponseRequest>,
     ) -> Result<tonic::Response<CompositeVerifyRedirectResponseResponse>, tonic::Status> {
         let (metadata, extensions, payload) = request.into_parts();
 
+        let verify_payload = PaymentServiceVerifyRedirectResponseRequest::foreign_from(&payload);
+
+        let mut verify_request = tonic::Request::new(verify_payload);
+        *verify_request.metadata_mut() = metadata;
+        *verify_request.extensions_mut() = extensions;
+
         let verify_response = self
-            .verify_redirect_response(&payload, &metadata, &extensions)
-            .await?;
+            .payment_service
+            .verify_redirect_response(verify_request)
+            .await?
+            .into_inner();
 
         Ok(tonic::Response::new(
             CompositeVerifyRedirectResponseResponse {

--- a/crates/internal/composite-service/src/payments.rs
+++ b/crates/internal/composite-service/src/payments.rs
@@ -18,7 +18,8 @@ use grpc_api_types::payments::{
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentMethod,
     PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse, PaymentServiceCaptureRequest,
     PaymentServiceCaptureResponse, PaymentServiceGetResponse, PaymentServiceRefundRequest,
-    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVoidRequest, PaymentServiceVoidResponse, RefundResponse, RefundServiceGetRequest,
+    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVoidRequest,
+    PaymentServiceVoidResponse, RefundResponse, RefundServiceGetRequest,
 };
 
 use crate::transformers::ForeignFrom;

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -1,12 +1,13 @@
 use domain_types::connector_types::ConnectorEnum;
 use grpc_api_types::payments::{
     CompositeAuthorizeRequest, CompositeCaptureRequest, CompositeGetRequest,
-    CompositeRefundGetRequest, CompositeRefundRequest, CompositeVoidRequest, ConnectorState,
-    CustomerServiceCreateRequest, CustomerServiceCreateResponse,
-    MerchantAuthenticationServiceCreateAccessTokenRequest,
+    CompositeRefundGetRequest, CompositeRefundRequest, CompositeVerifyRedirectResponseRequest,
+    CompositeVoidRequest, ConnectorState, CustomerServiceCreateRequest,
+    CustomerServiceCreateResponse, MerchantAuthenticationServiceCreateAccessTokenRequest,
     MerchantAuthenticationServiceCreateAccessTokenResponse, PaymentServiceAuthorizeRequest,
     PaymentServiceCaptureRequest, PaymentServiceGetRequest, PaymentServiceRefundRequest,
-    PaymentServiceVoidRequest, RefundServiceGetRequest,
+    PaymentServiceVerifyRedirectResponseRequest, PaymentServiceVoidRequest,
+    RefundServiceGetRequest,
 };
 
 use crate::utils::{
@@ -439,6 +440,18 @@ impl
             state: resolved_state,
             test_mode: item.test_mode,
             merchant_order_id: item.merchant_order_id.clone(),
+        }
+    }
+}
+
+impl ForeignFrom<&CompositeVerifyRedirectResponseRequest>
+    for PaymentServiceVerifyRedirectResponseRequest
+{
+    fn foreign_from(item: &CompositeVerifyRedirectResponseRequest) -> Self {
+        Self {
+            merchant_order_id: item.merchant_order_id.clone(),
+            request_details: item.request_details.clone(),
+            redirect_response_secrets: item.redirect_response_secrets.clone(),
         }
     }
 }

--- a/crates/internal/composite-service/tests/composite_request_schema_check.rs
+++ b/crates/internal/composite-service/tests/composite_request_schema_check.rs
@@ -66,6 +66,33 @@ const COMPOSITE_FLOW_SPECS: &[CompositeFlowSpec] = &[
         ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
         ignore_composite_only_fields: IGNORE_COMPOSITE_ONLY_FIELDS,
     },
+    CompositeFlowSpec {
+        name: "verify_redirect_response",
+        composite_request_message: "CompositeVerifyRedirectResponseRequest",
+        granular_request_messages: &["PaymentServiceVerifyRedirectResponseRequest"],
+        ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
+        ignore_composite_only_fields: DEFAULT_IGNORE_COMPOSITE_ONLY_FIELDS,
+    },
+    CompositeFlowSpec {
+        name: "void",
+        composite_request_message: "CompositeVoidRequest",
+        granular_request_messages: &[
+            "MerchantAuthenticationServiceCreateAccessTokenRequest",
+            "PaymentServiceVoidRequest",
+        ],
+        ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
+        ignore_composite_only_fields: IGNORE_COMPOSITE_ONLY_FIELDS,
+    },
+    CompositeFlowSpec {
+        name: "capture",
+        composite_request_message: "CompositeCaptureRequest",
+        granular_request_messages: &[
+            "MerchantAuthenticationServiceCreateAccessTokenRequest",
+            "PaymentServiceCaptureRequest",
+        ],
+        ignore_granular_only_fields: DEFAULT_IGNORE_GRANULAR_ONLY_FIELDS,
+        ignore_composite_only_fields: IGNORE_COMPOSITE_ONLY_FIELDS,
+    },
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/types-traits/grpc-api-types/proto/composite_payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_payment.proto
@@ -246,6 +246,23 @@ message CompositeRefundGetResponse {
   optional RefundResponse refund_response = 2; // Refund get flow response
 }
 
+// Request message for composite verify redirect response flow.
+message CompositeVerifyRedirectResponseRequest {
+  // Identification
+  optional string merchant_order_id = 1; // Merchant's order reference ID
+
+  // Request Details
+  RequestDetails request_details = 2; // The redirect response details to verify
+
+  // Security
+  optional RedirectResponseSecrets redirect_response_secrets = 3; // Secrets for verifying the redirect response
+}
+
+// Response message for composite verify redirect response flow.
+message CompositeVerifyRedirectResponseResponse {
+  optional PaymentServiceVerifyRedirectResponseResponse verify_redirect_response = 1; // Verify redirect response flow response
+}
+
 // Request message for composite void flow.
 message CompositeVoidRequest {
   // Payment Identification

--- a/crates/types-traits/grpc-api-types/proto/composite_services.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_services.proto
@@ -17,6 +17,9 @@ service CompositePaymentService {
   // Runs composite refund flow.
   rpc Refund(CompositeRefundRequest) returns (CompositeRefundResponse);
 
+  // Runs composite verify redirect response flow.
+  rpc VerifyRedirectResponse(CompositeVerifyRedirectResponseRequest) returns (CompositeVerifyRedirectResponseResponse);
+
   // Runs composite void flow.
   rpc Void(CompositeVoidRequest) returns (CompositeVoidResponse);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add composite verify_redirect_response flow. This wraps the granular PaymentService/VerifyRedirectResponse RPC behind the composite service HTTP layer, following the same pattern as other composite flows (authorize, get, refund, void, capture). Also adds schema check coverage for void, capture and verify_redirect_response flows.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Request:
```
curl --location 'http://localhost:8000/composite/payments/verify_redirect_response' \
--header 'Content-Type: application/json' \
--header 'x-connector: revolut' \
--header 'x-connector-config: {"config":{"Revolut":{"secret_api_key":"-"}}}' \
--header 'Content-Type: application/json' \
--data '{
    "merchant_order_id": "order_001",
    "request_details": {
      "method": "HTTP_METHOD_GET",
      "headers": {
        "Content-Type": "application/x-www-form-urlencoded"
      },
      "query_params": "payment_intent=pi_3Oxxx...&payment_intent_client_secret=pi_3Oxxx..._secret_xxx",
      "body": []
    },
    "test_mode": true,
    "merchant_access_token_id": "access_token_001"
  }'
  ```
  Response:
  ```
{
    "verify_redirect_response": {
        "source_verified": false,
        "error": {
            "connector_details": {}
        }
    }
}
```