### PR TITLE
feat(connector): implement SetupRecurring for TrustPay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/trustpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay.rs
@@ -55,7 +55,7 @@ use transformers::{
     TrustpayAuthUpdateRequest, TrustpayAuthUpdateResponse, TrustpayCreateIntentRequest,
     TrustpayCreateIntentResponse, TrustpayErrorResponse, TrustpayPaymentsRequest,
     TrustpayPaymentsResponse as TrustpayPaymentsSyncResponse, TrustpayPaymentsResponse,
-    TrustpayRefundRequest,
+    TrustpayRefundRequest, TrustpaySetupMandateRequest, TrustpaySetupMandateResponse,
 };
 
 use super::macros::{self, ContentTypeSelector};
@@ -489,6 +489,12 @@ macros::create_all_prerequisites!(
             flow: RSync,
             response_body: RefundSyncResponse,
             router_data: RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: TrustpaySetupMandateRequest<T>,
+            response_body: TrustpaySetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -1037,6 +1043,40 @@ macros::macro_connector_implementation!(
     }
 );
 
+// SetupMandate (SetupRecurring) - stores card credentials for recurring payments
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Trustpay,
+    curl_request: FormUrlEncoded(TrustpaySetupMandateRequest<T>),
+    curl_response: TrustpaySetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers_for_payments(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            // TrustPay uses the same card API endpoint for mandate setup (zero-auth validation)
+            Ok(format!(
+                "{}{}",
+                self.connector_base_url_payments(req),
+                "api/v1/purchase"
+            ))
+        }
+    }
+);
+
 // Implementation for empty stubs - these will need to be properly implemented later
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -1070,15 +1110,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentFlowData,
         ServerSessionAuthenticationTokenRequestData,
         ServerSessionAuthenticationTokenResponseData,
-    > for Trustpay<T>
-{
-}
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
     > for Trustpay<T>
 {
 }

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -20,11 +20,11 @@ use domain_types::{
         ApplepayClientAuthenticationResponse, ClientAuthenticationTokenData,
         GooglePaySessionResponse, GpayAllowedPaymentMethods, GpayClientAuthenticationResponse,
         GpayMerchantInfo, GpayShippingAddressParameters, MandateReference, NextActionCall,
-        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
-        PaymentsAuthorizeData, PaymentsResponseData, RefundFlowData, RefundsData,
-        RefundsResponseData, ResponseId, SdkNextAction, SecretInfoToInitiateSdk,
-        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
-        SetupMandateRequestData, ThirdPartySdkSessionResponse,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData,
+        PaymentsResponseData, RefundFlowData, RefundsData, RefundsResponseData, ResponseId,
+        SdkNextAction, SecretInfoToInitiateSdk, ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData, SetupMandateRequestData,
+        ThirdPartySdkSessionResponse,
     },
     errors::{ConnectorError, IntegrationError, WebhookError},
     payment_method_data::{
@@ -2558,7 +2558,12 @@ impl From<GooglePayAllowedPaymentMethods> for GpayAllowedPaymentMethods {
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
         TrustpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     > for TrustpaySetupMandateRequest<T>
@@ -2567,7 +2572,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
     fn try_from(
         item: TrustpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     ) -> Result<Self, Self::Error> {
@@ -2587,55 +2597,64 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // Get billing address
         let billing = router_data.resource_common_data.get_billing()?;
-        let address = billing.address.as_ref().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address",
-                context: Default::default(),
-            }
-        })?;
+        let address =
+            billing
+                .address
+                .as_ref()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address",
+                    context: Default::default(),
+                })?;
 
         // Extract mandatory params
-        let billing_city = address.city.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.city",
-                context: Default::default(),
-            }
-        })?;
-        let billing_country = address.country.ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.country",
-                context: Default::default(),
-            }
-        })?;
-        let billing_street1 = address.line1.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.line1",
-                context: Default::default(),
-            }
-        })?;
-        let billing_postcode = address.zip.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.zip",
-                context: Default::default(),
-            }
-        })?;
-        let billing_first_name = address.first_name.clone().ok_or_else(|| {
-            IntegrationError::MissingRequiredField {
-                field_name: "billing.address.first_name",
-                context: Default::default(),
-            }
-        })?;
+        let billing_city =
+            address
+                .city
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.city",
+                    context: Default::default(),
+                })?;
+        let billing_country =
+            address
+                .country
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.country",
+                    context: Default::default(),
+                })?;
+        let billing_street1 =
+            address
+                .line1
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.line1",
+                    context: Default::default(),
+                })?;
+        let billing_postcode =
+            address
+                .zip
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.zip",
+                    context: Default::default(),
+                })?;
+        let billing_first_name =
+            address
+                .first_name
+                .clone()
+                .ok_or_else(|| IntegrationError::MissingRequiredField {
+                    field_name: "billing.address.first_name",
+                    context: Default::default(),
+                })?;
         let billing_last_name = address.last_name.clone();
 
         // Get browser info
-        let browser_info = router_data
-            .request
-            .browser_info
-            .as_ref()
-            .ok_or_else(|| IntegrationError::MissingRequiredField {
+        let browser_info = router_data.request.browser_info.as_ref().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
                 field_name: "browser_info",
                 context: Default::default(),
-            })?;
+            }
+        })?;
 
         // Get email
         let customer_email = router_data.request.get_email()?;
@@ -2657,19 +2676,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let expiry_date = {
             let year = card_data.card_exp_year.peek();
             let year_2_digit = if year.len() == 4 { &year[2..] } else { year };
-            Secret::new(format!("{}/{}", card_data.card_exp_month.peek(), year_2_digit))
+            Secret::new(format!(
+                "{}/{}",
+                card_data.card_exp_month.peek(),
+                year_2_digit
+            ))
         };
 
         // Build cardholder name
         let cardholder = get_full_name(billing_first_name.clone(), billing_last_name);
 
         // Use zero amount for mandate setup verification
-        let amount = item.connector.amount_converter.convert(
-            MinorUnit::new(0),
-            router_data.request.currency,
-        ).change_context(IntegrationError::RequestEncodingFailed {
-            context: Default::default(),
-        })?;
+        let amount = item
+            .connector
+            .amount_converter
+            .convert(MinorUnit::new(0), router_data.request.currency)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
 
         Ok(Self {
             amount,
@@ -2709,16 +2733,32 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     TryFrom<
         ResponseRouterData<
             TrustpaySetupMandateResponse,
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
         >,
-    > for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+    >
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
 {
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(
         item: ResponseRouterData<
             TrustpaySetupMandateResponse,
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
         >,
     ) -> Result<Self, Self::Error> {
         let response = &item.response;

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -14,16 +14,17 @@ use common_utils::{
     Email,
 };
 use domain_types::{
-    connector_flow::{Authorize, CreateOrder, Refund, ServerAuthenticationToken},
+    connector_flow::{Authorize, CreateOrder, Refund, ServerAuthenticationToken, SetupMandate},
     connector_types::{
         AmountInfo, ApplePayPaymentRequest, ApplePaySessionResponse,
         ApplepayClientAuthenticationResponse, ClientAuthenticationTokenData,
         GooglePaySessionResponse, GpayAllowedPaymentMethods, GpayClientAuthenticationResponse,
-        GpayMerchantInfo, GpayShippingAddressParameters, NextActionCall, PaymentCreateOrderData,
-        PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData, PaymentsResponseData,
-        RefundFlowData, RefundsData, RefundsResponseData, ResponseId, SdkNextAction,
-        SecretInfoToInitiateSdk, ServerAuthenticationTokenRequestData,
-        ServerAuthenticationTokenResponseData, ThirdPartySdkSessionResponse,
+        GpayMerchantInfo, GpayShippingAddressParameters, MandateReference, NextActionCall,
+        PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
+        PaymentsAuthorizeData, PaymentsResponseData, RefundFlowData, RefundsData,
+        RefundsResponseData, ResponseId, SdkNextAction, SecretInfoToInitiateSdk,
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+        SetupMandateRequestData, ThirdPartySdkSessionResponse,
     },
     errors::{ConnectorError, IntegrationError, WebhookError},
     payment_method_data::{
@@ -1216,6 +1217,92 @@ pub enum TrustpayPaymentsRequest<
     BankTransferPaymentRequest(Box<PaymentRequestBankTransfer>),
     NetworkTokenPaymentRequest(Box<PaymentRequestNetworkToken>),
 }
+
+// ===== SetupMandate (SetupRecurring) flow structs =====
+
+/// TrustPay SetupMandate request - stores card credentials for future recurring payments
+/// Uses zero-amount verification to validate and store card without charging
+#[derive(Debug, Serialize, PartialEq)]
+pub struct TrustpaySetupMandateRequest<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+> {
+    /// Amount for verification (typically 0 or minimal amount)
+    pub amount: StringMajorUnit,
+    /// Currency code
+    pub currency: String,
+    /// Card number
+    pub pan: RawCardNumber<T>,
+    /// Card CVV
+    pub cvv: Secret<String>,
+    /// Card expiry date in MM/YY format
+    #[serde(rename = "exp")]
+    pub expiry_date: Secret<String>,
+    /// Cardholder name
+    pub cardholder: Secret<String>,
+    /// Merchant reference for the mandate setup
+    pub reference: String,
+    /// Return URL for 3DS redirect
+    #[serde(rename = "redirectUrl")]
+    pub redirect_url: String,
+    /// Billing city
+    #[serde(rename = "billing[city]")]
+    pub billing_city: String,
+    /// Billing country
+    #[serde(rename = "billing[country]")]
+    pub billing_country: common_enums::CountryAlpha2,
+    /// Billing street
+    #[serde(rename = "billing[street1]")]
+    pub billing_street1: Secret<String>,
+    /// Billing postal code
+    #[serde(rename = "billing[postcode]")]
+    pub billing_postcode: Secret<String>,
+    /// Customer email
+    #[serde(rename = "customer[email]")]
+    pub customer_email: Email,
+    /// Customer IP address
+    #[serde(rename = "customer[ipAddress]")]
+    pub customer_ip_address: Secret<String, pii::IpAddress>,
+    /// Browser accept header
+    #[serde(rename = "browser[acceptHeader]")]
+    pub browser_accept_header: String,
+    /// Browser language
+    #[serde(rename = "browser[language]")]
+    pub browser_language: String,
+    /// Browser screen height
+    #[serde(rename = "browser[screenHeight]")]
+    pub browser_screen_height: String,
+    /// Browser screen width
+    #[serde(rename = "browser[screenWidth]")]
+    pub browser_screen_width: String,
+    /// Browser timezone
+    #[serde(rename = "browser[timezone]")]
+    pub browser_timezone: String,
+    /// Browser user agent
+    #[serde(rename = "browser[userAgent]")]
+    pub browser_user_agent: String,
+    /// Browser Java enabled
+    #[serde(rename = "browser[javaEnabled]")]
+    pub browser_java_enabled: String,
+    /// Browser JavaScript enabled
+    #[serde(rename = "browser[javaScriptEnabled]")]
+    pub browser_java_script_enabled: String,
+    /// Browser screen color depth
+    #[serde(rename = "browser[screenColorDepth]")]
+    pub browser_screen_color_depth: String,
+    /// Challenge window size
+    #[serde(rename = "browser[challengeWindow]")]
+    pub browser_challenge_window: String,
+    /// Payment action - set to "preauth" for mandate setup
+    #[serde(rename = "browser[paymentAction]")]
+    pub payment_action: Option<String>,
+    /// Payment type
+    #[serde(rename = "browser[paymentType]")]
+    pub payment_type: String,
+}
+
+/// TrustPay SetupMandate response - reuses the card payment response structure
+/// The instance_id serves as the connector_mandate_id for future recurring transactions
+pub type TrustpaySetupMandateResponse = PaymentsResponseCards;
 
 // CreateOrder flow structs for wallet initialization
 #[derive(Default, Debug, Serialize)]
@@ -2463,5 +2550,240 @@ impl From<GooglePayAllowedPaymentMethods> for GpayAllowedPaymentMethods {
                     },
                 },
         }
+    }
+}
+
+// ===== SetupMandate (SetupRecurring) TryFrom implementations =====
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        TrustpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    > for TrustpaySetupMandateRequest<T>
+{
+    type Error = Error;
+
+    fn try_from(
+        item: TrustpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        // Extract card data
+        let card_data = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(card) => card,
+            _ => {
+                return Err(IntegrationError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("trustpay SetupMandate"),
+                    Default::default(),
+                )
+                .into())
+            }
+        };
+
+        // Get billing address
+        let billing = router_data.resource_common_data.get_billing()?;
+        let address = billing.address.as_ref().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address",
+                context: Default::default(),
+            }
+        })?;
+
+        // Extract mandatory params
+        let billing_city = address.city.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.city",
+                context: Default::default(),
+            }
+        })?;
+        let billing_country = address.country.ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.country",
+                context: Default::default(),
+            }
+        })?;
+        let billing_street1 = address.line1.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.line1",
+                context: Default::default(),
+            }
+        })?;
+        let billing_postcode = address.zip.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.zip",
+                context: Default::default(),
+            }
+        })?;
+        let billing_first_name = address.first_name.clone().ok_or_else(|| {
+            IntegrationError::MissingRequiredField {
+                field_name: "billing.address.first_name",
+                context: Default::default(),
+            }
+        })?;
+        let billing_last_name = address.last_name.clone();
+
+        // Get browser info
+        let browser_info = router_data
+            .request
+            .browser_info
+            .as_ref()
+            .ok_or_else(|| IntegrationError::MissingRequiredField {
+                field_name: "browser_info",
+                context: Default::default(),
+            })?;
+
+        // Get email
+        let customer_email = router_data.request.get_email()?;
+
+        // Get IP address
+        let customer_ip_address = browser_info.get_ip_address()?;
+
+        // Get return URL
+        let redirect_url = router_data
+            .request
+            .router_return_url
+            .clone()
+            .ok_or_else(|| IntegrationError::MissingRequiredField {
+                field_name: "return_url",
+                context: Default::default(),
+            })?;
+
+        // Format expiry date as MM/YY
+        let expiry_date = {
+            let year = card_data.card_exp_year.peek();
+            let year_2_digit = if year.len() == 4 { &year[2..] } else { year };
+            Secret::new(format!("{}/{}", card_data.card_exp_month.peek(), year_2_digit))
+        };
+
+        // Build cardholder name
+        let cardholder = get_full_name(billing_first_name.clone(), billing_last_name);
+
+        // Use zero amount for mandate setup verification
+        let amount = item.connector.amount_converter.convert(
+            MinorUnit::new(0),
+            router_data.request.currency,
+        ).change_context(IntegrationError::RequestEncodingFailed {
+            context: Default::default(),
+        })?;
+
+        Ok(Self {
+            amount,
+            currency: router_data.request.currency.to_string(),
+            pan: card_data.card_number.clone(),
+            cvv: card_data.card_cvc.clone(),
+            expiry_date,
+            cardholder,
+            reference: router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            redirect_url,
+            billing_city: billing_city.peek().to_string(),
+            billing_country,
+            billing_street1,
+            billing_postcode,
+            customer_email,
+            customer_ip_address,
+            browser_accept_header: browser_info.get_accept_header()?,
+            browser_language: browser_info.get_language()?,
+            browser_screen_height: browser_info.get_screen_height()?.to_string(),
+            browser_screen_width: browser_info.get_screen_width()?.to_string(),
+            browser_timezone: browser_info.get_time_zone()?.to_string(),
+            browser_user_agent: browser_info.get_user_agent()?,
+            browser_java_enabled: browser_info.get_java_enabled()?.to_string(),
+            browser_java_script_enabled: browser_info.get_java_script_enabled()?.to_string(),
+            browser_screen_color_depth: browser_info.get_color_depth()?.to_string(),
+            browser_challenge_window: CHALLENGE_WINDOW.to_string(),
+            payment_action: Some("preauth".to_string()), // Use preauth for mandate setup
+            payment_type: PAYMENT_TYPE.to_string(),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ResponseRouterData<
+            TrustpaySetupMandateResponse,
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        >,
+    > for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<
+            TrustpaySetupMandateResponse,
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let response = &item.response;
+
+        // Get transaction status from payment status
+        let (status, message) = get_transaction_status(
+            response.payment_status.clone(),
+            response.redirect_url.clone(),
+        )?;
+
+        // Build redirection data if redirect URL is present
+        let form_fields = response.redirect_params.clone().unwrap_or_default();
+        let redirection_data = response.redirect_url.clone().map(|url| RedirectForm::Form {
+            endpoint: url.to_string(),
+            method: Method::Post,
+            form_fields,
+        });
+
+        // Build error response if there's a failure
+        let error = if message.is_some() {
+            Some(ErrorResponse {
+                code: response
+                    .payment_status
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                message: message
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_MESSAGE.to_string()),
+                reason: message,
+                status_code: item.http_code,
+                attempt_status: None,
+                connector_transaction_id: Some(response.instance_id.clone()),
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+            })
+        } else {
+            None
+        };
+
+        // The instance_id serves as the connector_mandate_id for future recurring payments
+        let mandate_reference = Some(Box::new(MandateReference {
+            connector_mandate_id: Some(response.instance_id.clone()),
+            payment_method_id: None,
+            connector_mandate_request_reference_id: None,
+        }));
+
+        let payment_response_data = PaymentsResponseData::TransactionResponse {
+            resource_id: ResponseId::ConnectorTransactionId(response.instance_id.clone()),
+            redirection_data: redirection_data.map(Box::new),
+            mandate_reference,
+            connector_metadata: None,
+            network_txn_id: None,
+            connector_response_reference_id: None,
+            incremental_authorization_allowed: None,
+            status_code: item.http_code,
+        };
+
+        Ok(Self {
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            response: error.map_or_else(|| Ok(payment_response_data), Err),
+            ..item.router_data
+        })
     }
 }

--- a/data/field_probe/trustpay.json
+++ b/data/field_probe/trustpay.json
@@ -979,7 +979,8 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: billing.address.city — Missing required field: billing.address.city"
       }
     },
     "recurring_charge": {
@@ -1058,7 +1059,8 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: billing.address.city — Missing required field: billing.address.city"
       }
     },
     "token_authorize": {
@@ -1069,7 +1071,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through trustpay SetupMandate"
       }
     },
     "tokenize": {


### PR DESCRIPTION
## Summary
- Implement SetupMandate (SetupRecurring) flow for TrustPay connector
- Add TrustpaySetupMandateRequest for storing card credentials for recurring payments
- Use zero-auth verification (preauth) to validate cards without charging
- Extract instance_id as connector_mandate_id for future recurring transactions
- Support 3DS redirect handling during mandate setup

## Test plan
- [ ] Verify card credentials can be stored via SetupMandate flow
- [ ] Verify instance_id is returned as connector_mandate_id on success
- [ ] Verify 3DS redirect flow works when required
- [ ] Verify error handling for declined/invalid card responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)