### PR TITLE
[GRACE-FAILED] feat(connector): implement SetupMandate for worldpay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/worldpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay.rs
@@ -753,7 +753,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
-
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<
         ServerSessionAuthenticationToken,

--- a/crates/integrations/connector-integration/src/connectors/worldpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay.rs
@@ -5,12 +5,13 @@ pub mod transformers;
 use self::requests::{
     WorldpayAuthorizeRequest, WorldpayCaptureRequest, WorldpayPostAuthenticateRequest,
     WorldpayPreAuthenticateRequest, WorldpayRefundRequest, WorldpayRepeatPaymentRequest,
+    WorldpaySetupMandateRequest,
 };
 use self::response::{
     WorldpayAuthorizeResponse, WorldpayCaptureResponse, WorldpayErrorResponse,
     WorldpayPostAuthenticateResponse, WorldpayPreAuthenticateResponse, WorldpayRefundResponse,
-    WorldpayRefundSyncResponse, WorldpayRepeatPaymentResponse, WorldpaySyncResponse,
-    WorldpayVoidResponse,
+    WorldpayRefundSyncResponse, WorldpayRepeatPaymentResponse, WorldpaySetupMandateResponse,
+    WorldpaySyncResponse, WorldpayVoidResponse,
 };
 use common_utils::{errors::CustomResult, events, ext_traits::BytesExt};
 use domain_types::{
@@ -249,6 +250,12 @@ macros::create_all_prerequisites!(
             request_body: WorldpayRepeatPaymentRequest<T>,
             response_body: WorldpayRepeatPaymentResponse,
             router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: WorldpaySetupMandateRequest<T>,
+            response_body: WorldpaySetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -675,6 +682,36 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Worldpay,
+    curl_request: Json(WorldpaySetupMandateRequest<T>),
+    curl_response: WorldpaySetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            // SetupMandate uses the same payment endpoint as Authorize
+            // with zero amount and tokenization flags
+            Ok(format!("{}api/payments", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
 // Stub implementations for unsupported flows - removed conflicting ones that are now macro-generated
 
 // Authenticate flow is replaced by PreAuthenticate and PostAuthenticate, but we need this stub for trait bounds
@@ -716,15 +753,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
-    > for Worldpay<T>
-{
-}
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<

--- a/crates/integrations/connector-integration/src/connectors/worldpay/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/requests.rs
@@ -385,3 +385,7 @@ pub type WorldpayPostAuthenticateRequest = WorldpayAuthenticateRequest;
 
 // RepeatPayment uses the same request structure as Authorize (MIT vs CIT)
 pub type WorldpayRepeatPaymentRequest<T> = WorldpayAuthorizeRequest<T>;
+
+// SetupMandate uses the same request structure as Authorize but with zero amount
+// and mandate-specific customerAgreement settings
+pub type WorldpaySetupMandateRequest<T> = WorldpayAuthorizeRequest<T>;

--- a/crates/integrations/connector-integration/src/connectors/worldpay/response.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/response.rs
@@ -492,3 +492,4 @@ pub type WorldpayAuthenticateResponse = WorldpayPaymentsResponse;
 pub type WorldpayPreAuthenticateResponse = WorldpayPaymentsResponse;
 pub type WorldpayPostAuthenticateResponse = WorldpayPaymentsResponse;
 pub type WorldpayRepeatPaymentResponse = WorldpayPaymentsResponse;
+pub type WorldpaySetupMandateResponse = WorldpayPaymentsResponse;

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -89,6 +89,17 @@ fn fetch_payment_instrument<
                     context: Default::default(),
                 })?;
 
+            // Worldpay requires cardHolderName when tokenCreation is present
+            // (mandate / stored-credential flows). Fall back to the card's own
+            // card_holder_name field when billing_address does not carry a full
+            // name. Keeps existing Authorize behaviour (sending the name when
+            // available is always accepted by Worldpay) while unblocking the
+            // zero-amount SetupMandate path that the billing address alone
+            // could not satisfy.
+            let card_holder_name = billing_address
+                .and_then(|address| address.get_optional_full_name())
+                .or_else(|| card.card_holder_name.clone());
+
             Ok(PaymentInstrument::Card(CardPayment {
                 raw_card_details: RawCardDetails {
                     payment_type: PaymentType::Plain,
@@ -99,8 +110,7 @@ fn fetch_payment_instrument<
                     card_number: card.card_number
 },
                 cvc: card.card_cvc,
-                card_holder_name: billing_address
-                    .and_then(|address| address.get_optional_full_name()),
+                card_holder_name,
                 billing_address: billing_address
                     .and_then(|addr| addr.address.clone())
                     .and_then(|address| {

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use common_enums as enums;
 use common_utils::{ext_traits::OptionExt, pii, types::MinorUnit, CustomResult};
 use domain_types::{
-    connector_flow::{Authorize, Capture, Void},
+    connector_flow::{Authorize, Capture, SetupMandate, Void},
     connector_types::{
         MandateIds, MandateReference, MandateReferenceId, PaymentFlowData, PaymentVoidData,
         PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
         RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        ResponseId,
+        ResponseId, SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{
@@ -1547,5 +1547,102 @@ fn extract_three_ds_metadata(response: &WorldpayPaymentsResponse) -> Option<serd
             }
         }
         _ => None,
+    }
+}
+
+// SetupMandate request transformer
+// SetupMandate uses zero-amount authorization with tokenization to establish stored credentials
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        WorldpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    > for WorldpaySetupMandateRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+    fn try_from(
+        item: WorldpayRouterData<
+            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        // Extract merchant name from connector config
+        let auth = WorldpayAuthType::try_from(&item.router_data.connector_config)?;
+
+        let merchant_name = auth
+            .merchant_name
+            .clone()
+            .map(|name| name.expose())
+            .unwrap_or_else(|| "Mandate Setup".to_string());
+
+        // Get payment instrument from payment method data
+        // Use resource_common_data.get_optional_billing() for billing address (same pattern as Authorize)
+        let payment_instrument = fetch_payment_instrument(
+            item.router_data.request.payment_method_data.clone(),
+            item.router_data.resource_common_data.get_optional_billing(),
+        )?;
+
+        // Determine payment method from resource_common_data.payment_method and request.payment_method_type
+        let method = PaymentMethod::try_from((
+            item.router_data.resource_common_data.payment_method,
+            item.router_data.request.payment_method_type,
+        ))?;
+
+        // For SetupMandate, we always use zero amount and set up tokenization
+        // with customerAgreement for first stored card usage
+        Ok(Self {
+            transaction_reference: item
+                .router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .replace('_', "-"),
+            merchant: Merchant {
+                entity: auth.entity_id,
+                mcc: None,
+                payment_facilitator: None,
+            },
+            instruction: Instruction {
+                settlement: None, // No settlement for zero-amount mandate setup
+                method,
+                payment_instrument,
+                narrative: InstructionNarrative {
+                    line1: merchant_name,
+                },
+                value: PaymentValue {
+                    amount: MinorUnit::zero(), // Zero amount for mandate setup
+                    currency: item.router_data.request.currency,
+                },
+                debt_repayment: None,
+                three_ds: None, // 3DS can be added if needed via browser_info
+                // Enable tokenization for mandate setup
+                token_creation: Some(TokenCreation {
+                    token_type: TokenCreationType::Worldpay,
+                }),
+                // Mark as first stored card usage for CIT
+                customer_agreement: Some(CustomerAgreement {
+                    agreement_type: CustomerAgreementType::Subscription,
+                    stored_card_usage: Some(StoredCardUsageType::First),
+                    scheme_reference: None,
+                }),
+            },
+            customer: None,
+        })
+    }
+}
+
+// SetupMandate response transformer
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<WorldpayPaymentsResponse, Self>>
+    for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<WorldpayPaymentsResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        // Use zero amount for status determination (mandate setup is always zero amount)
+        let amount = MinorUnit::zero();
+        // Use the existing ForeignTryFrom implementation for payments response
+        Self::foreign_try_from((item, None, amount))
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -1555,7 +1555,12 @@ fn extract_three_ds_metadata(response: &WorldpayPaymentsResponse) -> Option<serd
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
         WorldpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     > for WorldpaySetupMandateRequest<T>
@@ -1563,7 +1568,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     type Error = error_stack::Report<IntegrationError>;
     fn try_from(
         item: WorldpayRouterData<
-            RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
             T,
         >,
     ) -> Result<Self, Self::Error> {
@@ -1634,7 +1644,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 // SetupMandate response transformer
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<ResponseRouterData<WorldpayPaymentsResponse, Self>>
-    for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
 {
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(

--- a/data/field_probe/worldpay.json
+++ b/data/field_probe/worldpay.json
@@ -643,7 +643,42 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "card_proxy": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "03",
+            "card_exp_year": "2030",
+            "card_cvc": "123",
+            "card_holder_name": "John Doe"
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          },
+          "auth_type": "NO_THREE_DS",
+          "setup_future_usage": "OFF_SESSION"
+        },
+        "sample": {
+          "url": "https://try.access.worldpay.com/api/payments",
+          "method": "Post",
+          "headers": {
+            "accept": "application/json",
+            "authorization": "Basic cHJvYmVfdXNlcjpwcm9iZV9wYXNz",
+            "content-type": "application/json",
+            "via": "HyperSwitch",
+            "wp-api-version": "2024-06-01"
+          },
+          "body": "{\"transactionReference\":\"probe-proxy-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"123\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
+        }
       }
     },
     "recurring_charge": {
@@ -746,7 +781,47 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "card": {
+              "card_number": "4111111111111111",
+              "card_exp_month": "03",
+              "card_exp_year": "2030",
+              "card_cvc": "737",
+              "card_holder_name": "John Doe"
+            }
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "auth_type": "NO_THREE_DS",
+          "enrolled_for_3ds": false,
+          "return_url": "https://example.com/mandate-return",
+          "setup_future_usage": "OFF_SESSION",
+          "request_incremental_authorization": false,
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          }
+        },
+        "sample": {
+          "url": "https://try.access.worldpay.com/api/payments",
+          "method": "Post",
+          "headers": {
+            "accept": "application/json",
+            "authorization": "Basic cHJvYmVfdXNlcjpwcm9iZV9wYXNz",
+            "content-type": "application/json",
+            "via": "HyperSwitch",
+            "wp-api-version": "2024-06-01"
+          },
+          "body": "{\"transactionReference\":\"probe-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"737\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
+        }
       }
     },
     "token_authorize": {
@@ -757,7 +832,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through worldpay"
       }
     },
     "tokenize": {

--- a/data/field_probe/worldpay.json
+++ b/data/field_probe/worldpay.json
@@ -162,7 +162,7 @@
             "via": "HyperSwitch",
             "wp-api-version": "2024-06-01"
           },
-          "body": "{\"transactionReference\":\"probe_txn_001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"settlement\":{\"auto\":true},\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"737\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":1000,\"currency\":\"USD\"},\"tokenCreation\":null,\"customerAgreement\":null}}"
+          "body": "{\"transactionReference\":\"probe_txn_001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"settlement\":{\"auto\":true},\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"737\",\"cardHolderName\":\"John Doe\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":1000,\"currency\":\"USD\"},\"tokenCreation\":null,\"customerAgreement\":null}}"
         }
       },
       "CashappQr": {
@@ -637,7 +637,7 @@
             "via": "HyperSwitch",
             "wp-api-version": "2024-06-01"
           },
-          "body": "{\"transactionReference\":\"probe_proxy_txn_001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"settlement\":{\"auto\":true},\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"123\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":1000,\"currency\":\"USD\"},\"tokenCreation\":null,\"customerAgreement\":null}}"
+          "body": "{\"transactionReference\":\"probe_proxy_txn_001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"settlement\":{\"auto\":true},\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"123\",\"cardHolderName\":\"John Doe\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":1000,\"currency\":\"USD\"},\"tokenCreation\":null,\"customerAgreement\":null}}"
         }
       }
     },
@@ -677,7 +677,7 @@
             "via": "HyperSwitch",
             "wp-api-version": "2024-06-01"
           },
-          "body": "{\"transactionReference\":\"probe-proxy-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"123\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
+          "body": "{\"transactionReference\":\"probe-proxy-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"123\",\"cardHolderName\":\"John Doe\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
         }
       }
     },
@@ -820,7 +820,7 @@
             "via": "HyperSwitch",
             "wp-api-version": "2024-06-01"
           },
-          "body": "{\"transactionReference\":\"probe-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"737\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
+          "body": "{\"transactionReference\":\"probe-mandate-001\",\"merchant\":{\"entity\":\"probe_id\"},\"instruction\":{\"method\":\"card\",\"paymentInstrument\":{\"type\":\"plain\",\"cardNumber\":\"4111111111111111\",\"expiryDate\":{\"month\":3,\"year\":2030},\"cvc\":\"737\",\"cardHolderName\":\"John Doe\"},\"narrative\":{\"line1\":\"Probe Merchant\"},\"value\":{\"amount\":0,\"currency\":\"USD\"},\"tokenCreation\":{\"type\":\"worldpay\"},\"customerAgreement\":{\"type\":\"subscription\",\"storedCardUsage\":\"first\"}}}"
         }
       }
     },

--- a/docs-generated/connectors/worldpay.md
+++ b/docs-generated/connectors/worldpay.md
@@ -108,7 +108,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L165) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L106) · [Rust](../../examples/worldpay/worldpay.rs#L158)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L228) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L110) · [Rust](../../examples/worldpay/worldpay.rs#L219)
 
 ### Card Payment (Authorize + Capture)
 
@@ -122,25 +122,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L184) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L122) · [Rust](../../examples/worldpay/worldpay.rs#L174)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L247) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L126) · [Rust](../../examples/worldpay/worldpay.rs#L235)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L209) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L144) · [Rust](../../examples/worldpay/worldpay.rs#L197)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L272) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L148) · [Rust](../../examples/worldpay/worldpay.rs#L258)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L234) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L166) · [Rust](../../examples/worldpay/worldpay.rs#L220)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L297) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L170) · [Rust](../../examples/worldpay/worldpay.rs#L281)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L256) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L185) · [Rust](../../examples/worldpay/worldpay.rs#L239)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L319) · [JavaScript](../../examples/worldpay/worldpay.js) · [Kotlin](../../examples/worldpay/worldpay.kt#L189) · [Rust](../../examples/worldpay/worldpay.rs#L300)
 
 ## API Reference
 
@@ -150,9 +150,11 @@ Retrieve current payment status from the connector.
 | [PaymentService.Capture](#paymentservicecapture) | Payments | `PaymentServiceCaptureRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
+| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 | [PaymentService.Void](#paymentservicevoid) | Payments | `PaymentServiceVoidRequest` |
 
 ### Payments
@@ -317,7 +319,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L278) · [TypeScript](../../examples/worldpay/worldpay.ts#L263) · [Kotlin](../../examples/worldpay/worldpay.kt#L203) · [Rust](../../examples/worldpay/worldpay.rs#L257)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L341) · [TypeScript](../../examples/worldpay/worldpay.ts#L322) · [Kotlin](../../examples/worldpay/worldpay.kt#L207) · [Rust](../../examples/worldpay/worldpay.rs#L318)
 
 #### PaymentService.Capture
 
@@ -328,7 +330,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L287) · [TypeScript](../../examples/worldpay/worldpay.ts#L272) · [Kotlin](../../examples/worldpay/worldpay.kt#L215) · [Rust](../../examples/worldpay/worldpay.rs#L269)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L350) · [TypeScript](../../examples/worldpay/worldpay.ts#L331) · [Kotlin](../../examples/worldpay/worldpay.kt#L219) · [Rust](../../examples/worldpay/worldpay.rs#L330)
 
 #### PaymentService.Get
 
@@ -339,7 +341,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L296) · [TypeScript](../../examples/worldpay/worldpay.ts#L281) · [Kotlin](../../examples/worldpay/worldpay.kt#L225) · [Rust](../../examples/worldpay/worldpay.rs#L276)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L359) · [TypeScript](../../examples/worldpay/worldpay.ts#L340) · [Kotlin](../../examples/worldpay/worldpay.kt#L229) · [Rust](../../examples/worldpay/worldpay.rs#L337)
 
 #### PaymentService.ProxyAuthorize
 
@@ -350,7 +352,18 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L305) · [TypeScript](../../examples/worldpay/worldpay.ts#L290) · [Kotlin](../../examples/worldpay/worldpay.kt#L233) · [Rust](../../examples/worldpay/worldpay.rs#L283)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L368) · [TypeScript](../../examples/worldpay/worldpay.ts#L349) · [Kotlin](../../examples/worldpay/worldpay.kt#L237) · [Rust](../../examples/worldpay/worldpay.rs#L344)
+
+#### PaymentService.ProxySetupRecurring
+
+Setup recurring mandate using vault-aliased card data.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceProxySetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L377) · [TypeScript](../../examples/worldpay/worldpay.ts#L358) · [Kotlin](../../examples/worldpay/worldpay.kt#L265) · [Rust](../../examples/worldpay/worldpay.rs#L351)
 
 #### PaymentService.Refund
 
@@ -361,7 +374,18 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L323) · [TypeScript](../../examples/worldpay/worldpay.ts#L308) · [Kotlin](../../examples/worldpay/worldpay.kt#L292) · [Rust](../../examples/worldpay/worldpay.rs#L297)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L395) · [TypeScript](../../examples/worldpay/worldpay.ts#L376) · [Kotlin](../../examples/worldpay/worldpay.kt#L327) · [Rust](../../examples/worldpay/worldpay.rs#L365)
+
+#### PaymentService.SetupRecurring
+
+Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceSetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L413) · [TypeScript](../../examples/worldpay/worldpay.ts#L394) · [Kotlin](../../examples/worldpay/worldpay.kt#L349) · [Rust](../../examples/worldpay/worldpay.rs#L379)
 
 #### PaymentService.Void
 
@@ -372,7 +396,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L341) · [TypeScript](../../examples/worldpay/worldpay.ts) · [Kotlin](../../examples/worldpay/worldpay.kt#L314) · [Rust](../../examples/worldpay/worldpay.rs#L311)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L422) · [TypeScript](../../examples/worldpay/worldpay.ts) · [Kotlin](../../examples/worldpay/worldpay.kt#L388) · [Rust](../../examples/worldpay/worldpay.rs#L389)
 
 ### Refunds
 
@@ -385,7 +409,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L332) · [TypeScript](../../examples/worldpay/worldpay.ts#L317) · [Kotlin](../../examples/worldpay/worldpay.kt#L302) · [Rust](../../examples/worldpay/worldpay.rs#L304)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L404) · [TypeScript](../../examples/worldpay/worldpay.ts#L385) · [Kotlin](../../examples/worldpay/worldpay.kt#L337) · [Rust](../../examples/worldpay/worldpay.rs#L372)
 
 ### Mandates
 
@@ -398,4 +422,4 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/worldpay/worldpay.py#L314) · [TypeScript](../../examples/worldpay/worldpay.ts#L299) · [Kotlin](../../examples/worldpay/worldpay.kt#L261) · [Rust](../../examples/worldpay/worldpay.rs#L290)
+**Examples:** [Python](../../examples/worldpay/worldpay.py#L386) · [TypeScript](../../examples/worldpay/worldpay.ts#L367) · [Kotlin](../../examples/worldpay/worldpay.kt#L296) · [Rust](../../examples/worldpay/worldpay.rs#L358)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -635,7 +635,7 @@ connector_id: worldpay
 doc: docs/connectors/worldpay.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: ApplePay, Card, GooglePay
-flows: authorize, capture, get, proxy_authorize, recurring_charge, refund, refund_get, void
+flows: authorize, capture, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, void
 examples_python: examples/worldpay/worldpay.py
 
 ## Worldpayvantiv

--- a/examples/worldpay/worldpay.kt
+++ b/examples/worldpay/worldpay.kt
@@ -16,11 +16,15 @@ import payments.PaymentServiceRefundRequest
 import payments.PaymentServiceVoidRequest
 import payments.PaymentServiceGetRequest
 import payments.PaymentServiceProxyAuthorizeRequest
+import payments.PaymentServiceProxySetupRecurringRequest
 import payments.RecurringPaymentServiceChargeRequest
 import payments.RefundServiceGetRequest
+import payments.PaymentServiceSetupRecurringRequest
+import payments.AcceptanceType
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
+import payments.FutureUsage
 import payments.PaymentMethodType
 import payments.ConnectorConfig
 import payments.SdkOptions
@@ -257,6 +261,37 @@ fun proxyAuthorize(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+fun proxySetupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_proxy_mandate_001"
+        amountBuilder.apply {
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
+            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+            cardExpMonthBuilder.value = "03"
+            cardExpYearBuilder.value = "2030"
+            cardCvcBuilder.value = "123"
+            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+        }
+        addressBuilder.apply {
+            billingAddressBuilder.apply {
+            }
+        }
+        customerAcceptanceBuilder.apply {
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+        authType = AuthenticationType.NO_THREE_DS
+        setupFutureUsage = FutureUsage.OFF_SESSION
+    }.build()
+    val response = client.proxy_setup_recurring(request)
+    println("Status: ${response.status.name}")
+}
+
 // Flow: RecurringPaymentService.Charge
 fun recurringCharge(txnId: String) {
     val client = RecurringPaymentClient(_defaultConfig)
@@ -310,6 +345,45 @@ fun refundGet(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.SetupRecurring
+fun setupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
+        amountBuilder.apply {  // Mandate Details.
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {
+            cardBuilder.apply {  // Generic card payment.
+                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+                cardExpMonthBuilder.value = "03"
+                cardExpYearBuilder.value = "2030"
+                cardCvcBuilder.value = "737"
+                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            }
+        }
+        addressBuilder.apply {  // Address Information.
+            billingAddressBuilder.apply {
+            }
+        }
+        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
+        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
+        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
+        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
+        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
+        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+    }.build()
+    val response = client.setup_recurring(request)
+    when (response.status.name) {
+        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
+        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
+    }
+}
+
 // Flow: PaymentService.Void
 fun void(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -334,10 +408,12 @@ fun main(args: Array<String>) {
         "capture" -> capture(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
+        "setupRecurring" -> setupRecurring(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, proxyAuthorize, recurringCharge, refund, refundGet, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, void")
     }
 }

--- a/examples/worldpay/worldpay.py
+++ b/examples/worldpay/worldpay.py
@@ -104,6 +104,35 @@ def _build_proxy_authorize_request():
         payment_pb2.PaymentServiceProxyAuthorizeRequest(),
     )
 
+def _build_proxy_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+            "amount": {
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "card_proxy": {  # Card proxy for vault-aliased payments.
+                "card_number": {"value": "4111111111111111"},  # Card Identification.
+                "card_exp_month": {"value": "03"},
+                "card_exp_year": {"value": "2030"},
+                "card_cvc": {"value": "123"},
+                "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+            },
+            "address": {
+                "billing_address": {
+                }
+            },
+            "customer_acceptance": {
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            },
+            "auth_type": "NO_THREE_DS",
+            "setup_future_usage": "OFF_SESSION"
+        },
+        payment_pb2.PaymentServiceProxySetupRecurringRequest(),
+    )
+
 def _build_recurring_charge_request():
     return ParseDict(
         {
@@ -152,6 +181,40 @@ def _build_refund_get_request():
             "refund_id": "probe_refund_id_001"
         },
         payment_pb2.RefundServiceGetRequest(),
+    )
+
+def _build_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_mandate_001",  # Identification.
+            "amount": {  # Mandate Details.
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {
+                "card": {  # Generic card payment.
+                    "card_number": {"value": "4111111111111111"},  # Card Identification.
+                    "card_exp_month": {"value": "03"},
+                    "card_exp_year": {"value": "2030"},
+                    "card_cvc": {"value": "737"},
+                    "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+                }
+            },
+            "address": {  # Address Information.
+                "billing_address": {
+                }
+            },
+            "auth_type": "NO_THREE_DS",  # Type of authentication to be used.
+            "enrolled_for_3ds": False,  # Indicates if the customer is enrolled for 3D Secure.
+            "return_url": "https://example.com/mandate-return",  # URL to redirect after setup.
+            "setup_future_usage": "OFF_SESSION",  # Indicates future usage intention.
+            "request_incremental_authorization": False,  # Indicates if incremental authorization is requested.
+            "customer_acceptance": {  # Details of customer acceptance.
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            }
+        },
+        payment_pb2.PaymentServiceSetupRecurringRequest(),
     )
 
 def _build_void_request(connector_transaction_id: str):
@@ -311,6 +374,15 @@ async def proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.C
     return {"status": proxy_response.status}
 
 
+async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.ProxySetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
+
+    return {"status": proxy_response.status}
+
+
 async def recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: RecurringPaymentService.Charge"""
     recurringpayment_client = RecurringPaymentClient(config)
@@ -336,6 +408,15 @@ async def refund_get(merchant_transaction_id: str, config: sdk_config_pb2.Connec
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
+
+
+async def setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.SetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
+
+    return {"status": setup_response.status, "mandate_id": setup_response.connector_transaction_id}
 
 
 async def void(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/worldpay/worldpay.rs
+++ b/examples/worldpay/worldpay.rs
@@ -96,6 +96,33 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     })).unwrap_or_default()
 }
 
+pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceProxySetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+    "amount": {
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "card_proxy": {  // Card proxy for vault-aliased payments.
+        "card_number": "4111111111111111",  // Card Identification.
+        "card_exp_month": "03",
+        "card_exp_year": "2030",
+        "card_cvc": "123",
+        "card_holder_name": "John Doe",  // Cardholder Information.
+    },
+    "address": {
+        "billing_address": {
+        },
+    },
+    "customer_acceptance": {
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
+    "auth_type": "NO_THREE_DS",
+    "setup_future_usage": "OFF_SESSION",
+    })).unwrap_or_default()
+}
+
 pub fn build_recurring_charge_request() -> RecurringPaymentServiceChargeRequest {
     serde_json::from_value::<RecurringPaymentServiceChargeRequest>(serde_json::json!({
     "connector_recurring_payment_id": {  // Reference to existing mandate.
@@ -141,6 +168,40 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
     "merchant_refund_id": "probe_refund_001",  // Identification.
     "connector_transaction_id": "probe_connector_txn_001",
     "refund_id": "probe_refund_id_001",
+    })).unwrap_or_default()
+}
+
+pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceSetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_mandate_001",  // Identification.
+    "amount": {  // Mandate Details.
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {
+        "payment_method": {
+            "card": {  // Generic card payment.
+                "card_number": "4111111111111111",  // Card Identification.
+                "card_exp_month": "03",
+                "card_exp_year": "2030",
+                "card_cvc": "737",
+                "card_holder_name": "John Doe",  // Cardholder Information.
+            },
+        }
+    },
+    "address": {  // Address Information.
+        "billing_address": {
+        },
+    },
+    "auth_type": "NO_THREE_DS",  // Type of authentication to be used.
+    "enrolled_for_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+    "return_url": "https://example.com/mandate-return",  // URL to redirect after setup.
+    "setup_future_usage": "OFF_SESSION",  // Indicates future usage intention.
+    "request_incremental_authorization": false,  // Indicates if incremental authorization is requested.
+    "customer_acceptance": {  // Details of customer acceptance.
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
     })).unwrap_or_default()
 }
 
@@ -285,6 +346,13 @@ pub async fn proxy_authorize(client: &ConnectorClient, _merchant_transaction_id:
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+#[allow(dead_code)]
+pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: RecurringPaymentService.Charge
 #[allow(dead_code)]
 pub async fn recurring_charge(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -304,6 +372,16 @@ pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) ->
 pub async fn refund_get(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
     let response = client.refund_get(build_refund_get_request(), &HashMap::new(), None).await?;
     Ok(format!("status: {:?}", response.status()))
+}
+
+// Flow: PaymentService.SetupRecurring
+#[allow(dead_code)]
+pub async fn setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.setup_recurring(build_setup_recurring_request(), &HashMap::new(), None).await?;
+    if response.status() == PaymentStatus::Failure {
+        return Err(format!("Setup failed: {:?}", response.error).into());
+    }
+    Ok(format!("Mandate: {}", response.connector_recurring_payment_id.as_deref().unwrap_or("")))
 }
 
 // Flow: PaymentService.Void
@@ -328,11 +406,13 @@ async fn main() {
         "capture" => capture(&client, "order_001").await,
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
+        "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
         "recurring_charge" => recurring_charge(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
+        "setup_recurring" => setup_recurring(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, get, proxy_authorize, recurring_charge, refund, refund_get, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/worldpay/worldpay.ts
+++ b/examples/worldpay/worldpay.ts
@@ -6,7 +6,7 @@
 // Run a scenario:  npx tsx worldpay.ts checkout_autocapture
 
 import { PaymentClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency, PaymentMethodType } = types;
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage, PaymentMethodType } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -91,6 +91,33 @@ function _buildProxyAuthorizeRequest(): PaymentServiceProxyAuthorizeRequest {
     };
 }
 
+function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
+        "amount": {
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "cardProxy": {  // Card proxy for vault-aliased payments.
+            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+            "cardExpMonth": {"value": "03"},
+            "cardExpYear": {"value": "2030"},
+            "cardCvc": {"value": "123"},
+            "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+        },
+        "address": {
+            "billingAddress": {
+            }
+        },
+        "customerAcceptance": {
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        },
+        "authType": AuthenticationType.NO_THREE_DS,
+        "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
 function _buildRecurringChargeRequest(): RecurringPaymentServiceChargeRequest {
     return {
         "connectorRecurringPaymentId": {  // Reference to existing mandate.
@@ -132,6 +159,38 @@ function _buildRefundGetRequest(): RefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"
+    };
+}
+
+function _buildSetupRecurringRequest(): PaymentServiceSetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
+        "amount": {  // Mandate Details.
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {
+            "card": {  // Generic card payment.
+                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+                "cardExpMonth": {"value": "03"},
+                "cardExpYear": {"value": "2030"},
+                "cardCvc": {"value": "737"},
+                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+            }
+        },
+        "address": {  // Address Information.
+            "billingAddress": {
+            }
+        },
+        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
+        "enrolledFor3Ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
+        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
+        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
+        "customerAcceptance": {  // Details of customer acceptance.
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
     };
 }
 
@@ -295,6 +354,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: ConnectorCo
     return { status: proxyResponse.status };
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+async function proxySetupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
+
+    return { status: proxyResponse.status };
+}
+
 // Flow: RecurringPaymentService.Charge
 async function recurringCharge(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RecurringPaymentServiceChargeResponse> {
     const recurringPaymentClient = new RecurringPaymentClient(config);
@@ -322,6 +390,15 @@ async function refundGet(merchantTransactionId: string, config: ConnectorConfig 
     return { status: refundResponse.status };
 }
 
+// Flow: PaymentService.SetupRecurring
+async function setupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
+
+    return { status: setupResponse.status, mandateId: setupResponse.connectorTransactionId };
+}
+
 // Flow: PaymentService.Void
 async function voidPayment(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceVoidResponse> {
     const paymentClient = new PaymentClient(config);
@@ -334,7 +411,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, proxyAuthorize, recurringCharge, refund, refundGet, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Summary

Implement **SetupMandate** (SetupRecurring) flow for the **Worldpay Access** connector.

Worldpay Access does not have a dedicated mandate-setup endpoint. This implementation submits a zero-amount payment to `POST /api/payments` with `tokenCreation={type:"worldpay"}` + `customerAgreement={type:"subscription", storedCardUsage:"first"}` to establish the stored-credential token. The `href` returned on the `token` object becomes the `connector_mandate_id` that `RepeatPayment` later replays as a `CardToken {type:"token", href:...}` payment instrument combined with `customerAgreement={type:"subscription", storedCardUsage:"subsequent"}` (and no `tokenCreation`).

## Changes

- `crates/integrations/connector-integration/src/connectors/worldpay.rs`
  - Added `SetupMandate` + `SetupMandateRequestData` to `domain_types` imports, plus `WorldpaySetupMandateRequest` / `WorldpaySetupMandateResponse`
  - Added `SetupMandate` entry to `macros::create_all_prerequisites!`
  - Added `macros::macro_connector_implementation!` block for `SetupMandate` (reuses the same `api/payments` URL, POST, Basic auth + `WP-API-Version`)
  - Removed the previous empty `ConnectorIntegrationV2<SetupMandate, ...>` impl
- `crates/integrations/connector-integration/src/connectors/worldpay/requests.rs`
  - Added `pub type WorldpaySetupMandateRequest<T> = WorldpayAuthorizeRequest<T>;`
- `crates/integrations/connector-integration/src/connectors/worldpay/response.rs`
  - Added `pub type WorldpaySetupMandateResponse = WorldpayPaymentsResponse;`
- `crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs`
  - Added `TryFrom` for `WorldpaySetupMandateRequest<T>` building the zero-amount CIT with `tokenCreation=worldpay` + `customerAgreement=subscription/first`
  - Added response `TryFrom` that reuses the shared `foreign_try_from` path, populating `MandateReference.connector_mandate_id` from `token.href` when Worldpay returns one
  - **Fix (2026-04-15):** `fetch_payment_instrument` now falls back to `card.card_holder_name` when the billing address does not carry a full name. Worldpay requires `cardHolderName` whenever `tokenCreation` is present.
- `examples/worldpay/worldpay.rs` / `examples/worldpay/worldpay.ts`
  - Added `setup_recurring` / `proxy_setup_recurring` scenarios
- `data/field_probe/worldpay.json`
  - Updated `setup_recurring` + `proxy_setup_recurring` probe entries from `not_implemented` to `supported`

## gRPC Test Results

**Final verdict: Step A SANDBOX-BLOCKED (Worldpay tokenization entitlement), Step B N/A (blocked by Step A).**

**cardHolderName 400 — FIXED in 35bdd1a23.** With the fix applied, the outbound request body is well-formed. The remaining 403 is a Worldpay merchant-level boarding problem, not a code bug.

### Step A — `types.PaymentService/SetupRecurring`

Final outbound request (masked):

```
POST https://try.access.worldpay.com/api/payments
Authorization: Basic <REDACTED>
WP-API-Version: 2024-06-01

{"transactionReference":"wp-sm-1776322689",
 "merchant":{"entity":"<REDACTED>"},
 "instruction":{
   "method":"card",
   "paymentInstrument":{"type":"plain","cardNumber":"<REDACTED_PAN>",
     "expiryDate":{"month":3,"year":2030},"cvc":"<REDACTED_CVV>",
     "cardHolderName":"<REDACTED>"},
   "narrative":{"line1":"Mandate Setup"},
   "value":{"amount":0,"currency":"USD"},
   "tokenCreation":{"type":"worldpay"},
   "customerAgreement":{"type":"subscription","storedCardUsage":"first"}}}
```

Worldpay response (HTTP 403):

```json
{"errorName":"boardingError",
 "message":"There has been a problem with your boarding and you cannot use this API yet, please contact support."}
```

### Evidence of correct request shape + credential validity

Regular Authorize with the SAME credentials succeeds:

```
POST https://try.access.worldpay.com/api/payments
...
{"transactionReference":"wp_auth_<ts>",
 "merchant":{"entity":"<REDACTED>"},
 "instruction":{"settlement":{"auto":true},"method":"card",
   "paymentInstrument":{"type":"plain","cardNumber":"<REDACTED_PAN>",
     "expiryDate":{"month":3,"year":2030},"cvc":"<REDACTED_CVV>",
     "cardHolderName":"<REDACTED>"},
   "narrative":{"line1":"Test Merchant"},"value":{"amount":100,"currency":"USD"},
   "tokenCreation":null,"customerAgreement":null}}
```

Response summary: `status=CHARGED, statusCode=202, networkTransactionId=060720116005062`, outcome `sentForSettlement`. Zero-amount Authorize (`value.amount=0`, no `tokenCreation`, no `customerAgreement`) also succeeds with outcome `authorized` HTTP 201. These show the creds, entity, cardHolderName wiring and URL are all correct.

### Before-fix evidence (demonstrates the cardHolderName issue was real)

```json
{"errorName":"bodyDoesNotMatchSchema",
 "message":"A JSON body matching the expected schema must be provided.",
 "validationErrors":[{"errorName":"fieldIsMissing",
   "message":"Field at path must be present when tokenCreation is present.",
   "jsonPath":"$.instruction.paymentInstrument.cardHolderName"}]}
```

This validated the code bug in `fetch_payment_instrument` (ignoring `card.card_holder_name`). Commit 35bdd1a23 resolves it.

### Why Step A is SANDBOX-BLOCKED, not a code issue

1. Request body matches upstream `hyperswitch_connectors/src/connectors/worldpay/transformers.rs` (`tokenCreation {type: Worldpay}` + `customerAgreement {type: Subscription, storedCardUsage: First}`). See `get_token_and_agreement` upstream vs. the SetupMandate `TryFrom` in this PR.
2. The 403 message "There has been a problem with your boarding and you cannot use this API yet, please contact support" is Worldpay's standard rejection for merchants that are NOT entitled to the tokenization / stored-credential API.
3. The same class of entitlement limitation blocked PR #1058 (`worldpayxml` — `VISAGOVTEST` merchant cannot use tokenization). This is an account-level admin control at Worldpay.
4. No Prism / connector code change can unblock a merchant that is not boarded for tokenization.

### Step B — `types.RecurringPaymentService/Charge`

Not exercised — without a successful Step A we have no `paymentInstrument.href` to feed in as `connector_mandate_id`. The Step B code path is implemented and follows the upstream reference:

- URL: `POST /api/payments` (same as CIT)
- Body: `paymentInstrument = CardToken {type:"token", href:<mandate_id>, cvc:None}`, `customerAgreement = Subscription/Subsequent`, `tokenCreation = None`, `settlement.auto` from capture method.

Re-running Step B against a tokenization-boarded Worldpay sandbox merchant is expected to PASS without further code changes.

## Files Modified

- crates/integrations/connector-integration/src/connectors/worldpay.rs
- crates/integrations/connector-integration/src/connectors/worldpay/requests.rs
- crates/integrations/connector-integration/src/connectors/worldpay/response.rs
- crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
- data/field_probe/worldpay.json
- examples/worldpay/worldpay.rs
- examples/worldpay/worldpay.ts

## Validation Checklist

- [x] `cargo build --bin grpc-server` passes with zero errors (warnings match main)
- [x] Outbound Step A body now includes `cardHolderName` when card carries one (cardHolderName 400 resolved)
- [x] Outbound request body for both Step A and Step B matches upstream hyperswitch reference
- [x] Plain Authorize with same creds returns HTTP 202 `CHARGED` (sanity check of URL/entity/auth wiring)
- [ ] Step A SetupRecurring returned success status — **blocked by sandbox merchant tokenization entitlement** (`boardingError`). Not a code bug; re-run on a tokenization-boarded merchant is expected to PASS.
- [ ] Step B Charge (MIT) — N/A until Step A produces a token
- [x] No credentials in committed source code
- [x] Only connector-specific files modified

## Latest commit

`35bdd1a23` — fix(connector): [Worldpay] fall back to card.card_holder_name for mandate setup
