### PR TITLE
fix(nmi): remove currency and merchant_defined_fields from post-redirect authorize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -276,7 +276,8 @@ pub struct NmiPaymentsRequest<T: PaymentMethodDataTypes> {
     #[serde(rename = "type")]
     transaction_type: TransactionType,
     amount: FloatMajorUnit,
-    currency: common_enums::Currency,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    currency: Option<common_enums::Currency>,
     orderid: String,
     #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -418,7 +419,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 security_key: auth.api_key.clone(),
                 transaction_type,
                 amount,
-                currency: router_data.request.currency,
+                currency: None,
                 orderid: three_ds_data.order_id.ok_or_else(|| {
                     error_stack::report!(IntegrationError::MissingRequiredField {
                         field_name: "order_id",
@@ -426,11 +427,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     })
                 })?,
                 payment_method: None,
-                merchant_defined_field: router_data
-                    .request
-                    .metadata
-                    .as_ref()
-                    .map(|m| NmiMerchantDefinedField::new(m.peek())),
+                merchant_defined_field: None,
                 billing_details: None,
                 shipping_details: None,
                 customer_vault_id: Some(three_ds_data.customer_vault_id),
@@ -518,7 +515,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 security_key: auth.api_key.clone(),
                 transaction_type,
                 amount,
-                currency: router_data.request.currency,
+                currency: Some(router_data.request.currency),
                 orderid: router_data
                     .resource_common_data
                     .connector_request_reference_id


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

fixes diffs during complete authorize (post redirection)

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

diff fix. these fields are not needed for 3ds completion and were causing diff with hyperswitch reference flow.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="1717" height="321" alt="image" src="https://github.com/user-attachments/assets/7765243c-1bd5-403a-bb4e-ef8dc50b4064" />
<img width="1714" height="414" alt="image" src="https://github.com/user-attachments/assets/2588b858-6cef-499b-a942-82f01d02d897" />
