### PR TITLE
feat(connector): implement MIT and CreateCustomer for shift4

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/shift4.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4.rs
@@ -460,14 +460,14 @@ macros::macro_connector_implementation!(
         fn get_headers(
             &self,
             req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
-        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
             self.build_headers(req)
         }
 
         fn get_url(
             &self,
             req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
-        ) -> CustomResult<String, errors::ConnectorError> {
+        ) -> CustomResult<String, IntegrationError> {
             let base_url = self.connector_base_url_payments(req);
             // MIT/RepeatPayment uses the same /charges endpoint as Authorize
             Ok(format!("{base_url}/charges"))
@@ -713,14 +713,14 @@ macros::macro_connector_implementation!(
         fn get_headers(
             &self,
             req: &RouterDataV2<CreateConnectorCustomer, PaymentFlowData, ConnectorCustomerData, ConnectorCustomerResponse>,
-        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
             self.build_headers(req)
         }
 
         fn get_url(
             &self,
             req: &RouterDataV2<CreateConnectorCustomer, PaymentFlowData, ConnectorCustomerData, ConnectorCustomerResponse>,
-        ) -> CustomResult<String, errors::ConnectorError> {
+        ) -> CustomResult<String, IntegrationError> {
             let base_url = self.connector_base_url_payments(req);
             Ok(format!("{base_url}/customers"))
         }

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -89,7 +89,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     > for Shift4CreateCustomerRequest
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
+    type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
         item: Shift4RouterData<
@@ -112,7 +112,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 impl<F, T> TryFrom<ResponseRouterData<Shift4CreateCustomerResponse, Self>>
     for RouterDataV2<F, PaymentFlowData, T, ConnectorCustomerResponse>
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
+    type Error = error_stack::Report<ConnectorResponseTransformationError>;
 
     fn try_from(
         item: ResponseRouterData<Shift4CreateCustomerResponse, Self>,
@@ -852,7 +852,7 @@ impl<T: PaymentMethodDataTypes>
         &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
     > for Shift4RepeatPaymentRequest<T>
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
+    type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
         item: &RouterDataV2<
@@ -887,24 +887,23 @@ impl<T: PaymentMethodDataTypes>
                         connector_mandate_ref
                             .get_connector_mandate_id()
                             .ok_or_else(|| {
-                                error_stack::report!(errors::ConnectorError::MissingRequiredField {
+                                error_stack::report!(IntegrationError::MissingRequiredField {
                                     field_name: "connector_mandate_id (card token)",
+                                    context: Default::default(),
                                 })
                             })?
                     }
                     MandateReferenceId::NetworkMandateId(_) => {
-                        return Err(error_stack::report!(
-                            errors::ConnectorError::NotImplemented(
-                                "NetworkMandateId is not supported for Shift4 MIT".to_string()
-                            )
-                        ));
+                        return Err(error_stack::report!(IntegrationError::NotImplemented(
+                            "NetworkMandateId is not supported for Shift4 MIT".to_string(),
+                            Default::default(),
+                        )));
                     }
                     MandateReferenceId::NetworkTokenWithNTI(_) => {
-                        return Err(error_stack::report!(
-                            errors::ConnectorError::NotImplemented(
-                                "NetworkTokenWithNTI is not supported for Shift4 MIT".to_string()
-                            )
-                        ));
+                        return Err(error_stack::report!(IntegrationError::NotImplemented(
+                            "NetworkTokenWithNTI is not supported for Shift4 MIT".to_string(),
+                            Default::default(),
+                        )));
                     }
                 };
                 (
@@ -921,10 +920,7 @@ impl<T: PaymentMethodDataTypes>
             _ => Shift4TransactionType::MerchantInitiated,
         };
 
-        let captured = item
-            .request
-            .is_auto_capture()
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let captured = item.request.is_auto_capture();
 
         Ok(Self {
             amount: item.request.minor_amount,
@@ -953,7 +949,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     > for Shift4RepeatPaymentRequest<T>
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
+    type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
         item: Shift4RouterData<
@@ -975,7 +971,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4RepeatPaymentResponse, Self>>
     for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
+    type Error = error_stack::Report<ConnectorResponseTransformationError>;
 
     fn try_from(
         item: ResponseRouterData<Shift4RepeatPaymentResponse, Self>,


### PR DESCRIPTION
## Summary

- Implement Merchant Initiated Transaction (MIT) flow for Shift4 via `RepeatPayment`
- Implement `CreateCustomer` flow (POST `/customers`) for Shift4
- Fix original MIT implementation: correct request format per Shift4 API docs
- Support two MIT approaches:
  - **Stored card**: card token (`card_xxx`) + `customerId` + `type: merchant_initiated`
  - **Raw card**: full card details + `type: merchant_initiated` (no customer needed)

## Changes

### MIT (RepeatPayment) Flow
- `card` field sent as plain string (stored card) or object (raw card), not `{"token": "..."}`
- Uses Shift4 `type` field (`merchant_initiated`, `subsequent_recurring`) instead of invalid `cardOnFile`
- `customerId` sourced from `resource_common_data.connector_customer` for stored card approach
- Response transformer fixed to match `Shift4PaymentsResponse` struct (not enum)

### CreateCustomer Flow
- New `Shift4CreateCustomerRequest` / `Shift4CreateCustomerResponse` types
- Endpoint: `POST {base_url}/customers`
- Extracts `email` and `description` from `ConnectorCustomerData`
- Returns `connector_customer_id` from Shift4 response

## gRPC Test Commands

### CreateCustomer
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto -proto payment.proto \
  -d '{
    "email": {"value": "customer@example.com"}
  }' \
  -H 'x-connector: shift4' \
  -H 'x-connector-config: {"config":{"Shift4":{"api_key":"<API_KEY>"}}}' \
  127.0.0.1:8000 types.CustomerService/Create
```

### Authorize (initial payment)
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto -proto payment.proto \
  -d '{
    "merchant_transaction_id": "txn_001",
    "amount": {"minor_amount": 1000, "currency": "USD"},
    "payment_method": {
      "card": {
        "card_number": {"value": "<CARD_NUMBER>"},
        "card_exp_month": {"value": "03"},
        "card_exp_year": {"value": "2030"},
        "card_cvc": {"value": "737"},
        "card_holder_name": {"value": "John Doe"}
      }
    },
    "capture_method": "AUTOMATIC",
    "address": {"billing_address": {"first_name": {"value": "John"}}},
    "auth_type": "NO_THREE_DS",
    "return_url": "https://example.com/return"
  }' \
  -H 'x-connector: shift4' \
  -H 'x-connector-config: {"config":{"Shift4":{"api_key":"<API_KEY>"}}}' \
  127.0.0.1:8000 types.PaymentService/Authorize
```

### MIT — Stored card (requires CreateCustomer + initial charge first)
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto -proto payment.proto \
  -d '{
    "connector_recurring_payment_id": {
      "connector_mandate_id": {
        "connector_mandate_id": "<STORED_CARD_ID>"
      }
    },
    "amount": {"minor_amount": 500, "currency": "USD"},
    "payment_method": {
      "token": {"token": {"value": "<STORED_CARD_ID>"}}
    },
    "connector_customer_id": "<CUSTOMER_ID>",
    "off_session": true,
    "capture_method": "AUTOMATIC",
    "payment_method_type": "CREDIT"
  }' \
  -H 'x-connector: shift4' \
  -H 'x-connector-config: {"config":{"Shift4":{"api_key":"<API_KEY>"}}}' \
  127.0.0.1:8000 types.RecurringPaymentService/Charge
```

### MIT — Raw card (no customer needed)
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto -proto payment.proto \
  -d '{
    "connector_recurring_payment_id": {
      "connector_mandate_id": {
        "connector_mandate_id": "unused"
      }
    },
    "amount": {"minor_amount": 500, "currency": "USD"},
    "payment_method": {
      "card": {
        "card_number": {"value": "<CARD_NUMBER>"},
        "card_exp_month": {"value": "03"},
        "card_exp_year": {"value": "2030"},
        "card_cvc": {"value": "737"},
        "card_holder_name": {"value": "John Doe"}
      }
    },
    "address": {
      "billing_address": {
        "first_name": {"value": "John"},
        "last_name": {"value": "Doe"}
      }
    },
    "off_session": true,
    "capture_method": "AUTOMATIC",
    "payment_method_type": "CREDIT"
  }' \
  -H 'x-connector: shift4' \
  -H 'x-connector-config: {"config":{"Shift4":{"api_key":"<API_KEY>"}}}' \
  127.0.0.1:8000 types.RecurringPaymentService/Charge
```

## Test Results

All flows tested against Shift4 sandbox API via gRPC:

| Flow | Service | Status |
|------|---------|--------|
| CreateCustomer | `CustomerService/Create` | 200 |
| Authorize (auto-capture) | `PaymentService/Authorize` | CHARGED (200) |
| Authorize (manual) | `PaymentService/Authorize` | AUTHORIZED (200) |
| Capture | `PaymentService/Capture` | CHARGED (200) |
| Get (PSync) | `PaymentService/Get` | CHARGED (200) |
| Refund | `PaymentService/Refund` | REFUND_SUCCESS (200) |
| MIT — stored card | `RecurringPaymentService/Charge` | CHARGED (200) |
| MIT — raw card | `RecurringPaymentService/Charge` | CHARGED (200) |