### PR TITLE
feat(connector): implement SetupRecurring for NMI

### DIFF
--- a/connectors.json
+++ b/connectors.json
@@ -1,0 +1,1 @@
+["nuvei", "paypal", "braintree", "nmi", "trustpay", "finix", "bluesnap", "redsys", "noon", "worldpay"]

--- a/crates/integrations/connector-integration/src/connectors/nmi.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi.rs
@@ -39,8 +39,9 @@ use interfaces::{
 };
 use serde::Serialize;
 use transformers::{
-    NmiCaptureRequest, NmiPaymentsRequest, NmiRefundRequest, NmiRefundSyncRequest, NmiSyncRequest,
-    NmiVaultRequest, NmiVaultResponse, NmiVoidRequest, StandardResponse, SyncResponse,
+    NmiCaptureRequest, NmiPaymentsRequest, NmiRefundRequest, NmiRefundSyncRequest,
+    NmiSetupMandateRequest, NmiSetupMandateResponse, NmiSyncRequest, NmiVaultRequest,
+    NmiVaultResponse, NmiVoidRequest, StandardResponse, SyncResponse,
 };
 
 // Type aliases to avoid duplicate templating in macros
@@ -246,6 +247,12 @@ macros::create_all_prerequisites!(
             request_body: NmiVaultRequest<T>,
             response_body: NmiPreAuthenticateResponse,
             router_data: RouterDataV2<PreAuthenticate, PaymentFlowData, PaymentsPreAuthenticateData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: NmiSetupMandateRequest<T>,
+            response_body: NmiSetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -598,22 +605,45 @@ macros::macro_connector_implementation!(
     }
 );
 
+// SetupMandate (SetupRecurring) - adds payment method to Customer Vault
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Nmi,
+    curl_request: FormUrlEncoded(NmiSetupMandateRequest),
+    curl_response: NmiSetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    preprocess_response: true,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            _req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            Ok(vec![(
+                headers::CONTENT_TYPE.to_string(),
+                "application/x-www-form-urlencoded".to_string().into(),
+            )])
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!("{}{}", self.connector_base_url_payments(req), endpoints::TRANSACT))
+        }
+    }
+);
+
 // ===== EMPTY CONNECTOR INTEGRATIONS =====
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<
         VoidPC,
         PaymentFlowData,
         PaymentsCancelPostCaptureData,
-        PaymentsResponseData,
-    > for Nmi<T>
-{
-}
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
         PaymentsResponseData,
     > for Nmi<T>
 {

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -2,7 +2,9 @@ use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector};
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, SetupMandate, Void},
+    connector_flow::{
+        Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, SetupMandate, Void,
+    },
     connector_types::{
         MandateReference, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
         PaymentsCaptureData, PaymentsPreAuthenticateData, PaymentsResponseData, PaymentsSyncData,
@@ -1629,7 +1631,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let payment_method = match &router_data.request.payment_method_data {
             PaymentMethodData::Card(card_data) => {
-                let ccexp = card_data.get_card_expiry_month_year_2_digit_with_delimiter("".to_string())?;
+                let ccexp =
+                    card_data.get_card_expiry_month_year_2_digit_with_delimiter("".to_string())?;
                 NmiSetupMandatePaymentMethod::Card(NmiSetupMandateCard {
                     ccnumber: card_data.card_number.clone(),
                     ccexp,
@@ -1776,9 +1779,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 // Unknown response - treat as pending
                 AttemptStatus::Pending,
                 Ok(PaymentsResponseData::TransactionResponse {
-                    resource_id: ResponseId::ConnectorTransactionId(
-                        response.transactionid.clone(),
-                    ),
+                    resource_id: ResponseId::ConnectorTransactionId(response.transactionid.clone()),
                     redirection_data: None,
                     mandate_reference: None,
                     connector_metadata: None,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -2,11 +2,12 @@ use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector};
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, Void},
+    connector_flow::{Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, SetupMandate, Void},
     connector_types::{
         MandateReference, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
         PaymentsCaptureData, PaymentsPreAuthenticateData, PaymentsResponseData, PaymentsSyncData,
         RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, ResponseId,
+        SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{
@@ -1518,6 +1519,273 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NmiVaultResponse, Sel
                     network_decline_code: None,
                     network_advice_code: None,
                     network_error_message: None,
+                }),
+            ),
+        };
+
+        Ok(Self {
+            response: payment_response,
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
+
+// ===== SETUP MANDATE (SetupRecurring) =====
+
+/// NMI SetupMandate request - adds payment method to Customer Vault for recurring payments
+#[derive(Debug, Serialize)]
+pub struct NmiSetupMandateRequest<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+> {
+    security_key: Secret<String>,
+    customer_vault: CustomerAction,
+    #[serde(flatten)]
+    payment_method: NmiSetupMandatePaymentMethod<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email: Option<common_utils::pii::Email>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address1: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address2: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    city: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    zip: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    country: Option<common_enums::CountryAlpha2>,
+}
+
+/// Payment method for SetupMandate - supports Card and ACH
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum NmiSetupMandatePaymentMethod<T: PaymentMethodDataTypes> {
+    Card(NmiSetupMandateCard<T>),
+    Ach(NmiSetupMandateAch),
+}
+
+/// Card payment method for SetupMandate
+#[derive(Debug, Serialize)]
+pub struct NmiSetupMandateCard<T: PaymentMethodDataTypes> {
+    ccnumber: RawCardNumber<T>,
+    ccexp: Secret<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cvv: Option<Secret<String>>,
+}
+
+/// ACH payment method for SetupMandate
+#[derive(Debug, Serialize)]
+pub struct NmiSetupMandateAch {
+    payment: &'static str,
+    checkname: Secret<String>,
+    checkaba: Secret<String>,
+    checkaccount: Secret<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_holder_type: Option<common_enums::BankHolderType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_type: Option<common_enums::BankType>,
+}
+
+/// NMI SetupMandate response - same as StandardResponse, includes customer_vault_id
+pub type NmiSetupMandateResponse = StandardResponse;
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        super::NmiRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for NmiSetupMandateRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: super::NmiRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+        let auth = NmiAuthType::try_from(&router_data.connector_config)?;
+
+        let payment_method = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(card_data) => {
+                let ccexp = card_data.get_card_expiry_month_year_2_digit_with_delimiter("".to_string())?;
+                NmiSetupMandatePaymentMethod::Card(NmiSetupMandateCard {
+                    ccnumber: card_data.card_number.clone(),
+                    ccexp,
+                    cvv: Some(card_data.card_cvc.clone()),
+                })
+            }
+            PaymentMethodData::BankDebit(BankDebitData::AchBankDebit {
+                account_number,
+                routing_number,
+                bank_account_holder_name,
+                bank_type,
+                bank_holder_type,
+                ..
+            }) => {
+                let checkname = bank_account_holder_name.clone().ok_or_else(|| {
+                    IntegrationError::MissingRequiredField {
+                        field_name: "bank_account_holder_name",
+                        context: Default::default(),
+                    }
+                })?;
+                NmiSetupMandatePaymentMethod::Ach(NmiSetupMandateAch {
+                    payment: ACH_PAYMENT_TYPE,
+                    checkname,
+                    checkaba: routing_number.clone(),
+                    checkaccount: account_number.clone(),
+                    account_holder_type: *bank_holder_type,
+                    account_type: *bank_type,
+                })
+            }
+            _ => {
+                return Err(IntegrationError::NotImplemented(
+                    get_unimplemented_payment_method_error_message("NMI SetupMandate"),
+                    Default::default(),
+                )
+                .into())
+            }
+        };
+
+        let billing_address = router_data
+            .resource_common_data
+            .get_optional_billing()
+            .and_then(|b| b.address.as_ref());
+
+        Ok(Self {
+            security_key: auth.api_key,
+            customer_vault: CustomerAction::AddCustomer,
+            payment_method,
+            first_name: billing_address.and_then(|a| a.first_name.clone()),
+            last_name: billing_address.and_then(|a| a.last_name.clone()),
+            email: router_data.request.email.clone(),
+            address1: billing_address.and_then(|a| a.line1.clone()),
+            address2: billing_address.and_then(|a| a.line2.clone()),
+            city: billing_address.and_then(|a| a.city.clone()),
+            state: billing_address.and_then(|a| a.state.clone()),
+            zip: billing_address.and_then(|a| a.zip.clone()),
+            country: billing_address.and_then(|a| a.country),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ResponseRouterData<
+            NmiSetupMandateResponse,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+        >,
+    >
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<
+            NmiSetupMandateResponse,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let response = &item.response;
+
+        // NMI response codes: "1" = Approved, "2" = Declined, "3" = Error
+        let (status, payment_response) = match response.response.as_str() {
+            "1" => {
+                // Approved - Extract customer_vault_id as the mandate reference
+                let connector_mandate_id = response
+                    .customer_vault_id
+                    .as_ref()
+                    .map(|id| id.clone().expose());
+
+                let mandate_reference = connector_mandate_id.clone().map(|id| {
+                    Box::new(MandateReference {
+                        connector_mandate_id: Some(id),
+                        payment_method_id: None,
+                        connector_mandate_request_reference_id: None,
+                    })
+                });
+
+                (
+                    AttemptStatus::Charged, // Mandate setup successful
+                    Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: ResponseId::ConnectorTransactionId(
+                            response.transactionid.clone(),
+                        ),
+                        redirection_data: None,
+                        mandate_reference,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id: Some(response.transactionid.clone()),
+                        incremental_authorization_allowed: None,
+                        status_code: item.http_code,
+                    }),
+                )
+            }
+            "2" | "3" => (
+                // Declined or Error
+                AttemptStatus::Failure,
+                Err(domain_types::router_data::ErrorResponse {
+                    code: response.response_code.clone(),
+                    message: response.responsetext.clone(),
+                    reason: Some(response.responsetext.clone()),
+                    status_code: item.http_code,
+                    attempt_status: Some(AttemptStatus::Failure),
+                    connector_transaction_id: Some(response.transactionid.clone()),
+                    network_decline_code: None,
+                    network_advice_code: None,
+                    network_error_message: None,
+                }),
+            ),
+            _ => (
+                // Unknown response - treat as pending
+                AttemptStatus::Pending,
+                Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transactionid.clone(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: Some(response.transactionid.clone()),
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
                 }),
             ),
         };

--- a/crates/integrations/connector-integration/src/connectors/trustpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay.rs
@@ -55,7 +55,7 @@ use transformers::{
     TrustpayAuthUpdateRequest, TrustpayAuthUpdateResponse, TrustpayCreateIntentRequest,
     TrustpayCreateIntentResponse, TrustpayErrorResponse, TrustpayPaymentsRequest,
     TrustpayPaymentsResponse as TrustpayPaymentsSyncResponse, TrustpayPaymentsResponse,
-    TrustpayRefundRequest,
+    TrustpayRefundRequest, TrustpaySetupMandateRequest, TrustpaySetupMandateResponse,
 };
 
 use super::macros::{self, ContentTypeSelector};
@@ -489,6 +489,12 @@ macros::create_all_prerequisites!(
             flow: RSync,
             response_body: RefundSyncResponse,
             router_data: RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: TrustpaySetupMandateRequest<T>,
+            response_body: TrustpaySetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -1037,6 +1043,40 @@ macros::macro_connector_implementation!(
     }
 );
 
+// SetupMandate (SetupRecurring) - stores card credentials for recurring payments
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Trustpay,
+    curl_request: FormUrlEncoded(TrustpaySetupMandateRequest<T>),
+    curl_response: TrustpaySetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers_for_payments(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            // TrustPay uses the same card API endpoint for mandate setup (zero-auth validation)
+            Ok(format!(
+                "{}{}",
+                self.connector_base_url_payments(req),
+                "api/v1/purchase"
+            ))
+        }
+    }
+);
+
 // Implementation for empty stubs - these will need to be properly implemented later
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -1070,15 +1110,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentFlowData,
         ServerSessionAuthenticationTokenRequestData,
         ServerSessionAuthenticationTokenResponseData,
-    > for Trustpay<T>
-{
-}
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
     > for Trustpay<T>
 {
 }

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -20,11 +20,11 @@ use domain_types::{
         ApplepayClientAuthenticationResponse, ClientAuthenticationTokenData,
         GooglePaySessionResponse, GpayAllowedPaymentMethods, GpayClientAuthenticationResponse,
         GpayMerchantInfo, GpayShippingAddressParameters, MandateReference, NextActionCall,
-        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
-        PaymentsAuthorizeData, PaymentsResponseData, RefundFlowData, RefundsData,
-        RefundsResponseData, ResponseId, SdkNextAction, SecretInfoToInitiateSdk,
-        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
-        SetupMandateRequestData, ThirdPartySdkSessionResponse,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData,
+        PaymentsResponseData, RefundFlowData, RefundsData, RefundsResponseData, ResponseId,
+        SdkNextAction, SecretInfoToInitiateSdk, ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData, SetupMandateRequestData,
+        ThirdPartySdkSessionResponse,
     },
     errors::{ConnectorError, IntegrationError, WebhookError},
     payment_method_data::{
@@ -2558,7 +2558,12 @@ impl From<GooglePayAllowedPaymentMethods> for GpayAllowedPaymentMethods {
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
         TrustpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     > for TrustpaySetupMandateRequest<T>
@@ -2567,7 +2572,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
     fn try_from(
         item: TrustpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     ) -> Result<Self, Self::Error> {
@@ -2587,55 +2597,64 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // Get billing address
         let billing = router_data.resource_common_data.get_billing()?;
-        let address = billing.address.as_ref().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address",
-                context: Default::default(),
-            }
-        })?;
+        let address =
+            billing
+                .address
+                .as_ref()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address",
+                    context: Default::default(),
+                })?;
 
         // Extract mandatory params
-        let billing_city = address.city.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.city",
-                context: Default::default(),
-            }
-        })?;
-        let billing_country = address.country.ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.country",
-                context: Default::default(),
-            }
-        })?;
-        let billing_street1 = address.line1.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.line1",
-                context: Default::default(),
-            }
-        })?;
-        let billing_postcode = address.zip.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.zip",
-                context: Default::default(),
-            }
-        })?;
-        let billing_first_name = address.first_name.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.first_name",
-                context: Default::default(),
-            }
-        })?;
+        let billing_city =
+            address
+                .city
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.city",
+                    context: Default::default(),
+                })?;
+        let billing_country =
+            address
+                .country
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.country",
+                    context: Default::default(),
+                })?;
+        let billing_street1 =
+            address
+                .line1
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.line1",
+                    context: Default::default(),
+                })?;
+        let billing_postcode =
+            address
+                .zip
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.zip",
+                    context: Default::default(),
+                })?;
+        let billing_first_name =
+            address
+                .first_name
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.first_name",
+                    context: Default::default(),
+                })?;
         let billing_last_name = address.last_name.clone();
 
         // Get browser info
-        let browser_info = router_data
-            .request
-            .browser_info
-            .as_ref()
-            .ok_or_else(|| IntegrationError::MissingRequiredField {
+        let browser_info = router_data.request.browser_info.as_ref().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
                 field_name: "browser_info",
                 context: Default::default(),
-            })?;
+            }
+        })?;
 
         // Get email
         let customer_email = router_data.request.get_email()?;
@@ -2657,19 +2676,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let expiry_date = {
             let year = card_data.card_exp_year.peek();
             let year_2_digit = if year.len() == 4 { &year[2..] } else { year };
-            Secret::new(format!("{}/{}", card_data.card_exp_month.peek(), year_2_digit))
+            Secret::new(format!(
+                "{}/{}",
+                card_data.card_exp_month.peek(),
+                year_2_digit
+            ))
         };
 
         // Build cardholder name
         let cardholder = get_full_name(billing_first_name.clone(), billing_last_name);
 
         // Use zero amount for mandate setup verification
-        let amount = item.connector.amount_converter.convert(
-            MinorUnit::new(0),
-            router_data.request.currency,
-        ).change_context(IntegrationError::RequestEncodingFailed {
-            context: Default::default(),
-        })?;
+        let amount = item
+            .connector
+            .amount_converter
+            .convert(MinorUnit::new(0), router_data.request.currency)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
 
         Ok(Self {
             amount,
@@ -2709,16 +2733,32 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     TryFrom<
         ResponseRouterData<
             TrustpaySetupMandateResponse,
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
         >,
-    > for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+    >
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
 {
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(
         item: ResponseRouterData<
             TrustpaySetupMandateResponse,
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
         >,
     ) -> Result<Self, Self::Error> {
         let response = &item.response;

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -14,16 +14,17 @@ use common_utils::{
     Email,
 };
 use domain_types::{
-    connector_flow::{Authorize, CreateOrder, Refund, ServerAuthenticationToken},
+    connector_flow::{Authorize, CreateOrder, Refund, ServerAuthenticationToken, SetupMandate},
     connector_types::{
         AmountInfo, ApplePayPaymentRequest, ApplePaySessionResponse,
         ApplepayClientAuthenticationResponse, ClientAuthenticationTokenData,
         GooglePaySessionResponse, GpayAllowedPaymentMethods, GpayClientAuthenticationResponse,
-        GpayMerchantInfo, GpayShippingAddressParameters, NextActionCall, PaymentCreateOrderData,
-        PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData, PaymentsResponseData,
-        RefundFlowData, RefundsData, RefundsResponseData, ResponseId, SdkNextAction,
-        SecretInfoToInitiateSdk, ServerAuthenticationTokenRequestData,
-        ServerAuthenticationTokenResponseData, ThirdPartySdkSessionResponse,
+        GpayMerchantInfo, GpayShippingAddressParameters, MandateReference, NextActionCall,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
+        PaymentsAuthorizeData, PaymentsResponseData, RefundFlowData, RefundsData,
+        RefundsResponseData, ResponseId, SdkNextAction, SecretInfoToInitiateSdk,
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+        SetupMandateRequestData, ThirdPartySdkSessionResponse,
     },
     errors::{ConnectorError, IntegrationError, WebhookError},
     payment_method_data::{
@@ -1216,6 +1217,92 @@ pub enum TrustpayPaymentsRequest<
     BankTransferPaymentRequest(Box<PaymentRequestBankTransfer>),
     NetworkTokenPaymentRequest(Box<PaymentRequestNetworkToken>),
 }
+
+// ===== SetupMandate (SetupRecurring) flow structs =====
+
+/// TrustPay SetupMandate request - stores card credentials for future recurring payments
+/// Uses zero-amount verification to validate and store card without charging
+#[derive(Debug, Serialize, PartialEq)]
+pub struct TrustpaySetupMandateRequest<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+> {
+    /// Amount for verification (typically 0 or minimal amount)
+    pub amount: StringMajorUnit,
+    /// Currency code
+    pub currency: String,
+    /// Card number
+    pub pan: RawCardNumber<T>,
+    /// Card CVV
+    pub cvv: Secret<String>,
+    /// Card expiry date in MM/YY format
+    #[serde(rename = "exp")]
+    pub expiry_date: Secret<String>,
+    /// Cardholder name
+    pub cardholder: Secret<String>,
+    /// Merchant reference for the mandate setup
+    pub reference: String,
+    /// Return URL for 3DS redirect
+    #[serde(rename = "redirectUrl")]
+    pub redirect_url: String,
+    /// Billing city
+    #[serde(rename = "billing[city]")]
+    pub billing_city: String,
+    /// Billing country
+    #[serde(rename = "billing[country]")]
+    pub billing_country: common_enums::CountryAlpha2,
+    /// Billing street
+    #[serde(rename = "billing[street1]")]
+    pub billing_street1: Secret<String>,
+    /// Billing postal code
+    #[serde(rename = "billing[postcode]")]
+    pub billing_postcode: Secret<String>,
+    /// Customer email
+    #[serde(rename = "customer[email]")]
+    pub customer_email: Email,
+    /// Customer IP address
+    #[serde(rename = "customer[ipAddress]")]
+    pub customer_ip_address: Secret<String, pii::IpAddress>,
+    /// Browser accept header
+    #[serde(rename = "browser[acceptHeader]")]
+    pub browser_accept_header: String,
+    /// Browser language
+    #[serde(rename = "browser[language]")]
+    pub browser_language: String,
+    /// Browser screen height
+    #[serde(rename = "browser[screenHeight]")]
+    pub browser_screen_height: String,
+    /// Browser screen width
+    #[serde(rename = "browser[screenWidth]")]
+    pub browser_screen_width: String,
+    /// Browser timezone
+    #[serde(rename = "browser[timezone]")]
+    pub browser_timezone: String,
+    /// Browser user agent
+    #[serde(rename = "browser[userAgent]")]
+    pub browser_user_agent: String,
+    /// Browser Java enabled
+    #[serde(rename = "browser[javaEnabled]")]
+    pub browser_java_enabled: String,
+    /// Browser JavaScript enabled
+    #[serde(rename = "browser[javaScriptEnabled]")]
+    pub browser_java_script_enabled: String,
+    /// Browser screen color depth
+    #[serde(rename = "browser[screenColorDepth]")]
+    pub browser_screen_color_depth: String,
+    /// Challenge window size
+    #[serde(rename = "browser[challengeWindow]")]
+    pub browser_challenge_window: String,
+    /// Payment action - set to "preauth" for mandate setup
+    #[serde(rename = "browser[paymentAction]")]
+    pub payment_action: Option<String>,
+    /// Payment type
+    #[serde(rename = "browser[paymentType]")]
+    pub payment_type: String,
+}
+
+/// TrustPay SetupMandate response - reuses the card payment response structure
+/// The instance_id serves as the connector_mandate_id for future recurring transactions
+pub type TrustpaySetupMandateResponse = PaymentsResponseCards;
 
 // CreateOrder flow structs for wallet initialization
 #[derive(Default, Debug, Serialize)]
@@ -2463,5 +2550,240 @@ impl From<GooglePayAllowedPaymentMethods> for GpayAllowedPaymentMethods {
                     },
                 },
         }
+    }
+}
+
+// ===== SetupMandate (SetupRecurring) TryFrom implementations =====
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        TrustpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    > for TrustpaySetupMandateRequest<T>
+{
+    type Error = Error;
+
+    fn try_from(
+        item: TrustpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        // Extract card data
+        let card_data = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(card) => card,
+            _ => {
+                return Err(IntegrationError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("trustpay SetupMandate"),
+                    Default::default(),
+                )
+                .into())
+            }
+        };
+
+        // Get billing address
+        let billing = router_data.resource_common_data.get_billing()?;
+        let address = billing.address.as_ref().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address",
+                context: Default::default(),
+            }
+        })?;
+
+        // Extract mandatory params
+        let billing_city = address.city.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.city",
+                context: Default::default(),
+            }
+        })?;
+        let billing_country = address.country.ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.country",
+                context: Default::default(),
+            }
+        })?;
+        let billing_street1 = address.line1.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.line1",
+                context: Default::default(),
+            }
+        })?;
+        let billing_postcode = address.zip.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.zip",
+                context: Default::default(),
+            }
+        })?;
+        let billing_first_name = address.first_name.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.first_name",
+                context: Default::default(),
+            }
+        })?;
+        let billing_last_name = address.last_name.clone();
+
+        // Get browser info
+        let browser_info = router_data
+            .request
+            .browser_info
+            .as_ref()
+            .ok_or_else(|| IntegrationError::MissingRequiredField {
+                field_name: "browser_info",
+                context: Default::default(),
+            })?;
+
+        // Get email
+        let customer_email = router_data.request.get_email()?;
+
+        // Get IP address
+        let customer_ip_address = browser_info.get_ip_address()?;
+
+        // Get return URL
+        let redirect_url = router_data
+            .request
+            .router_return_url
+            .clone()
+            .ok_or_else(|| IntegrationError::MissingRequiredField {
+                field_name: "return_url",
+                context: Default::default(),
+            })?;
+
+        // Format expiry date as MM/YY
+        let expiry_date = {
+            let year = card_data.card_exp_year.peek();
+            let year_2_digit = if year.len() == 4 { &year[2..] } else { year };
+            Secret::new(format!("{}/{}", card_data.card_exp_month.peek(), year_2_digit))
+        };
+
+        // Build cardholder name
+        let cardholder = get_full_name(billing_first_name.clone(), billing_last_name);
+
+        // Use zero amount for mandate setup verification
+        let amount = item.connector.amount_converter.convert(
+            MinorUnit::new(0),
+            router_data.request.currency,
+        ).change_context(IntegrationError::RequestEncodingFailed {
+            context: Default::default(),
+        })?;
+
+        Ok(Self {
+            amount,
+            currency: router_data.request.currency.to_string(),
+            pan: card_data.card_number.clone(),
+            cvv: card_data.card_cvc.clone(),
+            expiry_date,
+            cardholder,
+            reference: router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            redirect_url,
+            billing_city: billing_city.peek().to_string(),
+            billing_country,
+            billing_street1,
+            billing_postcode,
+            customer_email,
+            customer_ip_address,
+            browser_accept_header: browser_info.get_accept_header()?,
+            browser_language: browser_info.get_language()?,
+            browser_screen_height: browser_info.get_screen_height()?.to_string(),
+            browser_screen_width: browser_info.get_screen_width()?.to_string(),
+            browser_timezone: browser_info.get_time_zone()?.to_string(),
+            browser_user_agent: browser_info.get_user_agent()?,
+            browser_java_enabled: browser_info.get_java_enabled()?.to_string(),
+            browser_java_script_enabled: browser_info.get_java_script_enabled()?.to_string(),
+            browser_screen_color_depth: browser_info.get_color_depth()?.to_string(),
+            browser_challenge_window: CHALLENGE_WINDOW.to_string(),
+            payment_action: Some("preauth".to_string()), // Use preauth for mandate setup
+            payment_type: PAYMENT_TYPE.to_string(),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ResponseRouterData<
+            TrustpaySetupMandateResponse,
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        >,
+    > for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<
+            TrustpaySetupMandateResponse,
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let response = &item.response;
+
+        // Get transaction status from payment status
+        let (status, message) = get_transaction_status(
+            response.payment_status.clone(),
+            response.redirect_url.clone(),
+        )?;
+
+        // Build redirection data if redirect URL is present
+        let form_fields = response.redirect_params.clone().unwrap_or_default();
+        let redirection_data = response.redirect_url.clone().map(|url| RedirectForm::Form {
+            endpoint: url.to_string(),
+            method: Method::Post,
+            form_fields,
+        });
+
+        // Build error response if there's a failure
+        let error = if message.is_some() {
+            Some(ErrorResponse {
+                code: response
+                    .payment_status
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                message: message
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_MESSAGE.to_string()),
+                reason: message,
+                status_code: item.http_code,
+                attempt_status: None,
+                connector_transaction_id: Some(response.instance_id.clone()),
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+            })
+        } else {
+            None
+        };
+
+        // The instance_id serves as the connector_mandate_id for future recurring payments
+        let mandate_reference = Some(Box::new(MandateReference {
+            connector_mandate_id: Some(response.instance_id.clone()),
+            payment_method_id: None,
+            connector_mandate_request_reference_id: None,
+        }));
+
+        let payment_response_data = PaymentsResponseData::TransactionResponse {
+            resource_id: ResponseId::ConnectorTransactionId(response.instance_id.clone()),
+            redirection_data: redirection_data.map(Box::new),
+            mandate_reference,
+            connector_metadata: None,
+            network_txn_id: None,
+            connector_response_reference_id: None,
+            incremental_authorization_allowed: None,
+            status_code: item.http_code,
+        };
+
+        Ok(Self {
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            response: error.map_or_else(|| Ok(payment_response_data), Err),
+            ..item.router_data
+        })
     }
 }

--- a/data/field_probe/nmi.json
+++ b/data/field_probe/nmi.json
@@ -688,7 +688,39 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "card_proxy": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "03",
+            "card_exp_year": "2030",
+            "card_cvc": "123",
+            "card_holder_name": "John Doe"
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          },
+          "auth_type": "NO_THREE_DS",
+          "setup_future_usage": "OFF_SESSION"
+        },
+        "sample": {
+          "url": "https://secure.nmi.com/api/transact.php",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/x-www-form-urlencoded",
+            "via": "HyperSwitch"
+          },
+          "body": "security_key=probe_key&customer_vault=add_customer&ccnumber=4111111111111111&ccexp=0330&cvv=123"
+        }
       }
     },
     "recurring_charge": {
@@ -751,7 +783,44 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "card": {
+              "card_number": "4111111111111111",
+              "card_exp_month": "03",
+              "card_exp_year": "2030",
+              "card_cvc": "737",
+              "card_holder_name": "John Doe"
+            }
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "auth_type": "NO_THREE_DS",
+          "enrolled_for_3ds": false,
+          "return_url": "https://example.com/mandate-return",
+          "setup_future_usage": "OFF_SESSION",
+          "request_incremental_authorization": false,
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          }
+        },
+        "sample": {
+          "url": "https://secure.nmi.com/api/transact.php",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/x-www-form-urlencoded",
+            "via": "HyperSwitch"
+          },
+          "body": "security_key=probe_key&customer_vault=add_customer&ccnumber=4111111111111111&ccexp=0330&cvv=737"
+        }
       }
     },
     "token_authorize": {
@@ -762,7 +831,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through NMI SetupMandate"
       }
     },
     "tokenize": {

--- a/data/field_probe/trustpay.json
+++ b/data/field_probe/trustpay.json
@@ -979,7 +979,8 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: billing.address.city — Missing required field: billing.address.city"
       }
     },
     "recurring_charge": {
@@ -1058,7 +1059,8 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: billing.address.city — Missing required field: billing.address.city"
       }
     },
     "token_authorize": {
@@ -1069,7 +1071,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through trustpay SetupMandate"
       }
     },
     "tokenize": {

--- a/docs-generated/connectors/nmi.md
+++ b/docs-generated/connectors/nmi.md
@@ -108,7 +108,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L167) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L105) · [Rust](../../examples/nmi/nmi.rs#L158)
+**Examples:** [Python](../../examples/nmi/nmi.py#L230) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L109) · [Rust](../../examples/nmi/nmi.rs#L219)
 
 ### Card Payment (Authorize + Capture)
 
@@ -122,25 +122,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L186) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L121) · [Rust](../../examples/nmi/nmi.rs#L174)
+**Examples:** [Python](../../examples/nmi/nmi.py#L249) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L125) · [Rust](../../examples/nmi/nmi.rs#L235)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L211) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L143) · [Rust](../../examples/nmi/nmi.rs#L197)
+**Examples:** [Python](../../examples/nmi/nmi.py#L274) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L147) · [Rust](../../examples/nmi/nmi.rs#L258)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L236) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L165) · [Rust](../../examples/nmi/nmi.rs#L220)
+**Examples:** [Python](../../examples/nmi/nmi.py#L299) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L169) · [Rust](../../examples/nmi/nmi.rs#L281)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L258) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L184) · [Rust](../../examples/nmi/nmi.rs#L239)
+**Examples:** [Python](../../examples/nmi/nmi.py#L321) · [JavaScript](../../examples/nmi/nmi.js) · [Kotlin](../../examples/nmi/nmi.kt#L188) · [Rust](../../examples/nmi/nmi.rs#L300)
 
 ## API Reference
 
@@ -151,8 +151,10 @@ Retrieve current payment status from the connector.
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentMethodAuthenticationService.PreAuthenticate](#paymentmethodauthenticationservicepreauthenticate) | Authentication | `PaymentMethodAuthenticationServicePreAuthenticateRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
+| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 | [PaymentService.Void](#paymentservicevoid) | Payments | `PaymentServiceVoidRequest` |
 
 ### Payments
@@ -311,7 +313,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L280) · [TypeScript](../../examples/nmi/nmi.ts#L265) · [Kotlin](../../examples/nmi/nmi.kt#L202) · [Rust](../../examples/nmi/nmi.rs#L257)
+**Examples:** [Python](../../examples/nmi/nmi.py#L343) · [TypeScript](../../examples/nmi/nmi.ts#L324) · [Kotlin](../../examples/nmi/nmi.kt#L206) · [Rust](../../examples/nmi/nmi.rs#L318)
 
 #### PaymentService.Capture
 
@@ -322,7 +324,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L289) · [TypeScript](../../examples/nmi/nmi.ts#L274) · [Kotlin](../../examples/nmi/nmi.kt#L214) · [Rust](../../examples/nmi/nmi.rs#L269)
+**Examples:** [Python](../../examples/nmi/nmi.py#L352) · [TypeScript](../../examples/nmi/nmi.ts#L333) · [Kotlin](../../examples/nmi/nmi.kt#L218) · [Rust](../../examples/nmi/nmi.rs#L330)
 
 #### PaymentService.Get
 
@@ -333,7 +335,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L298) · [TypeScript](../../examples/nmi/nmi.ts#L283) · [Kotlin](../../examples/nmi/nmi.kt#L224) · [Rust](../../examples/nmi/nmi.rs#L276)
+**Examples:** [Python](../../examples/nmi/nmi.py#L361) · [TypeScript](../../examples/nmi/nmi.ts#L342) · [Kotlin](../../examples/nmi/nmi.kt#L228) · [Rust](../../examples/nmi/nmi.rs#L337)
 
 #### PaymentService.ProxyAuthorize
 
@@ -344,7 +346,18 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L316) · [TypeScript](../../examples/nmi/nmi.ts#L301) · [Kotlin](../../examples/nmi/nmi.kt#L261) · [Rust](../../examples/nmi/nmi.rs#L290)
+**Examples:** [Python](../../examples/nmi/nmi.py#L379) · [TypeScript](../../examples/nmi/nmi.ts#L360) · [Kotlin](../../examples/nmi/nmi.kt#L265) · [Rust](../../examples/nmi/nmi.rs#L351)
+
+#### PaymentService.ProxySetupRecurring
+
+Setup recurring mandate using vault-aliased card data.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceProxySetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/nmi/nmi.py#L388) · [TypeScript](../../examples/nmi/nmi.ts#L369) · [Kotlin](../../examples/nmi/nmi.kt#L293) · [Rust](../../examples/nmi/nmi.rs#L358)
 
 #### PaymentService.Refund
 
@@ -355,7 +368,18 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L325) · [TypeScript](../../examples/nmi/nmi.ts#L310) · [Kotlin](../../examples/nmi/nmi.kt#L289) · [Rust](../../examples/nmi/nmi.rs#L297)
+**Examples:** [Python](../../examples/nmi/nmi.py#L397) · [TypeScript](../../examples/nmi/nmi.ts#L378) · [Kotlin](../../examples/nmi/nmi.kt#L324) · [Rust](../../examples/nmi/nmi.rs#L365)
+
+#### PaymentService.SetupRecurring
+
+Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceSetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/nmi/nmi.py#L415) · [TypeScript](../../examples/nmi/nmi.ts#L396) · [Kotlin](../../examples/nmi/nmi.kt#L346) · [Rust](../../examples/nmi/nmi.rs#L379)
 
 #### PaymentService.Void
 
@@ -366,7 +390,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L343) · [TypeScript](../../examples/nmi/nmi.ts) · [Kotlin](../../examples/nmi/nmi.kt#L311) · [Rust](../../examples/nmi/nmi.rs#L311)
+**Examples:** [Python](../../examples/nmi/nmi.py#L424) · [TypeScript](../../examples/nmi/nmi.ts) · [Kotlin](../../examples/nmi/nmi.kt#L385) · [Rust](../../examples/nmi/nmi.rs#L389)
 
 ### Refunds
 
@@ -379,7 +403,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L334) · [TypeScript](../../examples/nmi/nmi.ts#L319) · [Kotlin](../../examples/nmi/nmi.kt#L299) · [Rust](../../examples/nmi/nmi.rs#L304)
+**Examples:** [Python](../../examples/nmi/nmi.py#L406) · [TypeScript](../../examples/nmi/nmi.ts#L387) · [Kotlin](../../examples/nmi/nmi.kt#L334) · [Rust](../../examples/nmi/nmi.rs#L372)
 
 ### Authentication
 
@@ -392,4 +416,4 @@ Initiate 3DS flow before payment authorization. Collects device data and prepare
 | **Request** | `PaymentMethodAuthenticationServicePreAuthenticateRequest` |
 | **Response** | `PaymentMethodAuthenticationServicePreAuthenticateResponse` |
 
-**Examples:** [Python](../../examples/nmi/nmi.py#L307) · [TypeScript](../../examples/nmi/nmi.ts#L292) · [Kotlin](../../examples/nmi/nmi.kt#L232) · [Rust](../../examples/nmi/nmi.rs#L283)
+**Examples:** [Python](../../examples/nmi/nmi.py#L370) · [TypeScript](../../examples/nmi/nmi.ts#L351) · [Kotlin](../../examples/nmi/nmi.kt#L236) · [Rust](../../examples/nmi/nmi.rs#L344)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -371,7 +371,7 @@ connector_id: nmi
 doc: docs/connectors/nmi.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: Ach, Card, GooglePay, GooglePayDecrypted
-flows: authorize, capture, get, pre_authenticate, proxy_authorize, refund, refund_get, void
+flows: authorize, capture, get, pre_authenticate, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, void
 examples_python: examples/nmi/nmi.py
 
 ## Noon

--- a/examples/nmi/nmi.kt
+++ b/examples/nmi/nmi.kt
@@ -17,10 +17,14 @@ import payments.PaymentServiceVoidRequest
 import payments.PaymentServiceGetRequest
 import payments.PaymentMethodAuthenticationServicePreAuthenticateRequest
 import payments.PaymentServiceProxyAuthorizeRequest
+import payments.PaymentServiceProxySetupRecurringRequest
 import payments.RefundServiceGetRequest
+import payments.PaymentServiceSetupRecurringRequest
+import payments.AcceptanceType
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
+import payments.FutureUsage
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -285,6 +289,37 @@ fun proxyAuthorize(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+fun proxySetupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_proxy_mandate_001"
+        amountBuilder.apply {
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
+            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+            cardExpMonthBuilder.value = "03"
+            cardExpYearBuilder.value = "2030"
+            cardCvcBuilder.value = "123"
+            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+        }
+        addressBuilder.apply {
+            billingAddressBuilder.apply {
+            }
+        }
+        customerAcceptanceBuilder.apply {
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+        authType = AuthenticationType.NO_THREE_DS
+        setupFutureUsage = FutureUsage.OFF_SESSION
+    }.build()
+    val response = client.proxy_setup_recurring(request)
+    println("Status: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -305,6 +340,45 @@ fun refundGet(txnId: String) {
     }.build()
     val response = client.refund_get(request)
     println("Status: ${response.status.name}")
+}
+
+// Flow: PaymentService.SetupRecurring
+fun setupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
+        amountBuilder.apply {  // Mandate Details.
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {
+            cardBuilder.apply {  // Generic card payment.
+                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+                cardExpMonthBuilder.value = "03"
+                cardExpYearBuilder.value = "2030"
+                cardCvcBuilder.value = "737"
+                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            }
+        }
+        addressBuilder.apply {  // Address Information.
+            billingAddressBuilder.apply {
+            }
+        }
+        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
+        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
+        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
+        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
+        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
+        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+    }.build()
+    val response = client.setup_recurring(request)
+    when (response.status.name) {
+        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
+        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
+    }
 }
 
 // Flow: PaymentService.Void
@@ -332,9 +406,11 @@ fun main(args: Array<String>) {
         "get" -> get(txnId)
         "preAuthenticate" -> preAuthenticate(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
+        "setupRecurring" -> setupRecurring(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, preAuthenticate, proxyAuthorize, refund, refundGet, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, preAuthenticate, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, void")
     }
 }

--- a/examples/nmi/nmi.py
+++ b/examples/nmi/nmi.py
@@ -131,6 +131,35 @@ def _build_proxy_authorize_request():
         payment_pb2.PaymentServiceProxyAuthorizeRequest(),
     )
 
+def _build_proxy_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+            "amount": {
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "card_proxy": {  # Card proxy for vault-aliased payments.
+                "card_number": {"value": "4111111111111111"},  # Card Identification.
+                "card_exp_month": {"value": "03"},
+                "card_exp_year": {"value": "2030"},
+                "card_cvc": {"value": "123"},
+                "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+            },
+            "address": {
+                "billing_address": {
+                }
+            },
+            "customer_acceptance": {
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            },
+            "auth_type": "NO_THREE_DS",
+            "setup_future_usage": "OFF_SESSION"
+        },
+        payment_pb2.PaymentServiceProxySetupRecurringRequest(),
+    )
+
 def _build_refund_request(connector_transaction_id: str):
     return ParseDict(
         {
@@ -154,6 +183,40 @@ def _build_refund_get_request():
             "refund_id": "probe_refund_id_001"
         },
         payment_pb2.RefundServiceGetRequest(),
+    )
+
+def _build_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_mandate_001",  # Identification.
+            "amount": {  # Mandate Details.
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {
+                "card": {  # Generic card payment.
+                    "card_number": {"value": "4111111111111111"},  # Card Identification.
+                    "card_exp_month": {"value": "03"},
+                    "card_exp_year": {"value": "2030"},
+                    "card_cvc": {"value": "737"},
+                    "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+                }
+            },
+            "address": {  # Address Information.
+                "billing_address": {
+                }
+            },
+            "auth_type": "NO_THREE_DS",  # Type of authentication to be used.
+            "enrolled_for_3ds": False,  # Indicates if the customer is enrolled for 3D Secure.
+            "return_url": "https://example.com/mandate-return",  # URL to redirect after setup.
+            "setup_future_usage": "OFF_SESSION",  # Indicates future usage intention.
+            "request_incremental_authorization": False,  # Indicates if incremental authorization is requested.
+            "customer_acceptance": {  # Details of customer acceptance.
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            }
+        },
+        payment_pb2.PaymentServiceSetupRecurringRequest(),
     )
 
 def _build_void_request(connector_transaction_id: str):
@@ -322,6 +385,15 @@ async def proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.C
     return {"status": proxy_response.status}
 
 
+async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.ProxySetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
+
+    return {"status": proxy_response.status}
+
+
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: PaymentService.Refund"""
     payment_client = PaymentClient(config)
@@ -338,6 +410,15 @@ async def refund_get(merchant_transaction_id: str, config: sdk_config_pb2.Connec
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
+
+
+async def setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.SetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
+
+    return {"status": setup_response.status, "mandate_id": setup_response.connector_transaction_id}
 
 
 async def void(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/nmi/nmi.rs
+++ b/examples/nmi/nmi.rs
@@ -123,6 +123,33 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     })).unwrap_or_default()
 }
 
+pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceProxySetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+    "amount": {
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "card_proxy": {  // Card proxy for vault-aliased payments.
+        "card_number": "4111111111111111",  // Card Identification.
+        "card_exp_month": "03",
+        "card_exp_year": "2030",
+        "card_cvc": "123",
+        "card_holder_name": "John Doe",  // Cardholder Information.
+    },
+    "address": {
+        "billing_address": {
+        },
+    },
+    "customer_acceptance": {
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
+    "auth_type": "NO_THREE_DS",
+    "setup_future_usage": "OFF_SESSION",
+    })).unwrap_or_default()
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -141,6 +168,40 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
     "merchant_refund_id": "probe_refund_001",  // Identification.
     "connector_transaction_id": "probe_connector_txn_001",
     "refund_id": "probe_refund_id_001",
+    })).unwrap_or_default()
+}
+
+pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceSetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_mandate_001",  // Identification.
+    "amount": {  // Mandate Details.
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {
+        "payment_method": {
+            "card": {  // Generic card payment.
+                "card_number": "4111111111111111",  // Card Identification.
+                "card_exp_month": "03",
+                "card_exp_year": "2030",
+                "card_cvc": "737",
+                "card_holder_name": "John Doe",  // Cardholder Information.
+            },
+        }
+    },
+    "address": {  // Address Information.
+        "billing_address": {
+        },
+    },
+    "auth_type": "NO_THREE_DS",  // Type of authentication to be used.
+    "enrolled_for_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+    "return_url": "https://example.com/mandate-return",  // URL to redirect after setup.
+    "setup_future_usage": "OFF_SESSION",  // Indicates future usage intention.
+    "request_incremental_authorization": false,  // Indicates if incremental authorization is requested.
+    "customer_acceptance": {  // Details of customer acceptance.
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
     })).unwrap_or_default()
 }
 
@@ -292,6 +353,13 @@ pub async fn proxy_authorize(client: &ConnectorClient, _merchant_transaction_id:
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+#[allow(dead_code)]
+pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -304,6 +372,16 @@ pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) ->
 pub async fn refund_get(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
     let response = client.refund_get(build_refund_get_request(), &HashMap::new(), None).await?;
     Ok(format!("status: {:?}", response.status()))
+}
+
+// Flow: PaymentService.SetupRecurring
+#[allow(dead_code)]
+pub async fn setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.setup_recurring(build_setup_recurring_request(), &HashMap::new(), None).await?;
+    if response.status() == PaymentStatus::Failure {
+        return Err(format!("Setup failed: {:?}", response.error).into());
+    }
+    Ok(format!("Mandate: {}", response.connector_recurring_payment_id.as_deref().unwrap_or("")))
 }
 
 // Flow: PaymentService.Void
@@ -329,10 +407,12 @@ async fn main() {
         "get" => get(&client, "order_001").await,
         "pre_authenticate" => pre_authenticate(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
+        "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
+        "setup_recurring" => setup_recurring(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, get, pre_authenticate, proxy_authorize, refund, refund_get, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, get, pre_authenticate, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/nmi/nmi.ts
+++ b/examples/nmi/nmi.ts
@@ -6,7 +6,7 @@
 // Run a scenario:  npx tsx nmi.ts checkout_autocapture
 
 import { PaymentClient, PaymentMethodAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency } = types;
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -116,6 +116,33 @@ function _buildProxyAuthorizeRequest(): PaymentServiceProxyAuthorizeRequest {
     };
 }
 
+function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
+        "amount": {
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "cardProxy": {  // Card proxy for vault-aliased payments.
+            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+            "cardExpMonth": {"value": "03"},
+            "cardExpYear": {"value": "2030"},
+            "cardCvc": {"value": "123"},
+            "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+        },
+        "address": {
+            "billingAddress": {
+            }
+        },
+        "customerAcceptance": {
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        },
+        "authType": AuthenticationType.NO_THREE_DS,
+        "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
 function _buildRefundRequest(connectorTransactionId: string): PaymentServiceRefundRequest {
     return {
         "merchantRefundId": "probe_refund_001",  // Identification.
@@ -134,6 +161,38 @@ function _buildRefundGetRequest(): RefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"
+    };
+}
+
+function _buildSetupRecurringRequest(): PaymentServiceSetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
+        "amount": {  // Mandate Details.
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {
+            "card": {  // Generic card payment.
+                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+                "cardExpMonth": {"value": "03"},
+                "cardExpYear": {"value": "2030"},
+                "cardCvc": {"value": "737"},
+                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+            }
+        },
+        "address": {  // Address Information.
+            "billingAddress": {
+            }
+        },
+        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
+        "enrolledFor3Ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
+        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
+        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
+        "customerAcceptance": {  // Details of customer acceptance.
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
     };
 }
 
@@ -306,6 +365,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: ConnectorCo
     return { status: proxyResponse.status };
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+async function proxySetupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
+
+    return { status: proxyResponse.status };
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -324,6 +392,15 @@ async function refundGet(merchantTransactionId: string, config: ConnectorConfig 
     return { status: refundResponse.status };
 }
 
+// Flow: PaymentService.SetupRecurring
+async function setupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
+
+    return { status: setupResponse.status, mandateId: setupResponse.connectorTransactionId };
+}
+
 // Flow: PaymentService.Void
 async function voidPayment(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceVoidResponse> {
     const paymentClient = new PaymentClient(config);
@@ -336,7 +413,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, preAuthenticate, proxyAuthorize, refund, refundGet, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildPreAuthenticateRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, preAuthenticate, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildPreAuthenticateRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Summary
- Implement SetupMandate (SetupRecurring) flow for NMI connector
- Add payment method to Customer Vault for recurring payments
- Support Card and ACH bank debit payment methods
- Include billing address information in vault request

## Test plan
- [ ] Verify Card payment method can be added to Customer Vault
- [ ] Verify ACH bank debit can be added to Customer Vault
- [ ] Verify customer_vault_id is returned as mandate reference on success
- [ ] Verify error handling for declined/error responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)