### PR TITLE
fix: avoid panic when kafka is not available during start up with event enabled config set

### DIFF
--- a/crates/common/common_utils/src/event_publisher.rs
+++ b/crates/common/common_utils/src/event_publisher.rs
@@ -13,14 +13,15 @@ use crate::{
 
 const PARTITION_KEY_METADATA: &str = "partitionKey";
 
-/// Global static EventPublisher instance
-static EVENT_PUBLISHER: OnceCell<EventPublisher> = OnceCell::new();
+/// Global static EventPublisher instance.
+/// `None` means initialization was attempted but failed (Kafka unavailable).
+/// `Some(p)` means the publisher is healthy and ready.
+static EVENT_PUBLISHER: OnceCell<Option<EventPublisher>> = OnceCell::new();
 
 /// An event publisher that sends events directly to Kafka.
 #[derive(Clone)]
 pub struct EventPublisher {
     writer: Arc<KafkaWriter>,
-    config: EventConfig,
 }
 
 impl EventPublisher {
@@ -66,7 +67,6 @@ impl EventPublisher {
 
         Ok(Self {
             writer: Arc::new(writer),
-            config: config.clone(),
         })
     }
 
@@ -294,37 +294,39 @@ fn set_nested_value(
     result.map(|_| ())
 }
 
-/// Initialize the global EventPublisher with the given configuration
-pub fn init_event_publisher(config: &EventConfig) -> CustomResult<(), EventPublisherError> {
+/// Initialize the global EventPublisher with the given configuration.
+/// If Kafka is unreachable, stores `None` and logs a warning instead of failing.
+/// Subsequent emits will be silently dropped until the process is restarted with Kafka available.
+pub fn init_event_publisher(config: &EventConfig) {
     tracing::info!(
         enabled = config.enabled,
         "Initializing global EventPublisher"
     );
 
-    let publisher = EventPublisher::new(config)?;
+    let value = match EventPublisher::new(config) {
+        Ok(publisher) => {
+            tracing::info!("Global EventPublisher initialized successfully");
+            Some(publisher)
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = ?e,
+                brokers = ?config.brokers,
+                topic = %config.topic,
+                "Failed to initialize EventPublisher (Kafka may be unavailable); \
+                 events will be dropped until the service is restarted with Kafka reachable"
+            );
+            None
+        }
+    };
 
-    EVENT_PUBLISHER.set(publisher).map_err(|failed_publisher| {
-        error_stack::Report::new(EventPublisherError::AlreadyInitialized)
-            .attach_printable("EventPublisher was already initialized")
-            .attach_printable(format!(
-                "Existing config: brokers={:?}, topic={}",
-                failed_publisher.config.brokers, failed_publisher.config.topic
-            ))
-            .attach_printable(format!(
-                "New config: brokers={:?}, topic={}",
-                config.brokers, config.topic
-            ))
-    })?;
-
-    tracing::info!("Global EventPublisher initialized successfully");
-    Ok(())
+    // Ignore AlreadyInitialized — can happen in tests; first writer wins.
+    let _ = EVENT_PUBLISHER.set(value);
 }
 
-/// Get or initialize the global EventPublisher
-fn get_event_publisher(
-    config: &EventConfig,
-) -> CustomResult<&'static EventPublisher, EventPublisherError> {
-    EVENT_PUBLISHER.get_or_try_init(|| EventPublisher::new(config))
+/// Returns the global EventPublisher if it was successfully initialized, otherwise `None`.
+fn get_event_publisher() -> Option<&'static EventPublisher> {
+    EVENT_PUBLISHER.get().and_then(|opt| opt.as_ref())
 }
 
 /// Standalone function to emit events using the global EventPublisher.
@@ -358,18 +360,20 @@ pub fn emit_event_with_config(event: Event, config: &EventConfig) {
 
     // Only publish to Kafka if enabled
     if config.enabled {
-        let _ = get_event_publisher(config)
-            .and_then(|publisher| {
-                let metadata = publisher.build_kafka_metadata(&event);
-                publisher.publish_event_with_metadata(
+        if let Some(publisher) = get_event_publisher() {
+            let metadata = publisher.build_kafka_metadata(&event);
+            let _ = publisher
+                .publish_event_with_metadata(
                     processed_event,
                     &config.topic,
                     &config.partition_key_field,
                     metadata,
                 )
-            })
-            .inspect_err(|e| {
-                tracing::error!(error = ?e, "Failed to publish event to Kafka");
-            });
+                .inspect_err(|e| {
+                    tracing::error!(error = ?e, "Failed to publish event to Kafka");
+                });
+        } else {
+            tracing::warn!("EventPublisher not available; audit event dropped");
+        }
     }
 }

--- a/crates/common/common_utils/src/lib.rs
+++ b/crates/common/common_utils/src/lib.rs
@@ -24,9 +24,7 @@ pub use errors::{CustomResult, EventPublisherError, ParsingError, ValidationErro
 pub use event_publisher::{emit_event_with_config, init_event_publisher};
 
 #[cfg(not(feature = "kafka"))]
-pub fn init_event_publisher(_config: &events::EventConfig) -> CustomResult<(), ()> {
-    Ok(())
-}
+pub fn init_event_publisher(_config: &events::EventConfig) {}
 #[cfg(not(feature = "kafka"))]
 pub fn emit_event_with_config(_event: events::Event, _config: &events::EventConfig) {
     // No-op when kafka feature is disabled

--- a/crates/grpc-server/grpc-server/src/app.rs
+++ b/crates/grpc-server/grpc-server/src/app.rs
@@ -121,15 +121,13 @@ pub struct Service {
 impl Service {
     /// # Panics
     ///
-    /// Will panic if EventPublisher initialization fails, database password, hash key isn't present in configs or unable to
+    /// Will panic if database password, hash key isn't present in configs or unable to
     /// deserialize any of the above keys
     #[allow(clippy::expect_used)]
     pub async fn new(config: Arc<configs::Config>) -> Self {
-        // Initialize the global EventPublisher - fail fast on startup
+        // Initialize the global EventPublisher - logs a warning if Kafka is unavailable
         if config.events.enabled {
-            common_utils::init_event_publisher(&config.events)
-                .expect("Failed to initialize global EventPublisher during startup");
-            logger::info!("Global EventPublisher initialized successfully");
+            common_utils::init_event_publisher(&config.events);
         } else {
             logger::info!("EventPublisher disabled in configuration");
         }


### PR DESCRIPTION

## Description
Since kafka is not an absolutely necessary dependency for UCS to handle transactions... And nowadays kafka is unavailable. 
Removing the fail fast logic when event is enabled but kafka is unavailable. 
But just log it.

Before this change, ucs will not run when kafka is unavailable at deployment. Either we have to disable the event enabled config.
After this change, During when event enabled config is true and kafka is unavailable. the audit events will be not emitted until kafka is up and ucs is restarted.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
