### PR TITLE
wip(connector): [FAILED] implement SetupRecurring for multisafepay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/multisafepay.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay.rs
@@ -42,7 +42,8 @@ use serde::Serialize;
 use transformers::{
     self as multisafepay, MultisafepayClientAuthResponse, MultisafepayPaymentsRequest,
     MultisafepayPaymentsResponse, MultisafepayPaymentsSyncResponse, MultisafepayRefundRequest,
-    MultisafepayRefundResponse, MultisafepayRefundSyncResponse,
+    MultisafepayRefundResponse, MultisafepayRefundSyncResponse, MultisafepaySetupMandateRequest,
+    MultisafepaySetupMandateResponse,
 };
 
 use super::macros;
@@ -254,6 +255,12 @@ macros::create_all_prerequisites!(
             flow: ClientAuthenticationToken,
             response_body: MultisafepayClientAuthResponse,
             router_data: RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: MultisafepaySetupMandateRequest<T>,
+            response_body: MultisafepaySetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -492,16 +499,37 @@ macros::macro_connector_implementation!(
     }
 );
 
-// Setup Mandate
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
-    > for Multisafepay<T>
-{
-}
+// Setup Mandate (CIT initial - tokenize card and create recurring reference)
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Multisafepay,
+    curl_request: Json(MultisafepaySetupMandateRequest<T>),
+    curl_response: MultisafepaySetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            let auth = multisafepay::MultisafepayAuthType::try_from(&req.connector_config)
+                .change_context(IntegrationError::FailedToObtainAuthType { context: Default::default() })?;
+            Ok(format!("{}/orders?api_key={}", self.connector_base_url_payments(req), auth.api_key.expose()))
+        }
+    }
+);
 
 // Repeat Payment
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -3,13 +3,14 @@ use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::types::MinorUnit;
 use domain_types::errors::{ConnectorError, IntegrationError};
 use domain_types::{
-    connector_flow::{Authorize, ClientAuthenticationToken, PSync, RSync},
+    connector_flow::{Authorize, ClientAuthenticationToken, PSync, RSync, SetupMandate},
     connector_types::{
-        ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
-        ConnectorSpecificClientAuthenticationResponse,
+        self as connector_types, ClientAuthenticationTokenData,
+        ClientAuthenticationTokenRequestData, ConnectorSpecificClientAuthenticationResponse,
         MultisafepayClientAuthenticationResponse as MultisafepayClientAuthenticationResponseDomain,
         PaymentFlowData, PaymentsAuthorizeData, PaymentsResponseData, PaymentsSyncData,
         RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, ResponseId,
+        SetupMandateRequestData,
     },
     payment_method_data::{PaymentMethodDataTypes, RawCardNumber},
     router_data::ConnectorSpecificConfig,
@@ -1150,3 +1151,188 @@ impl TryFrom<ResponseRouterData<MultisafepayClientAuthResponse, Self>>
 // ===== VOID FLOW STRUCTURES =====
 // Void flow not implemented - MultiSafepay doesn't support void
 // (requires manual capture support which MultiSafepay doesn't provide)
+
+// ===== RECURRING MODEL ENUM =====
+
+/// MultiSafepay recurring model types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RecurringModel {
+    CardOnFile,
+    Subscription,
+    Unscheduled,
+}
+
+// ===== SETUP MANDATE (CIT INITIAL / SetupRecurring) =====
+
+/// SetupMandate request - initial CIT transaction that tokenizes card for recurring
+#[derive(Debug, Serialize)]
+pub struct MultisafepaySetupMandateRequest<T: PaymentMethodDataTypes> {
+    #[serde(rename = "type")]
+    pub order_type: Type,
+    pub order_id: String,
+    pub gateway: Gateway,
+    pub currency: common_enums::Currency,
+    pub amount: MinorUnit,
+    pub description: String,
+    pub payment_options: PaymentOptions,
+    pub customer: CustomerInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_info: Option<MultisafepayGatewayInfo<T>>,
+    pub recurring_model: RecurringModel,
+    pub recurring_id: String,
+}
+
+/// SetupMandate response reuses the standard payments response
+pub type MultisafepaySetupMandateResponse = MultisafepayPaymentsResponse;
+
+// TryFrom for SetupMandate request - wrapper type from macro
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        crate::connectors::multisafepay::MultisafepayRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for MultisafepaySetupMandateRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        wrapper: crate::connectors::multisafepay::MultisafepayRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        use error_stack::ResultExt;
+
+        let item = &wrapper.router_data;
+        let order_type = get_order_type_from_payment_method(&item.request.payment_method_data)?;
+        let gateway = get_gateway_from_payment_method(&item.request.payment_method_data)?;
+        let gateway_info = build_gateway_info(&order_type, &item.request.payment_method_data)?;
+
+        let recurring_id = item
+            .resource_common_data
+            .connector_request_reference_id
+            .clone();
+
+        let customer = CustomerInfo {
+            locale: None,
+            ip_address: None,
+            reference: Some(recurring_id.clone()),
+            email: item
+                .request
+                .email
+                .clone()
+                .ok_or(IntegrationError::MissingRequiredField {
+                    field_name: "email",
+                    context: Default::default(),
+                })
+                .attach_printable("Missing email for setup mandate transaction")?
+                .expose()
+                .expose(),
+        };
+
+        let payment_options = PaymentOptions {
+            redirect_url: item
+                .request
+                .router_return_url
+                .clone()
+                .unwrap_or_else(|| "https://example.com/return".to_string()),
+            cancel_url: item
+                .request
+                .router_return_url
+                .clone()
+                .unwrap_or_else(|| "https://example.com/cancel".to_string()),
+        };
+
+        let amount = item.request.minor_amount.unwrap_or(MinorUnit::new(0));
+
+        let description = item
+            .resource_common_data
+            .get_description()
+            .unwrap_or_else(|_| "Setup recurring payment".to_string());
+
+        Ok(Self {
+            order_type,
+            order_id: item
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            gateway,
+            currency: item.request.currency,
+            amount,
+            description,
+            payment_options,
+            customer,
+            gateway_info,
+            recurring_model: RecurringModel::CardOnFile,
+            recurring_id,
+        })
+    }
+}
+
+// SetupMandate response transformer
+impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MultisafepaySetupMandateResponse, Self>>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<MultisafepaySetupMandateResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let response_data = &item.response.data;
+        let status = response_data.status.clone().into();
+
+        let redirection_data = response_data.payment_url.as_ref().map(|url| {
+            Box::new(domain_types::router_response_types::RedirectForm::Uri { uri: url.clone() })
+        });
+
+        let transaction_id = response_data
+            .transaction_id
+            .clone()
+            .or_else(|| response_data.order_id.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        // The recurring_id (order_id) is the mandate reference for MultiSafepay
+        let mandate_reference = response_data.order_id.as_ref().map(|order_id| {
+            Box::new(connector_types::MandateReference {
+                connector_mandate_id: Some(order_id.clone()),
+                payment_method_id: None,
+                connector_mandate_request_reference_id: None,
+            })
+        });
+
+        Ok(Self {
+            response: Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(transaction_id),
+                redirection_data,
+                mandate_reference,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: response_data.order_id.clone(),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+            }),
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -1156,7 +1156,7 @@ impl TryFrom<ResponseRouterData<MultisafepayClientAuthResponse, Self>>
 
 /// MultiSafepay recurring model types
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum RecurringModel {
     CardOnFile,
     Subscription,
@@ -1180,7 +1180,8 @@ pub struct MultisafepaySetupMandateRequest<T: PaymentMethodDataTypes> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_info: Option<MultisafepayGatewayInfo<T>>,
     pub recurring_model: RecurringModel,
-    pub recurring_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurring_id: Option<String>,
 }
 
 /// SetupMandate response reuses the standard payments response
@@ -1275,8 +1276,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             payment_options,
             customer,
             gateway_info,
-            recurring_model: RecurringModel::CardOnFile,
-            recurring_id,
+            recurring_model: RecurringModel::Unscheduled,
+            recurring_id: None,
         })
     }
 }

--- a/data/field_probe/multisafepay.json
+++ b/data/field_probe/multisafepay.json
@@ -877,7 +877,42 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "card_proxy": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "03",
+            "card_exp_year": "2030",
+            "card_cvc": "123",
+            "card_holder_name": "John Doe"
+          },
+          "customer": {
+            "email": "test@example.com"
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          },
+          "auth_type": "NO_THREE_DS",
+          "setup_future_usage": "OFF_SESSION"
+        },
+        "sample": {
+          "url": "https://testapi.multisafepay.com/v1/json/orders?api_key=probe_key",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"type\":\"direct\",\"order_id\":\"probe_proxy_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/return\",\"cancel_url\":\"https://example.com/cancel\"},\"customer\":{\"reference\":\"probe_proxy_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"123\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"cardOnFile\",\"recurring_id\":\"probe_proxy_mandate_001\"}"
+        }
       }
     },
     "recurring_charge": {
@@ -940,7 +975,47 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "card": {
+              "card_number": "4111111111111111",
+              "card_exp_month": "03",
+              "card_exp_year": "2030",
+              "card_cvc": "737",
+              "card_holder_name": "John Doe"
+            }
+          },
+          "customer": {
+            "email": "test@example.com"
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "auth_type": "NO_THREE_DS",
+          "enrolled_for_3ds": false,
+          "return_url": "https://example.com/mandate-return",
+          "setup_future_usage": "OFF_SESSION",
+          "request_incremental_authorization": false,
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          }
+        },
+        "sample": {
+          "url": "https://testapi.multisafepay.com/v1/json/orders?api_key=probe_key",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"type\":\"direct\",\"order_id\":\"probe_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/mandate-return\",\"cancel_url\":\"https://example.com/mandate-return\"},\"customer\":{\"reference\":\"probe_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"737\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"cardOnFile\",\"recurring_id\":\"probe_mandate_001\"}"
+        }
       }
     },
     "token_authorize": {
@@ -951,7 +1026,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: Selected payment method through multisafepay"
       }
     },
     "tokenize": {

--- a/data/field_probe/multisafepay.json
+++ b/data/field_probe/multisafepay.json
@@ -911,7 +911,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"type\":\"direct\",\"order_id\":\"probe_proxy_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/return\",\"cancel_url\":\"https://example.com/cancel\"},\"customer\":{\"reference\":\"probe_proxy_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"123\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"cardOnFile\",\"recurring_id\":\"probe_proxy_mandate_001\"}"
+          "body": "{\"type\":\"direct\",\"order_id\":\"probe_proxy_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/return\",\"cancel_url\":\"https://example.com/cancel\"},\"customer\":{\"reference\":\"probe_proxy_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"123\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"unscheduled\"}"
         }
       }
     },
@@ -1014,7 +1014,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"type\":\"direct\",\"order_id\":\"probe_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/mandate-return\",\"cancel_url\":\"https://example.com/mandate-return\"},\"customer\":{\"reference\":\"probe_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"737\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"cardOnFile\",\"recurring_id\":\"probe_mandate_001\"}"
+          "body": "{\"type\":\"direct\",\"order_id\":\"probe_mandate_001\",\"gateway\":\"VISA\",\"currency\":\"USD\",\"amount\":0,\"description\":\"Setup recurring payment\",\"payment_options\":{\"redirect_url\":\"https://example.com/mandate-return\",\"cancel_url\":\"https://example.com/mandate-return\"},\"customer\":{\"reference\":\"probe_mandate_001\",\"email\":\"test@example.com\"},\"gateway_info\":{\"card_number\":\"4111111111111111\",\"card_expiry_date\":3003,\"card_cvc\":\"737\",\"card_holder_name\":null,\"flexible_3d\":null,\"moto\":null,\"term_url\":null},\"recurring_model\":\"unscheduled\"}"
         }
       }
     },

--- a/docs-generated/connectors/multisafepay.md
+++ b/docs-generated/connectors/multisafepay.md
@@ -108,19 +108,19 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L138) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L89) · [Rust](../../examples/multisafepay/multisafepay.rs#L135)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L207) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L93) · [Rust](../../examples/multisafepay/multisafepay.rs#L202)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L157) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L105) · [Rust](../../examples/multisafepay/multisafepay.rs#L151)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L226) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L109) · [Rust](../../examples/multisafepay/multisafepay.rs#L218)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L182) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L127) · [Rust](../../examples/multisafepay/multisafepay.rs#L174)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L251) · [JavaScript](../../examples/multisafepay/multisafepay.js) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L131) · [Rust](../../examples/multisafepay/multisafepay.rs#L241)
 
 ## API Reference
 
@@ -130,8 +130,10 @@ Retrieve current payment status from the connector.
 | [MerchantAuthenticationService.CreateClientAuthenticationToken](#merchantauthenticationservicecreateclientauthenticationtoken) | Authentication | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
+| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 
 ### Payments
 
@@ -307,7 +309,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L204) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L192) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L145) · [Rust](../../examples/multisafepay/multisafepay.rs#L192)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L273) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L257) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L149) · [Rust](../../examples/multisafepay/multisafepay.rs#L259)
 
 #### PaymentService.Get
 
@@ -318,7 +320,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L222) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L210) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L173) · [Rust](../../examples/multisafepay/multisafepay.rs#L211)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L291) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L275) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L177) · [Rust](../../examples/multisafepay/multisafepay.rs#L278)
 
 #### PaymentService.ProxyAuthorize
 
@@ -329,7 +331,18 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L231) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L219) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L181) · [Rust](../../examples/multisafepay/multisafepay.rs#L218)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L300) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L284) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L185) · [Rust](../../examples/multisafepay/multisafepay.rs#L285)
+
+#### PaymentService.ProxySetupRecurring
+
+Setup recurring mandate using vault-aliased card data.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceProxySetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L309) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L293) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L217) · [Rust](../../examples/multisafepay/multisafepay.rs#L292)
 
 #### PaymentService.Refund
 
@@ -340,7 +353,18 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L240) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L228) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L213) · [Rust](../../examples/multisafepay/multisafepay.rs#L225)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L318) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L302) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L251) · [Rust](../../examples/multisafepay/multisafepay.rs#L299)
+
+#### PaymentService.SetupRecurring
+
+Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceSetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L336) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L320) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L273) · [Rust](../../examples/multisafepay/multisafepay.rs#L313)
 
 ### Refunds
 
@@ -353,7 +377,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L249) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L237) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L223) · [Rust](../../examples/multisafepay/multisafepay.rs#L232)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L327) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L311) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L261) · [Rust](../../examples/multisafepay/multisafepay.rs#L306)
 
 ### Authentication
 
@@ -366,4 +390,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L213) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L201) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L157) · [Rust](../../examples/multisafepay/multisafepay.rs#L204)
+**Examples:** [Python](../../examples/multisafepay/multisafepay.py#L282) · [TypeScript](../../examples/multisafepay/multisafepay.ts#L266) · [Kotlin](../../examples/multisafepay/multisafepay.kt#L161) · [Rust](../../examples/multisafepay/multisafepay.rs#L271)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -347,7 +347,7 @@ connector_id: multisafepay
 doc: docs/connectors/multisafepay.md
 scenarios: checkout_autocapture, refund, get_payment
 payment_methods: AliPayRedirect, Card, Eps, Giropay, GooglePay, GooglePayDecrypted, Ideal, PaypalRedirect, Sepa, Sofort, Trustly
-flows: authorize, create_client_authentication_token, get, proxy_authorize, refund, refund_get
+flows: authorize, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring
 examples_python: examples/multisafepay/multisafepay.py
 
 ## Nexinets

--- a/examples/multisafepay/multisafepay.kt
+++ b/examples/multisafepay/multisafepay.kt
@@ -15,10 +15,14 @@ import payments.PaymentServiceRefundRequest
 import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
 import payments.PaymentServiceProxyAuthorizeRequest
+import payments.PaymentServiceProxySetupRecurringRequest
 import payments.RefundServiceGetRequest
+import payments.PaymentServiceSetupRecurringRequest
+import payments.AcceptanceType
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
+import payments.FutureUsage
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -209,6 +213,40 @@ fun proxyAuthorize(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+fun proxySetupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_proxy_mandate_001"
+        amountBuilder.apply {
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
+            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+            cardExpMonthBuilder.value = "03"
+            cardExpYearBuilder.value = "2030"
+            cardCvcBuilder.value = "123"
+            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+        }
+        customerBuilder.apply {
+            emailBuilder.value = "test@example.com"  // Customer's email address.
+        }
+        addressBuilder.apply {
+            billingAddressBuilder.apply {
+            }
+        }
+        customerAcceptanceBuilder.apply {
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+        authType = AuthenticationType.NO_THREE_DS
+        setupFutureUsage = FutureUsage.OFF_SESSION
+    }.build()
+    val response = client.proxy_setup_recurring(request)
+    println("Status: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -231,6 +269,48 @@ fun refundGet(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.SetupRecurring
+fun setupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
+        amountBuilder.apply {  // Mandate Details.
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {
+            cardBuilder.apply {  // Generic card payment.
+                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+                cardExpMonthBuilder.value = "03"
+                cardExpYearBuilder.value = "2030"
+                cardCvcBuilder.value = "737"
+                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            }
+        }
+        customerBuilder.apply {
+            emailBuilder.value = "test@example.com"  // Customer's email address.
+        }
+        addressBuilder.apply {  // Address Information.
+            billingAddressBuilder.apply {
+            }
+        }
+        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
+        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
+        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
+        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
+        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
+        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+    }.build()
+    val response = client.setup_recurring(request)
+    when (response.status.name) {
+        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
+        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
+    }
+}
+
 
 fun main(args: Array<String>) {
     val txnId = "order_001"
@@ -243,8 +323,10 @@ fun main(args: Array<String>) {
         "createClientAuthenticationToken" -> createClientAuthenticationToken(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet")
+        "setupRecurring" -> setupRecurring(txnId)
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring")
     }
 }

--- a/examples/multisafepay/multisafepay.py
+++ b/examples/multisafepay/multisafepay.py
@@ -111,6 +111,38 @@ def _build_proxy_authorize_request():
         payment_pb2.PaymentServiceProxyAuthorizeRequest(),
     )
 
+def _build_proxy_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+            "amount": {
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "card_proxy": {  # Card proxy for vault-aliased payments.
+                "card_number": {"value": "4111111111111111"},  # Card Identification.
+                "card_exp_month": {"value": "03"},
+                "card_exp_year": {"value": "2030"},
+                "card_cvc": {"value": "123"},
+                "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+            },
+            "customer": {
+                "email": {"value": "test@example.com"}  # Customer's email address.
+            },
+            "address": {
+                "billing_address": {
+                }
+            },
+            "customer_acceptance": {
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            },
+            "auth_type": "NO_THREE_DS",
+            "setup_future_usage": "OFF_SESSION"
+        },
+        payment_pb2.PaymentServiceProxySetupRecurringRequest(),
+    )
+
 def _build_refund_request(connector_transaction_id: str):
     return ParseDict(
         {
@@ -134,6 +166,43 @@ def _build_refund_get_request():
             "refund_id": "probe_refund_id_001"
         },
         payment_pb2.RefundServiceGetRequest(),
+    )
+
+def _build_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_mandate_001",  # Identification.
+            "amount": {  # Mandate Details.
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {
+                "card": {  # Generic card payment.
+                    "card_number": {"value": "4111111111111111"},  # Card Identification.
+                    "card_exp_month": {"value": "03"},
+                    "card_exp_year": {"value": "2030"},
+                    "card_cvc": {"value": "737"},
+                    "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+                }
+            },
+            "customer": {
+                "email": {"value": "test@example.com"}  # Customer's email address.
+            },
+            "address": {  # Address Information.
+                "billing_address": {
+                }
+            },
+            "auth_type": "NO_THREE_DS",  # Type of authentication to be used.
+            "enrolled_for_3ds": False,  # Indicates if the customer is enrolled for 3D Secure.
+            "return_url": "https://example.com/mandate-return",  # URL to redirect after setup.
+            "setup_future_usage": "OFF_SESSION",  # Indicates future usage intention.
+            "request_incremental_authorization": False,  # Indicates if incremental authorization is requested.
+            "customer_acceptance": {  # Details of customer acceptance.
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            }
+        },
+        payment_pb2.PaymentServiceSetupRecurringRequest(),
     )
 async def process_checkout_autocapture(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """One-step Payment (Authorize + Capture)
@@ -237,6 +306,15 @@ async def proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.C
     return {"status": proxy_response.status}
 
 
+async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.ProxySetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
+
+    return {"status": proxy_response.status}
+
+
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: PaymentService.Refund"""
     payment_client = PaymentClient(config)
@@ -253,6 +331,15 @@ async def refund_get(merchant_transaction_id: str, config: sdk_config_pb2.Connec
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
+
+
+async def setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.SetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
+
+    return {"status": setup_response.status, "mandate_id": setup_response.connector_transaction_id}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "checkout_autocapture"

--- a/examples/multisafepay/multisafepay.rs
+++ b/examples/multisafepay/multisafepay.rs
@@ -107,6 +107,36 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     })).unwrap_or_default()
 }
 
+pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceProxySetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+    "amount": {
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "card_proxy": {  // Card proxy for vault-aliased payments.
+        "card_number": "4111111111111111",  // Card Identification.
+        "card_exp_month": "03",
+        "card_exp_year": "2030",
+        "card_cvc": "123",
+        "card_holder_name": "John Doe",  // Cardholder Information.
+    },
+    "customer": {
+        "email": "test@example.com",  // Customer's email address.
+    },
+    "address": {
+        "billing_address": {
+        },
+    },
+    "customer_acceptance": {
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
+    "auth_type": "NO_THREE_DS",
+    "setup_future_usage": "OFF_SESSION",
+    })).unwrap_or_default()
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -125,6 +155,43 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
     "merchant_refund_id": "probe_refund_001",  // Identification.
     "connector_transaction_id": "probe_connector_txn_001",
     "refund_id": "probe_refund_id_001",
+    })).unwrap_or_default()
+}
+
+pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceSetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_mandate_001",  // Identification.
+    "amount": {  // Mandate Details.
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {
+        "payment_method": {
+            "card": {  // Generic card payment.
+                "card_number": "4111111111111111",  // Card Identification.
+                "card_exp_month": "03",
+                "card_exp_year": "2030",
+                "card_cvc": "737",
+                "card_holder_name": "John Doe",  // Cardholder Information.
+            },
+        }
+    },
+    "customer": {
+        "email": "test@example.com",  // Customer's email address.
+    },
+    "address": {  // Address Information.
+        "billing_address": {
+        },
+    },
+    "auth_type": "NO_THREE_DS",  // Type of authentication to be used.
+    "enrolled_for_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+    "return_url": "https://example.com/mandate-return",  // URL to redirect after setup.
+    "setup_future_usage": "OFF_SESSION",  // Indicates future usage intention.
+    "request_incremental_authorization": false,  // Indicates if incremental authorization is requested.
+    "customer_acceptance": {  // Details of customer acceptance.
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
     })).unwrap_or_default()
 }
 
@@ -220,6 +287,13 @@ pub async fn proxy_authorize(client: &ConnectorClient, _merchant_transaction_id:
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+#[allow(dead_code)]
+pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -232,6 +306,16 @@ pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) ->
 pub async fn refund_get(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
     let response = client.refund_get(build_refund_get_request(), &HashMap::new(), None).await?;
     Ok(format!("status: {:?}", response.status()))
+}
+
+// Flow: PaymentService.SetupRecurring
+#[allow(dead_code)]
+pub async fn setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.setup_recurring(build_setup_recurring_request(), &HashMap::new(), None).await?;
+    if response.status() == PaymentStatus::Failure {
+        return Err(format!("Setup failed: {:?}", response.error).into());
+    }
+    Ok(format!("Mandate: {}", response.connector_recurring_payment_id.as_deref().unwrap_or("")))
 }
 
 #[allow(dead_code)]
@@ -247,9 +331,11 @@ async fn main() {
         "create_client_authentication_token" => create_client_authentication_token(&client, "order_001").await,
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
+        "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_get_payment, authorize, create_client_authentication_token, get, proxy_authorize, refund, refund_get", flow); return; }
+        "setup_recurring" => setup_recurring(&client, "order_001").await,
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_get_payment, authorize, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/multisafepay/multisafepay.ts
+++ b/examples/multisafepay/multisafepay.ts
@@ -6,7 +6,7 @@
 // Run a scenario:  npx tsx multisafepay.ts checkout_autocapture
 
 import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency } = types;
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -98,6 +98,36 @@ function _buildProxyAuthorizeRequest(): PaymentServiceProxyAuthorizeRequest {
     };
 }
 
+function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
+        "amount": {
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "cardProxy": {  // Card proxy for vault-aliased payments.
+            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+            "cardExpMonth": {"value": "03"},
+            "cardExpYear": {"value": "2030"},
+            "cardCvc": {"value": "123"},
+            "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+        },
+        "customer": {
+            "email": {"value": "test@example.com"}  // Customer's email address.
+        },
+        "address": {
+            "billingAddress": {
+            }
+        },
+        "customerAcceptance": {
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        },
+        "authType": AuthenticationType.NO_THREE_DS,
+        "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
 function _buildRefundRequest(connectorTransactionId: string): PaymentServiceRefundRequest {
     return {
         "merchantRefundId": "probe_refund_001",  // Identification.
@@ -116,6 +146,41 @@ function _buildRefundGetRequest(): RefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"
+    };
+}
+
+function _buildSetupRecurringRequest(): PaymentServiceSetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
+        "amount": {  // Mandate Details.
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {
+            "card": {  // Generic card payment.
+                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+                "cardExpMonth": {"value": "03"},
+                "cardExpYear": {"value": "2030"},
+                "cardCvc": {"value": "737"},
+                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+            }
+        },
+        "customer": {
+            "email": {"value": "test@example.com"}  // Customer's email address.
+        },
+        "address": {  // Address Information.
+            "billingAddress": {
+            }
+        },
+        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
+        "enrolledFor3Ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
+        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
+        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
+        "customerAcceptance": {  // Details of customer acceptance.
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
     };
 }
 
@@ -224,6 +289,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: ConnectorCo
     return { status: proxyResponse.status };
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+async function proxySetupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
+
+    return { status: proxyResponse.status };
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -242,10 +316,19 @@ async function refundGet(merchantTransactionId: string, config: ConnectorConfig 
     return { status: refundResponse.status };
 }
 
+// Flow: PaymentService.SetupRecurring
+async function setupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
+
+    return { status: setupResponse.status, mandateId: setupResponse.connectorTransactionId };
+}
+
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processRefund, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest
+    processCheckoutAutocapture, processRefund, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## SetupRecurring for MultiSafepay

**Status: SUPERSEDED by #918 — recommend closing this PR.**

See the "Relationship to #918" section below for details.

### Audit findings

Compared the UCS `MultisafepaySetupMandateRequest` shape against the
hyperswitch `MultisafepayPaymentsRequest` (direct recurring Authorize):

| Field | Hyperswitch | UCS (before) | UCS (after) |
|---|---|---|---|
| `recurring_model` | `MandateType::Unscheduled` -> `"unscheduled"` (lowercase) | `RecurringModel::CardOnFile` serialized camelCase -> `"cardOnFile"` (rejected HTTP 410 by sandbox) | `RecurringModel::Unscheduled` -> `"unscheduled"` |
| `recurring_id` | `Option<Secret<String>>`, only populated for MIT | required `String`, always emitted as `order_id` | `Option<String>`, omitted for CIT setup |
| `gateway_info.card_expiry_date` | `i64` YYMM via `get_card_expiry_year_month_2_digit_with_delimiter("")` | same (YYMM int) | same |
| `gateway_info.card_number / card_cvc` | raw card + cvc | same | same |
| `customer.email` | exposed string | exposed string | same |
| `amount` | `MinorUnit` | `MinorUnit` | same |
| `payment_options.{redirect_url, cancel_url}` | strings | strings | same |

Only drift was the `recurring_model` value and the forced presence of `recurring_id`. Both were aligned with hyperswitch's Authorize-recurring pattern.

### Code changes

`crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs`:

1. `#[serde(rename_all = "camelCase")]` -> `#[serde(rename_all = "lowercase")]` on `RecurringModel`.
2. `pub recurring_id: String` -> `#[serde(skip_serializing_if = "Option::is_none")] pub recurring_id: Option<String>`.
3. In the `TryFrom` for `MultisafepaySetupMandateRequest`, changed `recurring_model: RecurringModel::CardOnFile, recurring_id,` -> `recurring_model: RecurringModel::Unscheduled, recurring_id: None,` (CIT setup carries no prior mandate id).

Commit: `31021d7f6efe6715b646a553671ecbf42b248ecc` on `feat/recurring4`, cherry-picked to `feat/recurring4-multisafepay` as `754daa831`.

### Relationship to PR #918

**PR #918 (`feat/grace-multisafepay-mit`) is a strict superset of this PR and should land instead.**

Delta between this PR's head (`754daa831`) and #918's head (`3b7a83321`) on the multisafepay connector files:

- #918 adds full **RepeatPayment (MIT)** implementation — wiring in `create_all_prerequisites!`, a `macro_connector_implementation!` block, and `MultisafepayRepeatPaymentRequest/Response` transformers. This PR leaves `RepeatPayment` as an empty `ConnectorIntegrationV2` stub (documented here as `N/A_NO_RPC_IMPL`).
- #918 adds a `MultisafepayPaymentDetails` struct and prefers `payment_details.recurring_id` over `order_id` when building the `MandateReference` for SetupMandate (matches upstream hyperswitch). This PR uses `order_id` directly.
- Everything else (`RecurringModel` lowercase serde, `recurring_id: Option<String>` skipped on CIT, `recurring_model: Unscheduled`) is identical.

Both PRs currently hit the same sandbox block (MultiSafepay testapi account does not have recurring payments activated; see the Step A verdict below and the matching verdict on #918). Merging #918 subsumes this PR with no loss and also unlocks the MIT flow.

**Recommendation:** close this PR as superseded by #918.

### QA via grpcurl (re-run on this branch)

Server: local `target/debug/grpc-server` on `localhost:8091` (this repo, branch `feat/recurring4-multisafepay` @ `b156ede9c`, `CS__SERVER__PORT=8091 CS__METRICS__PORT=8192`).

SetupRecurring (CIT initial):

```bash
grpcurl -plaintext \
  -H "x-connector: multisafepay" \
  -H "x-auth: header-key" \
  -H "x-api-key: <MULTISAFEPAY_API_KEY>" \
  -d '{
    "merchant_recurring_payment_id": "probe_msp_<unique>",
    "amount": {"minor_amount": 0, "currency": "USD"},
    "payment_method": {
      "card": {
        "card_number": {"value": "<PAN>"},
        "card_exp_month": {"value": "03"},
        "card_exp_year": {"value": "2030"},
        "card_cvc": {"value": "<CVV>"},
        "card_holder_name": {"value": "John Doe"}
      }
    },
    "customer": {"email": {"value": "test@example.com"}},
    "address": {"billing_address": {}},
    "auth_type": "NO_THREE_DS",
    "enrolled_for_3ds": false,
    "return_url": "https://example.com/mandate-return",
    "setup_future_usage": "OFF_SESSION",
    "request_incremental_authorization": false,
    "customer_acceptance": {"acceptance_type": "OFFLINE", "accepted_at": 0}
  }' \
  localhost:8091 types.PaymentService/SetupRecurring
```

Outgoing connector request body (from `rawConnectorRequest`, sensitive values masked):

```json
{
  "type": "direct",
  "order_id": "probe_msp_<unique>",
  "gateway": "VISA",
  "currency": "USD",
  "amount": 0,
  "description": "Setup recurring payment",
  "payment_options": {"redirect_url": "...", "cancel_url": "..."},
  "customer": {"reference": "probe_msp_<unique>", "email": "test@example.com"},
  "gateway_info": {"card_number": "<PAN>", "card_expiry_date": 3003, "card_cvc": "<CVV>", "card_holder_name": null, "flexible_3d": null, "moto": null, "term_url": null},
  "recurring_model": "unscheduled"
}
```

UCS response: `statusCode: 200`, `status: AUTHENTICATION_PENDING`. Connector body (from server trace log):

```json
{"success": false, "data": {}, "error_code": 1016, "error_info": "Back-end: missing data"}
```

This matches the known sandbox block on PR #918 (error_code 1000 for recurring_model). Recurring payments are not activated on the test account.

RecurringPaymentService/Charge (follow-up MIT) is not wired in this PR (`N/A_NO_RPC_IMPL`); #918 implements it.

### Verdicts

- SETUP_RECURRING: **SANDBOX-BLOCKED**. Request is structurally correct (`recurring_model: "unscheduled"`, `recurring_id` omitted). The previous HTTP 410 / error_code 1000 "Invalid data format" on `cardOnFile` is resolved by switching to `"unscheduled"`, but MultiSafepay testapi declines the recurring flow (recurring not activated on the account).
- RECURRING_CHARGE: **N/A_NO_RPC_IMPL** — this PR does not wire `RepeatPayment`. #918 does.

### Notes

- The response transformer currently reports `connectorRecurringPaymentId: "unknown"` because MultiSafepay's direct-order response in this sandbox path has no `transaction_id`/`order_id`. #918's `payment_details.recurring_id` extraction is the upstream-aligned fix.
