### PR TITLE
fix(proto): add _UNSPECIFIED and fix enum naming consistency

### DIFF
--- a/backend/common_utils/Cargo.toml
+++ b/backend/common_utils/Cargo.toml
@@ -24,7 +24,7 @@ strum = { version = "0.26", features = ["derive"] }
 utoipa = { version = "4.2.0", features = ["preserve_order", "preserve_path_order"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 rust_decimal = { version = "1.0" }
-time = { version = "0.3.36", features = ["parsing"] }
+time = { version = "0.3.36", features = ["parsing", "macros"] }
 url = "2.5.0"
 uuid = { version = "1", features = ["v4", "v7"] }
 http = "1.2.0"

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -719,12 +719,20 @@ impl ForeignTryFrom<grpc_api_types::payments::UpiSource> for payment_method_data
         value: grpc_api_types::payments::UpiSource,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         match value {
-            grpc_api_types::payments::UpiSource::UpiCc => Ok(Self::UpiCc),
-            grpc_api_types::payments::UpiSource::UpiCl => Ok(Self::UpiCl),
-            grpc_api_types::payments::UpiSource::UpiAccount => Ok(Self::UpiAccount),
-            grpc_api_types::payments::UpiSource::UpiCcCl => Ok(Self::UpiCcCl),
-            grpc_api_types::payments::UpiSource::UpiPpi => Ok(Self::UpiPpi),
-            grpc_api_types::payments::UpiSource::UpiVoucher => Ok(Self::UpiVoucher),
+            grpc_api_types::payments::UpiSource::Unspecified => {
+                Err(report!(ApplicationErrorResponse::BadRequest(ApiError {
+                    sub_code: "INVALID_UPISOURCE".to_string(),
+                    error_identifier: 400,
+                    error_message: "UpiSource is unspecified".to_string(),
+                    error_object: None,
+                })))
+            }
+            grpc_api_types::payments::UpiSource::Cc => Ok(Self::UpiCc),
+            grpc_api_types::payments::UpiSource::Cl => Ok(Self::UpiCl),
+            grpc_api_types::payments::UpiSource::Account => Ok(Self::UpiAccount),
+            grpc_api_types::payments::UpiSource::CcCl => Ok(Self::UpiCcCl),
+            grpc_api_types::payments::UpiSource::Ppi => Ok(Self::UpiPpi),
+            grpc_api_types::payments::UpiSource::Voucher => Ok(Self::UpiVoucher),
         }
     }
 }
@@ -732,12 +740,12 @@ impl ForeignTryFrom<grpc_api_types::payments::UpiSource> for payment_method_data
 impl ForeignFrom<payment_method_data::UpiSource> for grpc_api_types::payments::UpiSource {
     fn foreign_from(value: payment_method_data::UpiSource) -> Self {
         match value {
-            payment_method_data::UpiSource::UpiCc => Self::UpiCc,
-            payment_method_data::UpiSource::UpiCl => Self::UpiCl,
-            payment_method_data::UpiSource::UpiAccount => Self::UpiAccount,
-            payment_method_data::UpiSource::UpiCcCl => Self::UpiCcCl,
-            payment_method_data::UpiSource::UpiPpi => Self::UpiPpi,
-            payment_method_data::UpiSource::UpiVoucher => Self::UpiVoucher,
+            payment_method_data::UpiSource::UpiCc => Self::Cc,
+            payment_method_data::UpiSource::UpiCl => Self::Cl,
+            payment_method_data::UpiSource::UpiAccount => Self::Account,
+            payment_method_data::UpiSource::UpiCcCl => Self::CcCl,
+            payment_method_data::UpiSource::UpiPpi => Self::Ppi,
+            payment_method_data::UpiSource::UpiVoucher => Self::Voucher,
         }
     }
 }

--- a/backend/ffi/src/bindings/uniffi.rs
+++ b/backend/ffi/src/bindings/uniffi.rs
@@ -44,7 +44,7 @@ mod uniffi_bindings_inner {
             Ok(p) => p,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(RequestError {
                         status: PaymentStatus::Pending.into(),
                         error_message: Some(format!("Request payload decode failed: {e}")),
@@ -60,7 +60,7 @@ mod uniffi_bindings_inner {
             Ok(o) => o,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(e)),
                 }
                 .encode_to_vec()
@@ -71,7 +71,7 @@ mod uniffi_bindings_inner {
             Ok(m) => m,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(e)),
                 }
                 .encode_to_vec()
@@ -90,7 +90,7 @@ mod uniffi_bindings_inner {
             Ok(r) => r,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(e)),
                 }
                 .encode_to_vec()
@@ -101,7 +101,7 @@ mod uniffi_bindings_inner {
             Some(r) => r,
             None => {
                 return FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(RequestError {
                         status: PaymentStatus::Pending.into(),
                         error_message: Some("Request encoding failed".to_string()),
@@ -116,12 +116,12 @@ mod uniffi_bindings_inner {
         match build_ffi_request_bytes(&connector_request) {
             Ok(bytes) => match FfiConnectorHttpRequest::decode(Bytes::from(bytes)) {
                 Ok(http_request) => FfiResult {
-                    r#type: ffi_result::Type::HttpRequest.into(),
+                    r#type: ffi_result::Type::FfiResultTypeHttpRequest.into(),
                     payload: Some(ffi_result::Payload::HttpRequest(http_request)),
                 }
                 .encode_to_vec(),
                 Err(e) => FfiResult {
-                    r#type: ffi_result::Type::RequestError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                     payload: Some(ffi_result::Payload::RequestError(RequestError {
                         status: PaymentStatus::Pending.into(),
                         error_message: Some(format!("Request re-decode failed: {e}")),
@@ -132,7 +132,7 @@ mod uniffi_bindings_inner {
                 .encode_to_vec(),
             },
             Err(e) => FfiResult {
-                r#type: ffi_result::Type::RequestError.into(),
+                r#type: ffi_result::Type::FfiResultTypeRequestError.into(),
                 payload: Some(ffi_result::Payload::RequestError(e)),
             }
             .encode_to_vec(),
@@ -160,7 +160,7 @@ mod uniffi_bindings_inner {
             Ok(r) => r,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(e)),
                 }
                 .encode_to_vec()
@@ -171,7 +171,7 @@ mod uniffi_bindings_inner {
             Ok(p) => p,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(ResponseError {
                         status: PaymentStatus::Pending.into(),
                         error_message: Some(format!("Request payload decode failed: {e}")),
@@ -187,7 +187,7 @@ mod uniffi_bindings_inner {
             Ok(o) => o,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(e)),
                 }
                 .encode_to_vec()
@@ -198,7 +198,7 @@ mod uniffi_bindings_inner {
             Ok(m) => m,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(e)),
                 }
                 .encode_to_vec()
@@ -240,13 +240,13 @@ mod uniffi_bindings_inner {
                     body: response_bytes,
                 };
                 FfiResult {
-                    r#type: ffi_result::Type::HttpResponse.into(),
+                    r#type: ffi_result::Type::FfiResultTypeHttpResponse.into(),
                     payload: Some(ffi_result::Payload::HttpResponse(http_response)),
                 }
                 .encode_to_vec()
             }
             Err(e) => FfiResult {
-                r#type: ffi_result::Type::ResponseError.into(),
+                r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                 payload: Some(ffi_result::Payload::ResponseError(e)),
             }
             .encode_to_vec(),
@@ -275,7 +275,7 @@ mod uniffi_bindings_inner {
             Ok(p) => p,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(ResponseError {
                         status: PaymentStatus::Pending.into(),
                         error_message: Some(format!(
@@ -293,7 +293,7 @@ mod uniffi_bindings_inner {
             Ok(o) => o,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(e)),
                 }
                 .encode_to_vec()
@@ -304,7 +304,7 @@ mod uniffi_bindings_inner {
             Ok(m) => m,
             Err(e) => {
                 return FfiResult {
-                    r#type: ffi_result::Type::ResponseError.into(),
+                    r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                     payload: Some(ffi_result::Payload::ResponseError(e)),
                 }
                 .encode_to_vec()
@@ -330,13 +330,13 @@ mod uniffi_bindings_inner {
                     body: response_bytes,
                 };
                 FfiResult {
-                    r#type: ffi_result::Type::HttpResponse.into(),
+                    r#type: ffi_result::Type::FfiResultTypeHttpResponse.into(),
                     payload: Some(ffi_result::Payload::HttpResponse(http_response)),
                 }
                 .encode_to_vec()
             }
             Err(e) => FfiResult {
-                r#type: ffi_result::Type::ResponseError.into(),
+                r#type: ffi_result::Type::FfiResultTypeResponseError.into(),
                 payload: Some(ffi_result::Payload::ResponseError(e)),
             }
             .encode_to_vec(),

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -226,11 +226,11 @@ enum DisputeStatus {
 // Status of a mandate
 enum MandateStatus {
   MANDATE_STATUS_UNSPECIFIED = 0; // Default value
-  MANDATE_PENDING = 1;
-  ACTIVE = 2;
-  MANDATE_INACTIVE = 3;
-  REVOKED = 4;
-  MANDATE_REVOKE_FAILED = 5;
+  MANDATE_STATUS_PENDING = 1;
+  MANDATE_STATUS_ACTIVE = 2;
+  MANDATE_STATUS_INACTIVE = 3;
+  MANDATE_STATUS_REVOKED = 4;
+  MANDATE_STATUS_REVOKE_FAILED = 5;
 }
 
 // Method for capturing a payment

--- a/backend/grpc-api-types/proto/payment_methods.proto
+++ b/backend/grpc-api-types/proto/payment_methods.proto
@@ -638,12 +638,13 @@ message PaypalSdkWallet {
 
 // UPI Source types for UPI payments
 enum UpiSource {
-  UPI_CC = 0;    // UPI Credit Card (RuPay credit on UPI)
-  UPI_CL = 1;    // UPI Credit Line
-  UPI_ACCOUNT = 2; // UPI Bank Account (Savings)
-  UPI_CC_CL = 3; // UPI Credit Card + Credit Line
-  UPI_PPI = 4;   // UPI Prepaid Payment Instrument
-  UPI_VOUCHER = 5; // UPI Voucher
+  UPI_SOURCE_UNSPECIFIED = 0; // Default value
+  UPI_SOURCE_CC = 1;    // UPI Credit Card (RuPay credit on UPI)
+  UPI_SOURCE_CL = 2;    // UPI Credit Line
+  UPI_SOURCE_ACCOUNT = 3; // UPI Bank Account (Savings)
+  UPI_SOURCE_CC_CL = 4; // UPI Credit Card + Credit Line
+  UPI_SOURCE_PPI = 5;   // UPI Prepaid Payment Instrument
+  UPI_SOURCE_VOUCHER = 6; // UPI Voucher
 }
 
 // UPI (Unified Payments Interface) - Indian instant real-time payment system

--- a/backend/grpc-api-types/proto/sdk_config.proto
+++ b/backend/grpc-api-types/proto/sdk_config.proto
@@ -194,14 +194,15 @@ message ResponseError {
 // Replaces the heuristic error detection with explicit enum-based type checking
 message FfiResult {
   enum Type {
-    HTTP_REQUEST = 0;
-    HTTP_RESPONSE = 1;
-    REQUEST_ERROR = 2;
-    RESPONSE_ERROR = 3;
+    FFI_RESULT_TYPE_UNSPECIFIED = 0; // Default value
+    FFI_RESULT_TYPE_HTTP_REQUEST = 1;
+    FFI_RESULT_TYPE_HTTP_RESPONSE = 2;
+    FFI_RESULT_TYPE_REQUEST_ERROR = 3;
+    FFI_RESULT_TYPE_RESPONSE_ERROR = 4;
   }
-  
+
   Type type = 1;
-  
+
   oneof payload {
     FfiConnectorHttpRequest http_request = 2;
     FfiConnectorHttpResponse http_response = 3;

--- a/backend/grpc-server/Cargo.toml
+++ b/backend/grpc-server/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = "0.1.16"
 thiserror = { workspace = true }
-time = { version = "0.3.36", features = ["parsing"] }
+time = { version = "0.3.36", features = ["parsing", "macros"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.3" }
 tracing-subscriber = { version = "0.3.18", default-features = true, features = [

--- a/backend/grpc-server/src/server/payments.rs
+++ b/backend/grpc-server/src/server/payments.rs
@@ -3833,10 +3833,10 @@ pub fn generate_mandate_revoke_response(
                     grpc_api_types::payments::MandateStatus::Active
                 }
                 common_enums::MandateStatus::Inactive => {
-                    grpc_api_types::payments::MandateStatus::MandateInactive
+                    grpc_api_types::payments::MandateStatus::Inactive
                 }
                 common_enums::MandateStatus::Pending => {
-                    grpc_api_types::payments::MandateStatus::MandatePending
+                    grpc_api_types::payments::MandateStatus::Pending
                 }
                 common_enums::MandateStatus::Revoked => {
                     grpc_api_types::payments::MandateStatus::Revoked
@@ -3852,7 +3852,7 @@ pub fn generate_mandate_revoke_response(
             raw_connector_request,
         }),
         Err(e) => Ok(RecurringPaymentServiceRevokeResponse {
-            status: grpc_api_types::payments::MandateStatus::MandateRevokeFailed.into(), // Default status for failed revoke
+            status: grpc_api_types::payments::MandateStatus::RevokeFailed.into(), // Default status for failed revoke
             error: Some(grpc_api_types::payments::ErrorInfo {
                 unified_details: None,
                 connector_details: Some(grpc_api_types::payments::ConnectorErrorDetails {

--- a/backend/ucs_env/Cargo.toml
+++ b/backend/ucs_env/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = "0.1.16"
 thiserror = { workspace = true }
-time = { version = "0.3.36", features = ["parsing"] }
+time = { version = "0.3.36", features = ["parsing", "macros"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.3" }
 tracing-subscriber = { version = "0.3.18", default-features = true, features = [


### PR DESCRIPTION
This PR fixes proto consistency issues by adding _UNSPECIFIED values and standardizing enum naming patterns.

## Changes

### MandateStatus enum (payment.proto)
- Fixed inconsistent naming: MANDATE_PENDING → MANDATE_STATUS_PENDING, ACTIVE → MANDATE_STATUS_ACTIVE, etc.

### UpiSource enum (payment_methods.proto)  
- Added UPI_SOURCE_UNSPECIFIED = 0
- Renamed all values to use UPI_SOURCE_ prefix

### FfiResult.Type enum (sdk_config.proto)
- Added FFI_RESULT_TYPE_UNSPECIFIED = 0
- Renamed all values to use FFI_RESULT_TYPE_ prefix

## Breaking Changes
This affects SDK clients using these enum values. All values have been renumbered.

Refs: #648