### PR TITLE
feat(connector): implement MIT for hipay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/hipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay.rs
@@ -44,8 +44,8 @@ use serde::Serialize;
 use transformers::{
     self as hipay, HipayAuthorizeResponse, HipayCaptureRequest, HipayCaptureResponse,
     HipayPSyncResponse, HipayPaymentsRequest, HipayRSyncResponse, HipayRefundRequest,
-    HipayRefundResponse, HipayTokenRequest, HipayTokenResponse, HipayVoidRequest,
-    HipayVoidResponse,
+    HipayRefundResponse, HipayRepeatPaymentRequest, HipayRepeatPaymentResponse,
+    HipayTokenRequest, HipayTokenResponse, HipayVoidRequest, HipayVoidResponse,
 };
 
 use super::macros;
@@ -271,6 +271,12 @@ macros::create_all_prerequisites!(
             request_body: HipayRefundRequest,
             response_body: HipayRefundResponse,
             router_data: RouterDataV2<Refund, RefundFlowData, RefundsData, RefundsResponseData>,
+        ),
+        (
+            flow: RepeatPayment,
+            request_body: HipayRepeatPaymentRequest,
+            response_body: HipayRepeatPaymentResponse,
+            router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -698,6 +704,47 @@ macros::macro_connector_implementation!(
     }
 );
 
+// RepeatPayment (MIT) flow - FormData (multipart/form-data), uses base_url
+// Same endpoint as Authorize (/v1/order) but with MIT-specific parameters
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_error_response_v2],
+    connector: Hipay,
+    curl_request: FormData(HipayRepeatPaymentRequest),
+    curl_response: HipayRepeatPaymentResponse,
+    flow_name: RepeatPayment,
+    resource_common_data: PaymentFlowData,
+    flow_request: RepeatPaymentData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            // Do NOT set Content-Type header manually for FormData - reqwest sets it with boundary
+            let mut header = vec![(
+                headers::ACCEPT.to_string(),
+                constants::JSON_CONTENT_TYPE.to_string().into(),
+            )];
+            let mut auth_header = self.get_auth_header(&req.connector_config)?;
+            header.append(&mut auth_header);
+            Ok(header)
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!(
+                "{}/v1/order",
+                self.connector_base_url_payments(req).trim_end_matches('/')
+            ))
+        }
+    }
+);
+
 // RSync flow - Manual implementation with custom handle_response_v2
 // Uses JSON deserialization from v3 API (same as PSync)
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -796,15 +843,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        RepeatPayment,
-        PaymentFlowData,
-        RepeatPaymentData<T>,
-        PaymentsResponseData,
-    > for Hipay<T>
-{
-}
+// RepeatPayment ConnectorIntegrationV2 is implemented by macro_connector_implementation! above
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<

--- a/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
@@ -7,12 +7,14 @@ use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::{request::MultipartData, types::StringMajorUnit};
 use domain_types::errors::{ConnectorError, IntegrationError};
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, PaymentMethodToken, RSync, Refund, Void},
+    connector_flow::{
+        Authorize, Capture, PSync, PaymentMethodToken, RSync, Refund, RepeatPayment, Void,
+    },
     connector_types::{
-        PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
-        PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
-        PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
-        ResponseId,
+        MandateReferenceId, PaymentFlowData, PaymentMethodTokenResponse,
+        PaymentMethodTokenizationData, PaymentVoidData, PaymentsAuthorizeData,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
+        RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId,
     },
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes},
     router_data::ConnectorSpecificConfig,
@@ -1009,6 +1011,245 @@ impl TryFrom<ResponseRouterData<HipayVoidResponse, Self>>
             },
             ..item.router_data
         })
