### PR TITLE
feat(connector): implement orderCreate for paypal

### DIFF
--- a/backend/connector-integration/src/connectors/paypal.rs
+++ b/backend/connector-integration/src/connectors/paypal.rs
@@ -50,10 +50,11 @@ use super::macros;
 use crate::{
     connectors::paypal::transformers::{
         self as paypal, auth_headers, PaypalAuthResponse, PaypalAuthUpdateRequest,
-        PaypalAuthUpdateResponse, PaypalCaptureResponse, PaypalPaymentsCancelResponse,
-        PaypalPaymentsCaptureRequest, PaypalPaymentsRequest, PaypalRefundRequest,
-        PaypalRepeatPaymentRequest, PaypalRepeatPaymentResponse, PaypalSetupMandatesResponse,
-        PaypalSyncResponse, PaypalZeroMandateRequest, RefundResponse, RefundSyncResponse,
+        PaypalAuthUpdateResponse, PaypalCaptureResponse, PaypalCreateOrderRequest,
+        PaypalCreateOrderResponse, PaypalPaymentsCancelResponse, PaypalPaymentsCaptureRequest,
+        PaypalPaymentsRequest, PaypalRefundRequest, PaypalRepeatPaymentRequest,
+        PaypalRepeatPaymentResponse, PaypalSetupMandatesResponse, PaypalSyncResponse,
+        PaypalZeroMandateRequest, RefundResponse, RefundSyncResponse,
     },
     types::ResponseRouterData,
     utils::{self, ConnectorErrorType, ConnectorErrorTypeMapping},
@@ -533,6 +534,12 @@ macros::create_all_prerequisites!(
             request_body: PaypalRepeatPaymentRequest<T>,
             response_body: PaypalRepeatPaymentResponse,
             router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: CreateOrder,
+            request_body: PaypalCreateOrderRequest,
+            response_body: PaypalCreateOrderResponse,
+            router_data: RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
         )
     ],
     amount_converters: [
@@ -1249,6 +1256,46 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Paypal,
+    curl_request: Json(PaypalCreateOrderRequest),
+    curl_response: PaypalCreateOrderResponse,
+    flow_name: CreateOrder,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentCreateOrderData,
+    flow_response: PaymentCreateOrderResponse,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, ConnectorError> {
+            let access_token = req.resource_common_data
+                .access_token
+                .clone()
+                .ok_or(ConnectorError::FailedToObtainAuthType)?;
+            let connector_metadata = req.resource_common_data.connector_feature_data
+                .as_ref()
+                .map(|secret| secret.clone().expose());
+            self.build_headers(
+                &access_token.access_token.expose(),
+                &req.resource_common_data.connector_request_reference_id,
+                &req.connector_config,
+                connector_metadata.as_ref(),
+            )
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<String, ConnectorError> {
+            Ok(format!("{}v2/checkout/orders", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>
     for Paypal<T>
@@ -1262,15 +1309,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>
     for Paypal<T>
-{
-}
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        CreateOrder,
-        PaymentFlowData,
-        PaymentCreateOrderData,
-        PaymentCreateOrderResponse,
-    > for Paypal<T>
 {
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>

--- a/backend/connector-integration/src/connectors/paypal/transformers.rs
+++ b/backend/connector-integration/src/connectors/paypal/transformers.rs
@@ -13,13 +13,15 @@ use common_utils::{
 };
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, PSync, PostAuthenticate, RepeatPayment, VerifyWebhookSource,
+        Authorize, Capture, CreateOrder, PSync, PostAuthenticate, RepeatPayment,
+        VerifyWebhookSource,
     },
     connector_types::{
-        AccessTokenResponseData, MandateReference, PaymentFlowData, PaymentsAuthorizeData,
-        PaymentsCaptureData, PaymentsPostAuthenticateData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        ResponseId, SetupMandateRequestData, VerifyWebhookSourceFlowData,
+        AccessTokenResponseData, MandateReference, PaymentCreateOrderData,
+        PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
+        PaymentsPostAuthenticateData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
+        RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId,
+        SetupMandateRequestData, VerifyWebhookSourceFlowData,
     },
     errors::ConnectorError,
     payment_method_data::{
@@ -3396,4 +3398,112 @@ fn get_paypal_error_message(error_code: &str) -> Option<&str> {
 pub struct PaypalAccessTokenErrorResponse {
     pub error: String,
     pub error_description: String,
+}
+
+// ----------------------------------------------------------------------------
+// CreateOrder Flow - For creating PayPal orders (wallet flows)
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct PaypalCreateOrderRequest {
+    intent: PaypalPaymentIntent,
+    purchase_units: Vec<PaypalCreateOrderPurchaseUnit>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaypalCreateOrderPurchaseUnit {
+    amount: OrderAmount,
+    reference_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaypalCreateOrderResponse {
+    pub id: String,
+    pub status: PaypalOrderStatus,
+    pub intent: PaypalPaymentIntent,
+    pub links: Option<Vec<PaypalLinks>>,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        PaypalRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    > for PaypalCreateOrderRequest
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: PaypalRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let value = item
+            .connector
+            .amount_converter
+            .convert(
+                item.router_data.request.amount,
+                item.router_data.request.currency,
+            )
+            .change_context(ConnectorError::AmountConversionFailed)?;
+
+        let amount = OrderAmount {
+            currency_code: item.router_data.request.currency,
+            value,
+        };
+
+        // Use CAPTURE as default intent for order creation
+        let intent = PaypalPaymentIntent::Capture;
+
+        let reference_id = item
+            .router_data
+            .resource_common_data
+            .connector_request_reference_id
+            .clone();
+
+        Ok(Self {
+            intent,
+            purchase_units: vec![PaypalCreateOrderPurchaseUnit {
+                amount,
+                reference_id: Some(reference_id),
+            }],
+        })
+    }
+}
+
+impl TryFrom<ResponseRouterData<PaypalCreateOrderResponse, Self>>
+    for RouterDataV2<
+        CreateOrder,
+        PaymentFlowData,
+        PaymentCreateOrderData,
+        PaymentCreateOrderResponse,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<PaypalCreateOrderResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let order_id = item.response.id.clone();
+
+        Ok(Self {
+            response: Ok(PaymentCreateOrderResponse {
+                order_id,
+                session_token: None,
+            }),
+            ..item.router_data
+        })
+    }
 }


### PR DESCRIPTION
## Summary

Implement **orderCreate** flow for **paypal** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added orderCreate support to `paypal.rs` (added to `create_all_prerequisites!` macro, added `macro_connector_implementation!`)
- Added orderCreate request/response types and `TryFrom` implementations in `paypal/transformers.rs`

## Files Modified

- backend/connector-integration/src/connectors/paypal.rs
- backend/connector-integration/src/connectors/paypal/transformers.rs

## gRPC Test Results

**Status: NOT_RUN**

The grpcurl test was not executed due to auth complexity requiring proper token management. The implementation has been validated through:
- Code compilation (`cargo build` passes)
- Type checking and trait implementations
- Connector integration patterns

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [ ] grpcurl Authorize returned success status (2xx) - Test not run (auth complexity)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified