### PR TITLE
refactor: webhook to two step - resourceid extraction in separate method

### DIFF
--- a/crates/types-traits/grpc-api-types/proto/composite_payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_payment.proto
@@ -333,3 +333,26 @@ message CompositeCaptureResponse {
   optional MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse access_token_response = 1;
   optional PaymentServiceCaptureResponse capture_response = 2;
 }
+
+// Request for CompositeEventService.HandleEvent.
+// Use when webhook secrets are already resolved (e.g. merchant identity in webhook URL).
+// Supply event_context for connectors that require it (see connector integration guide).
+message CompositeEventHandleRequest {
+  RequestDetails          request_details   = 1;
+  optional WebhookSecrets webhook_secrets   = 2;
+  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
+  optional string         merchant_event_id = 3;
+  optional AccessToken    access_token      = 4;
+  optional EventContext   event_context     = 5;
+}
+
+// Response for CompositeEventService.HandleEvent.
+// Returns INVALID_ARGUMENT if required EventContext fields are absent for this connector.
+message CompositeEventHandleResponse {
+  optional EventReference   reference          = 1;
+  WebhookEventType          event_type         = 2;
+  EventContent              event_content      = 3;
+  bool                      source_verified    = 4;
+  optional string           merchant_event_id  = 5;  // Echoed from request.
+  optional EventAckResponse event_ack_response = 6;
+}

--- a/crates/types-traits/grpc-api-types/proto/composite_services.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_services.proto
@@ -29,3 +29,9 @@ service CompositeRefundService {
   rpc Get(CompositeRefundGetRequest) returns (CompositeRefundGetResponse);
 }
 
+// Single-call webhook processing for callers that have secrets resolved upfront.
+// Use EventService (ParseEvent → HandleEvent) when secrets must be looked up first.
+service CompositeEventService {
+  rpc HandleEvent(CompositeEventHandleRequest) returns (CompositeEventHandleResponse);
+}
+

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3141,8 +3141,8 @@ message EventServiceParseResponse {
 // response from the webhook payload alone. Which fields are required depends on the
 // connector — refer to the connector integration guide.
 message EventContext {
-  // Needed by connectors that cannot distinguish CAPTURED vs PARTIALLY_CAPTURED
-  // without knowing the original authorization's capture method.
+  // Needed by connectors (e.g. Adyen) that map AUTHORISATION events to both
+  // CAPTURED (automatic) and AUTHORIZED (manual) depending on capture method.
   optional CaptureMethod capture_method = 1;
 }
 

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -1321,13 +1321,9 @@ message RedirectResponseSecrets {
   optional string additional_secret = 2;
 }
 
-// Incomplete transformation response
-message IncompleteTransformationResponse {
-  // The resource object bytes that should be sent in PSync call
-  bytes resource_object = 1;
-  // Reason why transformation is incomplete
-  string reason = 2;
-}
+// Response for EventService.HandleEvent.
+// event_content mirrors PaymentService.Get / RefundService.Get / DisputeService.Get.
+// Returns INVALID_ARGUMENT if required EventContext fields are absent for this connector.
 
 // Response for handling an event, which may contain different types of content
 // based on the event type.
@@ -1344,11 +1340,8 @@ message EventServiceHandleResponse {
   // Reference
   optional string merchant_event_id = 4;
 
-  // Event Status
-  EventStatus event_status = 5;
-
   // Suggested HTTP response to send back to the connector for webhook acknowledgement
-  optional EventAckResponse event_ack_response = 6;
+  optional EventAckResponse event_ack_response = 5;
 }
 
 // Suggested HTTP response for webhook acknowledgement (status, headers, body).
@@ -1367,9 +1360,6 @@ message EventContent {
     RefundResponse refunds_response = 2;
     // Content if the event is for a dispute synchronization.
     DisputeResponse disputes_response = 3;
-    // Content if the payment event transformation is incomplete and requires
-    // psync call.
-    IncompleteTransformationResponse incomplete_transformation = 4;
   }
 }
 
@@ -3080,26 +3070,93 @@ message PaymentServiceIncrementalAuthorizationResponse {
   optional ConnectorState state = 6;
 }
 
