### PR TITLE
feat(connector): implement GooglePay for stax

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stax.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax.rs
@@ -208,11 +208,13 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     fn should_do_payment_method_token(
         &self,
         payment_method: PaymentMethod,
-        _payment_method_type: Option<PaymentMethodType>,
+        payment_method_type: Option<PaymentMethodType>,
     ) -> bool {
         matches!(
-            payment_method,
-            PaymentMethod::Card | PaymentMethod::BankDebit
+            (payment_method, payment_method_type),
+            (PaymentMethod::Card, _)
+                | (PaymentMethod::BankDebit, _)
+                | (PaymentMethod::Wallet, Some(PaymentMethodType::GooglePay))
         )
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -270,7 +270,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
 
         let payment_method_id = match item.router_data.request.payment_method_data {
-            PaymentMethodData::Card(_) | PaymentMethodData::BankDebit(_) => {
+            PaymentMethodData::Card(_)
+            | PaymentMethodData::BankDebit(_)
+            | PaymentMethodData::Wallet(
+                domain_types::payment_method_data::WalletData::GooglePay(_),
+            ) => {
                 if let Ok(pm_token) = item
                     .router_data
                     .resource_common_data
@@ -291,7 +295,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
             _ => {
                 return Err(errors::ConnectorError::NotImplemented(
-                    "Only card and ACH bank debit payments are supported for Stax".to_string(),
+                    "Only card, ACH bank debit, and GooglePay wallet payments are supported for Stax".to_string(),
                 ))?;
             }
         };


### PR DESCRIPTION
## Summary

Implement **GooglePay** flow for **stax** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added GooglePay support to `stax.rs` (updated `should_do_payment_method_token` to handle Wallet/GooglePay payment method)
- Updated `StaxAuthorizeRequest` TryFrom implementation in `stax/transformers.rs` to handle GooglePay wallet payments

## Files Modified

- backend/connector-integration/src/connectors/stax.rs
- backend/connector-integration/src/connectors/stax/transformers.rs

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl Authorize call (credentials redacted)</summary>

```
grpcurl -plaintext \
  -H 'x-connector: stax' \
  -d '{
    "request_ref_id": {"id": "test_stax_googlepay_001"},
    "amount": 100,
    "minor_amount": 10000,
    "currency": "USD",
    "payment_method": {
      "wallet": {
        "type": "GooglePay",
        "payment_token": {"value": "<REDACTED>"}
      }
    },
    "email": {"value": "<REDACTED>"}
  }' \
  localhost:8000 \
  ucs.v2.PaymentService/Authorize
```

</details>

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [x] grpcurl Authorize returned success status (2xx)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified
