### PR TITLE
feat(connector): implement orderCreate for stripe

### DIFF
--- a/backend/connector-integration/src/connectors/stripe.rs
+++ b/backend/connector-integration/src/connectors/stripe.rs
@@ -53,7 +53,8 @@ use transformers::{
     PaymentsAuthorizeResponse, PaymentsAuthorizeResponse as RepeatPaymentResponse,
     PaymentsCaptureResponse, PaymentsVoidResponse, RefundResponse,
     RefundResponse as RefundSyncResponse, SetupMandateRequest, SetupMandateResponse,
-    StripeRefundRequest, StripeTokenResponse, TokenRequest,
+    StripeCreateOrderRequest, StripeCreateOrderResponse, StripeRefundRequest, StripeTokenResponse,
+    TokenRequest,
 };
 
 use super::macros;
@@ -213,6 +214,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 Some(common_enums::PaymentMethodType::GooglePay)
             )
     }
+    fn should_do_order_create(&self) -> bool {
+        true
+    }
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::MandateRevokeV2 for Stripe<T>
@@ -287,6 +291,12 @@ macros::create_all_prerequisites!(
             request_body: PaymentIncrementalAuthRequest,
             response_body: PaymentIncrementalAuthResponse,
             router_data: RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ),
+        (
+            flow: CreateOrder,
+            request_body: StripeCreateOrderRequest,
+            response_body: StripeCreateOrderResponse,
+            router_data: RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
         )
     ],
     amount_converters: [],
@@ -972,6 +982,40 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Stripe,
+    curl_request: FormUrlEncoded(StripeCreateOrderRequest),
+    curl_response: StripeCreateOrderResponse,
+    flow_name: CreateOrder,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentCreateOrderData,
+    flow_response: PaymentCreateOrderResponse,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + std::marker::Sync + std::marker::Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, ConnectorError> {
+            let mut header = vec![(
+                headers::CONTENT_TYPE.to_string(),
+                self.common_get_content_type().to_string().into(),
+            )];
+            let mut api_key = self.get_auth_header(&req.connector_config)?;
+            header.append(&mut api_key);
+            Ok(header)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<String, ConnectorError> {
+            Ok(format!("{}{}", self.connector_base_url_payments(req), "v1/payment_intents"))
+        }
+    }
+);
+
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>
     for Stripe<T>
@@ -987,15 +1031,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     for Stripe<T>
 {
 }
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        CreateOrder,
-        PaymentFlowData,
-        PaymentCreateOrderData,
-        PaymentCreateOrderResponse,
-    > for Stripe<T>
-{
-}
+
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<
         CreateSessionToken,

--- a/backend/connector-integration/src/connectors/stripe/transformers.rs
+++ b/backend/connector-integration/src/connectors/stripe/transformers.rs
@@ -11,16 +11,16 @@ use common_utils::{
 };
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, CreateConnectorCustomer, IncrementalAuthorization, PaymentMethodToken,
-        RepeatPayment, SetupMandate, Void,
+        Authorize, Capture, CreateConnectorCustomer, CreateOrder, IncrementalAuthorization,
+        PaymentMethodToken, RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         ConnectorCustomerData, ConnectorCustomerResponse, MandateReference, MandateReferenceId,
-        PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
-        PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsIncrementalAuthorizationData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        ResponseId, SetupMandateRequestData,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
+        PaymentMethodTokenResponse, PaymentMethodTokenizationData, PaymentVoidData,
+        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsIncrementalAuthorizationData,
+        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
+        RefundsResponseData, RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     errors::ConnectorError,
     mandates::AcceptanceType,
@@ -5261,6 +5261,109 @@ impl<F, T> TryFrom<ResponseRouterData<StripeTokenResponse, Self>>
         let token = item.response.id.clone().expose();
         Ok(Self {
             response: Ok(PaymentMethodTokenResponse { token }),
+            ..item.router_data
+        })
+    }
+}
+
+// CreateOrder flow types and transformations
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct StripeCreateOrderRequest {
+    pub amount: MinorUnit,
+    pub currency: String,
+    #[serde(flatten)]
+    pub meta_data: HashMap<String, String>,
+    pub description: Option<String>,
+    #[serde(rename = "automatic_payment_methods[enabled]")]
+    pub automatic_payment_methods: Option<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct StripeCreateOrderResponse {
+    pub id: String,
+    pub object: String,
+    pub amount: MinorUnit,
+    pub currency: String,
+    pub status: StripePaymentStatus,
+    pub client_secret: Option<Secret<String>>,
+    pub description: Option<String>,
+    pub metadata: StripeMetadata,
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        StripeRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    > for StripeCreateOrderRequest
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        value: StripeRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let item = value.router_data;
+        let amount = StripeAmountConvertor::convert(item.request.amount, item.request.currency)?;
+        let order_id = item
+            .resource_common_data
+            .connector_request_reference_id
+            .clone();
+        let meta_data = get_transaction_metadata(item.request.metadata.clone(), order_id);
+
+        Ok(Self {
+            amount,
+            currency: item.request.currency.to_string(),
+            meta_data,
+            description: None,
+            automatic_payment_methods: Some(true),
+        })
+    }
+}
+
+impl TryFrom<ResponseRouterData<StripeCreateOrderResponse, Self>>
+    for RouterDataV2<
+        CreateOrder,
+        PaymentFlowData,
+        PaymentCreateOrderData,
+        PaymentCreateOrderResponse,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<StripeCreateOrderResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        // For CreateOrder flow, map status differently - any non-error status is success
+        let status = match item.response.status {
+            StripePaymentStatus::Succeeded => common_enums::AttemptStatus::Charged,
+            StripePaymentStatus::RequiresPaymentMethod
+            | StripePaymentStatus::RequiresConfirmation => common_enums::AttemptStatus::Pending,
+            StripePaymentStatus::Canceled => common_enums::AttemptStatus::Voided,
+            _ => common_enums::AttemptStatus::Pending,
+        };
+
+        Ok(Self {
+            response: Ok(PaymentCreateOrderResponse {
+                order_id: item.response.id.clone(),
+                session_token: None,
+            }),
+            resource_common_data: PaymentFlowData {
+                status,
+                reference_id: Some(item.response.id),
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }


### PR DESCRIPTION
## Summary

Implement **orderCreate** flow for **Stripe** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added orderCreate support to `stripe.rs` (added to `create_all_prerequisites!` macro, added `macro_connector_implementation!`)
- Added orderCreate request/response types and `TryFrom` implementations in `stripe/transformers.rs`

## Files Modified

- backend/connector-integration/src/connectors/stripe.rs
- backend/connector-integration/src/connectors/stripe/transformers.rs

## gRPC Test Results

**Status: PASS**

Both tests passed successfully:

1. **CreateOrder Flow**: Returns PENDING status with connectorOrderId: `pi_3TDRTKEOqOywnAIx1npmoGWP` - Order created successfully!

2. **Authorize Flow**: Returns CHARGED status with connectorTransactionId: `pi_3TDRTUEOqOywnAIx0LUdeu1I` - Payment authorized successfully!

The implementation is complete.

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [x] grpcurl Authorize returned success status (2xx)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified