### PR TITLE
feat(connector): implement orderCreate for nuvei

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nuvei.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei.rs
@@ -40,10 +40,11 @@ use std::fmt::Debug;
 pub mod transformers;
 
 use transformers::{
-    NuveiCaptureRequest, NuveiCaptureResponse, NuveiErrorResponse, NuveiPaymentRequest,
-    NuveiPaymentResponse, NuveiRefundRequest, NuveiRefundResponse, NuveiRefundSyncRequest,
-    NuveiRefundSyncResponse, NuveiSessionTokenRequest, NuveiSessionTokenResponse, NuveiSyncRequest,
-    NuveiSyncResponse, NuveiVoidRequest, NuveiVoidResponse,
+    NuveiCaptureRequest, NuveiCaptureResponse, NuveiCreateOrderRequest, NuveiCreateOrderResponse,
+    NuveiErrorResponse, NuveiPaymentRequest, NuveiPaymentResponse, NuveiRefundRequest,
+    NuveiRefundResponse, NuveiRefundSyncRequest, NuveiRefundSyncResponse, NuveiSessionTokenRequest,
+    NuveiSessionTokenResponse, NuveiSyncRequest, NuveiSyncResponse, NuveiVoidRequest,
+    NuveiVoidResponse,
 };
 
 use super::macros;
@@ -203,6 +204,12 @@ macros::create_all_prerequisites!(
             router_data: RouterDataV2<CreateSessionToken, PaymentFlowData, SessionTokenRequestData, SessionTokenResponseData>,
         ),
         (
+            flow: CreateOrder,
+            request_body: NuveiCreateOrderRequest,
+            response_body: NuveiCreateOrderResponse,
+            router_data: RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ),
+        (
             flow: Authorize,
             request_body: NuveiPaymentRequest<T>,
             response_body: NuveiPaymentResponse,
@@ -295,6 +302,35 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<CreateSessionToken, PaymentFlowData, SessionTokenRequestData, SessionTokenResponseData>,
         ) -> CustomResult<String, errors::ConnectorError> {
             Ok(format!("{}/getSessionToken.do", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
+// Implement CreateOrder flow using macro
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Nuvei,
+    curl_request: Json(NuveiCreateOrderRequest),
+    curl_response: NuveiCreateOrderResponse,
+    flow_name: CreateOrder,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentCreateOrderData,
+    flow_response: PaymentCreateOrderResponse,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+        ) -> CustomResult<String, errors::ConnectorError> {
+            Ok(format!("{}/openOrder.do", self.connector_base_url_payments(req)))
         }
     }
 );
@@ -530,16 +566,6 @@ macros::macro_connector_implementation!(
 );
 
 // Implementation for empty stubs - these will need to be properly implemented later
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        CreateOrder,
-        PaymentFlowData,
-        PaymentCreateOrderData,
-        PaymentCreateOrderResponse,
-    > for Nuvei<T>
-{
-}
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -1,10 +1,10 @@
 use common_utils::{pii, types::StringMajorUnit};
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
+    connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void},
     connector_types::{
-        PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData, ResponseId,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData, PaymentVoidData,
+        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
+        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, ResponseId,
     },
     errors,
     payment_method_data::{
@@ -91,6 +91,88 @@ pub struct NuveiSessionTokenResponse {
     pub merchant_site_id: Option<String>,
     pub version: Option<String>,
     pub client_request_id: Option<String>,
+}
+
+// Create Order Request (for /openOrder endpoint)
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NuveiCreateOrderRequest {
+    pub merchant_id: Secret<String>,
+    pub merchant_site_id: Secret<String>,
+    pub client_request_id: String,
+    pub client_unique_id: Option<String>,
+    pub currency: common_enums::Currency,
+    pub amount: StringMajorUnit,
+    pub user_token_id: Option<String>,
+    pub time_stamp: common_utils::date_time::DateTime<common_utils::date_time::YYYYMMDDHHmmss>,
+    pub checksum: String,
+}
+
+// Create Order Response
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NuveiCreateOrderResponse {
+    pub session_token: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_order_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub order_id: Option<String>,
+    pub internal_request_id: Option<i64>,
+    pub status: NuveiPaymentStatus,
+    pub err_code: Option<i32>,
+    pub reason: Option<String>,
+    pub merchant_id: Option<String>,
+    pub merchant_site_id: Option<String>,
+    pub version: Option<String>,
+    pub client_request_id: Option<String>,
+}
+
+// Helper function to deserialize order_id which can be either string or integer
+fn deserialize_order_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct OrderIdVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for OrderIdVisitor {
+        type Value = Option<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("string or integer order_id")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(value))
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+    }
+
+    deserializer.deserialize_any(OrderIdVisitor)
 }
 
 // URL Details for redirect URLs
@@ -543,6 +625,147 @@ impl TryFrom<ResponseRouterData<NuveiSessionTokenResponse, Self>>
                 ..router_data.resource_common_data.clone()
             },
             response: Ok(session_response_data),
+            ..router_data.clone()
+        })
+    }
+}
+
+// Create Order Request Transformation
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        NuveiRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    > for NuveiCreateOrderRequest
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: NuveiRouterData<
+            RouterDataV2<
+                CreateOrder,
+                PaymentFlowData,
+                PaymentCreateOrderData,
+                PaymentCreateOrderResponse,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        // Extract auth data
+        let auth = NuveiAuthType::try_from(&router_data.connector_config)?;
+
+        let time_stamp = NuveiAuthType::get_timestamp();
+        let client_request_id = router_data
+            .resource_common_data
+            .connector_request_reference_id
+            .clone();
+
+        // Convert amount using the connector's amount converter
+        let amount = item
+            .connector
+            .amount_converter_webhooks
+            .convert(router_data.request.amount, router_data.request.currency)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+
+        let currency = router_data.request.currency;
+
+        // Generate checksum for /openOrder: merchantId + merchantSiteId + clientRequestId + amount + currency + timeStamp + merchantSecretKey
+        let checksum = auth.generate_checksum(&[
+            auth.merchant_id.peek(),
+            auth.merchant_site_id.peek(),
+            &client_request_id,
+            &amount.get_amount_as_string(),
+            &currency.to_string(),
+            &time_stamp.to_string(),
+        ]);
+
+        Ok(Self {
+            merchant_id: auth.merchant_id,
+            merchant_site_id: auth.merchant_site_id,
+            client_request_id,
+            client_unique_id: None,
+            currency,
+            amount,
+            user_token_id: None,
+            time_stamp,
+            checksum,
+        })
+    }
+}
+
+// Create Order Response Transformation
+impl TryFrom<ResponseRouterData<NuveiCreateOrderResponse, Self>>
+    for RouterDataV2<
+        CreateOrder,
+        PaymentFlowData,
+        PaymentCreateOrderData,
+        PaymentCreateOrderResponse,
+    >
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<NuveiCreateOrderResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let response = &item.response;
+        let router_data = &item.router_data;
+
+        // Check if the overall request status is SUCCESS or ERROR
+        if matches!(response.status, NuveiPaymentStatus::Error) {
+            let error_code = response.err_code.map(|c| c.to_string()).unwrap_or_default();
+            let error_message = response
+                .reason
+                .clone()
+                .unwrap_or_else(|| "Unknown error".to_string());
+
+            return Ok(Self {
+                resource_common_data: PaymentFlowData {
+                    status: common_enums::AttemptStatus::Failure,
+                    ..router_data.resource_common_data.clone()
+                },
+                response: Err(domain_types::router_data::ErrorResponse {
+                    code: error_code,
+                    message: error_message.clone(),
+                    reason: Some(error_message),
+                    status_code: item.http_code,
+                    attempt_status: Some(common_enums::AttemptStatus::Failure),
+                    connector_transaction_id: None,
+                    network_decline_code: None,
+                    network_advice_code: None,
+                    network_error_message: None,
+                }),
+                ..router_data.clone()
+            });
+        }
+
+        // Extract order ID
+        let order_id =
+            response
+                .order_id
+                .clone()
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "order_id",
+                })?;
+
+        let create_order_response_data = PaymentCreateOrderResponse {
+            order_id: order_id.clone(),
+            session_token: None,
+        };
+
+        Ok(Self {
+            resource_common_data: PaymentFlowData {
+                status: common_enums::AttemptStatus::Pending,
+                ..router_data.resource_common_data.clone()
+            },
+            response: Ok(create_order_response_data),
             ..router_data.clone()
         })
     }


### PR DESCRIPTION
## Summary

Implement **orderCreate** flow for **nuvei** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added orderCreate support to `nuvei.rs` (added to `create_all_prerequisites!` macro, added `macro_connector_implementation!`)
- Added orderCreate request/response types and `TryFrom` implementations in `nuvei/transformers.rs`

## Files Modified

- backend/connector-integration/src/connectors/nuvei.rs
- backend/connector-integration/src/connectors/nuvei/transformers.rs

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl Authorize call (credentials redacted)</summary>

```
Test passed - successfully created order 14917791111 with status PENDING
```

</details>

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [x] grpcurl Authorize returned success status (2xx)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified
