### PR TITLE
feat(connector): implement MIT for dlocal

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/dlocal.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal.rs
@@ -47,7 +47,8 @@ use transformers::{
     self as dlocal, DlocalPaymentsCaptureRequest, DlocalPaymentsRequest, DlocalPaymentsResponse,
     DlocalPaymentsResponse as DlocalPaymentsSyncResponse,
     DlocalPaymentsResponse as DlocalPaymentsCaptureResponse,
-    DlocalPaymentsResponse as DlocalPaymentsVoidResponse, DlocalRefundRequest, RefundResponse,
+    DlocalPaymentsResponse as DlocalPaymentsVoidResponse, DlocalRefundRequest,
+    DlocalRepeatPaymentRequest, DlocalRepeatPaymentResponse, RefundResponse,
     RefundResponse as RefundSyncResponse,
 };
 
@@ -244,6 +245,12 @@ macros::create_all_prerequisites!(
             flow: Void,
             response_body: DlocalPaymentsVoidResponse,
             router_data: RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ),
+        (
+            flow: RepeatPayment,
+            request_body: DlocalRepeatPaymentRequest,
+            response_body: DlocalRepeatPaymentResponse,
+            router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -540,6 +547,34 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Dlocal,
+    curl_request: Json(DlocalRepeatPaymentRequest),
+    curl_response: DlocalRepeatPaymentResponse,
+    flow_name: RepeatPayment,
+    resource_common_data: PaymentFlowData,
+    flow_request: RepeatPaymentData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, errors::ConnectorError> {
+            Ok(format!("{}payments", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
 // Stub implementations for unsupported flows
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<
@@ -574,16 +609,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         SetupMandate,
         PaymentFlowData,
         SetupMandateRequestData<T>,
-        PaymentsResponseData,
-    > for Dlocal<T>
-{
-}
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        RepeatPayment,
-        PaymentFlowData,
-        RepeatPaymentData<T>,
         PaymentsResponseData,
     > for Dlocal<T>
 {

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -1,10 +1,10 @@
 use common_utils::{pii, request::Method, FloatMajorUnit};
 use domain_types::{
-    connector_flow::{self, Authorize},
+    connector_flow::{self, Authorize, RepeatPayment},
     connector_types::{
-        PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData, ResponseId,
+        MandateReferenceId, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
+        RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId,
     },
     errors::ConnectorError,
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
@@ -236,6 +236,164 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         })
     }
 }
+// RepeatPayment (MIT) flow types
+
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StoredCredentialType {
+    CardOnFile,
+    Subscription,
+    UnscheduledCardOnFile,
+    Installments,
+}
+
+impl From<Option<common_enums::MitCategory>> for StoredCredentialType {
+    fn from(category: Option<common_enums::MitCategory>) -> Self {
+        match category {
+            Some(common_enums::MitCategory::Recurring) => Self::Subscription,
+            Some(common_enums::MitCategory::Installment) => Self::Installments,
+            Some(common_enums::MitCategory::Unscheduled) => Self::UnscheduledCardOnFile,
+            Some(common_enums::MitCategory::Resubmission) => Self::UnscheduledCardOnFile,
+            None => Self::CardOnFile,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StoredCredentialUsage {
+    Used,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DlocalRepeatPaymentCard {
+    pub card_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture: Option<String>,
+    pub stored_credential_type: StoredCredentialType,
+    pub stored_credential_usage: StoredCredentialUsage,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DlocalRepeatPaymentRequest {
+    pub amount: FloatMajorUnit,
+    pub currency: common_enums::Currency,
+    pub country: common_enums::CountryAlpha2,
+    pub payment_method_id: PaymentMethodId,
+    pub payment_method_flow: PaymentMethodFlow,
+    pub payer: Payer,
+    pub card: DlocalRepeatPaymentCard,
+    pub order_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notification_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        DlocalRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for DlocalRepeatPaymentRequest
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        item: DlocalRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        // Extract connector_mandate_id (card_id from a prior CIT)
+        let card_id = match &router_data.request.mandate_reference {
+            MandateReferenceId::ConnectorMandateId(connector_mandate_ref) => connector_mandate_ref
+                .get_connector_mandate_id()
+                .ok_or(ConnectorError::MissingRequiredField {
+                    field_name: "connector_mandate_id",
+                })?,
+            MandateReferenceId::NetworkMandateId(_)
+            | MandateReferenceId::NetworkTokenWithNTI(_) => {
+                return Err(ConnectorError::NotImplemented(
+                    "Network mandate ID not supported for repeat payments in dlocal".to_string(),
+                )
+                .into());
+            }
+        };
+
+        let address = router_data.resource_common_data.get_billing_address()?;
+        let country = *address.get_country()?;
+        let name = address.get_full_name()?;
+
+        let email =
+            router_data
+                .request
+                .email
+                .clone()
+                .ok_or(ConnectorError::MissingRequiredField {
+                    field_name: "email",
+                })?;
+
+        let amount = utils::convert_amount(
+            item.connector.amount_converter,
+            router_data.request.minor_amount,
+            router_data.request.currency,
+        )?;
+
+        let order_id = router_data
+            .resource_common_data
+            .connector_request_reference_id
+            .clone();
+
+        let should_capture = matches!(
+            router_data.request.capture_method,
+            Some(common_enums::CaptureMethod::Automatic)
+                | Some(common_enums::CaptureMethod::SequentialAutomatic)
+                | None
+        );
+
+        let stored_credential_type =
+            StoredCredentialType::from(router_data.request.mit_category.clone());
+
+        Ok(Self {
+            amount,
+            currency: router_data.request.currency,
+            country,
+            payment_method_id: PaymentMethodId::Card,
+            payment_method_flow: PaymentMethodFlow::Direct,
+            payer: Payer {
+                name,
+                email,
+                document: get_doc_from_currency(country.to_string()),
+            },
+            card: DlocalRepeatPaymentCard {
+                card_id,
+                capture: Some(should_capture.to_string()),
+                stored_credential_type,
+                stored_credential_usage: StoredCredentialUsage::Used,
+            },
+            order_id,
+            notification_url: router_data.request.webhook_url.clone(),
+            description: router_data.resource_common_data.description.clone(),
+        })
+    }
+}
+
+// RepeatPayment response - reuses DlocalPaymentsResponse (generic TryFrom covers this)
+pub type DlocalRepeatPaymentResponse = DlocalPaymentsResponse;
+
 // Auth Struct
 pub struct DlocalAuthType {
     pub(super) x_login: Secret<String>,


### PR DESCRIPTION
## Summary

Implement **MIT** flow for **Dlocal** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added MIT (RepeatPayment) support to `dlocal.rs` (added to `create_all_prerequisites!` macro, added `macro_connector_implementation!`)
- Added MIT request/response types and `TryFrom` implementations in `dlocal/transformers.rs`

## Files Modified

- `backend/connector-integration/src/connectors/dlocal.rs`
- `backend/connector-integration/src/connectors/dlocal/transformers.rs`

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl Charge call (credentials redacted)</summary>

```
grpcurl test PASSED - types.RecurringPaymentService/Charge returned status: CHARGED with statusCode: 200
```

</details>

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [x] grpcurl Charge returned success status (200)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified