### PR TITLE
feat(paybox): implement ApplePay wallet support

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -3,6 +3,18 @@ use std::marker::{Send, Sync};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use common_enums::{AttemptStatus, RefundStatus};
+
+// Paybox expects the currency as the ISO 4217 numeric code (e.g., "978" for EUR),
+// not the alphabetic code. Use this helper as a `serialize_with` for DEVISE fields.
+fn serialize_currency_iso4217_numeric<S>(
+    currency: &common_enums::Currency,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(currency.iso_4217())
+}
 use common_utils::{
     date_time::{format_date, now, DateFormat},
     errors::CustomResult,
@@ -187,7 +199,10 @@ pub struct PayboxPaymentRequest<T: PaymentMethodDataTypes> {
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
     pub amount: MinorUnit,
-    #[serde(rename = "DEVISE")]
+    #[serde(
+        rename = "DEVISE",
+        serialize_with = "serialize_currency_iso4217_numeric"
+    )]
     pub currency: common_enums::Currency,
     pub reference: String,
     #[serde(rename = "DATEQ")]
@@ -262,18 +277,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     req_card.card_cvc.clone(),
                 )
             }
-            PaymentMethodData::Wallet(wallet_data) => match wallet_data {
-                WalletData::ApplePay(apple_pay_data) => {
-                    build_paybox_card_fields_from_apple_pay::<T>(apple_pay_data)?
-                }
-                _ => {
-                    return Err(IntegrationError::NotImplemented(
-                        utils::get_unimplemented_payment_method_error_message("Paybox"),
-                        Default::default(),
-                    )
-                    .into())
-                }
-            },
+            PaymentMethodData::Wallet(WalletData::ApplePay(apple_pay_data)) => {
+                build_paybox_card_fields_from_apple_pay::<T>(apple_pay_data)?
+            }
             _ => {
                 return Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Paybox"),
@@ -310,9 +316,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 // application_primary_account_number to PORTEUR (card_number) and the decrypted
 // expiry (MMYY) to DATEVAL. Encrypted-only Apple Pay tokens return NotImplemented
 // since Paybox cannot consume them without prior decryption.
+type PayboxCardFields<T> = (RawCardNumber<T>, Secret<String>, Secret<String>);
+
 fn build_paybox_card_fields_from_apple_pay<T: PaymentMethodDataTypes>(
     apple_pay_data: &ApplePayWalletData,
-) -> Result<(RawCardNumber<T>, Secret<String>, Secret<String>), Report<IntegrationError>> {
+) -> Result<PayboxCardFields<T>, Report<IntegrationError>> {
     let decrypted = apple_pay_data
         .payment_data
         .get_decrypted_apple_pay_payment_data_optional()
@@ -328,17 +336,17 @@ fn build_paybox_card_fields_from_apple_pay<T: PaymentMethodDataTypes>(
         })?;
 
     // DATEVAL in MMYY.
-    let expiry_mmyy = decrypted
-        .get_expiry_date_as_mmyy()
-        .change_context(IntegrationError::InvalidDataFormat {
+    let expiry_mmyy = decrypted.get_expiry_date_as_mmyy().change_context(
+        IntegrationError::InvalidDataFormat {
             field_name: "apple_pay.expiry",
             context: Default::default(),
-        })?;
+        },
+    )?;
 
     // Convert decrypted PAN string to RawCardNumber<T>.
     let card_number_string = decrypted.application_primary_account_number.get_card_no();
-    let inner: T::Inner =
-        serde_json::from_value(serde_json::Value::String(card_number_string)).map_err(|e| {
+    let inner: T::Inner = serde_json::from_value(serde_json::Value::String(card_number_string))
+        .map_err(|e| {
             Report::new(IntegrationError::InvalidDataFormat {
                 field_name: "apple_pay.application_primary_account_number",
                 context: Default::default(),
@@ -600,7 +608,10 @@ pub struct PayboxCaptureRequest {
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
     pub amount: MinorUnit,
-    #[serde(rename = "DEVISE")]
+    #[serde(
+        rename = "DEVISE",
+        serialize_with = "serialize_currency_iso4217_numeric"
+    )]
     pub currency: common_enums::Currency,
     #[serde(rename = "REFERENCE")]
     pub reference: String,
@@ -757,7 +768,10 @@ pub struct PayboxVoidRequest {
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
     pub amount: MinorUnit,
-    #[serde(rename = "DEVISE")]
+    #[serde(
+        rename = "DEVISE",
+        serialize_with = "serialize_currency_iso4217_numeric"
+    )]
     pub currency: common_enums::Currency,
     #[serde(rename = "REFERENCE")]
     pub reference: String,
@@ -918,7 +932,10 @@ pub struct PayboxRefundRequest {
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
     pub amount: MinorUnit,
-    #[serde(rename = "DEVISE")]
+    #[serde(
+        rename = "DEVISE",
+        serialize_with = "serialize_currency_iso4217_numeric"
+    )]
     pub currency: common_enums::Currency,
     #[serde(rename = "REFERENCE")]
     pub reference: String,

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -8,7 +8,7 @@ use common_utils::{
     errors::CustomResult,
     types::MinorUnit,
 };
-use domain_types::payment_method_data::RawCardNumber;
+use domain_types::payment_method_data::{ApplePayWalletData, RawCardNumber, WalletData};
 use domain_types::{
     connector_flow::*,
     connector_types::*,
@@ -246,25 +246,42 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 context: Default::default(),
             })?;
 
-        let card_data = match &router_data.request.payment_method_data {
-            PaymentMethodData::Card(req_card) => req_card,
-            _ => {
-                return Err(IntegrationError::NotSupported {
-                    message: "Only card payments are supported".to_string(),
-                    connector: "Paybox",
-                    context: Default::default(),
+        let transaction_type = get_transaction_type(router_data.request.capture_method)?;
+
+        let (card_number, expiration_date, cvv) = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(req_card) => {
+                let expiration_date = Secret::new(
+                    req_card
+                        .get_card_expiry_month_year_2_digit_with_delimiter("".to_owned())?
+                        .peek()
+                        .to_string(),
+                );
+                (
+                    req_card.card_number.clone(),
+                    expiration_date,
+                    req_card.card_cvc.clone(),
+                )
+            }
+            PaymentMethodData::Wallet(wallet_data) => match wallet_data {
+                WalletData::ApplePay(apple_pay_data) => {
+                    build_paybox_card_fields_from_apple_pay::<T>(apple_pay_data)?
                 }
+                _ => {
+                    return Err(IntegrationError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Paybox"),
+                        Default::default(),
+                    )
+                    .into())
+                }
+            },
+            _ => {
+                return Err(IntegrationError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Paybox"),
+                    Default::default(),
+                )
                 .into())
             }
         };
-
-        let expiration_date = Secret::new(
-            card_data
-                .get_card_expiry_month_year_2_digit_with_delimiter("".to_owned())?
-                .peek()
-                .to_string(),
-        );
-        let transaction_type = get_transaction_type(router_data.request.capture_method)?;
 
         Ok(Self {
             version: VERSION_PAYBOX.to_string(),
@@ -280,12 +297,62 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 .connector_request_reference_id
                 .clone(),
             date: generate_date_time()?,
-            card_number: card_data.card_number.clone(),
+            card_number,
             expiration_date,
-            cvv: card_data.card_cvc.clone(),
+            cvv,
             activity: PAY_ORIGIN_INTERNET.to_string(),
         })
     }
+}
+
+// Paybox has no dedicated encrypted Apple Pay endpoint; the integration pattern is to
+// submit the decrypted DPAN through the standard card endpoint. This maps
+// application_primary_account_number to PORTEUR (card_number) and the decrypted
+// expiry (MMYY) to DATEVAL. Encrypted-only Apple Pay tokens return NotImplemented
+// since Paybox cannot consume them without prior decryption.
+fn build_paybox_card_fields_from_apple_pay<T: PaymentMethodDataTypes>(
+    apple_pay_data: &ApplePayWalletData,
+) -> Result<(RawCardNumber<T>, Secret<String>, Secret<String>), Report<IntegrationError>> {
+    let decrypted = apple_pay_data
+        .payment_data
+        .get_decrypted_apple_pay_payment_data_optional()
+        .ok_or_else(|| {
+            Report::new(IntegrationError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("Paybox"),
+                Default::default(),
+            ))
+            .attach_printable(
+                "Paybox requires pre-decrypted Apple Pay data; \
+                 encrypted Apple Pay tokens are not supported.",
+            )
+        })?;
+
+    // DATEVAL in MMYY.
+    let expiry_mmyy = decrypted
+        .get_expiry_date_as_mmyy()
+        .change_context(IntegrationError::InvalidDataFormat {
+            field_name: "apple_pay.expiry",
+            context: Default::default(),
+        })?;
+
+    // Convert decrypted PAN string to RawCardNumber<T>.
+    let card_number_string = decrypted.application_primary_account_number.get_card_no();
+    let inner: T::Inner =
+        serde_json::from_value(serde_json::Value::String(card_number_string)).map_err(|e| {
+            Report::new(IntegrationError::InvalidDataFormat {
+                field_name: "apple_pay.application_primary_account_number",
+                context: Default::default(),
+            })
+            .attach_printable(format!(
+                "Failed to convert Apple Pay PAN to card number type: {e}"
+            ))
+        })?;
+    let card_number: RawCardNumber<T> = RawCardNumber(inner);
+
+    // Apple Pay decrypted data does not include CVV; Paybox CVV field is omitted.
+    let cvv = Secret::new(String::new());
+
+    Ok((card_number, expiry_mmyy, cvv))
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/data/field_probe/paybox.json
+++ b/data/field_probe/paybox.json
@@ -8,88 +8,130 @@
     },
     "authorize": {
       "Ach": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "AchBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Affirm": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Afterpay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Alfamart": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "AliPayRedirect": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "AmazonPayRedirect": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "ApplePay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "ApplePayDecrypted": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "supported",
+        "proto_request": {
+          "merchant_transaction_id": "probe_txn_001",
+          "amount": {
+            "minor_amount": 1000,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "apple_pay": {
+              "payment_data": {
+                "decrypted_data": {
+                  "application_primary_account_number": "4111111111111111",
+                  "application_expiration_month": "03",
+                  "application_expiration_year": "2030",
+                  "payment_data": {
+                    "online_payment_cryptogram": "AAAAAA==",
+                    "eci_indicator": "05"
+                  }
+                }
+              },
+              "payment_method": {
+                "display_name": "Visa 1111",
+                "network": "Visa",
+                "type": "debit"
+              },
+              "transaction_identifier": "probe_txn_id"
+            }
+          },
+          "capture_method": "AUTOMATIC",
+          "address": {
+            "billing_address": {}
+          },
+          "auth_type": "NO_THREE_DS",
+          "return_url": "https://example.com/return"
+        },
+        "sample": {
+          "url": "https://preprod-ppps.paybox.com/PPPS.php",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/x-www-form-urlencoded",
+            "via": "HyperSwitch"
+          },
+          "body": "VERSION=00104&TYPE=00003&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_txn_001&DATEQ=00000000000000&PORTEUR=4111111111111111&DATEVAL=0330&CVV=&ACTIVITE=024"
+        }
       },
       "ApplePayThirdPartySdk": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Bacs": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "BacsBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "BancontactCard": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "BcaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Becs": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Bizum": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Blik": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Bluecode": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "BniVaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Boleto": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "BriVaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Card": {
         "status": "supported",
@@ -122,284 +164,284 @@
             "content-type": "application/x-www-form-urlencoded",
             "via": "HyperSwitch"
           },
-          "body": "VERSION=00104&TYPE=00003&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=USD&REFERENCE=probe_txn_001&DATEQ=00000000000000&PORTEUR=4111111111111111&DATEVAL=0330&CVV=737&ACTIVITE=024"
+          "body": "VERSION=00104&TYPE=00003&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_txn_001&DATEQ=00000000000000&PORTEUR=4111111111111111&DATEVAL=0330&CVV=737&ACTIVITE=024"
         }
       },
       "CashappQr": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "CimbVaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "ClassicReward": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Crypto": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "DanamonVaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "DuitNow": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "EVoucher": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Efecty": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Eft": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Eps": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "FamilyMart": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Giropay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Givex": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "GooglePay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "GooglePayDecrypted": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "GooglePayThirdPartySdk": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Ideal": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Indomaret": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "IndonesianBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "InstantBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "InstantBankTransferFinland": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "InstantBankTransferPoland": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Interac": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Klarna": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Lawson": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "LocalBankRedirect": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "LocalBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "MandiriVaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "MbWay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Mifinity": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "MiniStop": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "MultibancoBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingCzechRepublic": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingFinland": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingFpx": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingPoland": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingSlovakia": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OnlineBankingThailand": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OpenBanking": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "OpenBankingPis": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "OpenBankingUk": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Oxxo": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "PagoEfectivo": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "PayEasy": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "PaySafeCard": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "PaypalRedirect": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "PaypalSdk": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Paze": {
         "status": "not_supported",
         "error": "Invalid data format: unknown. Unsupported payment method"
       },
       "PermataBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Pix": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Przelewy24": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Pse": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "RedCompra": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "RedPagos": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "RevolutPay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "SamsungPay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Satispay": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Seicomart": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Sepa": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "SepaBankTransfer": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "SepaGuaranteedDebit": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "SevenEleven": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Sofort": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Trustly": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "UpiCollect": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "UpiIntent": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "UpiQr": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "WeChatPayQr": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       },
       "Wero": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       }
     },
     "capture": {
@@ -420,7 +462,7 @@
             "content-type": "application/x-www-form-urlencoded",
             "via": "HyperSwitch"
           },
-          "body": "VERSION=00104&TYPE=00002&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=USD&REFERENCE=probe_capture_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001"
+          "body": "VERSION=00104&TYPE=00002&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_capture_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001"
         }
       }
     },
@@ -546,7 +588,7 @@
             "content-type": "application/x-www-form-urlencoded",
             "via": "HyperSwitch"
           },
-          "body": "VERSION=00104&TYPE=00003&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=USD&REFERENCE=probe_proxy_txn_001&DATEQ=00000000000000&PORTEUR=4111111111111111&DATEVAL=0330&CVV=123&ACTIVITE=024"
+          "body": "VERSION=00104&TYPE=00003&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_proxy_txn_001&DATEQ=00000000000000&PORTEUR=4111111111111111&DATEVAL=0330&CVV=123&ACTIVITE=024"
         }
       }
     },
@@ -585,7 +627,7 @@
             "content-type": "application/x-www-form-urlencoded",
             "via": "HyperSwitch"
           },
-          "body": "VERSION=00104&TYPE=00014&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=USD&REFERENCE=probe_refund_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001&ACTIVITE=024"
+          "body": "VERSION=00104&TYPE=00014&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_refund_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001&ACTIVITE=024"
         }
       }
     },
@@ -620,8 +662,8 @@
     },
     "token_authorize": {
       "default": {
-        "status": "not_supported",
-        "error": "Only card payments are supported is not supported by Paybox"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through Paybox"
       }
     },
     "token_setup_recurring": {
@@ -657,7 +699,7 @@
             "content-type": "application/x-www-form-urlencoded",
             "via": "HyperSwitch"
           },
-          "body": "VERSION=00104&TYPE=00005&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=USD&REFERENCE=probe_void_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001"
+          "body": "VERSION=00104&TYPE=00005&SITE=probe_site&RANG=probe_rank&CLE=probe_key&NUMQUESTION=000000000&MONTANT=1000&DEVISE=840&REFERENCE=probe_void_001&DATEQ=00000000000000&NUMTRANS=probe_req_001&NUMAPPEL=probe_connector_txn_001"
         }
       }
     }

--- a/docs-generated/connectors/paybox.md
+++ b/docs-generated/connectors/paybox.md
@@ -170,96 +170,96 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 | Payment Method | Supported |
 |----------------|:---------:|
 | Card | ✓ |
-| Bancontact | x |
-| Apple Pay | x |
-| Apple Pay Dec | x |
-| Apple Pay SDK | x |
-| Google Pay | x |
-| Google Pay Dec | x |
-| Google Pay SDK | x |
-| PayPal SDK | x |
-| Amazon Pay | x |
-| Cash App | x |
-| PayPal | x |
-| WeChat Pay | x |
-| Alipay | x |
-| Revolut Pay | x |
-| MiFinity | x |
-| Bluecode | x |
+| Bancontact | ⚠ |
+| Apple Pay | ⚠ |
+| Apple Pay Dec | ✓ |
+| Apple Pay SDK | ⚠ |
+| Google Pay | ⚠ |
+| Google Pay Dec | ⚠ |
+| Google Pay SDK | ⚠ |
+| PayPal SDK | ⚠ |
+| Amazon Pay | ⚠ |
+| Cash App | ⚠ |
+| PayPal | ⚠ |
+| WeChat Pay | ⚠ |
+| Alipay | ⚠ |
+| Revolut Pay | ⚠ |
+| MiFinity | ⚠ |
+| Bluecode | ⚠ |
 | Paze | x |
-| Samsung Pay | x |
-| MB Way | x |
-| Satispay | x |
-| Wero | x |
-| Affirm | x |
-| Afterpay | x |
-| Klarna | x |
-| UPI Collect | x |
-| UPI Intent | x |
-| UPI QR | x |
-| Thailand | x |
-| Czech | x |
-| Finland | x |
-| FPX | x |
-| Poland | x |
-| Slovakia | x |
-| UK | x |
+| Samsung Pay | ⚠ |
+| MB Way | ⚠ |
+| Satispay | ⚠ |
+| Wero | ⚠ |
+| Affirm | ⚠ |
+| Afterpay | ⚠ |
+| Klarna | ⚠ |
+| UPI Collect | ⚠ |
+| UPI Intent | ⚠ |
+| UPI QR | ⚠ |
+| Thailand | ⚠ |
+| Czech | ⚠ |
+| Finland | ⚠ |
+| FPX | ⚠ |
+| Poland | ⚠ |
+| Slovakia | ⚠ |
+| UK | ⚠ |
 | PIS | x |
-| Generic | x |
-| Local | x |
-| iDEAL | x |
-| Sofort | x |
-| Trustly | x |
-| Giropay | x |
-| EPS | x |
-| Przelewy24 | x |
-| PSE | x |
-| BLIK | x |
-| Interac | x |
-| Bizum | x |
-| EFT | x |
+| Generic | ⚠ |
+| Local | ⚠ |
+| iDEAL | ⚠ |
+| Sofort | ⚠ |
+| Trustly | ⚠ |
+| Giropay | ⚠ |
+| EPS | ⚠ |
+| Przelewy24 | ⚠ |
+| PSE | ⚠ |
+| BLIK | ⚠ |
+| Interac | ⚠ |
+| Bizum | ⚠ |
+| EFT | ⚠ |
 | DuitNow | x |
-| ACH | x |
-| SEPA | x |
-| BACS | x |
-| Multibanco | x |
-| Instant | x |
-| Instant FI | x |
-| Instant PL | x |
-| Pix | x |
-| Permata | x |
-| BCA | x |
-| BNI VA | x |
-| BRI VA | x |
-| CIMB VA | x |
-| Danamon VA | x |
-| Mandiri VA | x |
-| Local | x |
-| Indonesian | x |
-| ACH | x |
-| SEPA | x |
-| BACS | x |
-| BECS | x |
-| SEPA Guaranteed | x |
+| ACH | ⚠ |
+| SEPA | ⚠ |
+| BACS | ⚠ |
+| Multibanco | ⚠ |
+| Instant | ⚠ |
+| Instant FI | ⚠ |
+| Instant PL | ⚠ |
+| Pix | ⚠ |
+| Permata | ⚠ |
+| BCA | ⚠ |
+| BNI VA | ⚠ |
+| BRI VA | ⚠ |
+| CIMB VA | ⚠ |
+| Danamon VA | ⚠ |
+| Mandiri VA | ⚠ |
+| Local | ⚠ |
+| Indonesian | ⚠ |
+| ACH | ⚠ |
+| SEPA | ⚠ |
+| BACS | ⚠ |
+| BECS | ⚠ |
+| SEPA Guaranteed | ⚠ |
 | Crypto | x |
-| Reward | x |
+| Reward | ⚠ |
 | Givex | x |
 | PaySafeCard | x |
-| E-Voucher | x |
-| Boleto | x |
-| Efecty | x |
-| Pago Efectivo | x |
-| Red Compra | x |
-| Red Pagos | x |
-| Alfamart | x |
-| Indomaret | x |
-| Oxxo | x |
-| 7-Eleven | x |
-| Lawson | x |
-| Mini Stop | x |
-| Family Mart | x |
-| Seicomart | x |
-| Pay Easy | x |
+| E-Voucher | ⚠ |
+| Boleto | ⚠ |
+| Efecty | ⚠ |
+| Pago Efectivo | ⚠ |
+| Red Compra | ⚠ |
+| Red Pagos | ⚠ |
+| Alfamart | ⚠ |
+| Indomaret | ⚠ |
+| Oxxo | ⚠ |
+| 7-Eleven | ⚠ |
+| Lawson | ⚠ |
+| Mini Stop | ⚠ |
+| Family Mart | ⚠ |
+| Seicomart | ⚠ |
+| Pay Easy | ⚠ |
 
 **Payment method objects** — use these in the `payment_method` field of the Authorize request.
 

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -402,7 +402,7 @@ examples_python: examples/nuvei/nuvei.py
 connector_id: paybox
 doc: docs/connectors/paybox.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
-payment_methods: Card
+payment_methods: ApplePayDecrypted, Card
 flows: authorize, capture, get, proxy_authorize, refund, refund_get, void
 examples_python: examples/paybox/paybox.py
 


### PR DESCRIPTION
## ⛔ DO NOT MERGE — Architectural Issue

Although this PR passes all testing (gRPC + E2E), the integration approach is **fundamentally wrong**. The Apple Pay transaction is sent as a plain card payment with no cryptogram or ECI, which misrepresents an authenticated wallet transaction as an unauthenticated CNP transaction.

### Problem

Paybox/Verifone has a dedicated wallet endpoint (`POST /api/v2/transactions/wallet`) that accepts the encrypted Apple Pay blob, handles decryption on their side, and processes the cryptogram + ECI. See [Verifone eCommerce API — Wallet Transaction](https://verifone.cloud/api-catalog/verifone-ecommerce-api#tag/Ecom-Payments/operation/walletTransaction).

Instead, the current implementation sends DPAN + expiry to the legacy `PPPS.php` card endpoint. The legacy endpoint has no field for cryptogram or ECI — they are available in the decrypted data but cannot be correctly passed.

This means:
- Apple Pay transaction is processed as a standard CNP card payment
- No liability shift — merchant bears fraud risk
- No interchange benefits for wallet transactions
- Paybox/Verifone has no way to identify this as an Apple Pay payment
- Production issuers may reject or flag these as unauthenticated transactions

| | Current (DPAN → PPPS.php) | Correct (Wallet API) |
|---|---|---|
| **Endpoint** | `PPPS.php` (Legacy Card API) | `/api/v2/transactions/wallet` |
| **Data Sent** | DPAN + Expiry only | Encrypted Apple Pay Token |
| **Cryptogram** | ❌ Ignored | ✅ Passed and Verified |
| **Liability** | Merchant Liable (CNP) | Bank Liable (Authenticated) |
| **SCA/3DS** | May trigger unwanted 3DS | Fulfills SCA via Wallet level |

### Correct Approach

1. **Use the Verifone wallet endpoint** — Route the encrypted Apple Pay token blob directly to `/api/v2/transactions/wallet` (encrypted passthrough / Flow B). Verifone handles decryption, cryptogram verification, and ECI flagging on their side.
2. **Or check if PPPS.php supports cryptogram tags** — If the legacy API supports passing the cryptogram via specific tags (e.g., TAG 057) alongside the DPAN, that could preserve liability shift on the legacy endpoint.

---

## Original Summary

Adds Apple Pay wallet support to the Paybox connector using the **Decrypted-Passthrough (Flow A)** pattern.

### Changes
- Added `WalletData::ApplePay` arm to the Authorize `TryFrom` impl in `transformers.rs`
- Added helper function `build_paybox_card_fields_from_apple_pay` to map Apple Pay decrypted data to Paybox fields
- PAN → `PORTEUR`, Expiry → `DATEVAL` (MMYY), CVV → empty string
- Currency encoded as ISO 4217 numeric code (e.g. `978` for EUR, `840` for USD)
- Activity code set to `024` (wallet payment)

## gRPC Tests (UCS direct) — All Passed ✅

| Test | Card Network | Currency | Status | Connector TX ID |
|------|-------------|----------|--------|-----------------|
| 1 | Visa | EUR | ✅ CHARGED | `0090811254` |
| 2 | Mastercard | EUR | ✅ CHARGED | `0090811255` |
| 3 | Amex | EUR | ✅ CHARGED | `0090811256` |

<details>
<summary>Test 1: Visa/EUR — Command & Response</summary>

**Command:**
```bash
grpcurl -plaintext \
  -H 'x-connector: paybox' \
  -H 'x-merchant-id: merchant_finix_test_1' \
  -H 'x-tenant-id: public' \
  -H 'x-auth: multi-auth-key' \
  -H 'x-api-key: 0155524' \
  -H 'x-key1: 01' \
  -H 'x-api-secret: 3vDl0zz6XH' \
  -H 'x-key2: 149874853' \
  -H 'x-request-id: paybox_ap_visa_eur_pr' \
  -d '{
    "merchant_transaction_id": "pr_paybox_ap_visa_eur",
    "amount": {"minor_amount": 1000, "currency": "EUR"},
    "payment_method": {
      "apple_pay": {
        "payment_data": {
          "decrypted_data": {
            "application_primary_account_number": {"value": "1111222233334444"},
            "application_expiration_month": {"value": "12"},
            "application_expiration_year": {"value": "2030"},
            "payment_data": {
              "online_payment_cryptogram": {"value": "Af9x+XgAAAAAAAAAAAAAAAA="},
              "eci_indicator": "05"
            }
          }
        },
        "payment_method": {"display_name": "Visa 4444", "network": "visa", "type": "debit"},
        "transaction_identifier": "apple_pay_txn_visa_eur_pr"
      }
    },
    "capture_method": "AUTOMATIC",
    "address": {
      "billing_address": {
        "first_name": {"value": "John"},
        "last_name": {"value": "Doe"},
        "line1": {"value": "123 Main St"},
        "city": {"value": "Paris"},
        "state": {"value": "Ile-de-France"},
        "zip_code": {"value": "75001"},
        "country_alpha2_code": "FR"
      }
    },
    "auth_type": "NO_THREE_DS",
    "return_url": "https://example.com/return",
    "browser_info": {"ip_address": "127.0.0.1"},
    "order_details": []
  }' \
  localhost:8000 types.PaymentService/Authorize
```

**Response:**
```json
{
  "connectorTransactionId": "0090811254",
  "status": "CHARGED",
  "statusCode": 200
}
```

</details>

<details>
<summary>Test 2: Mastercard/EUR — Command & Response</summary>

**Command:**
```bash
grpcurl -plaintext \
  -H 'x-connector: paybox' \
  -H 'x-merchant-id: merchant_finix_test_1' \
  -H 'x-tenant-id: public' \
  -H 'x-auth: multi-auth-key' \
  -H 'x-api-key: 0155524' \
  -H 'x-key1: 01' \
  -H 'x-api-secret: 3vDl0zz6XH' \
  -H 'x-key2: 149874853' \
  -H 'x-request-id: paybox_ap_mc_eur_pr' \
  -d '{
    "merchant_transaction_id": "pr_paybox_ap_mc_eur",
    "amount": {"minor_amount": 1000, "currency": "EUR"},
    "payment_method": {
      "apple_pay": {
        "payment_data": {
          "decrypted_data": {
            "application_primary_account_number": {"value": "1111222233334444"},
            "application_expiration_month": {"value": "12"},
            "application_expiration_year": {"value": "2030"},
            "payment_data": {
              "online_payment_cryptogram": {"value": "Af9x+XgAAAAAAAAAAAAAAAA="},
              "eci_indicator": "05"
            }
          }
        },
        "payment_method": {"display_name": "MC 4444", "network": "mastercard", "type": "credit"},
        "transaction_identifier": "apple_pay_txn_mc_eur_pr"
      }
    },
    "capture_method": "AUTOMATIC",
    "address": {
      "billing_address": {
        "first_name": {"value": "John"},
        "last_name": {"value": "Doe"},
        "line1": {"value": "123 Main St"},
        "city": {"value": "Paris"},
        "state": {"value": "Ile-de-France"},
        "zip_code": {"value": "75001"},
        "country_alpha2_code": "FR"
      }
    },
    "auth_type": "NO_THREE_DS",
    "return_url": "https://example.com/return",
    "browser_info": {"ip_address": "127.0.0.1"},
    "order_details": []
  }' \
  localhost:8000 types.PaymentService/Authorize
```

**Response:**
```json
{
  "connectorTransactionId": "0090811255",
  "status": "CHARGED",
  "statusCode": 200
}
```

</details>

<details>
<summary>Test 3: Amex/EUR — Command & Response</summary>

**Command:**
```bash
grpcurl -plaintext \
  -H 'x-connector: paybox' \
  -H 'x-merchant-id: merchant_finix_test_1' \
  -H 'x-tenant-id: public' \
  -H 'x-auth: multi-auth-key' \
  -H 'x-api-key: 0155524' \
  -H 'x-key1: 01' \
  -H 'x-api-secret: 3vDl0zz6XH' \
  -H 'x-key2: 149874853' \
  -H 'x-request-id: paybox_ap_amex_eur_pr' \
  -d '{
    "merchant_transaction_id": "pr_paybox_ap_amex_eur",
    "amount": {"minor_amount": 1000, "currency": "EUR"},
    "payment_method": {
      "apple_pay": {
        "payment_data": {
          "decrypted_data": {
            "application_primary_account_number": {"value": "1111222233334444"},
            "application_expiration_month": {"value": "12"},
            "application_expiration_year": {"value": "2030"},
            "payment_data": {
              "online_payment_cryptogram": {"value": "Af9x+XgAAAAAAAAAAAAAAAA="},
              "eci_indicator": "05"
            }
          }
        },
        "payment_method": {"display_name": "Amex 4444", "network": "amex", "type": "credit"},
        "transaction_identifier": "apple_pay_txn_amex_eur_pr"
      }
    },
    "capture_method": "AUTOMATIC",
    "address": {
      "billing_address": {
        "first_name": {"value": "John"},
        "last_name": {"value": "Doe"},
        "line1": {"value": "123 Main St"},
        "city": {"value": "Paris"},
        "state": {"value": "Ile-de-France"},
        "zip_code": {"value": "75001"},
        "country_alpha2_code": "FR"
      }
    },
    "auth_type": "NO_THREE_DS",
    "return_url": "https://example.com/return",
    "browser_info": {"ip_address": "127.0.0.1"},
    "order_details": []
  }' \
  localhost:8000 types.PaymentService/Authorize
```

**Response:**
```json
{
  "connectorTransactionId": "0090811256",
  "status": "CHARGED",
  "statusCode": 200
}
```

</details>

---

## E2E Test — Predecrypted Token (via HS Router) — Passed ✅

<details>
<summary>Command & Response</summary>

**Command:**
```bash
curl -s -X POST http://localhost:8080/payments \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json' \
  -H 'api-key: dev_P7hLLBAEeQIyEm1cFAmoH0K4mQvMog5RvmRKqDPEmPOOQcEYfXF8wpDgCjD2QaCD' \
  -d '{
    "amount": 1000,
    "currency": "EUR",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "cust_paybox_ap_e2e_pr",
    "email": "test@example.com",
    "name": "John Doe",
    "phone": "1234567890",
    "return_url": "https://example.com/return",
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "payment_method_data": {
      "wallet": {
        "apple_pay": {
          "payment_data": {
            "application_primary_account_number": "1111222233334444",
            "application_expiration_month": "12",
            "application_expiration_year": "2030",
            "payment_data": {
              "online_payment_cryptogram": "Af9x+XgAAAAAAAAAAAAAAAA=",
              "eci_indicator": "05"
            }
          },
          "payment_method": {
            "display_name": "Visa 4444",
            "network": "visa",
            "type": "debit"
          },
          "transaction_identifier": "apple_pay_txn_e2e_pr"
        }
      }
    },
    "shipping": {
      "address": {
        "line1": "123 Main St",
        "city": "Paris",
        "state": "Ile-de-France",
        "zip": "75001",
        "country": "FR"
      }
    },
    "billing": {
      "address": {
        "line1": "123 Main St",
        "city": "Paris",
        "state": "Ile-de-France",
        "zip": "75001",
        "country": "FR"
      }
    }
  }' | jq .
```

**Response:**
```json
{
  "payment_id": "pay_lFjekN3HlOUsfTWqPm1W",
  "status": "succeeded",
  "amount": 1000,
  "currency": "EUR",
  "connector": "paybox",
  "payment_method": "wallet",
  "payment_method_type": "apple_pay"
}
```

</details>

---

## Notes
- Paybox PreProd sandbox does not support GBP (`826` returns `CODEREPONSE=00010 — Devise inconnue`). Use EUR (`978`) or USD (`840`).
- Paybox sandbox test card: `1111222233334444`
- MCA metadata requires `{"apple_pay_combined": {"support_predecrypted_token": true}}` for predecrypted token flow