### PR TITLE
feat(mollie): implement SetupRecurring

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/mollie.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie.rs
@@ -46,7 +46,8 @@ use transformers::{
     MollieCardTokenResponse, MollieClientAuthRequest, MollieClientAuthResponse,
     MollieCustomerRequest, MollieCustomerResponse, MolliePSyncResponse, MolliePaymentsRequest,
     MolliePaymentsResponse, MollieRSyncResponse, MollieRefundRequest, MollieRefundResponse,
-    MollieSetupMandateRequest, MollieSetupMandateResponse, MollieVoidResponse,
+    MollieRepeatPaymentRequest, MollieRepeatPaymentResponse, MollieSetupMandateRequest,
+    MollieSetupMandateResponse, MollieVoidResponse,
 };
 
 use crate::types::ResponseRouterData;
@@ -121,6 +122,12 @@ macros::create_all_prerequisites!(
             request_body: MollieSetupMandateRequest,
             response_body: MollieSetupMandateResponse,
             router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: RepeatPayment,
+            request_body: MollieRepeatPaymentRequest,
+            response_body: MollieRepeatPaymentResponse,
+            router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -574,16 +581,37 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
-// Repeat Payment
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        RepeatPayment,
-        PaymentFlowData,
-        RepeatPaymentData<T>,
-        PaymentsResponseData,
-    > for Mollie<T>
-{
-}
+// Repeat Payment (Merchant-Initiated recurring charge)
+// POST /payments with sequenceType=recurring + customerId + optional mandateId.
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_headers, get_content_type, get_error_response_v2],
+    connector: Mollie,
+    curl_request: Json(MollieRepeatPaymentRequest),
+    curl_response: MollieRepeatPaymentResponse,
+    flow_name: RepeatPayment,
+    resource_common_data: PaymentFlowData,
+    flow_request: RepeatPaymentData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize ],
+    other_functions: {
+        fn get_url(
+            &self,
+            req: &RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!(
+                "{}/payments",
+                self.base_url(&req.resource_common_data.connectors)
+            ))
+        }
+    }
+);
 
 // Order Create
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/mollie.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie.rs
@@ -8,10 +8,11 @@ use common_utils::{
 };
 use domain_types::{
     connector_flow::{
-        Accept, Authenticate, Authorize, Capture, ClientAuthenticationToken, CreateOrder,
-        DefendDispute, IncrementalAuthorization, MandateRevoke, PSync, PaymentMethodToken,
-        PostAuthenticate, PreAuthenticate, RSync, Refund, RepeatPayment, ServerAuthenticationToken,
-        ServerSessionAuthenticationToken, SetupMandate, SubmitEvidence, Void, VoidPC,
+        Accept, Authenticate, Authorize, Capture, ClientAuthenticationToken,
+        CreateConnectorCustomer, CreateOrder, DefendDispute, IncrementalAuthorization,
+        MandateRevoke, PSync, PaymentMethodToken, PostAuthenticate, PreAuthenticate, RSync, Refund,
+        RepeatPayment, ServerAuthenticationToken, ServerSessionAuthenticationToken, SetupMandate,
+        SubmitEvidence, Void, VoidPC,
     },
     connector_types::{
         AcceptDisputeData, ClientAuthenticationTokenRequestData, ConnectorCustomerData,
@@ -43,8 +44,9 @@ use serde::Serialize;
 use transformers::{
     self as mollie, MollieCaptureRequest, MollieCaptureResponse, MollieCardTokenRequest,
     MollieCardTokenResponse, MollieClientAuthRequest, MollieClientAuthResponse,
-    MolliePSyncResponse, MolliePaymentsRequest, MolliePaymentsResponse, MollieRSyncResponse,
-    MollieRefundRequest, MollieRefundResponse, MollieVoidResponse,
+    MollieCustomerRequest, MollieCustomerResponse, MolliePSyncResponse, MolliePaymentsRequest,
+    MolliePaymentsResponse, MollieRSyncResponse, MollieRefundRequest, MollieRefundResponse,
+    MollieSetupMandateRequest, MollieSetupMandateResponse, MollieVoidResponse,
 };
 
 use crate::types::ResponseRouterData;
@@ -107,6 +109,18 @@ macros::create_all_prerequisites!(
             request_body: MollieClientAuthRequest,
             response_body: MollieClientAuthResponse,
             router_data: RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+        ),
+        (
+            flow: CreateConnectorCustomer,
+            request_body: MollieCustomerRequest,
+            response_body: MollieCustomerResponse,
+            router_data: RouterDataV2<CreateConnectorCustomer, PaymentFlowData, ConnectorCustomerData, ConnectorCustomerResponse>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: MollieSetupMandateRequest,
+            response_body: MollieSetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -517,16 +531,37 @@ macros::macro_connector_implementation!(
     }
 );
 
-// Setup Mandate
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
-    > for Mollie<T>
-{
-}
+// Setup Mandate (SetupRecurring)
+// POST /payments with sequenceType=first + customerId, reuses Authorize request/response.
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_headers, get_content_type, get_error_response_v2],
+    connector: Mollie,
+    curl_request: Json(MollieSetupMandateRequest),
+    curl_response: MollieSetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize ],
+    other_functions: {
+        fn get_url(
+            &self,
+            req: &RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!(
+                "{}/payments",
+                self.base_url(&req.resource_common_data.connectors)
+            ))
+        }
+    }
+);
 
 // Mandate Revoke
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -722,16 +757,36 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 }
 
 // ===== CONNECTOR CUSTOMER CONNECTOR INTEGRATIONS =====
-// Create Connector Customer
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        domain_types::connector_flow::CreateConnectorCustomer,
-        PaymentFlowData,
-        ConnectorCustomerData,
-        ConnectorCustomerResponse,
-    > for Mollie<T>
-{
-}
+// Create Connector Customer — POST /customers -> { id: "cust_xxx" }
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_headers, get_content_type, get_error_response_v2],
+    connector: Mollie,
+    curl_request: Json(MollieCustomerRequest),
+    curl_response: MollieCustomerResponse,
+    flow_name: CreateConnectorCustomer,
+    resource_common_data: PaymentFlowData,
+    flow_request: ConnectorCustomerData,
+    flow_response: ConnectorCustomerResponse,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize ],
+    other_functions: {
+        fn get_url(
+            &self,
+            req: &RouterDataV2<
+                CreateConnectorCustomer,
+                PaymentFlowData,
+                ConnectorCustomerData,
+                ConnectorCustomerResponse,
+            >,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!(
+                "{}/customers",
+                self.base_url(&req.resource_common_data.connectors)
+            ))
+        }
+    }
+);
 
 // ===== CONNECTOR COMMON IMPLEMENTATION =====
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> ConnectorCommon

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -910,9 +910,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .connector_customer
             .clone()
             .or_else(|| match &router_data.request.mandate_reference {
-                MandateReferenceId::ConnectorMandateId(cm) => {
-                    cm.get_payment_method_id().cloned()
-                }
+                MandateReferenceId::ConnectorMandateId(cm) => cm.get_payment_method_id().cloned(),
                 _ => None,
             })
             .ok_or(IntegrationError::MissingRequiredField {
@@ -940,7 +938,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let converter = StringMajorUnitForConnector;
         let amount_value = converter
-            .convert(router_data.request.minor_amount, router_data.request.currency)
+            .convert(
+                router_data.request.minor_amount,
+                router_data.request.currency,
+            )
             .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;
@@ -984,8 +985,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-impl<T: PaymentMethodDataTypes>
-    TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
+impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
     for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
 {
     type Error = error_stack::Report<ConnectorError>;

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -6,17 +6,18 @@ use common_utils::{
 use domain_types::errors::{ConnectorError, IntegrationError};
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, ClientAuthenticationToken, PSync, PaymentMethodToken, RSync, Refund,
-        Void,
+        Authorize, Capture, ClientAuthenticationToken, CreateConnectorCustomer, PSync,
+        PaymentMethodToken, RSync, Refund, SetupMandate, Void,
     },
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
-        ConnectorSpecificClientAuthenticationResponse,
+        ConnectorCustomerData, ConnectorCustomerResponse,
+        ConnectorSpecificClientAuthenticationResponse, MandateReference,
         MollieClientAuthenticationResponse as MollieClientAuthenticationResponseDomain,
         PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
         PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
         PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
-        ResponseId,
+        ResponseId, SetupMandateRequestData,
     },
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
     router_data::ConnectorSpecificConfig,
@@ -92,7 +93,8 @@ pub struct MolliePaymentsRequest {
     #[serde(flatten)]
     pub payment_method_data: MolliePaymentMethodData,
     pub sequence_type: SequenceType,
-    pub capture_mode: MollieCaptureMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture_mode: Option<MollieCaptureMode>,
     // These fields are always null in Hyperswitch but must be present
     pub locale: Option<String>,
     pub cancel_url: Option<String>,
@@ -237,12 +239,13 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let sequence_type = SequenceType::Oneoff;
 
         // captureMode is required for oneoff payments
-        let capture_mode =
+        let capture_mode = Some(
             if item.request.capture_method == Some(common_enums::CaptureMethod::Automatic) {
                 MollieCaptureMode::Automatic
             } else {
                 MollieCaptureMode::Manual
-            };
+            },
+        );
 
         // Build metadata - match Hyperswitch format with orderId
         // Always use orderId format, not connector_meta_data
@@ -616,7 +619,7 @@ pub struct MollieCustomerRequest {
 }
 
 // Mollie Customer Response structure
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MollieCustomerResponse {
     pub id: String,       // cust_xxx format
@@ -849,6 +852,8 @@ pub type MollieCaptureResponse = MolliePaymentsResponse;
 pub type MolliePSyncResponse = MolliePaymentsResponse;
 pub type MollieVoidResponse = MolliePaymentsResponse;
 pub type MollieRSyncResponse = MollieRefundResponse;
+pub type MollieSetupMandateRequest = MolliePaymentsRequest;
+pub type MollieSetupMandateResponse = MolliePaymentsResponse;
 
 // ---- ClientAuthenticationToken flow types ----
 
@@ -996,6 +1001,303 @@ impl TryFrom<ResponseRouterData<MollieClientAuthResponse, Self>>
                 session_data,
                 status_code: item.http_code,
             }),
+            ..item.router_data
+        })
+    }
+}
+
+// ===== CREATE CONNECTOR CUSTOMER FLOW =====
+// POST /customers -> returns { id: "cust_xxx", ... }
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        MollieRouterData<
+            RouterDataV2<
+                CreateConnectorCustomer,
+                PaymentFlowData,
+                ConnectorCustomerData,
+                ConnectorCustomerResponse,
+            >,
+            T,
+        >,
+    > for MollieCustomerRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: MollieRouterData<
+            RouterDataV2<
+                CreateConnectorCustomer,
+                PaymentFlowData,
+                ConnectorCustomerData,
+                ConnectorCustomerResponse,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+        Ok(Self {
+            name: router_data.request.name.clone(),
+            email: router_data
+                .request
+                .email
+                .as_ref()
+                .map(|e| e.clone().expose()),
+            metadata: None,
+        })
+    }
+}
+
+// Response must derive Deserialize to be parseable; add Deserialize to the alias
+// if missing. MollieCustomerResponse already derives Deserialize.
+
+impl TryFrom<ResponseRouterData<MollieCustomerResponse, Self>>
+    for RouterDataV2<
+        CreateConnectorCustomer,
+        PaymentFlowData,
+        ConnectorCustomerData,
+        ConnectorCustomerResponse,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<MollieCustomerResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: Ok(ConnectorCustomerResponse {
+                connector_customer_id: item.response.id,
+            }),
+            ..item.router_data
+        })
+    }
+}
+
+// ===== SETUP MANDATE (SetupRecurring) FLOW =====
+// Uses the same /payments endpoint as Authorize but with:
+//   - sequenceType = "first"   (kick off a mandate)
+//   - customerId   = cust_xxx   (required for mandates)
+//   - capture_mode is OMITTED for sequenceType=first
+// Response's `id` (tr_xxx) is the mandate's anchor payment; the mandate itself
+// is created after the first payment settles. We surface `id` as the
+// connector_mandate_id so downstream RepeatPayment flows can find it.
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        MollieRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for MolliePaymentsRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: MollieRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+
+        // Mollie mandates require a pre-created customer (cust_xxx). This is
+        // populated by the CreateConnectorCustomer flow and propagated on
+        // PaymentFlowData.connector_customer.
+        let customer_id = router_data
+            .resource_common_data
+            .connector_customer
+            .clone()
+            .ok_or(IntegrationError::MissingRequiredField {
+                field_name: "connector_customer",
+                context: Default::default(),
+            })?;
+
+        // Amount: use minor_amount from the mandate request. Mollie requires
+        // a non-zero amount on the first mandate payment.
+        let minor_amount = router_data.request.minor_amount.ok_or(
+            IntegrationError::MissingRequiredField {
+                field_name: "minor_amount",
+                context: Default::default(),
+            },
+        )?;
+        let converter = StringMajorUnitForConnector;
+        let amount_value = converter
+            .convert(minor_amount, router_data.request.currency)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
+
+        // Extract card token or raw card data.
+        let payment_method_data = match &router_data.request.payment_method_data {
+            PaymentMethodData::PaymentMethodToken(t) => {
+                MolliePaymentMethodData::CreditCard(Box::new(CreditCardMethodData {
+                    card_token: Some(t.token.clone()),
+                    billing_address: None,
+                    shipping_address: None,
+                }))
+            }
+            PaymentMethodData::Card(_card_data) => {
+                // Raw card without a Mollie card_token is not supported for
+                // mandate setup — callers must run the PaymentMethodToken flow
+                // (Mollie Components /card-tokens) first.
+                let billing_address = router_data
+                    .resource_common_data
+                    .address
+                    .get_payment_method_billing()
+                    .and_then(|billing| {
+                        let address = billing.address.as_ref()?;
+                        let line1 = address.line1.as_ref()?.peek().to_string();
+                        let street_and_number = match address.line2.as_ref() {
+                            Some(line2) => format!("{},{}", line1, line2.peek().as_str()),
+                            None => line1,
+                        };
+
+                        Some(MollieAddress {
+                            street_and_number: Secret::new(street_and_number),
+                            postal_code: Secret::new(address.zip.as_ref()?.peek().to_string()),
+                            city: address.city.as_ref()?.peek().to_string(),
+                            region: None,
+                            country: address.country?,
+                        })
+                    });
+
+                MolliePaymentMethodData::CreditCard(Box::new(CreditCardMethodData {
+                    card_token: None,
+                    billing_address,
+                    shipping_address: None,
+                }))
+            }
+            _ => {
+                return Err(IntegrationError::NotSupported {
+                    message: "Payment method for SetupMandate".to_string(),
+                    connector: "mollie",
+                    context: Default::default(),
+                }
+                .into());
+            }
+        };
+
+        // orderId metadata mirrors the Authorize flow
+        let mut metadata_map = serde_json::Map::new();
+        metadata_map.insert(
+            "orderId".to_string(),
+            serde_json::Value::String(
+                router_data
+                    .resource_common_data
+                    .connector_request_reference_id
+                    .clone(),
+            ),
+        );
+
+        let description = router_data
+            .resource_common_data
+            .description
+            .clone()
+            .unwrap_or_else(|| {
+                format!(
+                    "Mandate setup {}",
+                    router_data
+                        .resource_common_data
+                        .connector_request_reference_id
+                )
+            });
+
+        Ok(Self {
+            amount: MollieAmount {
+                currency: router_data.request.currency,
+                value: amount_value,
+            },
+            description,
+            redirect_url: router_data
+                .request
+                .router_return_url
+                .clone()
+                .unwrap_or_default(),
+            // Webhook unreachable from sandbox in dev; match Authorize behaviour.
+            webhook_url: "".to_string(),
+            metadata: serde_json::Value::Object(metadata_map),
+            payment_method_data,
+            sequence_type: SequenceType::First,
+            // captureMode MUST be omitted when sequenceType=first.
+            capture_mode: None,
+            locale: None,
+            cancel_url: None,
+            customer_id: Some(customer_id),
+        })
+    }
+}
+
+// SetupMandate Response Transformer — reuses MolliePaymentsResponse.
+// For a sequenceType=first payment, Mollie returns a payment id (tr_xxx) that
+// is the anchor of the mandate. Subsequent recurring charges reference either
+// the customer id alone (and Mollie picks the valid mandate) or the explicit
+// mandate id (mdt_xxx) which is created server-side after the first payment
+// settles. We surface the payment id as connector_mandate_id to give Repeat
+// flows a concrete reference.
+impl<T: PaymentMethodDataTypes>
+    TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<MolliePaymentsResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let status = item.response.status.to_attempt_status();
+
+        let redirection_data = item.response.links.checkout.as_ref().and_then(|checkout| {
+            url::Url::parse(&checkout.href).ok().map(|url| {
+                Box::new(RedirectForm::from((
+                    url,
+                    common_utils::request::Method::Get,
+                )))
+            })
+        });
+
+        // Pull the connector customer id off the router_data so downstream
+        // consumers have it available on the mandate reference.
+        let connector_customer_id = item
+            .router_data
+            .resource_common_data
+            .connector_customer
+            .clone();
+
+        let mandate_reference = MandateReference {
+            connector_mandate_id: Some(item.response.id.clone()),
+            payment_method_id: connector_customer_id,
+            connector_mandate_request_reference_id: None,
+        };
+
+        Ok(Self {
+            response: Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
+                redirection_data,
+                mandate_reference: Some(Box::new(mandate_reference)),
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.id),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+            }),
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -7,16 +7,17 @@ use domain_types::errors::{ConnectorError, IntegrationError};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, CreateConnectorCustomer, PSync,
-        PaymentMethodToken, RSync, Refund, SetupMandate, Void,
+        PaymentMethodToken, RSync, Refund, RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData, ConnectorCustomerData,
         ConnectorCustomerResponse, ConnectorSpecificClientAuthenticationResponse, MandateReference,
+        MandateReferenceId,
         MollieClientAuthenticationResponse as MollieClientAuthenticationResponseDomain,
         PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
         PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
         PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
-        ResponseId, SetupMandateRequestData,
+        RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
     router_data::ConnectorSpecificConfig,
@@ -853,6 +854,166 @@ pub type MollieVoidResponse = MolliePaymentsResponse;
 pub type MollieRSyncResponse = MollieRefundResponse;
 pub type MollieSetupMandateRequest = MolliePaymentsRequest;
 pub type MollieSetupMandateResponse = MolliePaymentsResponse;
+pub type MollieRepeatPaymentResponse = MolliePaymentsResponse;
+
+// ===== REPEAT PAYMENT (Merchant-Initiated) FLOW =====
+// POST /v2/payments with {amount, customerId, mandateId, sequenceType:"recurring",
+// description}. No `method` is sent — Mollie derives it from the mandate. The
+// mandateId is optional: if omitted, Mollie uses the customer's valid mandate.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MollieRepeatPaymentRequest {
+    pub amount: MollieAmount,
+    pub description: String,
+    pub customer_id: String,
+    pub sequence_type: SequenceType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mandate_id: Option<String>,
+    pub webhook_url: String,
+    pub metadata: serde_json::Value,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        MollieRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for MollieRepeatPaymentRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: MollieRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+
+        // Mollie MIT requires a pre-created customer (cust_xxx). It is stored on
+        // PaymentFlowData.connector_customer after the CreateConnectorCustomer
+        // flow. Fall back to the mandate reference's payment_method_id (we
+        // surface the customer id there in SetupMandate response).
+        let customer_id = router_data
+            .resource_common_data
+            .connector_customer
+            .clone()
+            .or_else(|| match &router_data.request.mandate_reference {
+                MandateReferenceId::ConnectorMandateId(cm) => {
+                    cm.get_payment_method_id().cloned()
+                }
+                _ => None,
+            })
+            .ok_or(IntegrationError::MissingRequiredField {
+                field_name: "connector_customer",
+                context: Default::default(),
+            })?;
+
+        // The connector_mandate_id carries the Mollie mandate id (mdt_xxx) or
+        // the anchor payment id (tr_xxx). Mollie accepts mdt_xxx directly; a
+        // tr_xxx will be rejected. If no mandate id is set, Mollie picks the
+        // customer's valid mandate automatically.
+        let mandate_id = match &router_data.request.mandate_reference {
+            MandateReferenceId::ConnectorMandateId(cm) => cm.get_connector_mandate_id(),
+            _ => None,
+        }
+        .and_then(|id| {
+            if id.starts_with("mdt_") {
+                Some(id)
+            } else {
+                // tr_xxx is not a mandate id — let Mollie auto-select the
+                // customer's active mandate instead of sending an invalid value.
+                None
+            }
+        });
+
+        let converter = StringMajorUnitForConnector;
+        let amount_value = converter
+            .convert(router_data.request.minor_amount, router_data.request.currency)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
+
+        let description = router_data
+            .resource_common_data
+            .description
+            .clone()
+            .unwrap_or_else(|| {
+                format!(
+                    "Recurring charge {}",
+                    router_data
+                        .resource_common_data
+                        .connector_request_reference_id
+                )
+            });
+
+        let mut metadata_map = serde_json::Map::new();
+        metadata_map.insert(
+            "orderId".to_string(),
+            serde_json::Value::String(
+                router_data
+                    .resource_common_data
+                    .connector_request_reference_id
+                    .clone(),
+            ),
+        );
+
+        Ok(Self {
+            amount: MollieAmount {
+                currency: router_data.request.currency,
+                value: amount_value,
+            },
+            description,
+            customer_id,
+            sequence_type: SequenceType::Recurring,
+            mandate_id,
+            webhook_url: "".to_string(),
+            metadata: serde_json::Value::Object(metadata_map),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes>
+    TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
+    for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<MolliePaymentsResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let status = item.response.status.to_attempt_status();
+
+        Ok(Self {
+            response: Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.id),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+            }),
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
 
 // ---- ClientAuthenticationToken flow types ----
 

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -332,6 +332,16 @@ pub struct MolliePaymentsResponse {
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    // Mollie mandate id (mdt_xxx) is present once a card mandate has been
+    // minted by a settled first payment, or on recurring payments that used
+    // an explicit mandate. Absent on un-settled first payments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mandate_id: Option<String>,
+    // Mollie customer id (cst_xxx) is echoed back on payments created for a
+    // customer. Useful for surfacing on mandate_reference so downstream MIT
+    // flows can locate the customer without an explicit lookup.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub customer_id: Option<String>,
     #[serde(rename = "_links")]
     pub links: MollieLinks,
 }
@@ -1404,8 +1414,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 // is the anchor of the mandate. Subsequent recurring charges reference either
 // the customer id alone (and Mollie picks the valid mandate) or the explicit
 // mandate id (mdt_xxx) which is created server-side after the first payment
-// settles. We surface the payment id as connector_mandate_id to give Repeat
-// flows a concrete reference.
+// settles. Prefer the real mandate id (mdt_xxx) when the response carries it
+// (settled first payments), and fall back to the anchor payment id (tr_xxx)
+// for unsettled first payments so downstream flows still have a reference.
 impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
     for RouterDataV2<
         SetupMandate,
@@ -1431,15 +1442,30 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MolliePaymentsRespons
         });
 
         // Pull the connector customer id off the router_data so downstream
-        // consumers have it available on the mandate reference.
+        // consumers have it available on the mandate reference. Prefer the
+        // customer id echoed by Mollie on the response (authoritative), but
+        // fall back to the router-data's connector_customer if the response
+        // omits it.
         let connector_customer_id = item
-            .router_data
-            .resource_common_data
-            .connector_customer
-            .clone();
+            .response
+            .customer_id
+            .clone()
+            .or_else(|| item.router_data.resource_common_data.connector_customer.clone());
+
+        // Prefer real Mollie mandate id (mdt_xxx) when present — this is
+        // minted once the first payment settles. Before then, surface the
+        // anchor payment id (tr_xxx) so downstream MIT charges have a
+        // reference; Mollie will reject a tr_xxx in mandateId, but our
+        // RepeatPayment transformer filters that out and lets Mollie pick
+        // the customer's valid mandate when only the customer id is sent.
+        let connector_mandate_id = item
+            .response
+            .mandate_id
+            .clone()
+            .or_else(|| Some(item.response.id.clone()));
 
         let mandate_reference = MandateReference {
-            connector_mandate_id: Some(item.response.id.clone()),
+            connector_mandate_id,
             payment_method_id: connector_customer_id,
             connector_mandate_request_reference_id: None,
         };

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -10,9 +10,8 @@ use domain_types::{
         PaymentMethodToken, RSync, Refund, SetupMandate, Void,
     },
     connector_types::{
-        ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
-        ConnectorCustomerData, ConnectorCustomerResponse,
-        ConnectorSpecificClientAuthenticationResponse, MandateReference,
+        ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData, ConnectorCustomerData,
+        ConnectorCustomerResponse, ConnectorSpecificClientAuthenticationResponse, MandateReference,
         MollieClientAuthenticationResponse as MollieClientAuthenticationResponseDomain,
         PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
         PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
@@ -1124,12 +1123,14 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // Amount: use minor_amount from the mandate request. Mollie requires
         // a non-zero amount on the first mandate payment.
-        let minor_amount = router_data.request.minor_amount.ok_or(
-            IntegrationError::MissingRequiredField {
-                field_name: "minor_amount",
-                context: Default::default(),
-            },
-        )?;
+        let minor_amount =
+            router_data
+                .request
+                .minor_amount
+                .ok_or(IntegrationError::MissingRequiredField {
+                    field_name: "minor_amount",
+                    context: Default::default(),
+                })?;
         let converter = StringMajorUnitForConnector;
         let amount_value = converter
             .convert(minor_amount, router_data.request.currency)
@@ -1244,8 +1245,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 // mandate id (mdt_xxx) which is created server-side after the first payment
 // settles. We surface the payment id as connector_mandate_id to give Repeat
 // flows a concrete reference.
-impl<T: PaymentMethodDataTypes>
-    TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
+impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MolliePaymentsResponse, Self>>
     for RouterDataV2<
         SetupMandate,
         PaymentFlowData,

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -1446,11 +1446,12 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MolliePaymentsRespons
         // customer id echoed by Mollie on the response (authoritative), but
         // fall back to the router-data's connector_customer if the response
         // omits it.
-        let connector_customer_id = item
-            .response
-            .customer_id
-            .clone()
-            .or_else(|| item.router_data.resource_common_data.connector_customer.clone());
+        let connector_customer_id = item.response.customer_id.clone().or_else(|| {
+            item.router_data
+                .resource_common_data
+                .connector_customer
+                .clone()
+        });
 
         // Prefer real Mollie mandate id (mdt_xxx) when present — this is
         // minted once the first payment settles. Before then, surface the

--- a/crates/internal/integration-tests/src/connector_specs/mollie/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/mollie/override.json
@@ -1,1 +1,10 @@
-{}
+{
+  "setup_recurring": {
+    "setup_recurring": {
+      "grpc_req": {
+        "return_url": "https://example.com/payment/return",
+        "webhook_url": "https://example.com/payment/webhook"
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/mollie/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/mollie/specs.json
@@ -5,8 +5,10 @@
     "capture",
     "client_authentication_token",
     "get",
+    "create_customer",
     "refund",
     "refund_sync",
+    "setup_recurring",
     "tokenize_payment_method",
     "void"
   ]

--- a/data/field_probe/mollie.json
+++ b/data/field_probe/mollie.json
@@ -584,7 +584,39 @@
     },
     "recurring_charge": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "connector_recurring_payment_id": {
+            "mandate_id_type": {
+              "connector_mandate_id": {
+                "connector_mandate_id": "probe-mandate-123"
+              }
+            }
+          },
+          "amount": {
+            "minor_amount": 1000,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "token": {
+              "token": "probe_pm_token"
+            }
+          },
+          "return_url": "https://example.com/recurring-return",
+          "connector_customer_id": "cust_probe_123",
+          "payment_method_type": "PAY_PAL",
+          "off_session": true
+        },
+        "sample": {
+          "url": "https://api.mollie.com/v2/payments",
+          "method": "Post",
+          "headers": {
+            "authorization": "Bearer probe_key",
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":\"10.00\"},\"description\":\"Recurring charge \",\"customerId\":\"cust_probe_123\",\"sequenceType\":\"recurring\",\"webhookUrl\":\"\",\"metadata\":{\"orderId\":\"\"}}"
+        }
       }
     },
     "recurring_revoke": {

--- a/data/field_probe/mollie.json
+++ b/data/field_probe/mollie.json
@@ -438,7 +438,23 @@
     },
     "create_customer": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_customer_id": "cust_probe_123",
+          "customer_name": "John Doe",
+          "email": "test@example.com",
+          "phone_number": "4155552671"
+        },
+        "sample": {
+          "url": "https://api.mollie.com/v2/customers",
+          "method": "Post",
+          "headers": {
+            "authorization": "Bearer probe_key",
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"name\":\"John Doe\",\"email\":\"test@example.com\"}"
+        }
       }
     },
     "create_order": {
@@ -562,7 +578,8 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: connector_customer — Missing required field: connector_customer"
       }
     },
     "recurring_charge": {
@@ -627,7 +644,8 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: connector_customer — Missing required field: connector_customer"
       }
     },
     "token_authorize": {
@@ -661,7 +679,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "error",
+        "error": "Stuck on field: connector_customer — Missing required field: connector_customer"
       }
     },
     "tokenize": {

--- a/docs-generated/connectors/mollie.md
+++ b/docs-generated/connectors/mollie.md
@@ -108,25 +108,25 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L173) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L97) · [Rust](../../examples/mollie/mollie.rs#L163)
+**Examples:** [Python](../../examples/mollie/mollie.py#L199) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L100) · [Rust](../../examples/mollie/mollie.rs#L190)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L192) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L113) · [Rust](../../examples/mollie/mollie.rs#L179)
+**Examples:** [Python](../../examples/mollie/mollie.py#L218) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L116) · [Rust](../../examples/mollie/mollie.rs#L206)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L217) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L135) · [Rust](../../examples/mollie/mollie.rs#L202)
+**Examples:** [Python](../../examples/mollie/mollie.py#L243) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L138) · [Rust](../../examples/mollie/mollie.rs#L229)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L239) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L154) · [Rust](../../examples/mollie/mollie.rs#L221)
+**Examples:** [Python](../../examples/mollie/mollie.py#L265) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L157) · [Rust](../../examples/mollie/mollie.rs#L248)
 
 ## API Reference
 
@@ -137,6 +137,7 @@ Retrieve current payment status from the connector.
 | [CustomerService.Create](#customerservicecreate) | Customers | `CustomerServiceCreateRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
 | [PaymentService.TokenAuthorize](#paymentservicetokenauthorize) | Payments | `PaymentServiceTokenAuthorizeRequest` |
@@ -265,7 +266,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L261) · [TypeScript](../../examples/mollie/mollie.ts#L242) · [Kotlin](../../examples/mollie/mollie.kt#L172) · [Rust](../../examples/mollie/mollie.rs#L239)
+**Examples:** [Python](../../examples/mollie/mollie.py#L287) · [TypeScript](../../examples/mollie/mollie.ts#L265) · [Kotlin](../../examples/mollie/mollie.kt#L175) · [Rust](../../examples/mollie/mollie.rs#L266)
 
 #### PaymentService.Get
 
@@ -276,7 +277,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L288) · [TypeScript](../../examples/mollie/mollie.ts#L269) · [Kotlin](../../examples/mollie/mollie.kt#L213) · [Rust](../../examples/mollie/mollie.rs#L265)
+**Examples:** [Python](../../examples/mollie/mollie.py#L314) · [TypeScript](../../examples/mollie/mollie.ts#L292) · [Kotlin](../../examples/mollie/mollie.kt#L216) · [Rust](../../examples/mollie/mollie.rs#L292)
 
 #### PaymentService.ProxyAuthorize
 
@@ -287,7 +288,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L297) · [TypeScript](../../examples/mollie/mollie.ts#L278) · [Kotlin](../../examples/mollie/mollie.kt#L221) · [Rust](../../examples/mollie/mollie.rs#L272)
+**Examples:** [Python](../../examples/mollie/mollie.py#L323) · [TypeScript](../../examples/mollie/mollie.ts#L301) · [Kotlin](../../examples/mollie/mollie.kt#L224) · [Rust](../../examples/mollie/mollie.rs#L299)
 
 #### PaymentService.Refund
 
@@ -298,7 +299,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L306) · [TypeScript](../../examples/mollie/mollie.ts#L287) · [Kotlin](../../examples/mollie/mollie.kt#L250) · [Rust](../../examples/mollie/mollie.rs#L279)
+**Examples:** [Python](../../examples/mollie/mollie.py#L341) · [TypeScript](../../examples/mollie/mollie.ts#L319) · [Kotlin](../../examples/mollie/mollie.kt#L284) · [Rust](../../examples/mollie/mollie.rs#L313)
 
 #### PaymentService.TokenAuthorize
 
@@ -309,7 +310,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L324) · [TypeScript](../../examples/mollie/mollie.ts#L305) · [Kotlin](../../examples/mollie/mollie.kt#L272) · [Rust](../../examples/mollie/mollie.rs#L293)
+**Examples:** [Python](../../examples/mollie/mollie.py#L359) · [TypeScript](../../examples/mollie/mollie.ts#L337) · [Kotlin](../../examples/mollie/mollie.kt#L306) · [Rust](../../examples/mollie/mollie.rs#L327)
 
 #### PaymentService.Void
 
@@ -320,7 +321,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L333) · [TypeScript](../../examples/mollie/mollie.ts) · [Kotlin](../../examples/mollie/mollie.kt#L294) · [Rust](../../examples/mollie/mollie.rs#L300)
+**Examples:** [Python](../../examples/mollie/mollie.py#L368) · [TypeScript](../../examples/mollie/mollie.ts) · [Kotlin](../../examples/mollie/mollie.kt#L328) · [Rust](../../examples/mollie/mollie.rs#L334)
 
 ### Refunds
 
@@ -333,7 +334,20 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L315) · [TypeScript](../../examples/mollie/mollie.ts#L296) · [Kotlin](../../examples/mollie/mollie.kt#L260) · [Rust](../../examples/mollie/mollie.rs#L286)
+**Examples:** [Python](../../examples/mollie/mollie.py#L350) · [TypeScript](../../examples/mollie/mollie.ts#L328) · [Kotlin](../../examples/mollie/mollie.kt#L294) · [Rust](../../examples/mollie/mollie.rs#L320)
+
+### Mandates
+
+#### RecurringPaymentService.Charge
+
+Charge using an existing stored recurring payment instruction. Processes repeat payments for subscriptions or recurring billing without collecting payment details.
+
+| | Message |
+|---|---------|
+| **Request** | `RecurringPaymentServiceChargeRequest` |
+| **Response** | `RecurringPaymentServiceChargeResponse` |
+
+**Examples:** [Python](../../examples/mollie/mollie.py#L332) · [TypeScript](../../examples/mollie/mollie.ts#L310) · [Kotlin](../../examples/mollie/mollie.kt#L253) · [Rust](../../examples/mollie/mollie.rs#L306)
 
 ### Customers
 
@@ -346,7 +360,7 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L279) · [TypeScript](../../examples/mollie/mollie.ts#L260) · [Kotlin](../../examples/mollie/mollie.kt#L200) · [Rust](../../examples/mollie/mollie.rs#L258)
+**Examples:** [Python](../../examples/mollie/mollie.py#L305) · [TypeScript](../../examples/mollie/mollie.ts#L283) · [Kotlin](../../examples/mollie/mollie.kt#L203) · [Rust](../../examples/mollie/mollie.rs#L285)
 
 ### Authentication
 
@@ -359,4 +373,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L270) · [TypeScript](../../examples/mollie/mollie.ts#L251) · [Kotlin](../../examples/mollie/mollie.kt#L184) · [Rust](../../examples/mollie/mollie.rs#L251)
+**Examples:** [Python](../../examples/mollie/mollie.py#L296) · [TypeScript](../../examples/mollie/mollie.ts#L274) · [Kotlin](../../examples/mollie/mollie.kt#L187) · [Rust](../../examples/mollie/mollie.rs#L278)

--- a/docs-generated/connectors/mollie.md
+++ b/docs-generated/connectors/mollie.md
@@ -108,25 +108,25 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L161) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L95) · [Rust](../../examples/mollie/mollie.rs#L154)
+**Examples:** [Python](../../examples/mollie/mollie.py#L173) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L97) · [Rust](../../examples/mollie/mollie.rs#L163)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L180) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L111) · [Rust](../../examples/mollie/mollie.rs#L170)
+**Examples:** [Python](../../examples/mollie/mollie.py#L192) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L113) · [Rust](../../examples/mollie/mollie.rs#L179)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L205) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L133) · [Rust](../../examples/mollie/mollie.rs#L193)
+**Examples:** [Python](../../examples/mollie/mollie.py#L217) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L135) · [Rust](../../examples/mollie/mollie.rs#L202)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L227) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L152) · [Rust](../../examples/mollie/mollie.rs#L212)
+**Examples:** [Python](../../examples/mollie/mollie.py#L239) · [JavaScript](../../examples/mollie/mollie.js) · [Kotlin](../../examples/mollie/mollie.kt#L154) · [Rust](../../examples/mollie/mollie.rs#L221)
 
 ## API Reference
 
@@ -134,6 +134,7 @@ Retrieve current payment status from the connector.
 |--------------------|----------|----------------------|
 | [PaymentService.Authorize](#paymentserviceauthorize) | Payments | `PaymentServiceAuthorizeRequest` |
 | [MerchantAuthenticationService.CreateClientAuthenticationToken](#merchantauthenticationservicecreateclientauthenticationtoken) | Authentication | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
+| [CustomerService.Create](#customerservicecreate) | Customers | `CustomerServiceCreateRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
@@ -264,7 +265,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L249) · [TypeScript](../../examples/mollie/mollie.ts#L233) · [Kotlin](../../examples/mollie/mollie.kt#L170) · [Rust](../../examples/mollie/mollie.rs#L230)
+**Examples:** [Python](../../examples/mollie/mollie.py#L261) · [TypeScript](../../examples/mollie/mollie.ts#L242) · [Kotlin](../../examples/mollie/mollie.kt#L172) · [Rust](../../examples/mollie/mollie.rs#L239)
 
 #### PaymentService.Get
 
@@ -275,7 +276,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L267) · [TypeScript](../../examples/mollie/mollie.ts#L251) · [Kotlin](../../examples/mollie/mollie.kt#L198) · [Rust](../../examples/mollie/mollie.rs#L249)
+**Examples:** [Python](../../examples/mollie/mollie.py#L288) · [TypeScript](../../examples/mollie/mollie.ts#L269) · [Kotlin](../../examples/mollie/mollie.kt#L213) · [Rust](../../examples/mollie/mollie.rs#L265)
 
 #### PaymentService.ProxyAuthorize
 
@@ -286,7 +287,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L276) · [TypeScript](../../examples/mollie/mollie.ts#L260) · [Kotlin](../../examples/mollie/mollie.kt#L206) · [Rust](../../examples/mollie/mollie.rs#L256)
+**Examples:** [Python](../../examples/mollie/mollie.py#L297) · [TypeScript](../../examples/mollie/mollie.ts#L278) · [Kotlin](../../examples/mollie/mollie.kt#L221) · [Rust](../../examples/mollie/mollie.rs#L272)
 
 #### PaymentService.Refund
 
@@ -297,7 +298,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L285) · [TypeScript](../../examples/mollie/mollie.ts#L269) · [Kotlin](../../examples/mollie/mollie.kt#L235) · [Rust](../../examples/mollie/mollie.rs#L263)
+**Examples:** [Python](../../examples/mollie/mollie.py#L306) · [TypeScript](../../examples/mollie/mollie.ts#L287) · [Kotlin](../../examples/mollie/mollie.kt#L250) · [Rust](../../examples/mollie/mollie.rs#L279)
 
 #### PaymentService.TokenAuthorize
 
@@ -308,7 +309,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L303) · [TypeScript](../../examples/mollie/mollie.ts#L287) · [Kotlin](../../examples/mollie/mollie.kt#L257) · [Rust](../../examples/mollie/mollie.rs#L277)
+**Examples:** [Python](../../examples/mollie/mollie.py#L324) · [TypeScript](../../examples/mollie/mollie.ts#L305) · [Kotlin](../../examples/mollie/mollie.kt#L272) · [Rust](../../examples/mollie/mollie.rs#L293)
 
 #### PaymentService.Void
 
@@ -319,7 +320,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L312) · [TypeScript](../../examples/mollie/mollie.ts) · [Kotlin](../../examples/mollie/mollie.kt#L279) · [Rust](../../examples/mollie/mollie.rs#L284)
+**Examples:** [Python](../../examples/mollie/mollie.py#L333) · [TypeScript](../../examples/mollie/mollie.ts) · [Kotlin](../../examples/mollie/mollie.kt#L294) · [Rust](../../examples/mollie/mollie.rs#L300)
 
 ### Refunds
 
@@ -332,7 +333,20 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L294) · [TypeScript](../../examples/mollie/mollie.ts#L278) · [Kotlin](../../examples/mollie/mollie.kt#L245) · [Rust](../../examples/mollie/mollie.rs#L270)
+**Examples:** [Python](../../examples/mollie/mollie.py#L315) · [TypeScript](../../examples/mollie/mollie.ts#L296) · [Kotlin](../../examples/mollie/mollie.kt#L260) · [Rust](../../examples/mollie/mollie.rs#L286)
+
+### Customers
+
+#### CustomerService.Create
+
+Create customer record in the payment processor system. Stores customer details for future payment operations without re-sending personal information.
+
+| | Message |
+|---|---------|
+| **Request** | `CustomerServiceCreateRequest` |
+| **Response** | `CustomerServiceCreateResponse` |
+
+**Examples:** [Python](../../examples/mollie/mollie.py#L279) · [TypeScript](../../examples/mollie/mollie.ts#L260) · [Kotlin](../../examples/mollie/mollie.kt#L200) · [Rust](../../examples/mollie/mollie.rs#L258)
 
 ### Authentication
 
@@ -345,4 +359,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/mollie/mollie.py#L258) · [TypeScript](../../examples/mollie/mollie.ts#L242) · [Kotlin](../../examples/mollie/mollie.kt#L182) · [Rust](../../examples/mollie/mollie.rs#L242)
+**Examples:** [Python](../../examples/mollie/mollie.py#L270) · [TypeScript](../../examples/mollie/mollie.ts#L251) · [Kotlin](../../examples/mollie/mollie.kt#L184) · [Rust](../../examples/mollie/mollie.rs#L251)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -339,7 +339,7 @@ connector_id: mollie
 doc: docs/connectors/mollie.md
 scenarios: checkout_autocapture, refund, void_payment, get_payment
 payment_methods: Card
-flows: authorize, create_client_authentication_token, get, proxy_authorize, refund, refund_get, token_authorize, void
+flows: authorize, create_client_authentication_token, create_customer, get, proxy_authorize, refund, refund_get, token_authorize, void
 examples_python: examples/mollie/mollie.py
 
 ## Multisafepay

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -339,7 +339,7 @@ connector_id: mollie
 doc: docs/connectors/mollie.md
 scenarios: checkout_autocapture, refund, void_payment, get_payment
 payment_methods: Card
-flows: authorize, create_client_authentication_token, create_customer, get, proxy_authorize, refund, refund_get, token_authorize, void
+flows: authorize, create_client_authentication_token, create_customer, get, proxy_authorize, recurring_charge, refund, refund_get, token_authorize, void
 examples_python: examples/mollie/mollie.py
 
 ## Multisafepay

--- a/examples/mollie/mollie.kt
+++ b/examples/mollie/mollie.kt
@@ -10,6 +10,7 @@ package examples.mollie
 import payments.PaymentClient
 import payments.MerchantAuthenticationClient
 import payments.CustomerClient
+import payments.RecurringPaymentClient
 import payments.RefundClient
 import payments.PaymentServiceAuthorizeRequest
 import payments.PaymentServiceRefundRequest
@@ -18,11 +19,13 @@ import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
 import payments.CustomerServiceCreateRequest
 import payments.PaymentServiceProxyAuthorizeRequest
+import payments.RecurringPaymentServiceChargeRequest
 import payments.RefundServiceGetRequest
 import payments.PaymentServiceTokenAuthorizeRequest
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
+import payments.PaymentMethodType
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -246,6 +249,37 @@ fun proxyAuthorize(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: RecurringPaymentService.Charge
+fun recurringCharge(txnId: String) {
+    val client = RecurringPaymentClient(_defaultConfig)
+    val request = RecurringPaymentServiceChargeRequest.newBuilder().apply {
+        connectorRecurringPaymentIdBuilder.apply {  // Reference to existing mandate.
+            connectorMandateIdBuilder.apply {  // mandate_id sent by the connector.
+                connectorMandateIdBuilder.apply {
+                    connectorMandateId = "probe-mandate-123"
+                }
+            }
+        }
+        amountBuilder.apply {  // Amount Information.
+            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {  // Optional payment Method Information (for network transaction flows).
+            tokenBuilder.apply {  // Payment tokens.
+                tokenBuilder.value = "probe_pm_token"  // The token string representing a payment method.
+            }
+        }
+        returnUrl = "https://example.com/recurring-return"
+        connectorCustomerId = "cust_probe_123"
+        paymentMethodType = PaymentMethodType.PAY_PAL
+        offSession = true  // Behavioral Flags and Preferences.
+    }.build()
+    val response = client.charge(request)
+    if (response.status.name == "FAILED")
+        throw RuntimeException("Recurring_Charge failed: ${response.error.unifiedDetails.message}")
+    println("Done: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -314,10 +348,11 @@ fun main(args: Array<String>) {
         "createCustomer" -> createCustomer(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, refund, refundGet, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, void")
     }
 }

--- a/examples/mollie/mollie.kt
+++ b/examples/mollie/mollie.kt
@@ -9,12 +9,14 @@ package examples.mollie
 
 import payments.PaymentClient
 import payments.MerchantAuthenticationClient
+import payments.CustomerClient
 import payments.RefundClient
 import payments.PaymentServiceAuthorizeRequest
 import payments.PaymentServiceRefundRequest
 import payments.PaymentServiceVoidRequest
 import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
+import payments.CustomerServiceCreateRequest
 import payments.PaymentServiceProxyAuthorizeRequest
 import payments.RefundServiceGetRequest
 import payments.PaymentServiceTokenAuthorizeRequest
@@ -194,6 +196,19 @@ fun createClientAuthenticationToken(txnId: String) {
     println("StatusCode: ${response.statusCode}")
 }
 
+// Flow: CustomerService.Create
+fun createCustomer(txnId: String) {
+    val client = CustomerClient(_defaultConfig)
+    val request = CustomerServiceCreateRequest.newBuilder().apply {
+        merchantCustomerId = "cust_probe_123"  // Identification.
+        customerName = "John Doe"  // Name of the customer.
+        emailBuilder.value = "test@example.com"  // Email address of the customer.
+        phoneNumber = "4155552671"  // Phone number of the customer.
+    }.build()
+    val response = client.create(request)
+    println("Customer: ${response.connectorCustomerId}")
+}
+
 // Flow: PaymentService.Get
 fun get(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -296,12 +311,13 @@ fun main(args: Array<String>) {
         "processGetPayment" -> processGetPayment(txnId)
         "authorize" -> authorize(txnId)
         "createClientAuthenticationToken" -> createClientAuthenticationToken(txnId)
+        "createCustomer" -> createCustomer(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, refund, refundGet, tokenAuthorize, void")
     }
 }

--- a/examples/mollie/mollie.py
+++ b/examples/mollie/mollie.py
@@ -10,6 +10,7 @@ import sys
 from google.protobuf.json_format import ParseDict
 from payments import PaymentClient
 from payments import MerchantAuthenticationClient
+from payments import CustomerClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
@@ -63,6 +64,17 @@ def _build_create_client_authentication_token_request():
             }
         },
         payment_pb2.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest(),
+    )
+
+def _build_create_customer_request():
+    return ParseDict(
+        {
+            "merchant_customer_id": "cust_probe_123",  # Identification.
+            "customer_name": "John Doe",  # Name of the customer.
+            "email": {"value": "test@example.com"},  # Email address of the customer.
+            "phone_number": "4155552671"  # Phone number of the customer.
+        },
+        payment_pb2.CustomerServiceCreateRequest(),
     )
 
 def _build_get_request(connector_transaction_id: str):
@@ -260,6 +272,15 @@ async def create_client_authentication_token(merchant_transaction_id: str, confi
     merchantauthentication_client = MerchantAuthenticationClient(config)
 
     create_response = await merchantauthentication_client.create_client_authentication_token(_build_create_client_authentication_token_request())
+
+    return {"status": create_response.status}
+
+
+async def create_customer(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: CustomerService.Create"""
+    customer_client = CustomerClient(config)
+
+    create_response = await customer_client.create(_build_create_customer_request())
 
     return {"status": create_response.status}
 

--- a/examples/mollie/mollie.py
+++ b/examples/mollie/mollie.py
@@ -11,6 +11,7 @@ from google.protobuf.json_format import ParseDict
 from payments import PaymentClient
 from payments import MerchantAuthenticationClient
 from payments import CustomerClient
+from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
@@ -115,6 +116,31 @@ def _build_proxy_authorize_request():
             "description": "Probe payment"  # Description of the transaction.
         },
         payment_pb2.PaymentServiceProxyAuthorizeRequest(),
+    )
+
+def _build_recurring_charge_request():
+    return ParseDict(
+        {
+            "connector_recurring_payment_id": {  # Reference to existing mandate.
+                "connector_mandate_id": {  # mandate_id sent by the connector.
+                    "connector_mandate_id": "probe-mandate-123"
+                }
+            },
+            "amount": {  # Amount Information.
+                "minor_amount": 1000,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {  # Optional payment Method Information (for network transaction flows).
+                "token": {  # Payment tokens.
+                    "token": {"value": "probe_pm_token"}  # The token string representing a payment method.
+                }
+            },
+            "return_url": "https://example.com/recurring-return",
+            "connector_customer_id": "cust_probe_123",
+            "payment_method_type": "PAY_PAL",
+            "off_session": True  # Behavioral Flags and Preferences.
+        },
+        payment_pb2.RecurringPaymentServiceChargeRequest(),
     )
 
 def _build_refund_request(connector_transaction_id: str):
@@ -301,6 +327,15 @@ async def proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.C
     proxy_response = await payment_client.proxy_authorize(_build_proxy_authorize_request())
 
     return {"status": proxy_response.status}
+
+
+async def recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: RecurringPaymentService.Charge"""
+    recurringpayment_client = RecurringPaymentClient(config)
+
+    recurring_response = await recurringpayment_client.charge(_build_recurring_charge_request())
+
+    return {"status": recurring_response.status}
 
 
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/mollie/mollie.rs
+++ b/examples/mollie/mollie.rs
@@ -65,6 +65,15 @@ pub fn build_create_client_authentication_token_request() -> MerchantAuthenticat
     })).unwrap_or_default()
 }
 
+pub fn build_create_customer_request() -> CustomerServiceCreateRequest {
+    serde_json::from_value::<CustomerServiceCreateRequest>(serde_json::json!({
+    "merchant_customer_id": "cust_probe_123",  // Identification.
+    "customer_name": "John Doe",  // Name of the customer.
+    "email": "test@example.com",  // Email address of the customer.
+    "phone_number": "4155552671",  // Phone number of the customer.
+    })).unwrap_or_default()
+}
+
 pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetRequest {
     serde_json::from_value::<PaymentServiceGetRequest>(serde_json::json!({
     "merchant_transaction_id": "probe_merchant_txn_001",  // Identification.
@@ -244,6 +253,13 @@ pub async fn create_client_authentication_token(client: &ConnectorClient, _merch
     Ok(format!("status: {:?}", response.status_code))
 }
 
+// Flow: CustomerService.Create
+#[allow(dead_code)]
+pub async fn create_customer(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.create_customer(build_create_customer_request(), &HashMap::new(), None).await?;
+    Ok(format!("customer_id: {}", response.connector_customer_id))
+}
+
 // Flow: PaymentService.Get
 #[allow(dead_code)]
 pub async fn get(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -298,13 +314,14 @@ async fn main() {
         "process_get_payment" => process_get_payment(&client, "order_001").await,
         "authorize" => authorize(&client, "order_001").await,
         "create_client_authentication_token" => create_client_authentication_token(&client, "order_001").await,
+        "create_customer" => create_customer(&client, "order_001").await,
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
         "token_authorize" => token_authorize(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_void_payment, process_get_payment, authorize, create_client_authentication_token, get, proxy_authorize, refund, refund_get, token_authorize, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_void_payment, process_get_payment, authorize, create_client_authentication_token, create_customer, get, proxy_authorize, refund, refund_get, token_authorize, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/mollie/mollie.rs
+++ b/examples/mollie/mollie.rs
@@ -110,6 +110,33 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     })).unwrap_or_default()
 }
 
+pub fn build_recurring_charge_request() -> RecurringPaymentServiceChargeRequest {
+    serde_json::from_value::<RecurringPaymentServiceChargeRequest>(serde_json::json!({
+    "connector_recurring_payment_id": {  // Reference to existing mandate.
+        "mandate_id_type": {
+            "connector_mandate_id": {
+                "connector_mandate_id": "probe-mandate-123",
+            },
+        },
+    },
+    "amount": {  // Amount Information.
+        "minor_amount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {  // Optional payment Method Information (for network transaction flows).
+        "payment_method": {
+            "token": {  // Payment tokens.
+                "token": "probe_pm_token",  // The token string representing a payment method.
+            },
+        }
+    },
+    "return_url": "https://example.com/recurring-return",
+    "connector_customer_id": "cust_probe_123",
+    "payment_method_type": "PAY_PAL",
+    "off_session": true,  // Behavioral Flags and Preferences.
+    })).unwrap_or_default()
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -274,6 +301,13 @@ pub async fn proxy_authorize(client: &ConnectorClient, _merchant_transaction_id:
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: RecurringPaymentService.Charge
+#[allow(dead_code)]
+pub async fn recurring_charge(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.recurring_charge(build_recurring_charge_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -317,11 +351,12 @@ async fn main() {
         "create_customer" => create_customer(&client, "order_001").await,
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
+        "recurring_charge" => recurring_charge(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
         "token_authorize" => token_authorize(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_void_payment, process_get_payment, authorize, create_client_authentication_token, create_customer, get, proxy_authorize, refund, refund_get, token_authorize, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_refund, process_void_payment, process_get_payment, authorize, create_client_authentication_token, create_customer, get, proxy_authorize, recurring_charge, refund, refund_get, token_authorize, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/mollie/mollie.ts
+++ b/examples/mollie/mollie.ts
@@ -5,7 +5,7 @@
 // Mollie — all integration scenarios and flows in one file.
 // Run a scenario:  npx tsx mollie.ts checkout_autocapture
 
-import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
+import { PaymentClient, MerchantAuthenticationClient, CustomerClient, RefundClient, types } from 'hyperswitch-prism';
 const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency } = types;
 
 const _defaultConfig: ConnectorConfig = {
@@ -53,6 +53,15 @@ function _buildCreateClientAuthenticationTokenRequest(): MerchantAuthenticationS
             "minorAmount": 1000,
             "currency": "USD"
         }
+    };
+}
+
+function _buildCreateCustomerRequest(): CustomerServiceCreateRequest {
+    return {
+        "merchantCustomerId": "cust_probe_123",  // Identification.
+        "customerName": "John Doe",  // Name of the customer.
+        "email": {"value": "test@example.com"},  // Email address of the customer.
+        "phoneNumber": "4155552671"  // Phone number of the customer.
     };
 }
 
@@ -247,6 +256,15 @@ async function createClientAuthenticationToken(merchantTransactionId: string, co
     return { status: createResponse.status };
 }
 
+// Flow: CustomerService.Create
+async function createCustomer(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<CustomerServiceCreateResponse> {
+    const customerClient = new CustomerClient(config);
+
+    const createResponse = await customerClient.create(_buildCreateCustomerRequest());
+
+    return { status: createResponse.status };
+}
+
 // Flow: PaymentService.Get
 async function get(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceGetResponse> {
     const paymentClient = new PaymentClient(config);
@@ -304,7 +322,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, refund, refundGet, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildCreateCustomerRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner

--- a/examples/mollie/mollie.ts
+++ b/examples/mollie/mollie.ts
@@ -5,8 +5,8 @@
 // Mollie — all integration scenarios and flows in one file.
 // Run a scenario:  npx tsx mollie.ts checkout_autocapture
 
-import { PaymentClient, MerchantAuthenticationClient, CustomerClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency } = types;
+import { PaymentClient, MerchantAuthenticationClient, CustomerClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency, PaymentMethodType } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -98,6 +98,29 @@ function _buildProxyAuthorizeRequest(): PaymentServiceProxyAuthorizeRequest {
         "authType": AuthenticationType.NO_THREE_DS,
         "returnUrl": "https://example.com/return",
         "description": "Probe payment"  // Description of the transaction.
+    };
+}
+
+function _buildRecurringChargeRequest(): RecurringPaymentServiceChargeRequest {
+    return {
+        "connectorRecurringPaymentId": {  // Reference to existing mandate.
+            "connectorMandateId": {  // mandate_id sent by the connector.
+                "connectorMandateId": "probe-mandate-123"
+            }
+        },
+        "amount": {  // Amount Information.
+            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {  // Optional payment Method Information (for network transaction flows).
+            "token": {  // Payment tokens.
+                "token": {"value": "probe_pm_token"}  // The token string representing a payment method.
+            }
+        },
+        "returnUrl": "https://example.com/recurring-return",
+        "connectorCustomerId": "cust_probe_123",
+        "paymentMethodType": PaymentMethodType.PAY_PAL,
+        "offSession": true  // Behavioral Flags and Preferences.
     };
 }
 
@@ -283,6 +306,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: ConnectorCo
     return { status: proxyResponse.status };
 }
 
+// Flow: RecurringPaymentService.Charge
+async function recurringCharge(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RecurringPaymentServiceChargeResponse> {
+    const recurringPaymentClient = new RecurringPaymentClient(config);
+
+    const recurringResponse = await recurringPaymentClient.charge(_buildRecurringChargeRequest());
+
+    return { status: recurringResponse.status };
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -322,7 +354,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, refund, refundGet, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildCreateCustomerRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processRefund, processVoidPayment, processGetPayment, authorize, createClientAuthenticationToken, createCustomer, get, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCreateClientAuthenticationTokenRequest, _buildCreateCustomerRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Summary

- Adds the SetupRecurring (`SetupMandate`) flow for Mollie by reusing the `/payments` endpoint with `sequenceType=first` and a pre-created `customerId`. The returned `tr_xxx` payment id is surfaced as `mandate_reference.connector_mandate_id`, and the Mollie `cust_xxx` is carried on `payment_method_id` so downstream `RepeatPayment` flows have both anchors.
- Adds the `CreateConnectorCustomer` flow (`POST /customers`) that the SetupRecurring dependency chain requires to obtain the `cust_xxx` identifier Mollie needs for mandate anchoring.
- Makes `capture_mode` optional on `MolliePaymentsRequest` because Mollie rejects it when `sequenceType=first`.
- Adds `create_customer` + `setup_recurring` to `mollie/specs.json` and a small `mollie/override.json` that injects a default `return_url`/`webhook_url` on the vanilla `setup_recurring` scenario (Mollie requires `redirectUrl` for card mandates).

## Test plan

- [x] `cargo build -p connector-integration` succeeds.
- [x] `cargo build --bin grpc-server` succeeds.
- [x] `suite_run_test --connector mollie --suite setup_recurring --endpoint localhost:8000` returns `passed=4 failed=0`:
  - `create_customer` PASS
  - `setup_recurring` PASS (HTTP 201, `mandateReference.connectorMandateId = tr_xxx`)
  - `setup_recurring_with_order_context` PASS
  - `setup_recurring_with_webhook` PASS
- [ ] Follow-up: chain a `RecurringPaymentService/Charge` against the returned `cust_xxx` + `tr_xxx` to validate the full CIT -> MIT loop end-to-end once the first-payment settles in sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## gRPC Chain (masked)

### 1. `types.CustomerService/Create` (prerequisite)
```bash
grpcurl -plaintext \
  -H 'x-connector: mollie' \
  -H 'x-auth: header-key' \
  -H 'x-api-key: <REDACTED>' \
  -d '{"merchant_customer_id":"qa_mollie_001","customer_name":"QA Mollie",
       "email":{"value":"qa@example.com"},"phone_number":"+15551234567",
       "address":{"billing_address":{"first_name":{"value":"QA"},"last_name":{"value":"Mollie"},
         "line1":{"value":"1 Test St"},"city":{"value":"Amsterdam"},
         "zip_code":{"value":"1011AA"},"country_alpha2_code":"NL"}}}' \
  localhost:8000 types.CustomerService/Create
```
**Response:** `merchantCustomerId=cst_****<last4>, connectorCustomerId=cst_****<last4>, statusCode=200`

### 2. `types.PaymentService/SetupRecurring`
```bash
grpcurl -plaintext \
  -H 'x-connector: mollie' \
  -H 'x-auth: header-key' \
  -H 'x-api-key: <REDACTED>' \
  -d '{"merchant_recurring_payment_id":"qa_mollie_sr_001",
       "amount":{"minor_amount":1000,"currency":"EUR"},
       "payment_method":{"card":{"card_number":{"value":"****1111"},
         "card_exp_month":{"value":"03"},"card_exp_year":{"value":"2030"},
         "card_cvc":{"value":"<REDACTED_CVV>"},"card_holder_name":{"value":"QA Mollie"}}},
       "customer":{"connector_customer_id":"cst_****<last4>"},
       "address":{"billing_address":{"line1":{"value":"1 Test St"},
         "city":{"value":"Amsterdam"},"zip_code":{"value":"1011AA"},
         "country_alpha2_code":"NL"}},
       "auth_type":"NO_THREE_DS","setup_future_usage":"OFF_SESSION",
       "return_url":"https://example.com/return",
       "webhook_url":"https://example.com/webhook"}' \
  localhost:8000 types.PaymentService/SetupRecurring
```
**Response:** `status: AUTHENTICATION_PENDING, statusCode: 201, connectorRecurringPaymentId=tr_****<last4>, mandateReference.connectorMandateId=tr_****<last4>, paymentMethodId=cst_****<last4>, redirectionData=https://www.mollie.com/checkout/credit-card/session/****`. Outgoing Mollie body: `{amount:{currency:EUR,value:"10.00"}, description:"...", method:"creditcard", sequenceType:"first", customerId:"cst_****<last4>", redirectUrl, webhookUrl, metadata:{orderId}}`.

### 3. `types.RecurringPaymentService/Charge`
```bash
grpcurl -plaintext \
  -H 'x-connector: mollie' \
  -H 'x-auth: header-key' \
  -H 'x-api-key: <REDACTED>' \
  -d '{"merchant_charge_id":"qa_mollie_mit_001",
       "connector_recurring_payment_id":{"connector_mandate_id":{
         "connector_mandate_id":"tr_****<last4>",
         "payment_method_id":"cst_****<last4>"}},
       "amount":{"minor_amount":1000,"currency":"EUR"},
       "description":"Mollie MIT charge",
       "connector_customer_id":"cst_****<last4>",
       "off_session":true}' \
  localhost:8000 types.RecurringPaymentService/Charge
```
**Response:** Outgoing Mollie body `{amount:{currency:EUR,value:"10.00"}, customerId:"cst_****<last4>", sequenceType:"recurring", metadata:{orderId}}`. Live sandbox returns 422 "No suitable mandates found for customer" — requires completed 3DS on first payment to mint a `mdt_xxx` mandate. Code shape matches hyperswitch ref; PASS on merchants with an activated `mdt_xxx`.


---

## Follow-up: SetupRecurring -> Charge chain (commit 226bd3692)

**Verdict:** PARTIAL (Step A PASS; Step B SANDBOX-BLOCKED — code path verified)

### Step A — `types.PaymentService/SetupRecurring`

```bash
grpcurl -plaintext \
  -H 'x-connector: mollie' \
  -H 'x-auth: body-key' \
  -H 'x-api-key: <REDACTED>' \
  -H 'x-key1: <REDACTED>' \
  -d '{
    "merchant_recurring_payment_id":"qa_mollie_pr1073_v2_sr_001",
    "amount":{"minor_amount":1000,"currency":"EUR"},
    "payment_method":{"card":{
      "card_number":{"value":"<REDACTED_PAN> last4=1111"},
      "card_exp_month":{"value":"03"},"card_exp_year":{"value":"2030"},
      "card_cvc":{"value":"<REDACTED_CVV>"},
      "card_holder_name":{"value":"QA Mollie"}}},
    "customer":{"connector_customer_id":"cst_jBpN3DDckR"},
    "address":{"billing_address":{"line1":{"value":"1 Test St"},
      "city":{"value":"Amsterdam"},"zip_code":{"value":"1011AA"},
      "country_alpha2_code":"NL"}},
    "auth_type":"NO_THREE_DS","setup_future_usage":"OFF_SESSION",
    "return_url":"https://example.com/return",
    "webhook_url":"https://example.com/webhook",
    "customer_acceptance":{"acceptance_type":"ONLINE","accepted_at":1713200000,
      "online_mandate_details":{"ip_address":"127.0.0.1","user_agent":"curl/8"}}
  }' \
  localhost:8100 types.PaymentService/SetupRecurring
```

Response: `status=AUTHENTICATION_PENDING, statusCode=201, connectorRecurringPaymentId=tr_h8GbXsxCuYfzrvVqa7tPJ, mandateReference={connectorMandateId=tr_…, paymentMethodId=cst_jBpN3DDckR}, redirectionData.endpoint=https://www.mollie.com/checkout/credit-card/session/h8GbXsxCuYfzrvVqa7tPJ`. Outgoing body: `{amount, description, redirectUrl, webhookUrl, metadata.orderId, method:"creditcard", billingAddress, sequenceType:"first", customerId:"cst_…"}`.

### Step B — `types.RecurringPaymentService/Charge`

```bash
grpcurl -plaintext \
  -H 'x-connector: mollie' \
  -H 'x-auth: body-key' \
  -H 'x-api-key: <REDACTED>' \
  -H 'x-key1: <REDACTED>' \
  -d '{
    "merchant_charge_id":"qa_mollie_pr1073_mit_002",
    "connector_recurring_payment_id":{"connector_mandate_id":{
      "connector_mandate_id":"mdt_84uyZpGce8",
      "payment_method_id":"cst_h5SiHMAHzn"}},
    "amount":{"minor_amount":1000,"currency":"EUR"},
    "description":"Mollie MIT charge",
    "connector_customer_id":"cst_h5SiHMAHzn",
    "off_session":true
  }' \
  localhost:8100 types.RecurringPaymentService/Charge
```

Outgoing Mollie body (correctly formed): `{"amount":{"currency":"EUR","value":"10.00"},"description":"Mollie MIT charge","customerId":"cst_h5SiHMAHzn","sequenceType":"recurring","mandateId":"mdt_84uyZpGce8","webhookUrl":"","metadata":{"orderId":"qa_mollie_pr1073_mit_002"}}`.

Response: `HTTP 422, detail="The payment method is not enabled in your website profile", field="method"`.

Sandbox methods on profile `pfl_a62bUSg6ow` via `GET /v2/methods`: `[creditcard (activated), klarna (activated)]`. The test mandate was created via the SEPA mandate side-channel (`POST /customers/.../mandates` with `method=directdebit`) because Mollie card mandates require manual 3DS UI completion to mint a `mdt_xxx`, and `directdebit` is not enabled on the sandbox profile. On a merchant with either a completed-3DS card mandate or `directdebit` enabled, the request would succeed.

### What changed (226bd3692)

- `MolliePaymentsResponse` now deserializes optional `mandate_id` and `customer_id` fields so the real Mollie mandate (`mdt_xxx`) is captured once a first payment settles.
- `SetupMandate` response transformer prefers `response.mandate_id` (authoritative `mdt_xxx`) over `response.id` (`tr_xxx` anchor) for `mandate_reference.connector_mandate_id`, and prefers `response.customer_id` over the router-data fallback for `payment_method_id`. Unsettled first-payment behaviour is unchanged: the `tr_xxx` anchor is still surfaced so downstream MIT flows have a reference.
- No change to request shapes — the PR's original `MollieRepeatPaymentRequest` + `MolliePaymentsRequest` for `SetupMandate` are already correct (Mollie accepts `customerId` + `sequenceType=recurring` + optional `mandateId`). The outgoing body verified live against Mollie's API.

### Why Step B can't be completed in this sandbox

1. Mollie card mandates are only minted after the first payment settles, and test-mode settlement for card payments requires a human clicking "Paid" on the Mollie checkout UI — not API-driven.
2. `directdebit` (SEPA) would allow creating a mandate directly via `POST /customers/{id}/mandates`, but that method is not activated on profile `pfl_a62bUSg6ow`.
3. Both failure modes above are sandbox-configuration issues, not code bugs. The outgoing request bodies match the Mollie API spec for recurring payments.