+    }
+}
+
+// ========================================================================================
+// REPEAT PAYMENT (MIT) REQUEST/RESPONSE TYPES
+// ========================================================================================
+// HiPay MIT uses the same /v1/order endpoint as Authorize, but with MIT-specific parameters:
+// - eci=9 (Recurring E-commerce)
+// - recurring_payment=1
+// - authentication_indicator=0 (bypass 3DS for merchant-initiated)
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HipayRepeatPaymentRequest {
+    pub payment_product: String,
+    pub orderid: String,
+    pub operation: Operation,
+    pub description: String,
+    pub currency: common_enums::Currency,
+    pub amount: StringMajorUnit,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cardtoken: Option<String>,
+    /// ECI=9 for MIT (Recurring E-commerce)
+    pub eci: String,
+    /// Always "1" for recurring/MIT
+    pub recurring_payment: String,
+    /// Always "0" for MIT (bypass 3DS)
+    pub authentication_indicator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notify_url: Option<String>,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        HipayRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for HipayRepeatPaymentRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: HipayRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        // Extract card token from mandate reference (connector_mandate_id)
+        let cardtoken = match &item.router_data.request.mandate_reference {
+            MandateReferenceId::ConnectorMandateId(connector_mandate_ref) => {
+                connector_mandate_ref
+                    .get_connector_mandate_id()
+                    .ok_or_else(|| {
+                        error_stack::report!(IntegrationError::MissingRequiredField {
+                            field_name: "connector_mandate_id",
+                            context: Default::default()
+                        })
+                    })?
+            }
+            MandateReferenceId::NetworkMandateId(network_mandate_id) => {
+                network_mandate_id.clone()
+            }
+            MandateReferenceId::NetworkTokenWithNTI(_) => {
+                return Err(error_stack::report!(
+                    IntegrationError::NotImplemented(
+                        "Network token with NTI not supported for HiPay repeat payments"
+                            .to_string(),
+                        Default::default(),
+                    )
+                ));
+            }
+        };
+
+        // Determine payment_product from payment_method_data
+        let payment_product = match &item.router_data.request.payment_method_data {
+            PaymentMethodData::Card(card_data) => {
+                match card_data.card_network.as_ref() {
+                    Some(network) => match network {
+                        common_enums::CardNetwork::Visa => "visa",
+                        common_enums::CardNetwork::Mastercard => "mastercard",
+                        common_enums::CardNetwork::AmericanExpress => "american-express",
+                        common_enums::CardNetwork::JCB => "jcb",
+                        common_enums::CardNetwork::DinersClub => "diners",
+                        common_enums::CardNetwork::Discover => "discover",
+                        common_enums::CardNetwork::CartesBancaires => "cb",
+                        common_enums::CardNetwork::UnionPay => "unionpay",
+                        common_enums::CardNetwork::Interac => "interac",
+                        common_enums::CardNetwork::RuPay => "rupay",
+                        common_enums::CardNetwork::Maestro => "maestro",
+                        _ => "visa", // Default to visa for unsupported networks
+                    },
+                    None => "visa", // Default to visa when network unknown
+                }
+                .to_string()
+            }
+            PaymentMethodData::CardToken(_) => {
+                // For tokenized cards, use connector_customer field
+                item.router_data
+                    .resource_common_data
+                    .connector_customer
+                    .clone()
+                    .unwrap_or_else(|| "visa".to_string())
+            }
+            PaymentMethodData::MandatePayment => {
+                // For mandate payments, default to visa (HiPay requires payment_product)
+                "visa".to_string()
+            }
+            _ => {
+                return Err(IntegrationError::not_implemented(
+                    "Payment method not supported for repeat payment".to_string(),
+                ))
+                .change_context(IntegrationError::not_implemented(
+                    "Payment method".to_string(),
+                ))
+            }
+        };
+
+        // Convert amount to StringMajorUnit
+        let amount = item
+            .connector
+            .amount_converter
+            .convert(
+                item.router_data.request.minor_amount,
+                item.router_data.request.currency,
+            )
+            .change_context(IntegrationError::AmountConversionFailed {
+                context: Default::default(),
+            })?;
+
+        // Determine operation based on capture method
+        let operation = match item.router_data.request.capture_method {
+            Some(common_enums::CaptureMethod::Manual) => Operation::Authorization,
+            _ => Operation::Sale,
+        };
+
+        let description = item
+            .router_data
+            .resource_common_data
+            .description
+            .clone()
+            .unwrap_or_else(|| "Recurring payment".to_string());
+
+        let notify_url = item.router_data.request.webhook_url.clone();
+
+        Ok(Self {
+            payment_product,
+            orderid: item
+                .router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            operation,
+            description,
+            currency: item.router_data.request.currency,
+            amount,
+            cardtoken: Some(cardtoken),
+            eci: "9".to_string(),
+            recurring_payment: "1".to_string(),
+            authentication_indicator: "0".to_string(),
+            notify_url,
+        })
+    }
+}
+
+// RepeatPayment response reuses the same Authorize response format
+pub type HipayRepeatPaymentResponse = HipayPaymentsResponse;
+
+impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<HipayRepeatPaymentResponse, Self>>
+    for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorResponseTransformationError>;
+
+    fn try_from(
+        item: ResponseRouterData<HipayRepeatPaymentResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let status = AttemptStatus::from(item.response.status.clone());
+
+        let response = if status == AttemptStatus::Failure {
+            Err(domain_types::router_data::ErrorResponse {
+                code: "DECLINED".to_string(),
+                message: item.response.message.clone(),
+                reason: Some(item.response.message.clone()),
+                status_code: item.http_code,
+                attempt_status: None,
+                connector_transaction_id: Some(item.response.transaction_reference.clone()),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            })
+        } else {
+            let redirection_data = if !item.response.forward_url.is_empty() {
+                Some(Box::new(
+                    domain_types::router_response_types::RedirectForm::Uri {
+                        uri: item.response.forward_url.clone(),
+                    },
+                ))
+            } else {
+                None
+            };
+
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(
+                    item.response.transaction_reference.clone(),
+                ),
+                redirection_data,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.order.id.clone()),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+            })
+        };
+
+        Ok(Self {
+            response,
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
+
+// GetFormData implementation for HipayRepeatPaymentRequest
+impl GetFormData for HipayRepeatPaymentRequest {
+    fn get_form_data(&self) -> MultipartData {
+        build_form_from_struct(self).unwrap_or_else(|_| MultipartData::new())
     }
 }
 


### PR DESCRIPTION
## Summary

Implement **MIT** (Merchant Initiated Transaction / RepeatPayment) flow for **hipay** connector.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added RepeatPayment support to `hipay.rs` (added to `create_all_prerequisites!` macro, added `macro_connector_implementation!`)
- Added RepeatPayment request/response types (`HipayRepeatPaymentRequest`, `HipayRepeatPaymentResponse`) and `TryFrom` implementations in `hipay/transformers.rs`
- MIT uses same `/v1/order` endpoint as Authorize with MIT-specific parameters: `eci=9`, `recurring_payment=1`, `authentication_indicator=0`
- Card token extracted from `MandateReferenceId::ConnectorMandateId`

## Files Modified

- `crates/integrations/connector-integration/src/connectors/hipay.rs`
- `crates/integrations/connector-integration/src/connectors/hipay/transformers.rs`

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl RecurringPaymentService/Charge call (credentials redacted)</summary>

\`\`\`
grpcurl -plaintext \\
  -H 'x-connector: hipay' \\
  -H 'x-auth: body-key' \\
  -H 'x-api-key: <REDACTED>' \\
  -H 'x-key1: <REDACTED>' \\
  -d '{
    "merchant_charge_id": "test_hipay_mit_002",
    "connector_recurring_payment_id": {
      "connector_mandate_id": {
        "connector_mandate_id": "<REDACTED_TOKEN>"
      }
    },
    "amount": {"minor_amount": 1000, "currency": "EUR"},
    "payment_method": {"card": {"card_number": {"value": "4111111111111111"}, "card_exp_month": {"value": "03"}, "card_exp_year": {"value": "2030"}, "card_cvc": {"value": "737"}, "card_holder_name": {"value": "John Doe"}, "card_network": "VISA"}},
    "capture_method": "AUTOMATIC",
    "return_url": "https://example.com/return",
    "description": "MIT recurring payment test"
  }' \\
  localhost:8000 types.RecurringPaymentService/Charge

Response:
{
  "connectorTransactionId": "800423309609",
  "status": "CHARGED",
  "statusCode": 200,
  "merchantChargeId": "test_hipay_mit_002"
}

HiPay raw response (key fields):
- state: completed
- status: 118 (Captured)
- eci: 9 (Recurring E-commerce / MIT)
- authorizedAmount: 10.00
- capturedAmount: 10.00
- paymentProduct: visa
- debitAgreement.id: 12284606
\`\`\`

</details>

## Validation Checklist

- [x] cargo build passed with zero errors
- [x] grpcurl RecurringPaymentService/Charge returned success status (200, CHARGED)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified