### PR TITLE
feat(stax): implement ApplePay wallet support via Tokenize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -1095,23 +1095,21 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         .get_card_no();
 
                     // Convert PAN string into the generic RawCardNumber<T> type
-                    let inner: T::Inner = serde_json::from_value(serde_json::Value::String(
-                        card_number_string,
-                    ))
-                    .map_err(|e| {
-                        error_stack::report!(IntegrationError::InvalidDataFormat {
-                            field_name: "apple_pay.application_primary_account_number",
-                            context: Default::default(),
-                        })
-                        .attach_printable(format!(
-                            "Failed to convert Apple Pay PAN to card number type: {e}"
-                        ))
-                    })?;
+                    let inner: T::Inner =
+                        serde_json::from_value(serde_json::Value::String(card_number_string))
+                            .map_err(|e| {
+                                error_stack::report!(IntegrationError::InvalidDataFormat {
+                                    field_name: "apple_pay.application_primary_account_number",
+                                    context: Default::default(),
+                                })
+                                .attach_printable(format!(
+                                    "Failed to convert Apple Pay PAN to card number type: {e}"
+                                ))
+                            })?;
                     let card_number: RawCardNumber<T> = RawCardNumber(inner);
 
                     // Stax requires expiry as MMYY (no delimiter)
-                    let exp_month_raw =
-                        apple_pay_decrypted_data.get_expiry_month().expose();
+                    let exp_month_raw = apple_pay_decrypted_data.get_expiry_month().expose();
                     let exp_month_padded = format!("{exp_month_raw:0>2}");
                     let exp_year_4d = apple_pay_decrypted_data
                         .get_four_digit_expiry_year()
@@ -1147,7 +1145,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         }
                     } else {
                         return Err(IntegrationError::MissingRequiredField {
-                            field_name: "billing address (required by Stax for Apple Pay tokenization)",
+                            field_name:
+                                "billing address (required by Stax for Apple Pay tokenization)",
                             context: Default::default(),
                         })?;
                     };
@@ -1184,7 +1183,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
                 Err(IntegrationError::not_implemented(
-                    "Only card, ACH bank debit, and Apple Pay tokenization are supported for Stax".to_string(),
+                    "Only card, ACH bank debit, and Apple Pay tokenization are supported for Stax"
+                        .to_string(),
                 ))?
             }
         }

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -14,7 +14,7 @@ use domain_types::{
         ResponseId,
     },
     payment_method_data::{
-        BankDebitData, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber,
+        BankDebitData, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber, WalletData,
     },
     router_data::ConnectorSpecificConfig,
     router_data_v2::RouterDataV2,
@@ -1071,9 +1071,102 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     customer_id: Secret::new(customer_id),
                 }))
             }
+            PaymentMethodData::Wallet(wallet_data) => match wallet_data {
+                WalletData::ApplePay(apple_pay_data) => {
+                    // Decrypted-passthrough: Stax requires raw card data for tokenization.
+                    // We extract the decrypted PAN/expiry from the Apple Pay token and
+                    // submit it as a card tokenize request.
+                    let apple_pay_decrypted_data = apple_pay_data
+                        .payment_data
+                        .get_decrypted_apple_pay_payment_data_optional()
+                        .ok_or_else(|| {
+                            error_stack::report!(IntegrationError::MissingRequiredField {
+                                field_name: "apple_pay_decrypted_data",
+                                context: Default::default(),
+                            })
+                            .attach_printable(
+                                "Stax requires pre-decrypted Apple Pay data; \
+                                 encrypted Apple Pay tokens are not supported.",
+                            )
+                        })?;
+
+                    let card_number_string = apple_pay_decrypted_data
+                        .application_primary_account_number
+                        .get_card_no();
+
+                    // Convert PAN string into the generic RawCardNumber<T> type
+                    let inner: T::Inner = serde_json::from_value(serde_json::Value::String(
+                        card_number_string,
+                    ))
+                    .map_err(|e| {
+                        error_stack::report!(IntegrationError::InvalidDataFormat {
+                            field_name: "apple_pay.application_primary_account_number",
+                            context: Default::default(),
+                        })
+                        .attach_printable(format!(
+                            "Failed to convert Apple Pay PAN to card number type: {e}"
+                        ))
+                    })?;
+                    let card_number: RawCardNumber<T> = RawCardNumber(inner);
+
+                    // Stax requires expiry as MMYY (no delimiter)
+                    let exp_month_raw =
+                        apple_pay_decrypted_data.get_expiry_month().expose();
+                    let exp_month_padded = format!("{exp_month_raw:0>2}");
+                    let exp_year_4d = apple_pay_decrypted_data
+                        .get_four_digit_expiry_year()
+                        .expose();
+                    let exp_year_2d = if exp_year_4d.len() >= 2 {
+                        exp_year_4d[exp_year_4d.len() - 2..].to_string()
+                    } else {
+                        exp_year_4d
+                    };
+                    let card_exp = Secret::new(format!("{exp_month_padded}{exp_year_2d}"));
+
+                    // Stax requires a cardholder full name (first + last)
+                    let person_name = if let Some(billing) = item
+                        .router_data
+                        .resource_common_data
+                        .address
+                        .get_payment_method_billing()
+                    {
+                        let first_name = billing.get_optional_first_name();
+                        let last_name = billing.get_optional_last_name();
+                        match (first_name, last_name) {
+                            (Some(first), Some(last)) => {
+                                Secret::new(format!("{} {}", first.peek(), last.peek()))
+                            }
+                            (Some(first), None) => first.clone(),
+                            (None, Some(last)) => last.clone(),
+                            (None, None) => {
+                                return Err(IntegrationError::MissingRequiredField {
+                                    field_name: "billing.first_name+last_name (required by Stax for Apple Pay tokenization)",
+                                    context: Default::default(),
+                                })?;
+                            }
+                        }
+                    } else {
+                        return Err(IntegrationError::MissingRequiredField {
+                            field_name: "billing address (required by Stax for Apple Pay tokenization)",
+                            context: Default::default(),
+                        })?;
+                    };
+
+                    Ok(Self::Card(StaxCardTokenizeData {
+                        person_name,
+                        card_number,
+                        card_exp,
+                        // Apple Pay tokens do not carry CVV; pass empty (matches forte/elavon pattern)
+                        card_cvv: Secret::new(String::new()),
+                        customer_id: Secret::new(customer_id),
+                    }))
+                }
+                _ => Err(IntegrationError::not_implemented(
+                    "Only Apple Pay wallet tokenization is supported for Stax".to_string(),
+                ))?,
+            },
             PaymentMethodData::BankDebit(_)
             | PaymentMethodData::CardRedirect(_)
-            | PaymentMethodData::Wallet(_)
             | PaymentMethodData::PayLater(_)
             | PaymentMethodData::BankRedirect(_)
             | PaymentMethodData::BankTransfer(_)
@@ -1091,7 +1184,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
                 Err(IntegrationError::not_implemented(
-                    "Only card and ACH bank debit tokenization are supported for Stax".to_string(),
+                    "Only card, ACH bank debit, and Apple Pay tokenization are supported for Stax".to_string(),
                 ))?
             }
         }


### PR DESCRIPTION
## Summary

Implement **ApplePay** wallet support for **stax** connector via Tokenize.

**Important:** stax is a tokenization-based connector — Apple Pay support lives in the **Tokenize** flow, not Authorize. The full end-to-end flow is:
`CustomerService/Create` → `PaymentMethodService/Tokenize` (Apple Pay decrypted data mapped to Stax card token) → `PaymentService/Authorize` (uses the returned `payment_method_id` as a token).

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- `stax/transformers.rs`: Added Apple Pay decrypted-passthrough handling in Tokenize — extracts DPAN, expiry (MMYY), and cardholder name from `WalletData::ApplePay.payment_data.decrypted_data`, mapped to `StaxCardTokenizeData` (PAN + MMYY expiry + full name; empty CVV since decrypted Apple Pay carries none).

## Files Modified

- `crates/integrations/connector-integration/src/connectors/stax/transformers.rs`

## gRPC Test Results

**Status: PASS (REAL_PASS — genuine Stax sandbox transaction)**

- `connector_customer_id`: `ce78ff1b-6d1e-46f3-a1ba-edf87194f239`
- `payment_method_id`: `ba3cde2f-e204-41cd-b228-bbf0f29736c9`
- `charge_id`: `4675ae57-f96f-408d-aff5-caddca828b0a`
- Status: `CHARGED` (USD 10.00, last_four 1111, `messages.transaction_succeeded` / "Successful purchase")

<details>
<summary>1. CustomerService/Create (credentials redacted)</summary>

```
grpcurl -plaintext \
  -H 'x-connector: stax' \
  -H 'x-auth: <REDACTED>' \
  -H 'x-api-key: <REDACTED>' \
  -d '{
    "merchant_customer_id": "cust_stax_ap_pr_001",
    "customer_name": "John Doe",
    "email": {"value": "john.doe@example.com"}
  }' \
  localhost:8000 types.CustomerService/Create

Response:
{
  "merchantCustomerId": "ce78ff1b-6d1e-46f3-a1ba-edf87194f239",
  "connectorCustomerId": "ce78ff1b-6d1e-46f3-a1ba-edf87194f239",
  "statusCode": 200
}
```
</details>

<details>
<summary>2. PaymentMethodService/Tokenize — Apple Pay decrypted (credentials redacted)</summary>

```
grpcurl -plaintext \
  -H 'x-connector: stax' \
  -H 'x-auth: <REDACTED>' \
  -H 'x-api-key: <REDACTED>' \
  -d '{
    "amount": {"minor_amount": 1000, "currency": "USD"},
    "payment_method": {
      "apple_pay": {
        "payment_data": {
          "decrypted_data": {
            "application_primary_account_number": {"value": "<REDACTED_DPAN>"},
            "application_expiration_month": {"value": "03"},
            "application_expiration_year": {"value": "2030"},
            "payment_data": {
              "online_payment_cryptogram": {"value": "<REDACTED_CRYPTOGRAM>"},
              "eci_indicator": "07"
            }
          }
        },
        "payment_method": {"display_name": "Visa 1111", "network": "visa", "type": "debit"},
        "transaction_identifier": "tx_ap_stax_pr_001"
      }
    },
    "customer": {
      "id": "ce78ff1b-6d1e-46f3-a1ba-edf87194f239",
      "name": "John Doe",
      "email": {"value": "john.doe@example.com"}
    },
    "address": {
      "billing_address": {
        "first_name": {"value": "John"}, "last_name": {"value": "Doe"},
        "line1": {"value": "1 Main St"}, "city": {"value": "San Francisco"},
        "state": {"value": "CA"}, "zip_code": {"value": "94105"},
        "country_alpha2_code": "US"
      }
    }
  }' \
  localhost:8000 types.PaymentMethodService/Tokenize

Response:
{
  "paymentMethodToken": "ba3cde2f-e204-41cd-b228-bbf0f29736c9",
  "merchantPaymentMethodId": "ba3cde2f-e204-41cd-b228-bbf0f29736c9",
  "statusCode": 200
}
```
</details>

<details>
<summary>3. PaymentService/Authorize — token (credentials redacted)</summary>

```
grpcurl -plaintext \
  -H 'x-connector: stax' \
  -H 'x-auth: <REDACTED>' \
  -H 'x-api-key: <REDACTED>' \
  -d '{
    "merchant_transaction_id": "stax_ap_pr_auth_001",
    "amount": {"minor_amount": 1000, "currency": "USD"},
    "payment_method": {
      "token": {"token": {"value": "ba3cde2f-e204-41cd-b228-bbf0f29736c9"}}
    },
    "address": {
      "billing_address": {
        "first_name": {"value": "John"}, "last_name": {"value": "Doe"},
        "line1": {"value": "1 Main St"}, "city": {"value": "San Francisco"},
        "state": {"value": "CA"}, "zip_code": {"value": "94105"},
        "country_alpha2_code": "US"
      }
    },
    "auth_type": "NO_THREE_DS"
  }' \
  localhost:8000 types.PaymentService/Authorize

Response:
{
  "connectorTransactionId": "4675ae57-f96f-408d-aff5-caddca828b0a",
  "status": "CHARGED",
  "statusCode": 200
}

Outbound to Stax (headers redacted):
  POST https://apiprod.fattlabs.com/charge
  Authorization: Bearer <REDACTED>
  body: {"total":10.0,"payment_method_id":"ba3cde2f-e204-41cd-b228-bbf0f29736c9","is_refundable":true,"pre_auth":false,"meta":{"tax":0},"idempotency_id":"stax_ap_pr_auth_001"}

Stax response: type=charge, success=true, is_voided=false, status=CHARGED,
  last_four=1111, gateway=test, message="Successful purchase".
```
</details>

## Validation Checklist

- [x] `cargo build --package connector-integration` passed with zero errors
- [x] `cargo clippy --package connector-integration -- -D warnings` clean for stax scope (pre-existing unrelated warnings in datatrans/hipay not touched)
- [x] `cargo +nightly fmt --all` applied; only stax fmt retained
- [x] grpcurl Authorize returned CHARGED (200)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified (`stax/transformers.rs`)
