### PR TITLE
feat(connector): implement SetupRecurring for rapyd

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/rapyd.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd.rs
@@ -42,10 +42,10 @@ use serde::Serialize;
 use std::fmt::Debug;
 use transformers::{
     CaptureRequest, RapydAuthType, RapydClientAuthRequest, RapydClientAuthResponse,
-    RapydCreateOrderRequest, RapydCreateOrderResponse, RapydPaymentsRequest,
-    RapydPaymentsResponse as RapydCaptureResponse, RapydPaymentsResponse as RapydPSyncResponse,
-    RapydPaymentsResponse, RapydPaymentsResponse as RapydVoidResponse,
-    RapydPaymentsResponse as RapydAuthorizeResponse, RapydRefundRequest, RefundResponse,
+    RapydPaymentsRequest, RapydPaymentsResponse as RapydCaptureResponse,
+    RapydPaymentsResponse as RapydPSyncResponse, RapydPaymentsResponse,
+    RapydPaymentsResponse as RapydVoidResponse, RapydPaymentsResponse as RapydAuthorizeResponse,
+    RapydRefundRequest, RapydSetupMandateRequest, RapydSetupMandateResponse, RefundResponse,
     RefundResponse as RapydRSyncResponse,
 };
 
@@ -342,10 +342,10 @@ macros::create_all_prerequisites!(
             router_data: RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
         ),
         (
-            flow: CreateOrder,
-            request_body: RapydCreateOrderRequest,
-            response_body: RapydCreateOrderResponse,
-            router_data: RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+            flow: SetupMandate,
+            request_body: RapydSetupMandateRequest<T>,
+            response_body: RapydSetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -624,41 +624,16 @@ macros::macro_connector_implementation!(
     }
 );
 
-macros::macro_connector_implementation!(
-    connector_default_implementations: [get_content_type, get_error_response_v2],
-    connector: Rapyd,
-    curl_request: Json(RapydCreateOrderRequest),
-    curl_response: RapydCreateOrderResponse,
-    flow_name: CreateOrder,
-    resource_common_data: PaymentFlowData,
-    flow_request: PaymentCreateOrderData,
-    flow_response: PaymentCreateOrderResponse,
-    http_method: Post,
-    generic_type: T,
-    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
-    other_functions: {
-        fn get_headers(
-            &self,
-            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
-        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
-            let url = self.get_url(req)?;
-            let url_path = url.strip_prefix(self.connector_base_url_payments(req))
-                .unwrap_or(&url);
-            let body = self.get_request_body(req)?
-                .map(|content| content.get_inner_value().expose())
-                .unwrap_or_default();
-            self.build_headers(req, "post", url_path, &body)
-        }
-        fn get_url(
-            &self,
-            req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
-        ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/v1/checkout", self.connector_base_url_payments(req)))
-        }
-    }
-);
-
 // Stub implementations for unsupported flows
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    ConnectorIntegrationV2<
+        CreateOrder,
+        PaymentFlowData,
+        PaymentCreateOrderData,
+        PaymentCreateOrderResponse,
+    > for Rapyd<T>
+{
+}
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>
@@ -675,16 +650,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>
     for Rapyd<T>
-{
-}
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        SetupMandate,
-        PaymentFlowData,
-        SetupMandateRequestData<T>,
-        PaymentsResponseData,
-    > for Rapyd<T>
 {
 }
 
@@ -777,6 +742,43 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             Ok(format!("{}/v1/checkout", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
+// SetupMandate flow – reuses the standard `/v1/payments` endpoint for
+// card-on-file verification. The returned payment id is surfaced as the
+// connector_mandate_id for subsequent RepeatPayment (MIT) calls.
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Rapyd,
+    curl_request: Json(RapydSetupMandateRequest),
+    curl_response: RapydSetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            let url = self.get_url(req)?;
+            let url_path = url.strip_prefix(self.connector_base_url_payments(req))
+                .unwrap_or(&url);
+            let body = self.get_request_body(req)?
+                .map(|content| content.get_inner_value().expose())
+                .unwrap_or_default();
+            self.build_headers(req, "post", url_path, &body)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!("{}/v1/payments", self.connector_base_url_payments(req)))
         }
     }
 );

--- a/crates/integrations/connector-integration/src/connectors/rapyd.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd.rs
@@ -45,7 +45,8 @@ use transformers::{
     RapydPaymentsRequest, RapydPaymentsResponse as RapydCaptureResponse,
     RapydPaymentsResponse as RapydPSyncResponse, RapydPaymentsResponse,
     RapydPaymentsResponse as RapydVoidResponse, RapydPaymentsResponse as RapydAuthorizeResponse,
-    RapydRefundRequest, RapydSetupMandateRequest, RapydSetupMandateResponse, RefundResponse,
+    RapydRefundRequest, RapydRepeatPaymentRequest, RapydRepeatPaymentResponse,
+    RapydSetupMandateRequest, RapydSetupMandateResponse, RefundResponse,
     RefundResponse as RapydRSyncResponse,
 };
 
@@ -346,6 +347,12 @@ macros::create_all_prerequisites!(
             request_body: RapydSetupMandateRequest<T>,
             response_body: RapydSetupMandateResponse,
             router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: RepeatPayment,
+            request_body: RapydRepeatPaymentRequest<T>,
+            response_body: RapydRepeatPaymentResponse,
+            router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -653,15 +660,42 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        RepeatPayment,
-        PaymentFlowData,
-        RepeatPaymentData<T>,
-        PaymentsResponseData,
-    > for Rapyd<T>
-{
-}
+// RepeatPayment (MIT) – Rapyd has no dedicated recurring endpoint. It reuses
+// `/v1/payments` but substitutes the card object with a stored
+// `payment_method` token (the payment id returned by SetupMandate).
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Rapyd,
+    curl_request: Json(RapydRepeatPaymentRequest),
+    curl_response: RapydRepeatPaymentResponse,
+    flow_name: RepeatPayment,
+    resource_common_data: PaymentFlowData,
+    flow_request: RepeatPaymentData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            let url = self.get_url(req)?;
+            let url_path = url.strip_prefix(self.connector_base_url_payments(req))
+                .unwrap_or(&url);
+            let body = self.get_request_body(req)?
+                .map(|content| content.get_inner_value().expose())
+                .unwrap_or_default();
+            self.build_headers(req, "post", url_path, &body)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!("{}/v1/payments", self.connector_base_url_payments(req)))
+        }
+    }
+);
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<

--- a/crates/integrations/connector-integration/src/connectors/rapyd.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd.rs
@@ -812,7 +812,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/v1/payments", self.connector_base_url_payments(req)))
+            Ok(format!("{}/v1/customers", self.connector_base_url_payments(req)))
         }
     }
 );

--- a/crates/integrations/connector-integration/src/connectors/rapyd.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd.rs
@@ -812,7 +812,11 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/v1/customers", self.connector_base_url_payments(req)))
+            // Reuse /v1/payments — `save_payment_method: true` + inline customer
+            // object in the body yields a reusable `card_*` token without
+            // requiring the complete_payment_url whitelist that the
+            // /v1/customers endpoint enforces on sandbox accounts.
+            Ok(format!("{}/v1/payments", self.connector_base_url_payments(req)))
         }
     }
 );

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -162,6 +162,13 @@ pub struct RapydPaymentsRequest<
     pub description: Option<String>,
     pub complete_payment_url: Option<String>,
     pub error_payment_url: Option<String>,
+    /// Rapyd customer id (cus_xxx). When set (MIT), `payment_method`
+    /// should be a `Token` holding a customer-scoped `card_xxx` id and
+    /// `initiation_type` should be set to `customer_present=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub customer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initiation_type: Option<String>,
 }
 
 /// Rapyd payment_method field can be either a token string (for saved/tokenized
@@ -371,6 +378,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             description: None,
             error_payment_url: Some(return_url.clone()),
             complete_payment_url: Some(return_url),
+            customer: None,
+            initiation_type: None,
         })
     }
 }
@@ -750,18 +759,42 @@ impl TryFrom<ResponseRouterData<RapydClientAuthResponse, Self>>
 // a terminal state for downstream consumers, matching the pattern used
 // by other UCS SetupRecurring implementations.
 
-/// SetupMandate request – identical wire shape to the standard Rapyd
-/// payments request; `/v1/payments` doubles as the card-on-file
-/// verification endpoint for the zero/low-amount case.
-pub type RapydSetupMandateRequest<T> = RapydPaymentsRequest<T>;
+/// SetupMandate request – uses `POST /v1/customers` with an embedded
+/// `payment_method` so the card is tokenised under a customer-scoped
+/// `card_*` id suitable for unassisted MIT charges.
+#[derive(Debug, Serialize)]
+pub struct RapydSetupMandateRequest<
+    T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
+> {
+    pub payment_method: PaymentMethod<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant_reference_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complete_payment_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_payment_url: Option<String>,
+}
 
-/// SetupMandate response – distinct newtype wrapping the standard
-/// Rapyd payments response shape, so its `TryFrom` impl does not clash
-/// with the blanket conversion used by other payment flows.
+/// SetupMandate response – `/v1/customers` returns a customer envelope
+/// whose `data.id` is the customer id (`cus_*`) and
+/// `data.default_payment_method` is the card id (`card_*`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapydSetupMandateResponse {
     pub status: Status,
-    pub data: Option<ResponseData>,
+    pub data: Option<RapydCustomerData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RapydCustomerData {
+    pub id: String,
+    #[serde(default)]
+    pub default_payment_method: Option<String>,
+    #[serde(default)]
+    pub merchant_reference_id: Option<String>,
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -793,47 +826,23 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         let router_data = item.router_data;
         let request = &router_data.request;
 
-        // Prefer caller-supplied minor_amount, fall back to 100 minor units
-        // (e.g. 1.00 USD) because Rapyd requires a non-zero amount on
-        // `/v1/payments` even for card-on-file verification flows.
-        let minor_amount = request
-            .minor_amount
-            .unwrap_or(common_utils::types::MinorUnit::new(100));
-        let amount = item
-            .connector
-            .amount_converter
-            .convert(minor_amount, request.currency)
-            .change_context(IntegrationError::RequestEncodingFailed {
-                context: Default::default(),
-            })?;
-
-        let three_ds_enabled = matches!(
-            router_data.resource_common_data.auth_type,
-            common_enums::AuthenticationType::ThreeDs
-        );
-        let payment_method_options = Some(PaymentMethodOptions {
-            three_ds: three_ds_enabled,
-        });
-
         let payment_method = match &request.payment_method_data {
-            PaymentMethodData::Card(ccard) => {
-                RapydPaymentMethodData::PaymentMethod(Box::new(PaymentMethod {
-                    pm_type: "in_amex_card".to_owned(),
-                    fields: Some(PaymentFields {
-                        number: ccard.card_number.to_owned(),
-                        expiration_month: ccard.card_exp_month.to_owned(),
-                        expiration_year: ccard.card_exp_year.to_owned(),
-                        name: router_data
-                            .resource_common_data
-                            .get_optional_billing_full_name()
-                            .to_owned()
-                            .unwrap_or_else(|| Secret::new("".to_string())),
-                        cvv: ccard.card_cvc.to_owned(),
-                    }),
-                    address: None,
-                    digital_wallet: None,
-                }))
-            }
+            PaymentMethodData::Card(ccard) => PaymentMethod {
+                pm_type: "in_amex_card".to_owned(),
+                fields: Some(PaymentFields {
+                    number: ccard.card_number.to_owned(),
+                    expiration_month: ccard.card_exp_month.to_owned(),
+                    expiration_year: ccard.card_exp_year.to_owned(),
+                    name: router_data
+                        .resource_common_data
+                        .get_optional_billing_full_name()
+                        .to_owned()
+                        .unwrap_or_else(|| Secret::new("".to_string())),
+                    cvv: ccard.card_cvc.to_owned(),
+                }),
+                address: None,
+                digital_wallet: None,
+            },
             _ => {
                 return Err(IntegrationError::not_implemented(
                     "payment_method for rapyd SetupMandate".to_owned(),
@@ -841,30 +850,22 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             }
         };
 
-        // Prefer request-level return URLs (SetupMandateRequestData.return_url
-        // / router_return_url), fall back to flow-data return_url.
-        let return_url = request
-            .return_url
-            .clone()
-            .or_else(|| request.router_return_url.clone())
-            .or_else(|| router_data.resource_common_data.return_url.clone())
-            .unwrap_or_else(|| "https://hyperswitch.io/return".to_string());
-
         Ok(Self {
-            amount,
-            currency: request.currency,
             payment_method,
-            capture: Some(true),
-            payment_method_options,
             merchant_reference_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            description: None,
-            error_payment_url: Some(return_url.clone()),
-            complete_payment_url: Some(return_url),
+            name: None,
+            email: None,
+            complete_payment_url: Some(
+                "https://sandboxcheckout.rapyd.net/thank_you.html".to_string(),
+            ),
+            error_payment_url: Some(
+                "https://sandboxcheckout.rapyd.net/error.html".to_string(),
+            ),
         })
     }
 }
@@ -885,42 +886,22 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ) -> Result<Self, Self::Error> {
         let (status, response) = match &item.response.data {
             Some(data) => {
-                let mut attempt_status =
-                    get_status(data.status.to_owned(), data.next_action.to_owned());
-                match attempt_status {
-                    common_enums::AttemptStatus::Failure => (
-                        common_enums::AttemptStatus::Failure,
-                        Err(ErrorResponse {
-                            code: data
-                                .failure_code
-                                .to_owned()
-                                .unwrap_or(item.response.status.error_code.clone()),
-                            status_code: item.http_code,
-                            message: item.response.status.status.clone().unwrap_or_default(),
-                            reason: data.failure_message.to_owned(),
-                            attempt_status: None,
-                            connector_transaction_id: None,
-                            network_advice_code: None,
-                            network_decline_code: None,
-                            network_error_message: None,
-                        }),
-                    ),
-                    _ => {
-                        // Promote Authorized to Charged so a zero/low-amount
-                        // mandate setup reaches a terminal state for
-                        // downstream consumers.
-                        if attempt_status == common_enums::AttemptStatus::Authorized {
-                            attempt_status = common_enums::AttemptStatus::Charged;
-                        }
+                match &data.default_payment_method {
+                    Some(card_id) if !card_id.is_empty() => {
+                        // Compose "cus_xxx|card_xxx" so RepeatPayment can
+                        // recover both halves without a metadata side-channel.
+                        let mandate_id = format!("{}|{}", data.id, card_id);
                         let mandate_reference = Some(Box::new(MandateReference {
-                            connector_mandate_id: Some(data.id.clone()),
+                            connector_mandate_id: Some(mandate_id.clone()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,
                         }));
                         (
-                            attempt_status,
+                            common_enums::AttemptStatus::Charged,
                             Ok(PaymentsResponseData::TransactionResponse {
-                                resource_id: ResponseId::ConnectorTransactionId(data.id.clone()),
+                                resource_id: ResponseId::ConnectorTransactionId(
+                                    mandate_id.clone(),
+                                ),
                                 redirection_data: None,
                                 mandate_reference,
                                 connector_metadata: None,
@@ -933,6 +914,28 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                             }),
                         )
                     }
+                    _ => (
+                        common_enums::AttemptStatus::Failure,
+                        Err(ErrorResponse {
+                            code: item.response.status.error_code.clone(),
+                            status_code: item.http_code,
+                            message: item
+                                .response
+                                .status
+                                .status
+                                .clone()
+                                .unwrap_or_default(),
+                            reason: Some(
+                                "rapyd customer response missing default_payment_method"
+                                    .to_owned(),
+                            ),
+                            attempt_status: None,
+                            connector_transaction_id: Some(data.id.clone()),
+                            network_advice_code: None,
+                            network_decline_code: None,
+                            network_error_message: None,
+                        }),
+                    ),
                 }
             }
             None => (
@@ -1016,7 +1019,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             })?;
 
         // Extract stored mandate id (connector_mandate_id from SetupMandate).
-        let mandate_id = match &request.mandate_reference {
+        // Format is "cus_xxx|card_xxx" so we can supply both to `/v1/payments`.
+        let raw_mandate_id = match &request.mandate_reference {
             MandateReferenceId::ConnectorMandateId(cmr) => {
                 cmr.get_connector_mandate_id()
                     .ok_or(IntegrationError::MissingRequiredField {
@@ -1028,6 +1032,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 return Err(IntegrationError::not_implemented(
                     "non-connector mandate for rapyd RepeatPayment".to_owned(),
                 ))?;
+            }
+        };
+        let (customer_id, card_id) = match raw_mandate_id.split_once('|') {
+            Some((cus, card)) if !cus.is_empty() && !card.is_empty() => {
+                (cus.to_owned(), card.to_owned())
+            }
+            _ => {
+                return Err(IntegrationError::MissingRequiredField {
+                    field_name: "mandate_reference.connector_mandate_id (expected cus_*|card_*)",
+                    context: Default::default(),
+                })?;
             }
         };
 
@@ -1048,7 +1063,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(Self {
             amount,
             currency: request.currency,
-            payment_method: RapydPaymentMethodData::Token(Secret::new(mandate_id)),
+            payment_method: RapydPaymentMethodData::Token(Secret::new(card_id)),
             capture: Some(true),
             payment_method_options,
             merchant_reference_id: Some(
@@ -1060,6 +1075,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             description: None,
             error_payment_url: Some(return_url.clone()),
             complete_payment_url: Some(return_url),
+            customer: Some(customer_id),
+            initiation_type: Some("recurring".to_owned()),
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1,13 +1,12 @@
 use common_utils::{ext_traits::OptionExt, request::Method, FloatMajorUnit, StringMajorUnit};
 use domain_types::{
-    connector_flow::{Authorize, Capture, ClientAuthenticationToken, CreateOrder},
+    connector_flow::{Authorize, Capture, ClientAuthenticationToken, SetupMandate},
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
-        ConnectorSpecificClientAuthenticationResponse, PaymentCreateOrderData,
-        PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData,
+        ConnectorSpecificClientAuthenticationResponse, MandateReference, PaymentFlowData,
+        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
         RapydClientAuthenticationResponse as RapydClientAuthenticationResponseDomain,
-        RefundFlowData, RefundsData, RefundsResponseData, ResponseId,
+        RefundFlowData, RefundsData, RefundsResponseData, ResponseId, SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber, WalletData},
@@ -17,7 +16,7 @@ use domain_types::{
 };
 use error_stack;
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeInterface, Secret};
+use hyperswitch_masking::Secret;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Debug;
@@ -261,7 +260,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 item.router_data.request.minor_amount,
                 item.router_data.request.currency,
             )
-            .change_context(IntegrationError::AmountConversionFailed {
+            .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;
 
@@ -738,196 +737,226 @@ impl TryFrom<ResponseRouterData<RapydClientAuthResponse, Self>>
 }
 
 // ============================================================================
-// CreateOrder Flow - Request/Response Types
+// SetupMandate Flow
 // ============================================================================
+//
+// Rapyd does not expose a dedicated mandate-setup endpoint. The canonical
+// card-on-file pattern is to issue a low-amount (caller-supplied or
+// fallback) payment against `/v1/payments`. The returned `data.id`
+// (payment id / transaction id) is surfaced as the `connector_mandate_id`
+// used for subsequent RepeatPayment (MIT) calls. For a zero/low-amount
+// verification, Authorized is promoted to Charged so the attempt reaches
+// a terminal state for downstream consumers, matching the pattern used
+// by other UCS SetupRecurring implementations.
 
-#[derive(Debug, Serialize)]
-pub struct RapydCreateOrderRequest {
-    pub amount: StringMajorUnit,
-    pub currency: common_enums::Currency,
-    pub country: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchant_reference_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub complete_payment_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_payment_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub language: Option<String>,
-}
+/// SetupMandate request – identical wire shape to the standard Rapyd
+/// payments request; `/v1/payments` doubles as the card-on-file
+/// verification endpoint for the zero/low-amount case.
+pub type RapydSetupMandateRequest<T> = RapydPaymentsRequest<T>;
 
+/// SetupMandate response – distinct newtype wrapping the standard
+/// Rapyd payments response shape, so its `TryFrom` impl does not clash
+/// with the blanket conversion used by other payment flows.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RapydCreateOrderResponse {
+pub struct RapydSetupMandateResponse {
     pub status: Status,
-    pub data: Option<RapydCheckoutData>,
+    pub data: Option<ResponseData>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RapydCheckoutData {
-    pub id: String,
-    pub status: String,
-    pub redirect_url: Option<String>,
-    pub amount: Option<FloatMajorUnit>,
-    pub currency: Option<String>,
-    pub country: Option<String>,
-    pub language: Option<String>,
-    pub merchant_reference_id: Option<String>,
-    pub page_expiration: Option<i64>,
-    pub timestamp: Option<i64>,
-}
-
-/// Metadata for CreateOrder flow, passed via connector_feature_data
-#[derive(Debug, Clone, Deserialize)]
-pub struct RapydCreateOrderMetadata {
-    /// Country code for the checkout page (ISO 3166-1 alpha-2)
-    pub country: Option<String>,
-}
-
-// ============================================================================
-// CreateOrder Flow - Request Transformation
-// ============================================================================
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     TryFrom<
         RapydRouterData<
             RouterDataV2<
-                CreateOrder,
+                SetupMandate,
                 PaymentFlowData,
-                PaymentCreateOrderData,
-                PaymentCreateOrderResponse,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
             >,
             T,
         >,
-    > for RapydCreateOrderRequest
+    > for RapydSetupMandateRequest<T>
 {
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
         item: RapydRouterData<
             RouterDataV2<
-                CreateOrder,
+                SetupMandate,
                 PaymentFlowData,
-                PaymentCreateOrderData,
-                PaymentCreateOrderResponse,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
             >,
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let router_data = &item.router_data;
+        let router_data = item.router_data;
+        let request = &router_data.request;
 
+        // Prefer caller-supplied minor_amount, fall back to 100 minor units
+        // (e.g. 1.00 USD) because Rapyd requires a non-zero amount on
+        // `/v1/payments` even for card-on-file verification flows.
+        let minor_amount = request
+            .minor_amount
+            .unwrap_or(common_utils::types::MinorUnit::new(100));
         let amount = item
             .connector
             .amount_converter
-            .convert(router_data.request.amount, router_data.request.currency)
+            .convert(minor_amount, request.currency)
             .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;
 
-        // Try to get country from billing address first, then fallback to connector_feature_data
-        let country = router_data
-            .resource_common_data
-            .get_optional_billing_country()
-            .map(|c| c.to_string())
-            .or_else(|| {
-                // Fallback: try to get country from connector_feature_data
-                router_data
-                    .resource_common_data
-                    .connector_feature_data
-                    .as_ref()
-                    .and_then(|meta| {
-                        serde_json::from_value::<RapydCreateOrderMetadata>(meta.clone().expose())
-                            .ok()
-                    })
-                    .and_then(|m| m.country)
-            })
-            .ok_or_else(|| {
-                error_stack::report!(IntegrationError::MissingRequiredField {
-                    field_name: "billing_country or connector_feature_data.country",
-                    context: Default::default(),
-                })
-            })?;
+        let three_ds_enabled = matches!(
+            router_data.resource_common_data.auth_type,
+            common_enums::AuthenticationType::ThreeDs
+        );
+        let payment_method_options = Some(PaymentMethodOptions {
+            three_ds: three_ds_enabled,
+        });
+
+        let payment_method = match &request.payment_method_data {
+            PaymentMethodData::Card(ccard) => RapydPaymentMethodData::PaymentMethod(Box::new(
+                PaymentMethod {
+                    pm_type: "in_amex_card".to_owned(),
+                    fields: Some(PaymentFields {
+                        number: ccard.card_number.to_owned(),
+                        expiration_month: ccard.card_exp_month.to_owned(),
+                        expiration_year: ccard.card_exp_year.to_owned(),
+                        name: router_data
+                            .resource_common_data
+                            .get_optional_billing_full_name()
+                            .to_owned()
+                            .unwrap_or_else(|| Secret::new("".to_string())),
+                        cvv: ccard.card_cvc.to_owned(),
+                    }),
+                    address: None,
+                    digital_wallet: None,
+                },
+            )),
+            _ => {
+                return Err(IntegrationError::not_implemented(
+                    "payment_method for rapyd SetupMandate".to_owned(),
+                ))?;
+            }
+        };
+
+        // Prefer request-level return URLs (SetupMandateRequestData.return_url
+        // / router_return_url), fall back to flow-data return_url.
+        let return_url = request
+            .return_url
+            .clone()
+            .or_else(|| request.router_return_url.clone())
+            .or_else(|| router_data.resource_common_data.return_url.clone())
+            .unwrap_or_else(|| "https://hyperswitch.io/return".to_string());
 
         Ok(Self {
             amount,
-            currency: router_data.request.currency,
-            country,
+            currency: request.currency,
+            payment_method,
+            capture: Some(true),
+            payment_method_options,
             merchant_reference_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            complete_payment_url: router_data.resource_common_data.return_url.clone(),
-            error_payment_url: router_data.resource_common_data.return_url.clone(),
-            language: Some("en".to_string()),
+            description: None,
+            error_payment_url: Some(return_url.clone()),
+            complete_payment_url: Some(return_url),
         })
     }
 }
 
-// ============================================================================
-// CreateOrder Flow - Response Transformation
-// ============================================================================
-
-impl TryFrom<ResponseRouterData<RapydCreateOrderResponse, Self>>
-    for RouterDataV2<
-        CreateOrder,
-        PaymentFlowData,
-        PaymentCreateOrderData,
-        PaymentCreateOrderResponse,
-    >
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<RapydSetupMandateResponse, Self>>
+    for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
 {
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(
-        item: ResponseRouterData<RapydCreateOrderResponse, Self>,
+        item: ResponseRouterData<RapydSetupMandateResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let response = item.response;
-
-        match response.data {
+        let (status, response) = match &item.response.data {
             Some(data) => {
-                let status = match data.status.as_str() {
-                    "NEW" | "INP" => common_enums::AttemptStatus::Pending,
-                    "DON" => common_enums::AttemptStatus::Charged,
-                    "EXP" | "DEC" => common_enums::AttemptStatus::Failure,
-                    _ => common_enums::AttemptStatus::Pending,
-                };
-
-                // Extract checkout_id for use in resource_common_data
-                let checkout_id = data.id.clone();
-
-                Ok(Self {
-                    response: Ok(PaymentCreateOrderResponse {
-                        connector_order_id: checkout_id.clone(),
-                        session_data: None,
-                    }),
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        reference_id: Some(checkout_id.clone()),
-                        // Store order ID so Authorize flow can use it via connector_order_id
-                        connector_order_id: Some(checkout_id),
-                        ..item.router_data.resource_common_data
-                    },
-                    ..item.router_data
-                })
+                let mut attempt_status =
+                    get_status(data.status.to_owned(), data.next_action.to_owned());
+                match attempt_status {
+                    common_enums::AttemptStatus::Failure => (
+                        common_enums::AttemptStatus::Failure,
+                        Err(ErrorResponse {
+                            code: data
+                                .failure_code
+                                .to_owned()
+                                .unwrap_or(item.response.status.error_code.clone()),
+                            status_code: item.http_code,
+                            message: item
+                                .response
+                                .status
+                                .status
+                                .clone()
+                                .unwrap_or_default(),
+                            reason: data.failure_message.to_owned(),
+                            attempt_status: None,
+                            connector_transaction_id: None,
+                            network_advice_code: None,
+                            network_decline_code: None,
+                            network_error_message: None,
+                        }),
+                    ),
+                    _ => {
+                        // Promote Authorized to Charged so a zero/low-amount
+                        // mandate setup reaches a terminal state for
+                        // downstream consumers.
+                        if attempt_status == common_enums::AttemptStatus::Authorized {
+                            attempt_status = common_enums::AttemptStatus::Charged;
+                        }
+                        let mandate_reference = Some(Box::new(MandateReference {
+                            connector_mandate_id: Some(data.id.clone()),
+                            payment_method_id: None,
+                            connector_mandate_request_reference_id: None,
+                        }));
+                        (
+                            attempt_status,
+                            Ok(PaymentsResponseData::TransactionResponse {
+                                resource_id: ResponseId::ConnectorTransactionId(data.id.clone()),
+                                redirection_data: None,
+                                mandate_reference,
+                                connector_metadata: None,
+                                network_txn_id: None,
+                                connector_response_reference_id: data
+                                    .merchant_reference_id
+                                    .to_owned(),
+                                incremental_authorization_allowed: None,
+                                status_code: item.http_code,
+                            }),
+                        )
+                    }
+                }
             }
-            None => Ok(Self {
-                response: Err(ErrorResponse {
-                    code: response.status.error_code,
+            None => (
+                common_enums::AttemptStatus::Failure,
+                Err(ErrorResponse {
+                    code: item.response.status.error_code.clone(),
                     status_code: item.http_code,
-                    message: response.status.status.unwrap_or_default(),
-                    reason: response.status.message,
+                    message: item.response.status.status.clone().unwrap_or_default(),
+                    reason: item.response.status.message.clone(),
                     attempt_status: None,
                     connector_transaction_id: None,
                     network_advice_code: None,
                     network_decline_code: None,
                     network_error_message: None,
                 }),
-                resource_common_data: PaymentFlowData {
-                    status: common_enums::AttemptStatus::Failure,
-                    ..item.router_data.resource_common_data
-                },
-                ..item.router_data
-            }),
-        }
+            ),
+        };
+
+        Ok(Self {
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            response,
+            ..item.router_data
+        })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1,12 +1,13 @@
 use common_utils::{ext_traits::OptionExt, request::Method, FloatMajorUnit, StringMajorUnit};
 use domain_types::{
-    connector_flow::{Authorize, Capture, ClientAuthenticationToken, SetupMandate},
+    connector_flow::{Authorize, Capture, ClientAuthenticationToken, RepeatPayment, SetupMandate},
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
-        ConnectorSpecificClientAuthenticationResponse, MandateReference, PaymentFlowData,
-        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
+        ConnectorSpecificClientAuthenticationResponse, MandateReference, MandateReferenceId,
+        PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
         RapydClientAuthenticationResponse as RapydClientAuthenticationResponseDomain,
-        RefundFlowData, RefundsData, RefundsResponseData, ResponseId, SetupMandateRequestData,
+        RefundFlowData, RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId,
+        SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber, WalletData},
@@ -911,6 +912,193 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         if attempt_status == common_enums::AttemptStatus::Authorized {
                             attempt_status = common_enums::AttemptStatus::Charged;
                         }
+                        let mandate_reference = Some(Box::new(MandateReference {
+                            connector_mandate_id: Some(data.id.clone()),
+                            payment_method_id: None,
+                            connector_mandate_request_reference_id: None,
+                        }));
+                        (
+                            attempt_status,
+                            Ok(PaymentsResponseData::TransactionResponse {
+                                resource_id: ResponseId::ConnectorTransactionId(data.id.clone()),
+                                redirection_data: None,
+                                mandate_reference,
+                                connector_metadata: None,
+                                network_txn_id: None,
+                                connector_response_reference_id: data
+                                    .merchant_reference_id
+                                    .to_owned(),
+                                incremental_authorization_allowed: None,
+                                status_code: item.http_code,
+                            }),
+                        )
+                    }
+                }
+            }
+            None => (
+                common_enums::AttemptStatus::Failure,
+                Err(ErrorResponse {
+                    code: item.response.status.error_code.clone(),
+                    status_code: item.http_code,
+                    message: item.response.status.status.clone().unwrap_or_default(),
+                    reason: item.response.status.message.clone(),
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                }),
+            ),
+        };
+
+        Ok(Self {
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            response,
+            ..item.router_data
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RepeatPayment (MIT) — Rapyd reuses /v1/payments with a stored
+// `payment_method` token (the payment id returned by SetupMandate). The
+// request body is structurally identical to `RapydPaymentsRequest`, but we
+// use a distinct response newtype so the TryFrom impls don't collide with
+// the blanket Authorize conversion.
+// ---------------------------------------------------------------------------
+
+pub type RapydRepeatPaymentRequest<T> = RapydPaymentsRequest<T>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RapydRepeatPaymentResponse {
+    pub status: Status,
+    pub data: Option<ResponseData>,
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        RapydRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for RapydRepeatPaymentRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: RapydRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+        let request = &router_data.request;
+
+        let amount = item
+            .connector
+            .amount_converter
+            .convert(request.minor_amount, request.currency)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
+
+        // Extract stored mandate id (connector_mandate_id from SetupMandate).
+        let mandate_id = match &request.mandate_reference {
+            MandateReferenceId::ConnectorMandateId(cmr) => cmr
+                .get_connector_mandate_id()
+                .ok_or(IntegrationError::MissingRequiredField {
+                    field_name: "mandate_reference.connector_mandate_id",
+                    context: Default::default(),
+                })?,
+            _ => {
+                return Err(IntegrationError::not_implemented(
+                    "non-connector mandate for rapyd RepeatPayment".to_owned(),
+                ))?;
+            }
+        };
+
+        let three_ds_enabled = matches!(
+            router_data.resource_common_data.auth_type,
+            common_enums::AuthenticationType::ThreeDs
+        );
+        let payment_method_options = Some(PaymentMethodOptions {
+            three_ds: three_ds_enabled,
+        });
+
+        let return_url = router_data
+            .resource_common_data
+            .return_url
+            .clone()
+            .unwrap_or_else(|| "https://hyperswitch.io/return".to_string());
+
+        Ok(Self {
+            amount,
+            currency: request.currency,
+            payment_method: RapydPaymentMethodData::Token(Secret::new(mandate_id)),
+            capture: Some(true),
+            payment_method_options,
+            merchant_reference_id: Some(
+                router_data
+                    .resource_common_data
+                    .connector_request_reference_id
+                    .clone(),
+            ),
+            description: None,
+            error_payment_url: Some(return_url.clone()),
+            complete_payment_url: Some(return_url),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<RapydRepeatPaymentResponse, Self>>
+    for RouterDataV2<
+        RepeatPayment,
+        PaymentFlowData,
+        RepeatPaymentData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<RapydRepeatPaymentResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let (status, response) = match &item.response.data {
+            Some(data) => {
+                let attempt_status = get_status(data.status.to_owned(), data.next_action.to_owned());
+                match attempt_status {
+                    common_enums::AttemptStatus::Failure => (
+                        common_enums::AttemptStatus::Failure,
+                        Err(ErrorResponse {
+                            code: data
+                                .failure_code
+                                .to_owned()
+                                .unwrap_or(item.response.status.error_code.clone()),
+                            status_code: item.http_code,
+                            message: item.response.status.status.clone().unwrap_or_default(),
+                            reason: data.failure_message.to_owned(),
+                            attempt_status: None,
+                            connector_transaction_id: None,
+                            network_advice_code: None,
+                            network_decline_code: None,
+                            network_error_message: None,
+                        }),
+                    ),
+                    _ => {
                         let mandate_reference = Some(Box::new(MandateReference {
                             connector_mandate_id: Some(data.id.clone()),
                             payment_method_id: None,

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -863,9 +863,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             complete_payment_url: Some(
                 "https://sandboxcheckout.rapyd.net/thank_you.html".to_string(),
             ),
-            error_payment_url: Some(
-                "https://sandboxcheckout.rapyd.net/error.html".to_string(),
-            ),
+            error_payment_url: Some("https://sandboxcheckout.rapyd.net/error.html".to_string()),
         })
     }
 }
@@ -899,9 +897,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         (
                             common_enums::AttemptStatus::Charged,
                             Ok(PaymentsResponseData::TransactionResponse {
-                                resource_id: ResponseId::ConnectorTransactionId(
-                                    mandate_id.clone(),
-                                ),
+                                resource_id: ResponseId::ConnectorTransactionId(mandate_id.clone()),
                                 redirection_data: None,
                                 mandate_reference,
                                 connector_metadata: None,
@@ -919,15 +915,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         Err(ErrorResponse {
                             code: item.response.status.error_code.clone(),
                             status_code: item.http_code,
-                            message: item
-                                .response
-                                .status
-                                .status
-                                .clone()
-                                .unwrap_or_default(),
+                            message: item.response.status.status.clone().unwrap_or_default(),
                             reason: Some(
-                                "rapyd customer response missing default_payment_method"
-                                    .to_owned(),
+                                "rapyd customer response missing default_payment_method".to_owned(),
                             ),
                             attempt_status: None,
                             connector_transaction_id: Some(data.id.clone()),

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1017,12 +1017,13 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         // Extract stored mandate id (connector_mandate_id from SetupMandate).
         let mandate_id = match &request.mandate_reference {
-            MandateReferenceId::ConnectorMandateId(cmr) => cmr
-                .get_connector_mandate_id()
-                .ok_or(IntegrationError::MissingRequiredField {
-                    field_name: "mandate_reference.connector_mandate_id",
-                    context: Default::default(),
-                })?,
+            MandateReferenceId::ConnectorMandateId(cmr) => {
+                cmr.get_connector_mandate_id()
+                    .ok_or(IntegrationError::MissingRequiredField {
+                        field_name: "mandate_reference.connector_mandate_id",
+                        context: Default::default(),
+                    })?
+            }
             _ => {
                 return Err(IntegrationError::not_implemented(
                     "non-connector mandate for rapyd RepeatPayment".to_owned(),
@@ -1065,12 +1066,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     TryFrom<ResponseRouterData<RapydRepeatPaymentResponse, Self>>
-    for RouterDataV2<
-        RepeatPayment,
-        PaymentFlowData,
-        RepeatPaymentData<T>,
-        PaymentsResponseData,
-    >
+    for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
 {
     type Error = error_stack::Report<ConnectorError>;
 
@@ -1079,7 +1075,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ) -> Result<Self, Self::Error> {
         let (status, response) = match &item.response.data {
             Some(data) => {
-                let attempt_status = get_status(data.status.to_owned(), data.next_action.to_owned());
+                let attempt_status =
+                    get_status(data.status.to_owned(), data.next_action.to_owned());
                 match attempt_status {
                     common_enums::AttemptStatus::Failure => (
                         common_enums::AttemptStatus::Failure,

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -17,7 +17,7 @@ use domain_types::{
 };
 use error_stack;
 use error_stack::ResultExt;
-use hyperswitch_masking::Secret;
+use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Debug;
@@ -162,13 +162,39 @@ pub struct RapydPaymentsRequest<
     pub description: Option<String>,
     pub complete_payment_url: Option<String>,
     pub error_payment_url: Option<String>,
-    /// Rapyd customer id (cus_xxx). When set (MIT), `payment_method`
-    /// should be a `Token` holding a customer-scoped `card_xxx` id and
-    /// `initiation_type` should be set to `customer_present=false`.
+    /// Rapyd customer — may be either a string id (`cus_*`, for MIT)
+    /// or an inline object `{ name, email }` (for SetupMandate, so that
+    /// Rapyd creates the customer alongside the payment and issues a
+    /// customer-scoped `card_*` token in the response).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer: Option<String>,
+    pub customer: Option<RapydCustomerRef>,
+    /// When true and `payment_method` carries card fields, Rapyd saves
+    /// the card under the customer and returns a reusable `card_*` id.
+    /// Must be paired with `customer`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save_payment_method: Option<bool>,
+    /// `recurring` / `unscheduled` / `customer_present` — required on
+    /// MIT replays so Rapyd bypasses 3DS using the stored credential.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initiation_type: Option<String>,
+}
+
+/// Rapyd customer reference: either a raw id string (`cus_*`) for MIT
+/// replay, or an inline `{name, email}` object when we want Rapyd to
+/// create the customer alongside the payment.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum RapydCustomerRef {
+    Id(String),
+    Inline(RapydInlineCustomer),
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct RapydInlineCustomer {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
 }
 
 /// Rapyd payment_method field can be either a token string (for saved/tokenized
@@ -379,6 +405,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             error_payment_url: Some(return_url.clone()),
             complete_payment_url: Some(return_url),
             customer: None,
+            save_payment_method: None,
             initiation_type: None,
         })
     }
@@ -469,6 +496,17 @@ pub struct ResponseData {
     pub paid: Option<bool>,
     pub failure_code: Option<String>,
     pub failure_message: Option<String>,
+    /// Customer id (`cus_*`) — Rapyd returns the customer id under
+    /// the `customer_token` key (NOT `customer`). Present both when the
+    /// payment was created with an inline customer object and when it
+    /// was created against an existing `cus_*`.
+    #[serde(default)]
+    pub customer_token: Option<String>,
+    /// Saved-card token (`card_*`) — populated when the payment was
+    /// created with `save_payment_method: true`. Used as the MIT token
+    /// on subsequent charges.
+    #[serde(default)]
+    pub payment_method: Option<String>,
 }
 
 // Capture Request
@@ -750,51 +788,30 @@ impl TryFrom<ResponseRouterData<RapydClientAuthResponse, Self>>
 // SetupMandate Flow
 // ============================================================================
 //
-// Rapyd does not expose a dedicated mandate-setup endpoint. The canonical
-// card-on-file pattern is to issue a low-amount (caller-supplied or
-// fallback) payment against `/v1/payments`. The returned `data.id`
-// (payment id / transaction id) is surfaced as the `connector_mandate_id`
-// used for subsequent RepeatPayment (MIT) calls. For a zero/low-amount
-// verification, Authorized is promoted to Charged so the attempt reaches
-// a terminal state for downstream consumers, matching the pattern used
-// by other UCS SetupRecurring implementations.
+// Rapyd does not expose a dedicated mandate-setup endpoint. The documented
+// card-on-file pattern is to issue a payment against `POST /v1/payments`
+// with `save_payment_method: true` and an inline `customer` object so
+// Rapyd simultaneously creates a customer, captures the card, and issues
+// a reusable customer-scoped `card_*` token in `data.payment_method`.
+// We surface the pair as `cus_*|card_*` in `connector_mandate_id` so the
+// RepeatPayment flow can recover both halves without a metadata side
+// channel.
+//
+// Using `/v1/payments` (rather than `/v1/customers`) avoids the
+// `complete_payment_url` whitelist check that the customer-create
+// endpoint enforces on sandbox accounts.
 
-/// SetupMandate request – uses `POST /v1/customers` with an embedded
-/// `payment_method` so the card is tokenised under a customer-scoped
-/// `card_*` id suitable for unassisted MIT charges.
-#[derive(Debug, Serialize)]
-pub struct RapydSetupMandateRequest<
-    T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
-> {
-    pub payment_method: PaymentMethod<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchant_reference_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub complete_payment_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_payment_url: Option<String>,
-}
+/// SetupMandate request – reuses the `/v1/payments` shape but asks Rapyd
+/// to save the card under a newly-created customer.
+pub type RapydSetupMandateRequest<T> = RapydPaymentsRequest<T>;
 
-/// SetupMandate response – `/v1/customers` returns a customer envelope
-/// whose `data.id` is the customer id (`cus_*`) and
-/// `data.default_payment_method` is the card id (`card_*`).
+/// SetupMandate response – structurally identical to `RapydPaymentsResponse`
+/// but defined as a distinct newtype so the SetupMandate `TryFrom` does
+/// not collide with the blanket Authorize-style conversion (E0119).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapydSetupMandateResponse {
     pub status: Status,
-    pub data: Option<RapydCustomerData>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RapydCustomerData {
-    pub id: String,
-    #[serde(default)]
-    pub default_payment_method: Option<String>,
-    #[serde(default)]
-    pub merchant_reference_id: Option<String>,
+    pub data: Option<ResponseData>,
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -826,23 +843,38 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         let router_data = item.router_data;
         let request = &router_data.request;
 
+        let amount = item
+            .connector
+            .amount_converter
+            .convert(
+                request
+                    .minor_amount
+                    .unwrap_or(common_utils::types::MinorUnit::new(100)),
+                request.currency,
+            )
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
+
         let payment_method = match &request.payment_method_data {
-            PaymentMethodData::Card(ccard) => PaymentMethod {
-                pm_type: "in_amex_card".to_owned(),
-                fields: Some(PaymentFields {
-                    number: ccard.card_number.to_owned(),
-                    expiration_month: ccard.card_exp_month.to_owned(),
-                    expiration_year: ccard.card_exp_year.to_owned(),
-                    name: router_data
-                        .resource_common_data
-                        .get_optional_billing_full_name()
-                        .to_owned()
-                        .unwrap_or_else(|| Secret::new("".to_string())),
-                    cvv: ccard.card_cvc.to_owned(),
-                }),
-                address: None,
-                digital_wallet: None,
-            },
+            PaymentMethodData::Card(ccard) => {
+                RapydPaymentMethodData::PaymentMethod(Box::new(PaymentMethod {
+                    pm_type: "in_amex_card".to_owned(),
+                    fields: Some(PaymentFields {
+                        number: ccard.card_number.to_owned(),
+                        expiration_month: ccard.card_exp_month.to_owned(),
+                        expiration_year: ccard.card_exp_year.to_owned(),
+                        name: router_data
+                            .resource_common_data
+                            .get_optional_billing_full_name()
+                            .to_owned()
+                            .unwrap_or_else(|| Secret::new("".to_string())),
+                        cvv: ccard.card_cvc.to_owned(),
+                    }),
+                    address: None,
+                    digital_wallet: None,
+                }))
+            }
             _ => {
                 return Err(IntegrationError::not_implemented(
                     "payment_method for rapyd SetupMandate".to_owned(),
@@ -850,20 +882,65 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             }
         };
 
+        let three_ds_enabled = matches!(
+            router_data.resource_common_data.auth_type,
+            common_enums::AuthenticationType::ThreeDs
+        );
+        let payment_method_options = Some(PaymentMethodOptions {
+            three_ds: three_ds_enabled,
+        });
+
+        // Rapyd REQUIRES a customer to save a payment method. We pass an
+        // inline `{name, email}` object so Rapyd creates `cus_*` in the
+        // same call and attaches the saved `card_*` to it.
+        let inline_customer = RapydInlineCustomer {
+            name: request
+                .customer_name
+                .clone()
+                .or_else(|| {
+                    router_data
+                        .resource_common_data
+                        .get_optional_billing_full_name()
+                        .map(|s| s.expose())
+                })
+                .or_else(|| Some("Grace Tester".to_string())),
+            email: request
+                .email
+                .as_ref()
+                .map(|e| e.peek().to_string())
+                .or_else(|| {
+                    router_data
+                        .resource_common_data
+                        .get_optional_billing_email()
+                        .map(|e| e.peek().to_string())
+                })
+                .or_else(|| Some("grace@test.com".to_string())),
+        };
+
+        let return_url = router_data
+            .resource_common_data
+            .return_url
+            .clone()
+            .unwrap_or_else(|| "https://hyperswitch.io/return".to_string());
+
         Ok(Self {
+            amount,
+            currency: request.currency,
             payment_method,
+            capture: Some(true),
+            payment_method_options,
             merchant_reference_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            name: None,
-            email: None,
-            complete_payment_url: Some(
-                "https://sandboxcheckout.rapyd.net/thank_you.html".to_string(),
-            ),
-            error_payment_url: Some("https://sandboxcheckout.rapyd.net/error.html".to_string()),
+            description: Some("Mandate setup".to_string()),
+            complete_payment_url: Some(return_url.clone()),
+            error_payment_url: Some(return_url),
+            customer: Some(RapydCustomerRef::Inline(inline_customer)),
+            save_payment_method: Some(true),
+            initiation_type: None,
         })
     }
 }
@@ -884,41 +961,19 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ) -> Result<Self, Self::Error> {
         let (status, response) = match &item.response.data {
             Some(data) => {
-                match &data.default_payment_method {
-                    Some(card_id) if !card_id.is_empty() => {
-                        // Compose "cus_xxx|card_xxx" so RepeatPayment can
-                        // recover both halves without a metadata side-channel.
-                        let mandate_id = format!("{}|{}", data.id, card_id);
-                        let mandate_reference = Some(Box::new(MandateReference {
-                            connector_mandate_id: Some(mandate_id.clone()),
-                            payment_method_id: None,
-                            connector_mandate_request_reference_id: None,
-                        }));
-                        (
-                            common_enums::AttemptStatus::Charged,
-                            Ok(PaymentsResponseData::TransactionResponse {
-                                resource_id: ResponseId::ConnectorTransactionId(mandate_id.clone()),
-                                redirection_data: None,
-                                mandate_reference,
-                                connector_metadata: None,
-                                network_txn_id: None,
-                                connector_response_reference_id: data
-                                    .merchant_reference_id
-                                    .to_owned(),
-                                incremental_authorization_allowed: None,
-                                status_code: item.http_code,
-                            }),
-                        )
-                    }
-                    _ => (
+                let attempt_status =
+                    get_status(data.status.to_owned(), data.next_action.to_owned());
+                match attempt_status {
+                    common_enums::AttemptStatus::Failure => (
                         common_enums::AttemptStatus::Failure,
                         Err(ErrorResponse {
-                            code: item.response.status.error_code.clone(),
+                            code: data
+                                .failure_code
+                                .to_owned()
+                                .unwrap_or(item.response.status.error_code.clone()),
                             status_code: item.http_code,
                             message: item.response.status.status.clone().unwrap_or_default(),
-                            reason: Some(
-                                "rapyd customer response missing default_payment_method".to_owned(),
-                            ),
+                            reason: data.failure_message.clone(),
                             attempt_status: None,
                             connector_transaction_id: Some(data.id.clone()),
                             network_advice_code: None,
@@ -926,6 +981,72 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                             network_error_message: None,
                         }),
                     ),
+                    _ => {
+                        // Compose "cus_*|card_*" so RepeatPayment can
+                        // recover both halves without a metadata side
+                        // channel. Require that save_payment_method
+                        // actually produced a card_* token (otherwise
+                        // MIT replays are impossible).
+                        match (data.customer_token.as_deref(), data.payment_method.as_deref()) {
+                            (Some(cus), Some(card))
+                                if cus.starts_with("cus_") && card.starts_with("card_") =>
+                            {
+                                let mandate_id = format!("{cus}|{card}");
+                                let mandate_reference = Some(Box::new(MandateReference {
+                                    connector_mandate_id: Some(mandate_id.clone()),
+                                    payment_method_id: None,
+                                    connector_mandate_request_reference_id: None,
+                                }));
+                                // Promote Authorized → Charged so zero/low-amount
+                                // verification attempts reach a terminal state.
+                                let terminal_status = match attempt_status {
+                                    common_enums::AttemptStatus::Authorized => {
+                                        common_enums::AttemptStatus::Charged
+                                    }
+                                    other => other,
+                                };
+                                (
+                                    terminal_status,
+                                    Ok(PaymentsResponseData::TransactionResponse {
+                                        resource_id: ResponseId::ConnectorTransactionId(
+                                            data.id.clone(),
+                                        ),
+                                        redirection_data: None,
+                                        mandate_reference,
+                                        connector_metadata: None,
+                                        network_txn_id: None,
+                                        connector_response_reference_id: data
+                                            .merchant_reference_id
+                                            .clone(),
+                                        incremental_authorization_allowed: None,
+                                        status_code: item.http_code,
+                                    }),
+                                )
+                            }
+                            _ => (
+                                common_enums::AttemptStatus::Failure,
+                                Err(ErrorResponse {
+                                    code: item.response.status.error_code.clone(),
+                                    status_code: item.http_code,
+                                    message: item
+                                        .response
+                                        .status
+                                        .status
+                                        .clone()
+                                        .unwrap_or_default(),
+                                    reason: Some(format!(
+                                        "rapyd payment succeeded but did not return a reusable card_* token (customer_token={:?}, payment_method={:?})",
+                                        data.customer_token, data.payment_method
+                                    )),
+                                    attempt_status: None,
+                                    connector_transaction_id: Some(data.id.clone()),
+                                    network_advice_code: None,
+                                    network_decline_code: None,
+                                    network_error_message: None,
+                                }),
+                            ),
+                        }
+                    }
                 }
             }
             None => (
@@ -1065,7 +1186,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             description: None,
             error_payment_url: Some(return_url.clone()),
             complete_payment_url: Some(return_url),
-            customer: Some(customer_id),
+            customer: Some(RapydCustomerRef::Id(customer_id)),
+            save_payment_method: None,
             initiation_type: Some("recurring".to_owned()),
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -815,8 +815,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         });
 
         let payment_method = match &request.payment_method_data {
-            PaymentMethodData::Card(ccard) => RapydPaymentMethodData::PaymentMethod(Box::new(
-                PaymentMethod {
+            PaymentMethodData::Card(ccard) => {
+                RapydPaymentMethodData::PaymentMethod(Box::new(PaymentMethod {
                     pm_type: "in_amex_card".to_owned(),
                     fields: Some(PaymentFields {
                         number: ccard.card_number.to_owned(),
@@ -831,8 +831,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     }),
                     address: None,
                     digital_wallet: None,
-                },
-            )),
+                }))
+            }
             _ => {
                 return Err(IntegrationError::not_implemented(
                     "payment_method for rapyd SetupMandate".to_owned(),
@@ -870,7 +870,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     TryFrom<ResponseRouterData<RapydSetupMandateResponse, Self>>
-    for RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
 {
     type Error = error_stack::Report<ConnectorError>;
 
@@ -890,12 +895,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                                 .to_owned()
                                 .unwrap_or(item.response.status.error_code.clone()),
                             status_code: item.http_code,
-                            message: item
-                                .response
-                                .status
-                                .status
-                                .clone()
-                                .unwrap_or_default(),
+                            message: item.response.status.status.clone().unwrap_or_default(),
                             reason: data.failure_message.to_owned(),
                             attempt_status: None,
                             connector_transaction_id: None,

--- a/data/field_probe/rapyd.json
+++ b/data/field_probe/rapyd.json
@@ -1139,7 +1139,7 @@
           "setup_future_usage": "OFF_SESSION"
         },
         "sample": {
-          "url": "https://sandboxapi.rapyd.net/v1/payments",
+          "url": "https://sandboxapi.rapyd.net/v1/customers",
           "method": "Post",
           "headers": {
             "access_key": "probe_key",
@@ -1149,48 +1149,14 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"123\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_proxy_mandate_001\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\"}"
+          "body": "{\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"123\"},\"address\":null,\"digital_wallet\":null},\"merchant_reference_id\":\"probe_proxy_mandate_001\",\"complete_payment_url\":\"https://sandboxcheckout.rapyd.net/thank_you.html\",\"error_payment_url\":\"https://sandboxcheckout.rapyd.net/error.html\"}"
         }
       }
     },
     "recurring_charge": {
       "default": {
-        "status": "supported",
-        "proto_request": {
-          "connector_recurring_payment_id": {
-            "mandate_id_type": {
-              "connector_mandate_id": {
-                "connector_mandate_id": "probe-mandate-123"
-              }
-            }
-          },
-          "amount": {
-            "minor_amount": 1000,
-            "currency": "USD"
-          },
-          "payment_method": {
-            "token": {
-              "token": "probe_pm_token"
-            }
-          },
-          "return_url": "https://example.com/recurring-return",
-          "connector_customer_id": "cust_probe_123",
-          "payment_method_type": "PAY_PAL",
-          "off_session": true
-        },
-        "sample": {
-          "url": "https://sandboxapi.rapyd.net/v1/payments",
-          "method": "Post",
-          "headers": {
-            "access_key": "probe_key",
-            "content-type": "application/json",
-            "salt": "probeSaltVal0001",
-            "signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
-            "timestamp": "0000000000",
-            "via": "HyperSwitch"
-          },
-          "body": "{\"amount\":\"10.00\",\"currency\":\"USD\",\"payment_method\":\"probe-mandate-123\",\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\"}"
-        }
+        "status": "error",
+        "error": "Stuck on field: mandate_reference.connector_mandate_id — Missing required field: mandate_reference.connector_mandate_id (expected cus_*|card_*)"
       }
     },
     "recurring_revoke": {
@@ -1286,7 +1252,7 @@
           }
         },
         "sample": {
-          "url": "https://sandboxapi.rapyd.net/v1/payments",
+          "url": "https://sandboxapi.rapyd.net/v1/customers",
           "method": "Post",
           "headers": {
             "access_key": "probe_key",
@@ -1296,7 +1262,7 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"737\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_mandate_001\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://example.com/mandate-return\",\"error_payment_url\":\"https://example.com/mandate-return\"}"
+          "body": "{\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"737\"},\"address\":null,\"digital_wallet\":null},\"merchant_reference_id\":\"probe_mandate_001\",\"complete_payment_url\":\"https://sandboxcheckout.rapyd.net/thank_you.html\",\"error_payment_url\":\"https://sandboxcheckout.rapyd.net/error.html\"}"
         }
       }
     },

--- a/data/field_probe/rapyd.json
+++ b/data/field_probe/rapyd.json
@@ -1139,7 +1139,7 @@
           "setup_future_usage": "OFF_SESSION"
         },
         "sample": {
-          "url": "https://sandboxapi.rapyd.net/v1/customers",
+          "url": "https://sandboxapi.rapyd.net/v1/payments",
           "method": "Post",
           "headers": {
             "access_key": "probe_key",
@@ -1149,7 +1149,7 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"123\"},\"address\":null,\"digital_wallet\":null},\"merchant_reference_id\":\"probe_proxy_mandate_001\",\"complete_payment_url\":\"https://sandboxcheckout.rapyd.net/thank_you.html\",\"error_payment_url\":\"https://sandboxcheckout.rapyd.net/error.html\"}"
+          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"123\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_proxy_mandate_001\",\"capture\":true,\"description\":\"Mandate setup\",\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\",\"customer\":{\"name\":\"Grace Tester\",\"email\":\"grace@test.com\"},\"save_payment_method\":true}"
         }
       }
     },
@@ -1252,7 +1252,7 @@
           }
         },
         "sample": {
-          "url": "https://sandboxapi.rapyd.net/v1/customers",
+          "url": "https://sandboxapi.rapyd.net/v1/payments",
           "method": "Post",
           "headers": {
             "access_key": "probe_key",
@@ -1262,7 +1262,7 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"737\"},\"address\":null,\"digital_wallet\":null},\"merchant_reference_id\":\"probe_mandate_001\",\"complete_payment_url\":\"https://sandboxcheckout.rapyd.net/thank_you.html\",\"error_payment_url\":\"https://sandboxcheckout.rapyd.net/error.html\"}"
+          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"737\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_mandate_001\",\"capture\":true,\"description\":\"Mandate setup\",\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\",\"customer\":{\"name\":\"Grace Tester\",\"email\":\"grace@test.com\"},\"save_payment_method\":true}"
         }
       }
     },

--- a/data/field_probe/rapyd.json
+++ b/data/field_probe/rapyd.json
@@ -990,8 +990,7 @@
     },
     "create_order": {
       "default": {
-        "status": "error",
-        "error": "Stuck on field: billing_country or connector_feature_data.country — Missing required field: billing_country or connector_feature_data.country"
+        "status": "not_implemented"
       }
     },
     "create_server_authentication_token": {
@@ -1115,7 +1114,43 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "card_proxy": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "03",
+            "card_exp_year": "2030",
+            "card_cvc": "123",
+            "card_holder_name": "John Doe"
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          },
+          "auth_type": "NO_THREE_DS",
+          "setup_future_usage": "OFF_SESSION"
+        },
+        "sample": {
+          "url": "https://sandboxapi.rapyd.net/v1/payments",
+          "method": "Post",
+          "headers": {
+            "access_key": "probe_key",
+            "content-type": "application/json",
+            "salt": "probeSaltVal0001",
+            "signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "timestamp": "0000000000",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"123\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_proxy_mandate_001\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\"}"
+        }
       }
     },
     "recurring_charge": {
@@ -1186,7 +1221,48 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "card": {
+              "card_number": "4111111111111111",
+              "card_exp_month": "03",
+              "card_exp_year": "2030",
+              "card_cvc": "737",
+              "card_holder_name": "John Doe"
+            }
+          },
+          "address": {
+            "billing_address": {}
+          },
+          "auth_type": "NO_THREE_DS",
+          "enrolled_for_3ds": false,
+          "return_url": "https://example.com/mandate-return",
+          "setup_future_usage": "OFF_SESSION",
+          "request_incremental_authorization": false,
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          }
+        },
+        "sample": {
+          "url": "https://sandboxapi.rapyd.net/v1/payments",
+          "method": "Post",
+          "headers": {
+            "access_key": "probe_key",
+            "content-type": "application/json",
+            "salt": "probeSaltVal0001",
+            "signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "timestamp": "0000000000",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"amount\":\"0.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"4111111111111111\",\"expiration_month\":\"03\",\"expiration_year\":\"2030\",\"name\":\"\",\"cvv\":\"737\"},\"address\":null,\"digital_wallet\":null},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"probe_mandate_001\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://example.com/mandate-return\",\"error_payment_url\":\"https://example.com/mandate-return\"}"
+        }
       }
     },
     "token_authorize": {
@@ -1222,7 +1298,8 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: payment_method for rapyd SetupMandate"
       }
     },
     "tokenize": {

--- a/data/field_probe/rapyd.json
+++ b/data/field_probe/rapyd.json
@@ -1155,7 +1155,42 @@
     },
     "recurring_charge": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "connector_recurring_payment_id": {
+            "mandate_id_type": {
+              "connector_mandate_id": {
+                "connector_mandate_id": "probe-mandate-123"
+              }
+            }
+          },
+          "amount": {
+            "minor_amount": 1000,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "token": {
+              "token": "probe_pm_token"
+            }
+          },
+          "return_url": "https://example.com/recurring-return",
+          "connector_customer_id": "cust_probe_123",
+          "payment_method_type": "PAY_PAL",
+          "off_session": true
+        },
+        "sample": {
+          "url": "https://sandboxapi.rapyd.net/v1/payments",
+          "method": "Post",
+          "headers": {
+            "access_key": "probe_key",
+            "content-type": "application/json",
+            "salt": "probeSaltVal0001",
+            "signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "timestamp": "0000000000",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"amount\":\"10.00\",\"currency\":\"USD\",\"payment_method\":\"probe-mandate-123\",\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"\",\"capture\":true,\"description\":null,\"complete_payment_url\":\"https://hyperswitch.io/return\",\"error_payment_url\":\"https://hyperswitch.io/return\"}"
+        }
       }
     },
     "recurring_revoke": {

--- a/docs-generated/connectors/rapyd.md
+++ b/docs-generated/connectors/rapyd.md
@@ -108,7 +108,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L234) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L110) · [Rust](../../examples/rapyd/rapyd.rs#L223)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L260) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L113) · [Rust](../../examples/rapyd/rapyd.rs#L250)
 
 ### Card Payment (Authorize + Capture)
 
@@ -122,25 +122,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L253) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L126) · [Rust](../../examples/rapyd/rapyd.rs#L239)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L279) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L129) · [Rust](../../examples/rapyd/rapyd.rs#L266)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L278) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L148) · [Rust](../../examples/rapyd/rapyd.rs#L262)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L304) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L151) · [Rust](../../examples/rapyd/rapyd.rs#L289)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L303) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L170) · [Rust](../../examples/rapyd/rapyd.rs#L285)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L329) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L173) · [Rust](../../examples/rapyd/rapyd.rs#L312)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L325) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L189) · [Rust](../../examples/rapyd/rapyd.rs#L304)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L351) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L192) · [Rust](../../examples/rapyd/rapyd.rs#L331)
 
 ## API Reference
 
@@ -152,6 +152,7 @@ Retrieve current payment status from the connector.
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
 | [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
+| [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
 | [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
@@ -350,7 +351,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L347) · [TypeScript](../../examples/rapyd/rapyd.ts#L326) · [Kotlin](../../examples/rapyd/rapyd.kt#L207) · [Rust](../../examples/rapyd/rapyd.rs#L322)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L373) · [TypeScript](../../examples/rapyd/rapyd.ts#L349) · [Kotlin](../../examples/rapyd/rapyd.kt#L210) · [Rust](../../examples/rapyd/rapyd.rs#L349)
 
 #### PaymentService.Capture
 
@@ -361,7 +362,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L356) · [TypeScript](../../examples/rapyd/rapyd.ts#L335) · [Kotlin](../../examples/rapyd/rapyd.kt#L219) · [Rust](../../examples/rapyd/rapyd.rs#L334)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L382) · [TypeScript](../../examples/rapyd/rapyd.ts#L358) · [Kotlin](../../examples/rapyd/rapyd.kt#L222) · [Rust](../../examples/rapyd/rapyd.rs#L361)
 
 #### PaymentService.Get
 
@@ -372,7 +373,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L374) · [TypeScript](../../examples/rapyd/rapyd.ts#L353) · [Kotlin](../../examples/rapyd/rapyd.kt#L245) · [Rust](../../examples/rapyd/rapyd.rs#L348)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L400) · [TypeScript](../../examples/rapyd/rapyd.ts#L376) · [Kotlin](../../examples/rapyd/rapyd.kt#L248) · [Rust](../../examples/rapyd/rapyd.rs#L375)
 
 #### PaymentService.ProxyAuthorize
 
@@ -383,7 +384,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L383) · [TypeScript](../../examples/rapyd/rapyd.ts#L362) · [Kotlin](../../examples/rapyd/rapyd.kt#L253) · [Rust](../../examples/rapyd/rapyd.rs#L355)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L409) · [TypeScript](../../examples/rapyd/rapyd.ts#L385) · [Kotlin](../../examples/rapyd/rapyd.kt#L256) · [Rust](../../examples/rapyd/rapyd.rs#L382)
 
 #### PaymentService.ProxySetupRecurring
 
@@ -394,7 +395,7 @@ Setup recurring mandate using vault-aliased card data.
 | **Request** | `PaymentServiceProxySetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L392) · [TypeScript](../../examples/rapyd/rapyd.ts#L371) · [Kotlin](../../examples/rapyd/rapyd.kt#L281) · [Rust](../../examples/rapyd/rapyd.rs#L362)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L418) · [TypeScript](../../examples/rapyd/rapyd.ts#L394) · [Kotlin](../../examples/rapyd/rapyd.kt#L284) · [Rust](../../examples/rapyd/rapyd.rs#L389)
 
 #### PaymentService.Refund
 
@@ -405,7 +406,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L401) · [TypeScript](../../examples/rapyd/rapyd.ts#L380) · [Kotlin](../../examples/rapyd/rapyd.kt#L312) · [Rust](../../examples/rapyd/rapyd.rs#L369)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L436) · [TypeScript](../../examples/rapyd/rapyd.ts#L412) · [Kotlin](../../examples/rapyd/rapyd.kt#L346) · [Rust](../../examples/rapyd/rapyd.rs#L403)
 
 #### PaymentService.SetupRecurring
 
@@ -416,7 +417,7 @@ Configure a payment method for recurring billing. Sets up the mandate and paymen
 | **Request** | `PaymentServiceSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L419) · [TypeScript](../../examples/rapyd/rapyd.ts#L398) · [Kotlin](../../examples/rapyd/rapyd.kt#L334) · [Rust](../../examples/rapyd/rapyd.rs#L383)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L454) · [TypeScript](../../examples/rapyd/rapyd.ts#L430) · [Kotlin](../../examples/rapyd/rapyd.kt#L368) · [Rust](../../examples/rapyd/rapyd.rs#L417)
 
 #### PaymentService.TokenAuthorize
 
@@ -427,7 +428,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L428) · [TypeScript](../../examples/rapyd/rapyd.ts#L407) · [Kotlin](../../examples/rapyd/rapyd.kt#L373) · [Rust](../../examples/rapyd/rapyd.rs#L393)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L463) · [TypeScript](../../examples/rapyd/rapyd.ts#L439) · [Kotlin](../../examples/rapyd/rapyd.kt#L407) · [Rust](../../examples/rapyd/rapyd.rs#L427)
 
 #### PaymentService.Void
 
@@ -438,7 +439,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L437) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L394) · [Rust](../../examples/rapyd/rapyd.rs#L400)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L472) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L428) · [Rust](../../examples/rapyd/rapyd.rs#L434)
 
 ### Refunds
 
@@ -451,7 +452,20 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L410) · [TypeScript](../../examples/rapyd/rapyd.ts#L389) · [Kotlin](../../examples/rapyd/rapyd.kt#L322) · [Rust](../../examples/rapyd/rapyd.rs#L376)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L445) · [TypeScript](../../examples/rapyd/rapyd.ts#L421) · [Kotlin](../../examples/rapyd/rapyd.kt#L356) · [Rust](../../examples/rapyd/rapyd.rs#L410)
+
+### Mandates
+
+#### RecurringPaymentService.Charge
+
+Charge using an existing stored recurring payment instruction. Processes repeat payments for subscriptions or recurring billing without collecting payment details.
+
+| | Message |
+|---|---------|
+| **Request** | `RecurringPaymentServiceChargeRequest` |
+| **Response** | `RecurringPaymentServiceChargeResponse` |
+
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L427) · [TypeScript](../../examples/rapyd/rapyd.ts#L403) · [Kotlin](../../examples/rapyd/rapyd.kt#L315) · [Rust](../../examples/rapyd/rapyd.rs#L396)
 
 ### Authentication
 
@@ -464,4 +478,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L365) · [TypeScript](../../examples/rapyd/rapyd.ts#L344) · [Kotlin](../../examples/rapyd/rapyd.kt#L229) · [Rust](../../examples/rapyd/rapyd.rs#L341)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L391) · [TypeScript](../../examples/rapyd/rapyd.ts#L367) · [Kotlin](../../examples/rapyd/rapyd.kt#L232) · [Rust](../../examples/rapyd/rapyd.rs#L368)

--- a/docs-generated/connectors/rapyd.md
+++ b/docs-generated/connectors/rapyd.md
@@ -108,7 +108,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L171) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L106) · [Rust](../../examples/rapyd/rapyd.rs#L162)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L234) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L110) · [Rust](../../examples/rapyd/rapyd.rs#L223)
 
 ### Card Payment (Authorize + Capture)
 
@@ -122,25 +122,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L190) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L122) · [Rust](../../examples/rapyd/rapyd.rs#L178)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L253) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L126) · [Rust](../../examples/rapyd/rapyd.rs#L239)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L215) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L144) · [Rust](../../examples/rapyd/rapyd.rs#L201)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L278) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L148) · [Rust](../../examples/rapyd/rapyd.rs#L262)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L240) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L166) · [Rust](../../examples/rapyd/rapyd.rs#L224)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L303) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L170) · [Rust](../../examples/rapyd/rapyd.rs#L285)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L262) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L185) · [Rust](../../examples/rapyd/rapyd.rs#L243)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L325) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L189) · [Rust](../../examples/rapyd/rapyd.rs#L304)
 
 ## API Reference
 
@@ -151,8 +151,10 @@ Retrieve current payment status from the connector.
 | [MerchantAuthenticationService.CreateClientAuthenticationToken](#merchantauthenticationservicecreateclientauthenticationtoken) | Authentication | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
+| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 | [PaymentService.TokenAuthorize](#paymentservicetokenauthorize) | Payments | `PaymentServiceTokenAuthorizeRequest` |
 | [PaymentService.Void](#paymentservicevoid) | Payments | `PaymentServiceVoidRequest` |
 
@@ -348,7 +350,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L284) · [TypeScript](../../examples/rapyd/rapyd.ts#L267) · [Kotlin](../../examples/rapyd/rapyd.kt#L203) · [Rust](../../examples/rapyd/rapyd.rs#L261)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L347) · [TypeScript](../../examples/rapyd/rapyd.ts#L326) · [Kotlin](../../examples/rapyd/rapyd.kt#L207) · [Rust](../../examples/rapyd/rapyd.rs#L322)
 
 #### PaymentService.Capture
 
@@ -359,7 +361,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L293) · [TypeScript](../../examples/rapyd/rapyd.ts#L276) · [Kotlin](../../examples/rapyd/rapyd.kt#L215) · [Rust](../../examples/rapyd/rapyd.rs#L273)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L356) · [TypeScript](../../examples/rapyd/rapyd.ts#L335) · [Kotlin](../../examples/rapyd/rapyd.kt#L219) · [Rust](../../examples/rapyd/rapyd.rs#L334)
 
 #### PaymentService.Get
 
@@ -370,7 +372,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L311) · [TypeScript](../../examples/rapyd/rapyd.ts#L294) · [Kotlin](../../examples/rapyd/rapyd.kt#L241) · [Rust](../../examples/rapyd/rapyd.rs#L287)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L374) · [TypeScript](../../examples/rapyd/rapyd.ts#L353) · [Kotlin](../../examples/rapyd/rapyd.kt#L245) · [Rust](../../examples/rapyd/rapyd.rs#L348)
 
 #### PaymentService.ProxyAuthorize
 
@@ -381,7 +383,18 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L320) · [TypeScript](../../examples/rapyd/rapyd.ts#L303) · [Kotlin](../../examples/rapyd/rapyd.kt#L249) · [Rust](../../examples/rapyd/rapyd.rs#L294)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L383) · [TypeScript](../../examples/rapyd/rapyd.ts#L362) · [Kotlin](../../examples/rapyd/rapyd.kt#L253) · [Rust](../../examples/rapyd/rapyd.rs#L355)
+
+#### PaymentService.ProxySetupRecurring
+
+Setup recurring mandate using vault-aliased card data.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceProxySetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L392) · [TypeScript](../../examples/rapyd/rapyd.ts#L371) · [Kotlin](../../examples/rapyd/rapyd.kt#L281) · [Rust](../../examples/rapyd/rapyd.rs#L362)
 
 #### PaymentService.Refund
 
@@ -392,7 +405,18 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L329) · [TypeScript](../../examples/rapyd/rapyd.ts#L312) · [Kotlin](../../examples/rapyd/rapyd.kt#L277) · [Rust](../../examples/rapyd/rapyd.rs#L301)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L401) · [TypeScript](../../examples/rapyd/rapyd.ts#L380) · [Kotlin](../../examples/rapyd/rapyd.kt#L312) · [Rust](../../examples/rapyd/rapyd.rs#L369)
+
+#### PaymentService.SetupRecurring
+
+Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceSetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L419) · [TypeScript](../../examples/rapyd/rapyd.ts#L398) · [Kotlin](../../examples/rapyd/rapyd.kt#L334) · [Rust](../../examples/rapyd/rapyd.rs#L383)
 
 #### PaymentService.TokenAuthorize
 
@@ -403,7 +427,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L347) · [TypeScript](../../examples/rapyd/rapyd.ts#L330) · [Kotlin](../../examples/rapyd/rapyd.kt#L299) · [Rust](../../examples/rapyd/rapyd.rs#L315)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L428) · [TypeScript](../../examples/rapyd/rapyd.ts#L407) · [Kotlin](../../examples/rapyd/rapyd.kt#L373) · [Rust](../../examples/rapyd/rapyd.rs#L393)
 
 #### PaymentService.Void
 
@@ -414,7 +438,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L356) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L320) · [Rust](../../examples/rapyd/rapyd.rs#L322)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L437) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L394) · [Rust](../../examples/rapyd/rapyd.rs#L400)
 
 ### Refunds
 
@@ -427,7 +451,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L338) · [TypeScript](../../examples/rapyd/rapyd.ts#L321) · [Kotlin](../../examples/rapyd/rapyd.kt#L287) · [Rust](../../examples/rapyd/rapyd.rs#L308)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L410) · [TypeScript](../../examples/rapyd/rapyd.ts#L389) · [Kotlin](../../examples/rapyd/rapyd.kt#L322) · [Rust](../../examples/rapyd/rapyd.rs#L376)
 
 ### Authentication
 
@@ -440,4 +464,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L302) · [TypeScript](../../examples/rapyd/rapyd.ts#L285) · [Kotlin](../../examples/rapyd/rapyd.kt#L225) · [Rust](../../examples/rapyd/rapyd.rs#L280)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L365) · [TypeScript](../../examples/rapyd/rapyd.ts#L344) · [Kotlin](../../examples/rapyd/rapyd.kt#L229) · [Rust](../../examples/rapyd/rapyd.rs#L341)

--- a/docs-generated/connectors/rapyd.md
+++ b/docs-generated/connectors/rapyd.md
@@ -108,7 +108,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L260) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L113) · [Rust](../../examples/rapyd/rapyd.rs#L250)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L234) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L110) · [Rust](../../examples/rapyd/rapyd.rs#L223)
 
 ### Card Payment (Authorize + Capture)
 
@@ -122,25 +122,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L279) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L129) · [Rust](../../examples/rapyd/rapyd.rs#L266)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L253) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L126) · [Rust](../../examples/rapyd/rapyd.rs#L239)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L304) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L151) · [Rust](../../examples/rapyd/rapyd.rs#L289)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L278) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L148) · [Rust](../../examples/rapyd/rapyd.rs#L262)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L329) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L173) · [Rust](../../examples/rapyd/rapyd.rs#L312)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L303) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L170) · [Rust](../../examples/rapyd/rapyd.rs#L285)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L351) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L192) · [Rust](../../examples/rapyd/rapyd.rs#L331)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L325) · [JavaScript](../../examples/rapyd/rapyd.js) · [Kotlin](../../examples/rapyd/rapyd.kt#L189) · [Rust](../../examples/rapyd/rapyd.rs#L304)
 
 ## API Reference
 
@@ -152,7 +152,6 @@ Retrieve current payment status from the connector.
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
 | [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
-| [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
 | [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
@@ -351,7 +350,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L373) · [TypeScript](../../examples/rapyd/rapyd.ts#L349) · [Kotlin](../../examples/rapyd/rapyd.kt#L210) · [Rust](../../examples/rapyd/rapyd.rs#L349)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L347) · [TypeScript](../../examples/rapyd/rapyd.ts#L326) · [Kotlin](../../examples/rapyd/rapyd.kt#L207) · [Rust](../../examples/rapyd/rapyd.rs#L322)
 
 #### PaymentService.Capture
 
@@ -362,7 +361,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L382) · [TypeScript](../../examples/rapyd/rapyd.ts#L358) · [Kotlin](../../examples/rapyd/rapyd.kt#L222) · [Rust](../../examples/rapyd/rapyd.rs#L361)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L356) · [TypeScript](../../examples/rapyd/rapyd.ts#L335) · [Kotlin](../../examples/rapyd/rapyd.kt#L219) · [Rust](../../examples/rapyd/rapyd.rs#L334)
 
 #### PaymentService.Get
 
@@ -373,7 +372,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L400) · [TypeScript](../../examples/rapyd/rapyd.ts#L376) · [Kotlin](../../examples/rapyd/rapyd.kt#L248) · [Rust](../../examples/rapyd/rapyd.rs#L375)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L374) · [TypeScript](../../examples/rapyd/rapyd.ts#L353) · [Kotlin](../../examples/rapyd/rapyd.kt#L245) · [Rust](../../examples/rapyd/rapyd.rs#L348)
 
 #### PaymentService.ProxyAuthorize
 
@@ -384,7 +383,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L409) · [TypeScript](../../examples/rapyd/rapyd.ts#L385) · [Kotlin](../../examples/rapyd/rapyd.kt#L256) · [Rust](../../examples/rapyd/rapyd.rs#L382)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L383) · [TypeScript](../../examples/rapyd/rapyd.ts#L362) · [Kotlin](../../examples/rapyd/rapyd.kt#L253) · [Rust](../../examples/rapyd/rapyd.rs#L355)
 
 #### PaymentService.ProxySetupRecurring
 
@@ -395,7 +394,7 @@ Setup recurring mandate using vault-aliased card data.
 | **Request** | `PaymentServiceProxySetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L418) · [TypeScript](../../examples/rapyd/rapyd.ts#L394) · [Kotlin](../../examples/rapyd/rapyd.kt#L284) · [Rust](../../examples/rapyd/rapyd.rs#L389)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L392) · [TypeScript](../../examples/rapyd/rapyd.ts#L371) · [Kotlin](../../examples/rapyd/rapyd.kt#L281) · [Rust](../../examples/rapyd/rapyd.rs#L362)
 
 #### PaymentService.Refund
 
@@ -406,7 +405,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L436) · [TypeScript](../../examples/rapyd/rapyd.ts#L412) · [Kotlin](../../examples/rapyd/rapyd.kt#L346) · [Rust](../../examples/rapyd/rapyd.rs#L403)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L401) · [TypeScript](../../examples/rapyd/rapyd.ts#L380) · [Kotlin](../../examples/rapyd/rapyd.kt#L312) · [Rust](../../examples/rapyd/rapyd.rs#L369)
 
 #### PaymentService.SetupRecurring
 
@@ -417,7 +416,7 @@ Configure a payment method for recurring billing. Sets up the mandate and paymen
 | **Request** | `PaymentServiceSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L454) · [TypeScript](../../examples/rapyd/rapyd.ts#L430) · [Kotlin](../../examples/rapyd/rapyd.kt#L368) · [Rust](../../examples/rapyd/rapyd.rs#L417)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L419) · [TypeScript](../../examples/rapyd/rapyd.ts#L398) · [Kotlin](../../examples/rapyd/rapyd.kt#L334) · [Rust](../../examples/rapyd/rapyd.rs#L383)
 
 #### PaymentService.TokenAuthorize
 
@@ -428,7 +427,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L463) · [TypeScript](../../examples/rapyd/rapyd.ts#L439) · [Kotlin](../../examples/rapyd/rapyd.kt#L407) · [Rust](../../examples/rapyd/rapyd.rs#L427)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L428) · [TypeScript](../../examples/rapyd/rapyd.ts#L407) · [Kotlin](../../examples/rapyd/rapyd.kt#L373) · [Rust](../../examples/rapyd/rapyd.rs#L393)
 
 #### PaymentService.Void
 
@@ -439,7 +438,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L472) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L428) · [Rust](../../examples/rapyd/rapyd.rs#L434)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L437) · [TypeScript](../../examples/rapyd/rapyd.ts) · [Kotlin](../../examples/rapyd/rapyd.kt#L394) · [Rust](../../examples/rapyd/rapyd.rs#L400)
 
 ### Refunds
 
@@ -452,20 +451,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L445) · [TypeScript](../../examples/rapyd/rapyd.ts#L421) · [Kotlin](../../examples/rapyd/rapyd.kt#L356) · [Rust](../../examples/rapyd/rapyd.rs#L410)
-
-### Mandates
-
-#### RecurringPaymentService.Charge
-
-Charge using an existing stored recurring payment instruction. Processes repeat payments for subscriptions or recurring billing without collecting payment details.
-
-| | Message |
-|---|---------|
-| **Request** | `RecurringPaymentServiceChargeRequest` |
-| **Response** | `RecurringPaymentServiceChargeResponse` |
-
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L427) · [TypeScript](../../examples/rapyd/rapyd.ts#L403) · [Kotlin](../../examples/rapyd/rapyd.kt#L315) · [Rust](../../examples/rapyd/rapyd.rs#L396)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L410) · [TypeScript](../../examples/rapyd/rapyd.ts#L389) · [Kotlin](../../examples/rapyd/rapyd.kt#L322) · [Rust](../../examples/rapyd/rapyd.rs#L376)
 
 ### Authentication
 
@@ -478,4 +464,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/rapyd/rapyd.py#L391) · [TypeScript](../../examples/rapyd/rapyd.ts#L367) · [Kotlin](../../examples/rapyd/rapyd.kt#L232) · [Rust](../../examples/rapyd/rapyd.rs#L368)
+**Examples:** [Python](../../examples/rapyd/rapyd.py#L365) · [TypeScript](../../examples/rapyd/rapyd.ts#L344) · [Kotlin](../../examples/rapyd/rapyd.kt#L229) · [Rust](../../examples/rapyd/rapyd.rs#L341)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -499,7 +499,7 @@ connector_id: rapyd
 doc: docs/connectors/rapyd.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: AliPayRedirect, AmazonPayRedirect, ApplePay, ApplePayThirdPartySdk, Bluecode, Card, CashappQr, GooglePay, GooglePayThirdPartySdk, MbWay, Mifinity, PaypalRedirect, PaypalSdk, RevolutPay, SamsungPay, Satispay, WeChatPayQr, Wero
-flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, refund, refund_get, token_authorize, void
+flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void
 examples_python: examples/rapyd/rapyd.py
 
 ## Razorpay

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -499,7 +499,7 @@ connector_id: rapyd
 doc: docs/connectors/rapyd.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: AliPayRedirect, AmazonPayRedirect, ApplePay, ApplePayThirdPartySdk, Bluecode, Card, CashappQr, GooglePay, GooglePayThirdPartySdk, MbWay, Mifinity, PaypalRedirect, PaypalSdk, RevolutPay, SamsungPay, Satispay, WeChatPayQr, Wero
-flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void
+flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, token_authorize, void
 examples_python: examples/rapyd/rapyd.py
 
 ## Razorpay

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -499,7 +499,7 @@ connector_id: rapyd
 doc: docs/connectors/rapyd.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: AliPayRedirect, AmazonPayRedirect, ApplePay, ApplePayThirdPartySdk, Bluecode, Card, CashappQr, GooglePay, GooglePayThirdPartySdk, MbWay, Mifinity, PaypalRedirect, PaypalSdk, RevolutPay, SamsungPay, Satispay, WeChatPayQr, Wero
-flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, token_authorize, void
+flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void
 examples_python: examples/rapyd/rapyd.py
 
 ## Razorpay

--- a/examples/rapyd/rapyd.kt
+++ b/examples/rapyd/rapyd.kt
@@ -17,11 +17,15 @@ import payments.PaymentServiceVoidRequest
 import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
 import payments.PaymentServiceProxyAuthorizeRequest
+import payments.PaymentServiceProxySetupRecurringRequest
 import payments.RefundServiceGetRequest
+import payments.PaymentServiceSetupRecurringRequest
 import payments.PaymentServiceTokenAuthorizeRequest
+import payments.AcceptanceType
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
+import payments.FutureUsage
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -273,6 +277,37 @@ fun proxyAuthorize(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+fun proxySetupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_proxy_mandate_001"
+        amountBuilder.apply {
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
+            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+            cardExpMonthBuilder.value = "03"
+            cardExpYearBuilder.value = "2030"
+            cardCvcBuilder.value = "123"
+            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+        }
+        addressBuilder.apply {
+            billingAddressBuilder.apply {
+            }
+        }
+        customerAcceptanceBuilder.apply {
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+        authType = AuthenticationType.NO_THREE_DS
+        setupFutureUsage = FutureUsage.OFF_SESSION
+    }.build()
+    val response = client.proxy_setup_recurring(request)
+    println("Status: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -293,6 +328,45 @@ fun refundGet(txnId: String) {
     }.build()
     val response = client.refund_get(request)
     println("Status: ${response.status.name}")
+}
+
+// Flow: PaymentService.SetupRecurring
+fun setupRecurring(txnId: String) {
+    val client = PaymentClient(_defaultConfig)
+    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
+        amountBuilder.apply {  // Mandate Details.
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {
+            cardBuilder.apply {  // Generic card payment.
+                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+                cardExpMonthBuilder.value = "03"
+                cardExpYearBuilder.value = "2030"
+                cardCvcBuilder.value = "737"
+                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            }
+        }
+        addressBuilder.apply {  // Address Information.
+            billingAddressBuilder.apply {
+            }
+        }
+        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
+        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
+        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
+        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
+        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
+        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+    }.build()
+    val response = client.setup_recurring(request)
+    when (response.status.name) {
+        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
+        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
+    }
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -341,10 +415,12 @@ fun main(args: Array<String>) {
         "createClientAuthenticationToken" -> createClientAuthenticationToken(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
+        "setupRecurring" -> setupRecurring(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, void")
     }
 }

--- a/examples/rapyd/rapyd.kt
+++ b/examples/rapyd/rapyd.kt
@@ -9,6 +9,7 @@ package examples.rapyd
 
 import payments.PaymentClient
 import payments.MerchantAuthenticationClient
+import payments.RecurringPaymentClient
 import payments.RefundClient
 import payments.PaymentServiceAuthorizeRequest
 import payments.PaymentServiceCaptureRequest
@@ -18,6 +19,7 @@ import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
 import payments.PaymentServiceProxyAuthorizeRequest
 import payments.PaymentServiceProxySetupRecurringRequest
+import payments.RecurringPaymentServiceChargeRequest
 import payments.RefundServiceGetRequest
 import payments.PaymentServiceSetupRecurringRequest
 import payments.PaymentServiceTokenAuthorizeRequest
@@ -26,6 +28,7 @@ import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
 import payments.FutureUsage
+import payments.PaymentMethodType
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -308,6 +311,37 @@ fun proxySetupRecurring(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: RecurringPaymentService.Charge
+fun recurringCharge(txnId: String) {
+    val client = RecurringPaymentClient(_defaultConfig)
+    val request = RecurringPaymentServiceChargeRequest.newBuilder().apply {
+        connectorRecurringPaymentIdBuilder.apply {  // Reference to existing mandate.
+            connectorMandateIdBuilder.apply {  // mandate_id sent by the connector.
+                connectorMandateIdBuilder.apply {
+                    connectorMandateId = "probe-mandate-123"
+                }
+            }
+        }
+        amountBuilder.apply {  // Amount Information.
+            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {  // Optional payment Method Information (for network transaction flows).
+            tokenBuilder.apply {  // Payment tokens.
+                tokenBuilder.value = "probe_pm_token"  // The token string representing a payment method.
+            }
+        }
+        returnUrl = "https://example.com/recurring-return"
+        connectorCustomerId = "cust_probe_123"
+        paymentMethodType = PaymentMethodType.PAY_PAL
+        offSession = true  // Behavioral Flags and Preferences.
+    }.build()
+    val response = client.charge(request)
+    if (response.status.name == "FAILED")
+        throw RuntimeException("Recurring_Charge failed: ${response.error.unifiedDetails.message}")
+    println("Done: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -416,11 +450,12 @@ fun main(args: Array<String>) {
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
         "proxySetupRecurring" -> proxySetupRecurring(txnId)
+        "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "setupRecurring" -> setupRecurring(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, void")
     }
 }

--- a/examples/rapyd/rapyd.kt
+++ b/examples/rapyd/rapyd.kt
@@ -9,7 +9,6 @@ package examples.rapyd
 
 import payments.PaymentClient
 import payments.MerchantAuthenticationClient
-import payments.RecurringPaymentClient
 import payments.RefundClient
 import payments.PaymentServiceAuthorizeRequest
 import payments.PaymentServiceCaptureRequest
@@ -19,7 +18,6 @@ import payments.PaymentServiceGetRequest
 import payments.MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest
 import payments.PaymentServiceProxyAuthorizeRequest
 import payments.PaymentServiceProxySetupRecurringRequest
-import payments.RecurringPaymentServiceChargeRequest
 import payments.RefundServiceGetRequest
 import payments.PaymentServiceSetupRecurringRequest
 import payments.PaymentServiceTokenAuthorizeRequest
@@ -28,7 +26,6 @@ import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.Currency
 import payments.FutureUsage
-import payments.PaymentMethodType
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -311,37 +308,6 @@ fun proxySetupRecurring(txnId: String) {
     println("Status: ${response.status.name}")
 }
 
-// Flow: RecurringPaymentService.Charge
-fun recurringCharge(txnId: String) {
-    val client = RecurringPaymentClient(_defaultConfig)
-    val request = RecurringPaymentServiceChargeRequest.newBuilder().apply {
-        connectorRecurringPaymentIdBuilder.apply {  // Reference to existing mandate.
-            connectorMandateIdBuilder.apply {  // mandate_id sent by the connector.
-                connectorMandateIdBuilder.apply {
-                    connectorMandateId = "probe-mandate-123"
-                }
-            }
-        }
-        amountBuilder.apply {  // Amount Information.
-            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
-            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
-        paymentMethodBuilder.apply {  // Optional payment Method Information (for network transaction flows).
-            tokenBuilder.apply {  // Payment tokens.
-                tokenBuilder.value = "probe_pm_token"  // The token string representing a payment method.
-            }
-        }
-        returnUrl = "https://example.com/recurring-return"
-        connectorCustomerId = "cust_probe_123"
-        paymentMethodType = PaymentMethodType.PAY_PAL
-        offSession = true  // Behavioral Flags and Preferences.
-    }.build()
-    val response = client.charge(request)
-    if (response.status.name == "FAILED")
-        throw RuntimeException("Recurring_Charge failed: ${response.error.unifiedDetails.message}")
-    println("Done: ${response.status.name}")
-}
-
 // Flow: PaymentService.Refund
 fun refund(txnId: String) {
     val client = PaymentClient(_defaultConfig)
@@ -450,12 +416,11 @@ fun main(args: Array<String>) {
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
         "proxySetupRecurring" -> proxySetupRecurring(txnId)
-        "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "setupRecurring" -> setupRecurring(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, void")
     }
 }

--- a/examples/rapyd/rapyd.py
+++ b/examples/rapyd/rapyd.py
@@ -116,6 +116,35 @@ def _build_proxy_authorize_request():
         payment_pb2.PaymentServiceProxyAuthorizeRequest(),
     )
 
+def _build_proxy_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+            "amount": {
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "card_proxy": {  # Card proxy for vault-aliased payments.
+                "card_number": {"value": "4111111111111111"},  # Card Identification.
+                "card_exp_month": {"value": "03"},
+                "card_exp_year": {"value": "2030"},
+                "card_cvc": {"value": "123"},
+                "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+            },
+            "address": {
+                "billing_address": {
+                }
+            },
+            "customer_acceptance": {
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            },
+            "auth_type": "NO_THREE_DS",
+            "setup_future_usage": "OFF_SESSION"
+        },
+        payment_pb2.PaymentServiceProxySetupRecurringRequest(),
+    )
+
 def _build_refund_request(connector_transaction_id: str):
     return ParseDict(
         {
@@ -139,6 +168,40 @@ def _build_refund_get_request():
             "refund_id": "probe_refund_id_001"
         },
         payment_pb2.RefundServiceGetRequest(),
+    )
+
+def _build_setup_recurring_request():
+    return ParseDict(
+        {
+            "merchant_recurring_payment_id": "probe_mandate_001",  # Identification.
+            "amount": {  # Mandate Details.
+                "minor_amount": 0,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {
+                "card": {  # Generic card payment.
+                    "card_number": {"value": "4111111111111111"},  # Card Identification.
+                    "card_exp_month": {"value": "03"},
+                    "card_exp_year": {"value": "2030"},
+                    "card_cvc": {"value": "737"},
+                    "card_holder_name": {"value": "John Doe"}  # Cardholder Information.
+                }
+            },
+            "address": {  # Address Information.
+                "billing_address": {
+                }
+            },
+            "auth_type": "NO_THREE_DS",  # Type of authentication to be used.
+            "enrolled_for_3ds": False,  # Indicates if the customer is enrolled for 3D Secure.
+            "return_url": "https://example.com/mandate-return",  # URL to redirect after setup.
+            "setup_future_usage": "OFF_SESSION",  # Indicates future usage intention.
+            "request_incremental_authorization": False,  # Indicates if incremental authorization is requested.
+            "customer_acceptance": {  # Details of customer acceptance.
+                "acceptance_type": "OFFLINE",  # Type of acceptance (e.g., online, offline).
+                "accepted_at": 0  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            }
+        },
+        payment_pb2.PaymentServiceSetupRecurringRequest(),
     )
 
 def _build_token_authorize_request():
@@ -326,6 +389,15 @@ async def proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.C
     return {"status": proxy_response.status}
 
 
+async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.ProxySetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
+
+    return {"status": proxy_response.status}
+
+
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: PaymentService.Refund"""
     payment_client = PaymentClient(config)
@@ -342,6 +414,15 @@ async def refund_get(merchant_transaction_id: str, config: sdk_config_pb2.Connec
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
+
+
+async def setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.SetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
+
+    return {"status": setup_response.status, "mandate_id": setup_response.connector_transaction_id}
 
 
 async def token_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/rapyd/rapyd.py
+++ b/examples/rapyd/rapyd.py
@@ -10,6 +10,7 @@ import sys
 from google.protobuf.json_format import ParseDict
 from payments import PaymentClient
 from payments import MerchantAuthenticationClient
+from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
@@ -143,6 +144,31 @@ def _build_proxy_setup_recurring_request():
             "setup_future_usage": "OFF_SESSION"
         },
         payment_pb2.PaymentServiceProxySetupRecurringRequest(),
+    )
+
+def _build_recurring_charge_request():
+    return ParseDict(
+        {
+            "connector_recurring_payment_id": {  # Reference to existing mandate.
+                "connector_mandate_id": {  # mandate_id sent by the connector.
+                    "connector_mandate_id": "probe-mandate-123"
+                }
+            },
+            "amount": {  # Amount Information.
+                "minor_amount": 1000,  # Amount in minor units (e.g., 1000 = $10.00).
+                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
+            },
+            "payment_method": {  # Optional payment Method Information (for network transaction flows).
+                "token": {  # Payment tokens.
+                    "token": {"value": "probe_pm_token"}  # The token string representing a payment method.
+                }
+            },
+            "return_url": "https://example.com/recurring-return",
+            "connector_customer_id": "cust_probe_123",
+            "payment_method_type": "PAY_PAL",
+            "off_session": True  # Behavioral Flags and Preferences.
+        },
+        payment_pb2.RecurringPaymentServiceChargeRequest(),
     )
 
 def _build_refund_request(connector_transaction_id: str):
@@ -396,6 +422,15 @@ async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config
     proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
 
     return {"status": proxy_response.status}
+
+
+async def recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: RecurringPaymentService.Charge"""
+    recurringpayment_client = RecurringPaymentClient(config)
+
+    recurring_response = await recurringpayment_client.charge(_build_recurring_charge_request())
+
+    return {"status": recurring_response.status}
 
 
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/rapyd/rapyd.py
+++ b/examples/rapyd/rapyd.py
@@ -10,7 +10,6 @@ import sys
 from google.protobuf.json_format import ParseDict
 from payments import PaymentClient
 from payments import MerchantAuthenticationClient
-from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
@@ -144,31 +143,6 @@ def _build_proxy_setup_recurring_request():
             "setup_future_usage": "OFF_SESSION"
         },
         payment_pb2.PaymentServiceProxySetupRecurringRequest(),
-    )
-
-def _build_recurring_charge_request():
-    return ParseDict(
-        {
-            "connector_recurring_payment_id": {  # Reference to existing mandate.
-                "connector_mandate_id": {  # mandate_id sent by the connector.
-                    "connector_mandate_id": "probe-mandate-123"
-                }
-            },
-            "amount": {  # Amount Information.
-                "minor_amount": 1000,  # Amount in minor units (e.g., 1000 = $10.00).
-                "currency": "USD"  # ISO 4217 currency code (e.g., "USD", "EUR").
-            },
-            "payment_method": {  # Optional payment Method Information (for network transaction flows).
-                "token": {  # Payment tokens.
-                    "token": {"value": "probe_pm_token"}  # The token string representing a payment method.
-                }
-            },
-            "return_url": "https://example.com/recurring-return",
-            "connector_customer_id": "cust_probe_123",
-            "payment_method_type": "PAY_PAL",
-            "off_session": True  # Behavioral Flags and Preferences.
-        },
-        payment_pb2.RecurringPaymentServiceChargeRequest(),
     )
 
 def _build_refund_request(connector_transaction_id: str):
@@ -422,15 +396,6 @@ async def proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config
     proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
 
     return {"status": proxy_response.status}
-
-
-async def recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Flow: RecurringPaymentService.Charge"""
-    recurringpayment_client = RecurringPaymentClient(config)
-
-    recurring_response = await recurringpayment_client.charge(_build_recurring_charge_request())
-
-    return {"status": recurring_response.status}
 
 
 async def refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/rapyd/rapyd.rs
+++ b/examples/rapyd/rapyd.rs
@@ -137,33 +137,6 @@ pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurrin
     })).unwrap_or_default()
 }
 
-pub fn build_recurring_charge_request() -> RecurringPaymentServiceChargeRequest {
-    serde_json::from_value::<RecurringPaymentServiceChargeRequest>(serde_json::json!({
-    "connector_recurring_payment_id": {  // Reference to existing mandate.
-        "mandate_id_type": {
-            "connector_mandate_id": {
-                "connector_mandate_id": "probe-mandate-123",
-            },
-        },
-    },
-    "amount": {  // Amount Information.
-        "minor_amount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
-        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
-    },
-    "payment_method": {  // Optional payment Method Information (for network transaction flows).
-        "payment_method": {
-            "token": {  // Payment tokens.
-                "token": "probe_pm_token",  // The token string representing a payment method.
-            },
-        }
-    },
-    "return_url": "https://example.com/recurring-return",
-    "connector_customer_id": "cust_probe_123",
-    "payment_method_type": "PAY_PAL",
-    "off_session": true,  // Behavioral Flags and Preferences.
-    })).unwrap_or_default()
-}
-
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -391,13 +364,6 @@ pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transacti
     Ok(format!("status: {:?}", response.status()))
 }
 
-// Flow: RecurringPaymentService.Charge
-#[allow(dead_code)]
-pub async fn recurring_charge(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client.recurring_charge(build_recurring_charge_request(), &HashMap::new(), None).await?;
-    Ok(format!("status: {:?}", response.status()))
-}
-
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -453,13 +419,12 @@ async fn main() {
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
         "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
-        "recurring_charge" => recurring_charge(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
         "setup_recurring" => setup_recurring(&client, "order_001").await,
         "token_authorize" => token_authorize(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, token_authorize, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/rapyd/rapyd.rs
+++ b/examples/rapyd/rapyd.rs
@@ -110,6 +110,33 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     })).unwrap_or_default()
 }
 
+pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceProxySetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+    "amount": {
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "card_proxy": {  // Card proxy for vault-aliased payments.
+        "card_number": "4111111111111111",  // Card Identification.
+        "card_exp_month": "03",
+        "card_exp_year": "2030",
+        "card_cvc": "123",
+        "card_holder_name": "John Doe",  // Cardholder Information.
+    },
+    "address": {
+        "billing_address": {
+        },
+    },
+    "customer_acceptance": {
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
+    "auth_type": "NO_THREE_DS",
+    "setup_future_usage": "OFF_SESSION",
+    })).unwrap_or_default()
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -128,6 +155,40 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
     "merchant_refund_id": "probe_refund_001",  // Identification.
     "connector_transaction_id": "probe_connector_txn_001",
     "refund_id": "probe_refund_id_001",
+    })).unwrap_or_default()
+}
+
+pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    serde_json::from_value::<PaymentServiceSetupRecurringRequest>(serde_json::json!({
+    "merchant_recurring_payment_id": "probe_mandate_001",  // Identification.
+    "amount": {  // Mandate Details.
+        "minor_amount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {
+        "payment_method": {
+            "card": {  // Generic card payment.
+                "card_number": "4111111111111111",  // Card Identification.
+                "card_exp_month": "03",
+                "card_exp_year": "2030",
+                "card_cvc": "737",
+                "card_holder_name": "John Doe",  // Cardholder Information.
+            },
+        }
+    },
+    "address": {  // Address Information.
+        "billing_address": {
+        },
+    },
+    "auth_type": "NO_THREE_DS",  // Type of authentication to be used.
+    "enrolled_for_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+    "return_url": "https://example.com/mandate-return",  // URL to redirect after setup.
+    "setup_future_usage": "OFF_SESSION",  // Indicates future usage intention.
+    "request_incremental_authorization": false,  // Indicates if incremental authorization is requested.
+    "customer_acceptance": {  // Details of customer acceptance.
+        "acceptance_type": "OFFLINE",  // Type of acceptance (e.g., online, offline).
+        "accepted_at": 0,  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+    },
     })).unwrap_or_default()
 }
 
@@ -296,6 +357,13 @@ pub async fn proxy_authorize(client: &ConnectorClient, _merchant_transaction_id:
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+#[allow(dead_code)]
+pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -308,6 +376,16 @@ pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) ->
 pub async fn refund_get(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
     let response = client.refund_get(build_refund_get_request(), &HashMap::new(), None).await?;
     Ok(format!("status: {:?}", response.status()))
+}
+
+// Flow: PaymentService.SetupRecurring
+#[allow(dead_code)]
+pub async fn setup_recurring(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.setup_recurring(build_setup_recurring_request(), &HashMap::new(), None).await?;
+    if response.status() == PaymentStatus::Failure {
+        return Err(format!("Setup failed: {:?}", response.error).into());
+    }
+    Ok(format!("Mandate: {}", response.connector_recurring_payment_id.as_deref().unwrap_or("")))
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -340,11 +418,13 @@ async fn main() {
         "create_client_authentication_token" => create_client_authentication_token(&client, "order_001").await,
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
+        "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
+        "setup_recurring" => setup_recurring(&client, "order_001").await,
         "token_authorize" => token_authorize(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, refund, refund_get, token_authorize, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/rapyd/rapyd.rs
+++ b/examples/rapyd/rapyd.rs
@@ -137,6 +137,33 @@ pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurrin
     })).unwrap_or_default()
 }
 
+pub fn build_recurring_charge_request() -> RecurringPaymentServiceChargeRequest {
+    serde_json::from_value::<RecurringPaymentServiceChargeRequest>(serde_json::json!({
+    "connector_recurring_payment_id": {  // Reference to existing mandate.
+        "mandate_id_type": {
+            "connector_mandate_id": {
+                "connector_mandate_id": "probe-mandate-123",
+            },
+        },
+    },
+    "amount": {  // Amount Information.
+        "minor_amount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
+        "currency": "USD",  // ISO 4217 currency code (e.g., "USD", "EUR").
+    },
+    "payment_method": {  // Optional payment Method Information (for network transaction flows).
+        "payment_method": {
+            "token": {  // Payment tokens.
+                "token": "probe_pm_token",  // The token string representing a payment method.
+            },
+        }
+    },
+    "return_url": "https://example.com/recurring-return",
+    "connector_customer_id": "cust_probe_123",
+    "payment_method_type": "PAY_PAL",
+    "off_session": true,  // Behavioral Flags and Preferences.
+    })).unwrap_or_default()
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     serde_json::from_value::<PaymentServiceRefundRequest>(serde_json::json!({
     "merchant_refund_id": "probe_refund_001",  // Identification.
@@ -364,6 +391,13 @@ pub async fn proxy_setup_recurring(client: &ConnectorClient, _merchant_transacti
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: RecurringPaymentService.Charge
+#[allow(dead_code)]
+pub async fn recurring_charge(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.recurring_charge(build_recurring_charge_request(), &HashMap::new(), None).await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: PaymentService.Refund
 #[allow(dead_code)]
 pub async fn refund(client: &ConnectorClient, _merchant_transaction_id: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -419,12 +453,13 @@ async fn main() {
         "get" => get(&client, "order_001").await,
         "proxy_authorize" => proxy_authorize(&client, "order_001").await,
         "proxy_setup_recurring" => proxy_setup_recurring(&client, "order_001").await,
+        "recurring_charge" => recurring_charge(&client, "order_001").await,
         "refund" => refund(&client, "order_001").await,
         "refund_get" => refund_get(&client, "order_001").await,
         "setup_recurring" => setup_recurring(&client, "order_001").await,
         "token_authorize" => token_authorize(&client, "order_001").await,
         "void" => void(&client, "order_001").await,
-        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, setup_recurring, token_authorize, void", flow); return; }
+        _ => { eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, token_authorize, void", flow); return; }
     };
     match result {
         Ok(msg) => println!("✓ {msg}"),

--- a/examples/rapyd/rapyd.ts
+++ b/examples/rapyd/rapyd.ts
@@ -5,8 +5,8 @@
 // Rapyd — all integration scenarios and flows in one file.
 // Run a scenario:  npx tsx rapyd.ts checkout_autocapture
 
-import { PaymentClient, MerchantAuthenticationClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage, PaymentMethodType } = types;
+import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -125,29 +125,6 @@ function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRe
         },
         "authType": AuthenticationType.NO_THREE_DS,
         "setupFutureUsage": FutureUsage.OFF_SESSION
-    };
-}
-
-function _buildRecurringChargeRequest(): RecurringPaymentServiceChargeRequest {
-    return {
-        "connectorRecurringPaymentId": {  // Reference to existing mandate.
-            "connectorMandateId": {  // mandate_id sent by the connector.
-                "connectorMandateId": "probe-mandate-123"
-            }
-        },
-        "amount": {  // Amount Information.
-            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
-            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        },
-        "paymentMethod": {  // Optional payment Method Information (for network transaction flows).
-            "token": {  // Payment tokens.
-                "token": {"value": "probe_pm_token"}  // The token string representing a payment method.
-            }
-        },
-        "returnUrl": "https://example.com/recurring-return",
-        "connectorCustomerId": "cust_probe_123",
-        "paymentMethodType": PaymentMethodType.PAY_PAL,
-        "offSession": true  // Behavioral Flags and Preferences.
     };
 }
 
@@ -399,15 +376,6 @@ async function proxySetupRecurring(merchantTransactionId: string, config: Connec
     return { status: proxyResponse.status };
 }
 
-// Flow: RecurringPaymentService.Charge
-async function recurringCharge(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RecurringPaymentServiceChargeResponse> {
-    const recurringPaymentClient = new RecurringPaymentClient(config);
-
-    const recurringResponse = await recurringPaymentClient.charge(_buildRecurringChargeRequest());
-
-    return { status: recurringResponse.status };
-}
-
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -456,7 +424,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner

--- a/examples/rapyd/rapyd.ts
+++ b/examples/rapyd/rapyd.ts
@@ -6,7 +6,7 @@
 // Run a scenario:  npx tsx rapyd.ts checkout_autocapture
 
 import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AuthenticationType, CaptureMethod, Currency } = types;
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -101,6 +101,33 @@ function _buildProxyAuthorizeRequest(): PaymentServiceProxyAuthorizeRequest {
     };
 }
 
+function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
+        "amount": {
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "cardProxy": {  // Card proxy for vault-aliased payments.
+            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+            "cardExpMonth": {"value": "03"},
+            "cardExpYear": {"value": "2030"},
+            "cardCvc": {"value": "123"},
+            "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+        },
+        "address": {
+            "billingAddress": {
+            }
+        },
+        "customerAcceptance": {
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        },
+        "authType": AuthenticationType.NO_THREE_DS,
+        "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
 function _buildRefundRequest(connectorTransactionId: string): PaymentServiceRefundRequest {
     return {
         "merchantRefundId": "probe_refund_001",  // Identification.
@@ -119,6 +146,38 @@ function _buildRefundGetRequest(): RefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"
+    };
+}
+
+function _buildSetupRecurringRequest(): PaymentServiceSetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
+        "amount": {  // Mandate Details.
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {
+            "card": {  // Generic card payment.
+                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+                "cardExpMonth": {"value": "03"},
+                "cardExpYear": {"value": "2030"},
+                "cardCvc": {"value": "737"},
+                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+            }
+        },
+        "address": {  // Address Information.
+            "billingAddress": {
+            }
+        },
+        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
+        "enrolledFor3Ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
+        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
+        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
+        "customerAcceptance": {  // Details of customer acceptance.
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
     };
 }
 
@@ -308,6 +367,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: ConnectorCo
     return { status: proxyResponse.status };
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+async function proxySetupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
+
+    return { status: proxyResponse.status };
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -324,6 +392,15 @@ async function refundGet(merchantTransactionId: string, config: ConnectorConfig 
     const refundResponse = await refundClient.refundGet(_buildRefundGetRequest());
 
     return { status: refundResponse.status };
+}
+
+// Flow: PaymentService.SetupRecurring
+async function setupRecurring(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<PaymentServiceSetupRecurringResponse> {
+    const paymentClient = new PaymentClient(config);
+
+    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
+
+    return { status: setupResponse.status, mandateId: setupResponse.connectorTransactionId };
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -347,7 +424,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner

--- a/examples/rapyd/rapyd.ts
+++ b/examples/rapyd/rapyd.ts
@@ -5,8 +5,8 @@
 // Rapyd — all integration scenarios and flows in one file.
 // Run a scenario:  npx tsx rapyd.ts checkout_autocapture
 
-import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
-const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage } = types;
+import { PaymentClient, MerchantAuthenticationClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
+const { ConnectorConfig, ConnectorSpecificConfig, SdkOptions, Environment, AcceptanceType, AuthenticationType, CaptureMethod, Currency, FutureUsage, PaymentMethodType } = types;
 
 const _defaultConfig: ConnectorConfig = {
     options: {
@@ -125,6 +125,29 @@ function _buildProxySetupRecurringRequest(): PaymentServiceProxySetupRecurringRe
         },
         "authType": AuthenticationType.NO_THREE_DS,
         "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
+function _buildRecurringChargeRequest(): RecurringPaymentServiceChargeRequest {
+    return {
+        "connectorRecurringPaymentId": {  // Reference to existing mandate.
+            "connectorMandateId": {  // mandate_id sent by the connector.
+                "connectorMandateId": "probe-mandate-123"
+            }
+        },
+        "amount": {  // Amount Information.
+            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {  // Optional payment Method Information (for network transaction flows).
+            "token": {  // Payment tokens.
+                "token": {"value": "probe_pm_token"}  // The token string representing a payment method.
+            }
+        },
+        "returnUrl": "https://example.com/recurring-return",
+        "connectorCustomerId": "cust_probe_123",
+        "paymentMethodType": PaymentMethodType.PAY_PAL,
+        "offSession": true  // Behavioral Flags and Preferences.
     };
 }
 
@@ -376,6 +399,15 @@ async function proxySetupRecurring(merchantTransactionId: string, config: Connec
     return { status: proxyResponse.status };
 }
 
+// Flow: RecurringPaymentService.Charge
+async function recurringCharge(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RecurringPaymentServiceChargeResponse> {
+    const recurringPaymentClient = new RecurringPaymentClient(config);
+
+    const recurringResponse = await recurringPaymentClient.charge(_buildRecurringChargeRequest());
+
+    return { status: recurringResponse.status };
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: ConnectorConfig = _defaultConfig): Promise<RefundResponse> {
     const paymentClient = new PaymentClient(config);
@@ -424,7 +456,7 @@ async function voidPayment(merchantTransactionId: string, config: ConnectorConfi
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Summary
Implement **SetupRecurring** (SetupMandate) flow for **rapyd** connector.

Generated and validated by **GRACE**.

## Changes
- Added SetupMandate to `rapyd.rs` (`create_all_prerequisites!` + `macro_connector_implementation!` POST /v1/payments — Rapyd has no dedicated mandate endpoint)
- `RapydSetupMandateRequest` (alias of `RapydPaymentsRequest`) + `RapydSetupMandateResponse` (distinct newtype to avoid E0119 TryFrom collision) + TryFroms in `rapyd/transformers.rs`; Authorized->Charged promotion for terminal state
- Populates `MandateReference.connector_mandate_id` from `data.id`
- Minimum amount 100 (Rapyd rejects zero)

## Files Modified
- `crates/integrations/connector-integration/src/connectors/rapyd.rs`
- `crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs`

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl SetupRecurring call (credentials masked)</summary>

```
grpcurl -plaintext -d @ \
  -H "x-connector: rapyd" \
  -H "x-auth: body-key" \
  -H "x-api-key: <REDACTED_API_KEY>" \
  -H "x-key1: <REDACTED>" \
  -H "x-merchant-id: test_merchant" \
  -H "x-tenant-id: default" \
  -H "x-request-id: grace-rapyd-setup-001" \
  -H "x-connector-request-reference-id: grace-rapyd-setup-001" \
  localhost:19332 types.PaymentService/SetupRecurring <<EOF2
{
  "merchant_recurring_payment_id": "grace-rapyd-setup-001",
  "amount": {"minor_amount": 100, "currency": "USD"},
  "payment_method": {"card": {
    "card_number": {"value": "<REDACTED_PAN>"},
    "card_exp_month": {"value": "12"},
    "card_exp_year": {"value": "2030"},
    "card_cvc": {"value": "<REDACTED_CVV>"},
    "card_holder_name": {"value": "Grace Tester"}
  }},
  "address": {"billing_address": {
    "first_name": {"value": "Grace"}, "last_name": {"value": "Tester"},
    "line1": {"value": "123 Test St"}, "city": {"value": "London"},
    "country_alpha2_code": "GB", "zip_code": {"value": "EC1A1BB"},
    "email": {"value": "grace@test.com"}
  }},
  "customer": {"email": {"value": "grace@test.com"}},
  "customer_acceptance": {"acceptance_type": "ONLINE", "accepted_at": 1713100000,
    "online_mandate_details": {"ip_address": "127.0.0.1", "user_agent": "Mozilla/5.0"}},
  "auth_type": "NO_THREE_DS", "enrolled_for_3ds": false,
  "request_incremental_authorization": false,
  "setup_future_usage": "OFF_SESSION",
  "return_url": "https://example.com/return"
}
EOF2
```

**Response:**

```json
{
  "connectorRecurringPaymentId": "payment_3bf3245d443b58860f8c6bb26b5ab9b1",
  "status": "CHARGED",
  "statusCode": 200,
  "mandateReference": {
    "connectorMandateId": {
      "connectorMandateId": "payment_3bf3245d443b58860f8c6bb26b5ab9b1"
    }
  },
  "merchantRecurringPaymentId": "grace-rapyd-setup-001",
  "capturedAmount": "100",
  "rawConnectorRequest": {
    "value": "{\"url\":\"https://sandboxapi.rapyd.net/v1/payments\",\"method\":\"POST\",\"headers\":{\"salt\":\"<REDACTED>\",\"Content-Type\":\"application/json\",\"access_key\":\"<REDACTED_API_KEY>\",\"signature\":\"<REDACTED>\",\"via\":\"HyperSwitch\",\"timestamp\":\"1776178054\"},\"body\":{\"amount\":\"1.00\",\"currency\":\"USD\",\"payment_method\":{\"type\":\"in_amex_card\",\"fields\":{\"number\":\"<REDACTED_PAN>\",\"expiration_month\":\"12\",\"expiration_year\":\"2030\",\"name\":\"Grace Tester\",\"cvv\":\"<REDACTED_CVV>\"}},\"payment_method_options\":{\"3d_required\":false},\"merchant_reference_id\":\"grace-rapyd-setup-001\",\"capture\":true,\"complete_payment_url\":\"https://example.com/return\",\"error_payment_url\":\"https://example.com/return\"}}"
  }
}
```

</details>

## Validation Checklist
- [x] cargo build passed
- [x] grpcurl SetupRecurring returned 2xx + success status (CHARGED)
- [x] No credentials in committed source code
- [x] Only connector-specific files modified

## Follow-up: SetupRecurring -> Charge chain (commit 9a076032b)

**Verdict: PASS** — Full SetupMandate → MIT Charge chain passes live on Rapyd sandbox.

### What changed and why

Previous commit (`a339cce3a`) routed SetupMandate to `POST /v1/customers`, which forced a `complete_payment_url` that the sandbox merchant account does not whitelist → `INVALID_COMPLETE_PAYMENT_URL`.

This push reverts SetupMandate to `POST /v1/payments` but keeps the "customer-scoped card token" architecture that MIT needs:
- Send `save_payment_method: true` plus an inline `customer: {name, email}` object. Rapyd creates the customer, captures the card, and returns a reusable `card_*` token — no URL whitelist required.
- Extract the real customer id from the Rapyd response field `data.customer_token` (NOT `data.customer`, which the sandbox returns as `null` in this mode). Pack `"cus_*|card_*"` in `connector_mandate_id`.
- RepeatPayment unpacks both halves and sends `{ customer: "cus_*", payment_method: "card_*", initiation_type: "recurring" }` to `/v1/payments` — the Rapyd-documented MIT shape.

### Step A — PaymentService/SetupRecurring (PASS)

```
grpcurl -plaintext \
  -H "x-connector: rapyd" -H "x-auth: body-key" \
  -H "x-api-key: <REDACTED_API_KEY>" -H "x-key1: <REDACTED>" \
  -H "x-merchant-id: test_merchant" -H "x-tenant-id: public" \
  -H "x-request-id: grace-rapyd-setup-1776298629" \
  -H "x-connector-request-reference-id: grace-rapyd-setup-1776298629" \
  -d @ localhost:50081 types.PaymentService/SetupRecurring
```

Request (masked):
```json
{
  "merchant_recurring_payment_id": "grace-rapyd-setup-1776298629",
  "amount": {"minor_amount": 100, "currency": "USD"},
  "payment_method": {"card": {
    "card_number": {"value": "<REDACTED_PAN>"},
    "card_exp_month": {"value": "12"}, "card_exp_year": {"value": "2030"},
    "card_cvc": {"value": "<REDACTED_CVV>"}, "card_holder_name": {"value": "Grace Tester"}
  }},
  "customer": {"name": "Grace Tester", "email": {"value": "grace@test.com"}},
  "customer_acceptance": {"acceptance_type": "ONLINE", "accepted_at": 1713100000,
    "online_mandate_details": {"ip_address": "127.0.0.1", "user_agent": "Mozilla/5.0"}},
  "auth_type": "NO_THREE_DS", "setup_future_usage": "OFF_SESSION",
  "return_url": "https://example.com/return"
}
```

Outgoing Rapyd call (masked):
```
POST https://sandboxapi.rapyd.net/v1/payments
body: {"amount":"1.00","currency":"USD",
       "payment_method":{"type":"in_amex_card","fields":{"number":"<REDACTED_PAN>","expiration_month":"12","expiration_year":"2030","name":"Grace Tester","cvv":"<REDACTED_CVV>"}},
       "payment_method_options":{"3d_required":false},
       "merchant_reference_id":"grace-rapyd-setup-1776298629",
       "capture":true,"description":"Mandate setup",
       "complete_payment_url":"https://hyperswitch.io/return","error_payment_url":"https://hyperswitch.io/return",
       "customer":{"name":"Grace Tester","email":"grace@test.com"},
       "save_payment_method":true}
```

Rapyd response (HTTP 200):
```json
{"status":{"status":"SUCCESS",...},
 "data":{"id":"payment_e014020403bfa263bd198a474918c2f7","status":"CLO","paid":true,"captured":true,
         "customer_token":"cus_05cb554b350ae6cfcc07aff54eaa69f3",
         "payment_method":"card_1ad5f5378b2127f9743e02180e93b793",...}}
```

gRPC response:
```json
{
  "connectorRecurringPaymentId": "payment_e014020403bfa263bd198a474918c2f7",
  "status": "CHARGED",
  "statusCode": 200,
  "mandateReference": {
    "connectorMandateId": {"connectorMandateId": "cus_05cb554b350ae6cfcc07aff54eaa69f3|card_1ad5f5378b2127f9743e02180e93b793"}
  },
  "capturedAmount": "100"
}
```

### Step B — RecurringPaymentService/Charge (PASS)

```
grpcurl -plaintext \
  -H "x-connector: rapyd" -H "x-auth: body-key" \
  -H "x-api-key: <REDACTED_API_KEY>" -H "x-key1: <REDACTED>" \
  -H "x-merchant-id: test_merchant" -H "x-tenant-id: public" \
  -H "x-request-id: grace-rapyd-charge-1776298640" \
  -H "x-connector-request-reference-id: grace-rapyd-charge-1776298640" \
  -d @ localhost:50081 types.RecurringPaymentService/Charge
```

Request:
```json
{
  "merchant_charge_id": "grace-rapyd-charge-1776298640",
  "connector_recurring_payment_id": {
    "connector_mandate_id": {"connector_mandate_id": "cus_05cb554b350ae6cfcc07aff54eaa69f3|card_1ad5f5378b2127f9743e02180e93b793"}
  },
  "amount": {"minor_amount": 200, "currency": "USD"},
  "email": {"value": "grace@test.com"},
  "return_url": "https://example.com/return"
}
```

Outgoing Rapyd call (masked):
```
POST https://sandboxapi.rapyd.net/v1/payments
body: {"amount":"2.00","currency":"USD",
       "payment_method":"<REDACTED_TOKEN>",
       "payment_method_options":{"3d_required":false},
       "merchant_reference_id":"grace-rapyd-charge-1776298640",
       "capture":true,
       "complete_payment_url":"https://hyperswitch.io/return","error_payment_url":"https://hyperswitch.io/return",
       "customer":"cus_05cb554b350ae6cfcc07aff54eaa69f3",
       "initiation_type":"recurring"}
```

Rapyd response (HTTP 200):
```json
{"status":{"status":"SUCCESS",...},
 "data":{"id":"payment_1f0c4ed460225ab7727eeeb92c6eb626","status":"CLO","amount":2,
         "customer_token":"cus_05cb554b350ae6cfcc07aff54eaa69f3",
         "initiation_type":"recurring","captured":true,"paid":true,...}}
```

gRPC response:
```json
{
  "connectorTransactionId": "payment_1f0c4ed460225ab7727eeeb92c6eb626",
  "status": "CHARGED",
  "statusCode": 200,
  "merchantChargeId": "grace-rapyd-charge-1776298640"
}
```

### Chain status
| Step | Flow | Verdict |
|------|------|---------|
| A | PaymentService/SetupRecurring | PASS (CHARGED / 200) |
| B | RecurringPaymentService/Charge | PASS (CHARGED / 200) |

Spec compliance: **FIXES_APPLIED** — end-to-end MIT chain now passes on Rapyd sandbox without merchant URL whitelist configuration.
