### PR TITLE
docs(sdk): FFI performance findings — boundary-crossing overhead across SDKs

### DIFF
--- a/docs-generated/sdks/FFI_PERFORMANCE.md
+++ b/docs-generated/sdks/FFI_PERFORMANCE.md
@@ -1,0 +1,98 @@
+# SDK FFI Performance Report
+
+## Summary
+
+The FFI boundary crossing adds **<4ms overhead per call** across all SDKs, accounting for **0.2–0.3% of total round-trip time**. The pure penalty of crossing from a host language into Rust and back is **~1ms for JavaScript and ~1.8ms for Python** on top of the native Rust baseline.
+
+## Cross-SDK Comparison
+
+| Metric | Rust (baseline) | JavaScript | Python |
+|---|---:|---:|---:|
+| Avg req\_transformer | 0.47ms | 0.79ms | 0.78ms |
+| Avg res\_transformer | 1.57ms | 2.26ms | 3.04ms |
+| **Avg total overhead** | **2.04ms** | **3.05ms** | **3.82ms** |
+| **Overhead as % of round-trip** | **0.18%** | **0.25%** | **0.31%** |
+
+> Kotlin uses the same FFI mechanism (UniFFI → JNA) and is expected to fall in the same range. Data will be added once its Maven publish pipeline includes the perf instrumentation.
+
+## FFI Boundary Cost (Delta vs Rust)
+
+Since Rust calls its own handlers directly with zero FFI overhead, it serves as the baseline. The delta isolates the pure language-boundary cost:
+
+| | req\_transformer | res\_transformer | Total per call |
+|---|---:|---:|---:|
+| **JavaScript** (koffi) | +0.32ms | +0.69ms | **+1.01ms** |
+| **Python** (ctypes) | +0.31ms | +1.47ms | **+1.78ms** |
+
+- **req side** is nearly identical (~0.3ms) — request payloads are small and serialization is fast in both languages.
+- **res side** diverges — Python's ctypes marshals large byte buffers slower than koffi's direct memory access, which doubles the response-side penalty.
+
+## What Was Measured
+
+Each connector client flow does a three-phase round-trip through the Rust core:
+
+```
+req_transformer:  serialize request proto → FFI call into Rust → decode HTTP request
+       │
+     HTTP:        network round-trip to connector API (Stripe sandbox)
+       │
+res_transformer:  encode HTTP response → FFI call into Rust → decode domain response
+```
+
+Timers are placed **inside the ConnectorClient** (not the test harness), directly around each phase. Measurements were taken against live Stripe sandbox with production-shaped payloads.
+
+## Architecture
+
+| SDK | FFI binding | HTTP client |
+|---|---|---|
+| Rust | Direct call (no FFI) | reqwest |
+| Python | UniFFI → ctypes | httpx (h2) |
+| JavaScript | UniFFI → koffi | undici (fetch) |
+| Kotlin | UniFFI → JNA | OkHttp |
+
+All SDKs share the same compiled `libconnector_service_ffi` (Rust, `release-fast` profile). The connector-specific transformation logic is identical — only the language binding layer and HTTP transport differ.
+
+## Raw Data
+
+<details>
+<summary>Per-call breakdown (click to expand)</summary>
+
+### Rust (3 calls — single-step harness flows)
+
+| Flow | req\_ffi | HTTP | res\_ffi | Total |
+|---|---:|---:|---:|---:|
+| proxy\_authorize | 0.27ms | 1265.38ms | 3.20ms | 1268.85ms |
+| proxy\_setup\_recurring | 0.70ms | 1122.81ms | 0.84ms | 1124.35ms |
+| setup\_recurring | 0.45ms | 1068.30ms | 0.67ms | 1069.42ms |
+
+### Python (10 calls — composite example flows)
+
+| Flow | req\_ffi | HTTP | res\_ffi | Total |
+|---|---:|---:|---:|---:|
+| authorize | 3.02ms | 1526.44ms | 2.47ms | 1531.93ms |
+| capture | 0.35ms | 1450.10ms | 3.27ms | 1453.71ms |
+| authorize | 0.87ms | 1121.34ms | 3.84ms | 1126.06ms |
+| capture | 0.58ms | 1436.68ms | 3.04ms | 1440.30ms |
+| authorize | 0.76ms | 1188.71ms | 1.27ms | 1190.74ms |
+| get | 0.31ms | 436.58ms | 4.76ms | 441.64ms |
+| authorize | 0.76ms | 1385.68ms | 3.06ms | 1389.50ms |
+| refund | 0.35ms | 1222.98ms | 1.39ms | 1224.72ms |
+| authorize | 0.31ms | 1166.88ms | 3.07ms | 1170.26ms |
+| void | 0.51ms | 1429.06ms | 4.23ms | 1433.81ms |
+
+### JavaScript (10 calls — composite example flows)
+
+| Flow | req\_ffi | HTTP | res\_ffi | Total |
+|---|---:|---:|---:|---:|
+| authorize | 3.42ms | 1219.74ms | 2.90ms | 1226.06ms |
+| capture | 0.41ms | 1646.62ms | 3.58ms | 1650.61ms |
+| authorize | 0.86ms | 1143.32ms | 1.76ms | 1145.94ms |
+| capture | 0.28ms | 1230.85ms | 0.95ms | 1232.08ms |
+| authorize | 0.32ms | 1095.93ms | 3.76ms | 1100.01ms |
+| get | 0.85ms | 500.41ms | 3.39ms | 504.66ms |
+| authorize | 0.84ms | 1472.74ms | 1.15ms | 1474.72ms |
+| refund | 0.33ms | 1384.69ms | 1.08ms | 1386.11ms |
+| authorize | 0.32ms | 1217.08ms | 2.90ms | 1220.30ms |
+| void | 0.33ms | 1336.76ms | 1.07ms | 1338.17ms |
+
+</details>


### PR DESCRIPTION
## What

Adds `sdk/FFI_PERFORMANCE.md` documenting measured FFI boundary-crossing overhead across Rust, Python, and JavaScript SDKs.

## Key Findings

The pure cost of crossing from a host language into Rust and back:

| | req_transformer | res_transformer | Total per call |
|---|---:|---:|---:|
| **JavaScript** (koffi) | +0.32ms | +0.69ms | **+1.01ms** |
| **Python** (ctypes) | +0.31ms | +1.47ms | **+1.78ms** |

- FFI overhead is **0.2–0.3%** of total round-trip time
- Request side is identical across languages (~0.3ms) — payloads are small
- Response side diverges — Python ctypes marshals large byte buffers ~2× slower than koffi
- Measured against live Stripe sandbox with production-shaped payloads
- Timers placed inside ConnectorClient, not the test harness
