### PR TITLE
fix: restore merchant_secret fallback and webhook_uri in webhook

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -34,9 +34,21 @@ impl EventService for EventServiceImpl {
         name = "EventService::handle_event",
         skip(self, request),
         fields(
+            name = common_utils::consts::NAME,
+            service_name = tracing::field::Empty,
+            service_method = FlowName::IncomingWebhook.to_string(),
+            request_body = tracing::field::Empty,
+            response_body = tracing::field::Empty,
+            error_message = tracing::field::Empty,
+            merchant_id = tracing::field::Empty,
+            gateway = tracing::field::Empty,
             request_id = tracing::field::Empty,
+            status_code = tracing::field::Empty,
+            message_ = "Golden Log Line (incoming)",
+            response_time = tracing::field::Empty,
             tenant_id = tracing::field::Empty,
             flow = FlowName::IncomingWebhook.to_string(),
+            flow_specific_fields.status = tracing::field::Empty,
         )
     )]
     async fn handle_event(


### PR DESCRIPTION
## Description
restore merchant_secret fallback and webhook_uri in webhook

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