-// Request message for EventService.HandleEvent RPC
-message EventServiceHandleRequest {
-  // Identification
-  optional string merchant_event_id = 1;
-
-  // Request Details
-  RequestDetails request_details = 2;
-
-  // Security
-  optional WebhookSecrets webhook_secrets = 3;
-
-  // State Information
-  optional ConnectorState state = 4;
+// IDs extracted from a payment webhook.
+// connector_transaction_id: connector-assigned ID (e.g. Stripe "pi_xxx", Adyen "pspReference" on capture events).
+// merchant_transaction_id:  merchant reference echoed by the connector (e.g. Adyen "merchantReference"
+//                           on transaction events, Stripe metadata.order_id).
+// Exactly one is expected to be present; both may be present when the connector echoes both.
+message PaymentEventReference {
+  optional string connector_transaction_id = 1;
+  optional string merchant_transaction_id  = 2;
 }
 
-// Status of event processing
-enum EventStatus {
-  EVENT_STATUS_UNSPECIFIED = 0;
-  EVENT_STATUS_COMPLETE = 1;
-  EVENT_STATUS_INCOMPLETE = 2;
+// IDs extracted from a refund webhook.
+// connector_refund_id:      connector-assigned refund ID (e.g. PayPal refund resource.id).
+// merchant_refund_id:       merchant reference echoed for the refund (e.g. Adyen "merchantReference"
+//                           on refund events).
+// connector_transaction_id: parent payment ID, if the connector includes it.
+message RefundEventReference {
+  optional string connector_refund_id      = 1;
+  optional string merchant_refund_id       = 2;
+  optional string connector_transaction_id = 3;  // Parent payment ID, if present.
+}
+
+// IDs extracted from a dispute webhook.
+// Connectors typically reference disputes via the parent payment's connector_transaction_id
+// (e.g. Adyen originalReference, PayPal seller_transaction_id).
+// connector_dispute_id is populated when the connector issues a dispute-specific identifier.
+message DisputeEventReference {
+  optional string connector_dispute_id     = 1;
+  optional string connector_transaction_id = 2;  // Parent payment ID.
+}
+
+// IDs extracted from a mandate webhook.
+message MandateEventReference {
+  optional string connector_mandate_id = 1;
+}
+
+// IDs extracted from a payout webhook.
+// connector_payout_id: connector-assigned payout ID (e.g. PayPal payout_batch_id).
+// merchant_payout_id:  merchant reference echoed by the connector (e.g. Adyen "merchantReference"
+//                      on payout events).
+message PayoutEventReference {
+  optional string connector_payout_id = 1;
+  optional string merchant_payout_id  = 2;
+}
+
+// Resource reference extracted from a webhook payload.
+// The oneof variant identifies the entity class. Unset for non-resource events (e.g. account/capability notifications).
+message EventReference {
+  oneof resource {
+    PaymentEventReference payment = 1;
+    RefundEventReference  refund  = 2;
+    DisputeEventReference dispute = 3;
+    MandateEventReference mandate = 4;
+    PayoutEventReference  payout  = 5;
+  }
+}
+
+// Request for EventService.ParseEvent. No credentials required.
+message EventServiceParseRequest {
+  RequestDetails request_details = 1;
+}
+
+// Response for EventService.ParseEvent.
+message EventServiceParseResponse {
+  optional EventReference   reference  = 1;  // Absent for non-resource events (e.g. account/capability notifications).
+  optional WebhookEventType event_type = 2;
+}
+
+// Additional business context for connectors that cannot produce a complete unified
+// response from the webhook payload alone. Which fields are required depends on the
+// connector — refer to the connector integration guide.
+message EventContext {
+  // Needed by connectors that cannot distinguish CAPTURED vs PARTIALLY_CAPTURED
+  // without knowing the original authorization's capture method.
+  optional CaptureMethod capture_method = 1;
+}
+
+// Request for EventService.HandleEvent.
+// Supply event_context for connectors that require it (see connector integration guide).
+// access_token required for connectors that verify webhooks via an outbound API call
+// (e.g. PayPal POST /v1/notifications/verify-webhook-signature requires OAuth2).
+message EventServiceHandleRequest {
+  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
+  optional string         merchant_event_id = 1;
+  RequestDetails          request_details   = 2;
+  optional WebhookSecrets webhook_secrets   = 3;
+  optional AccessToken    access_token      = 4;
+  optional EventContext   event_context     = 5;
 }
 
 // Request message for VerifyRedirectResponse

--- a/crates/types-traits/grpc-api-types/proto/services.proto
+++ b/crates/types-traits/grpc-api-types/proto/services.proto
@@ -73,13 +73,19 @@ option go_package = "github.com/juspay/connector-service/crates/types-traits/grp
 // ============================================================================
 
 // ============================================================================
-// EVENT SERVICE — Common event handler for processing inbound connector
-//                  webhooks across all services.
+// EVENT SERVICE — Two-phase inbound webhook processing.
+//   1. ParseEvent   — parse payload, return reference + event type (no credentials).
+//   2. HandleEvent  — verify source, return unified typed response (PSync/RSync/Dispute shape).
+// For single-call processing when secrets are known upfront, use CompositeEventService.
 // ============================================================================
 
 service EventService {
-  // Process webhook notifications from connectors. Translates connector events
-  // into standardized responses for asynchronous payment state updates.
+  // Parse a raw webhook payload without credentials.
+  // Returns resource reference and event type — sufficient to resolve secrets or early-exit.
+  rpc ParseEvent(EventServiceParseRequest) returns (EventServiceParseResponse);
+
+  // Verify webhook source and return a unified typed response.
+  // Response mirrors PaymentService.Get / RefundService.Get / DisputeService.Get.
   rpc HandleEvent(EventServiceHandleRequest) returns (EventServiceHandleResponse);
 }
 


### PR DESCRIPTION
## Summary

Refactors the UCS webhook flow from a single combined RPC into a clean two-phase API, with a composite option for callers that have all context upfront.

## Core Problem

The old single-RPC `HandleEvent` required credentials (webhook secret) upfront to verify the event, but the credentials can only be resolved **after** parsing the payload to extract the resource reference. This is a circular dependency (If mca_id is available in webhook url then fine, But some cases we need to have only connectornname in webhook url): 

> To verify, you need the secret. To find the secret, you need to know which resource the event refers to. To know the resource, you need to parse the payload. But parsing is bundled with verification in a single call.

Additional problems with the old design:

1. **`IncompleteTransformationResponse`** — some connectors (e.g. those needing `capture_method` to distinguish `CAPTURED` vs `PARTIALLY_CAPTURED`) could not produce a complete unified response without extra business context. Callers had to handle a degraded partial response and fall back to PSync.
2. **Account-level events** — events like capability/account notifications carry no resource reference. There was no clean way to early-exit before credential resolution.
3. **`ConnectorState` overreach** — the event request used `ConnectorState` which carries `connector_customer_id`, irrelevant for webhooks. Only an OAuth2 access token is needed (e.g. PayPal verifies webhooks via `POST /v1/notifications/verify-webhook-signature`).

## New Design

### Two-phase `EventService`

```
ParseEvent(request_details)
  → EventReference  { oneof: payment | refund | dispute | mandate | payout }
  → WebhookEventType

  // Caller resolves credentials + event_context using the reference, then:

HandleEvent(request_details, webhook_secrets?, access_token?, event_context?)
  → EventContent  { oneof: payments_response | refunds_response | disputes_response }
  → source_verified
  → event_ack_response?
```

- `ParseEvent` is a pure stateless parse — no credentials, no outbound calls. Returns a structured `EventReference` typed per entity (payment/refund/dispute/mandate/payout) and `WebhookEventType`. Caller can early-exit on irrelevant events without any further resolution.
- `HandleEvent` does source verification and returns a unified typed response mirroring `PaymentService.Get` / `RefundService.Get` / `DisputeService.Get`.

### `CompositeEventService.HandleEvent`

Single-call option for callers that already have all credentials resolved upfront. Returns `EventReference` alongside the full event response since the caller skipped `ParseEvent`.

## Key Removals

### `IncompleteTransformationResponse` removed
Replaced by `EventContext` — the caller supplies required business context fields (e.g. `capture_method`) in `HandleEvent`. Missing required context returns `INVALID_ARGUMENT` instead of a degraded partial response.

### `EventStatus` enum removed
`EventStatus.COMPLETE / INCOMPLETE` was redundant with the `EventContent` oneof. Removed entirely.

### `ConnectorState` replaced with `AccessToken`
`ConnectorState` carries `connector_customer_id` which is irrelevant for webhooks. Replaced with `optional AccessToken` directly.

## `EventReference` design

Rather than a plain `string connector_reference_id`, the extracted reference is a typed `oneof`:

```proto
message EventReference {
  oneof resource {
    PaymentEventReference payment = 1;   // connector_transaction_id + merchant_transaction_id
    RefundEventReference  refund  = 2;   // connector_refund_id + merchant_refund_id + parent payment
    DisputeEventReference dispute = 3;   // connector_dispute_id + parent payment
    MandateEventReference mandate = 4;
    PayoutEventReference  payout  = 5;   // connector_payout_id + merchant_payout_id
  }
}
```

Proven against actual HS connector implementations:
- **Stripe**: `connector_transaction_id` (pi_xxx) OR `merchant_transaction_id` (metadata.order_id)
- **Adyen**: `merchant_transaction_id` (merchantReference) for transaction events, `connector_transaction_id` (originalReference) for capture/cancel, `merchant_refund_id` for refund events, `merchant_payout_id` for payout events
- **PayPal**: `connector_transaction_id` for payments, `connector_refund_id` for refunds, parent `connector_transaction_id` for disputes

## Files Changed

- `payment.proto` — new `EventReference` type hierarchy, `EventServiceParseRequest/Response`, updated `EventServiceHandleRequest/Response`, new `EventContext`, removed `IncompleteTransformationResponse`, removed `EventStatus`
- `services.proto` — `EventService` updated with `ParseEvent` + `HandleEvent` RPCs
- `composite_payment.proto` — new `CompositeEventHandleRequest/Response`
- `composite_services.proto` — new `CompositeEventService`

### Additional Changes
- [x] This PR modifies the API contract

##Additional Context

One practical motivation for this flow is connectors such as **Nuvei**, where a merchant account can expose only a single webhook endpoint. In setups where the same connector credentials are reused across multiple business profiles, a profile-specific webhook URL is not always a workable integration shape.

A connector-level webhook endpoint plus payload-driven reference extraction gives callers a clean way to receive webhooks on a single generic endpoint and then resolve the correct internal account/profile using the extracted transaction metadata or connector reference.

This aligns with the standardized webhook URL shape being discussed on the caller side:

```
/webhooks/{merchant_id}/{connector_name}
```

with internal account resolution happening after the reference is parsed from the webhook payload.

## How did you test it?
Proto-only change. No runtime behavior changed in this PR.