### PR TITLE
[GRACE-FAILED] feat(connector): implement INCREMENTAL_AUTH for elavon

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/elavon.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon.rs
@@ -38,9 +38,9 @@ use interfaces::{
 };
 use serde::Serialize;
 use transformers::{
-    self as elavon, ElavonCaptureResponse, ElavonPSyncResponse, ElavonPaymentsResponse,
-    ElavonRSyncResponse, ElavonRefundResponse, XMLCaptureRequest, XMLElavonRequest,
-    XMLPSyncRequest, XMLRSyncRequest, XMLRefundRequest,
+    self as elavon, ElavonCaptureResponse, ElavonIncrementalAuthResponse, ElavonPSyncResponse,
+    ElavonPaymentsResponse, ElavonRSyncResponse, ElavonRefundResponse, XMLCaptureRequest,
+    XMLElavonRequest, XMLIncrementalAuthRequest, XMLPSyncRequest, XMLRSyncRequest, XMLRefundRequest,
 };
 
 use super::macros;
@@ -50,16 +50,6 @@ use crate::{
 
 pub(crate) mod headers {
     pub(crate) const CONTENT_TYPE: &str = "Content-Type";
-}
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        IncrementalAuthorization,
-        PaymentFlowData,
-        PaymentsIncrementalAuthorizationData,
-        PaymentsResponseData,
-    > for Elavon<T>
-{
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -312,6 +302,12 @@ macros::create_all_prerequisites!(
             request_body: XMLRSyncRequest,
             response_body: ElavonRSyncResponse,
             router_data: RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ),
+        (
+            flow: IncrementalAuthorization,
+            request_body: XMLIncrementalAuthRequest,
+            response_body: ElavonIncrementalAuthResponse,
+            router_data: RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -502,6 +498,42 @@ macros::macro_connector_implementation!(
         fn get_url(
             &self,
             req: &RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ) -> CustomResult<String, errors::ConnectorError> {
+            Ok(format!(
+                "{}processxml.do",
+                req.resource_common_data.connectors.elavon.base_url
+            ))
+        }
+    }
+);
+
+// IncrementalAuthorization flow - increases the authorized amount of a
+// pre-authorized transaction (Elavon Converge `ccincrauth`). Shares the
+// same processxml.do endpoint as other flows.
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type],
+    connector: Elavon,
+    curl_request: FormUrlEncoded(XMLIncrementalAuthRequest),
+    curl_response: ElavonIncrementalAuthResponse,
+    flow_name: IncrementalAuthorization,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentsIncrementalAuthorizationData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    preprocess_response: true,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
+            self.build_headers(req)
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
         ) -> CustomResult<String, errors::ConnectorError> {
             Ok(format!(
                 "{}processxml.do",

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -9,10 +9,11 @@ use common_utils::{
     types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, RSync, Refund},
+    connector_flow::{Authorize, Capture, IncrementalAuthorization, PSync, RSync, Refund},
     connector_types::{
-        PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
-        PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
+        PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
+        PaymentsIncrementalAuthorizationData, PaymentsResponseData, PaymentsSyncData,
+        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
         ResponseId as DomainResponseId,
     },
     errors::{self},
@@ -65,6 +66,7 @@ pub enum TransactionType {
     CcComplete,
     CcReturn,
     TxnQuery,
+    CcIncrement,
 }
 
 impl Serialize for TransactionType {
@@ -78,6 +80,7 @@ impl Serialize for TransactionType {
             Self::CcComplete => "cccomplete",
             Self::CcReturn => "ccreturn",
             Self::TxnQuery => "txnquery",
+            Self::CcIncrement => "ccincrauth",
         };
         serializer.serialize_str(value)
     }
@@ -280,6 +283,9 @@ pub struct XMLRefundRequest(pub HashMap<String, Secret<String, WithoutType>>);
 #[derive(Debug, Serialize)]
 pub struct XMLRSyncRequest(pub HashMap<String, Secret<String, WithoutType>>);
 
+#[derive(Debug, Serialize)]
+pub struct XMLIncrementalAuthRequest(pub HashMap<String, Secret<String, WithoutType>>);
+
 // TryFrom implementation to convert from the router data to XMLElavonRequest
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -449,6 +455,11 @@ pub struct ElavonCaptureResponse {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ElavonRefundResponse {
+    pub result: ElavonResult,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ElavonIncrementalAuthResponse {
     pub result: ElavonResult,
 }
 
@@ -638,6 +649,96 @@ impl<'de> Deserialize<'de> for ElavonRefundResponse {
             #[serde(default)]
             error_message: Option<String>,
             #[serde(default)]
+            error_name: Option<String>,
+            #[serde(default)]
+            ssl_result: Option<String>,
+            #[serde(default)]
+            ssl_txn_id: Option<String>,
+            #[serde(default)]
+            ssl_result_message: Option<String>,
+            #[serde(default)]
+            ssl_token: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_token_response: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_approval_code: Option<String>,
+            #[serde(default)]
+            ssl_transaction_type: Option<String>,
+            #[serde(default)]
+            ssl_cvv2_response: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_avs_response: Option<String>,
+        }
+
+        let flat_res = XmlIshResponse::deserialize(deserializer)?;
+
+        let result = {
+            if flat_res.ssl_result.as_deref() == Some("0") {
+                ElavonResult::Success(PaymentResponse {
+                    ssl_result: SslResult::try_from(
+                        flat_res
+                            .ssl_result
+                            .ok_or_else(|| de::Error::missing_field("ssl_result"))?,
+                    )
+                    .map_err(de::Error::custom)?,
+                    ssl_txn_id: flat_res
+                        .ssl_txn_id
+                        .ok_or_else(|| de::Error::missing_field("ssl_txn_id"))?,
+                    ssl_result_message: flat_res
+                        .ssl_result_message
+                        .ok_or_else(|| de::Error::missing_field("ssl_result_message"))?,
+                    ssl_token: flat_res.ssl_token,
+                    ssl_approval_code: flat_res.ssl_approval_code,
+                    ssl_transaction_type: flat_res.ssl_transaction_type.clone(),
+                    ssl_cvv2_response: flat_res.ssl_cvv2_response,
+                    ssl_avs_response: flat_res.ssl_avs_response,
+                    ssl_token_response: flat_res.ssl_token_response.map(|s| s.expose()),
+                })
+            } else if flat_res.error_message.is_some() {
+                ElavonResult::Error(ElavonErrorResponse {
+                    error_code: flat_res.error_code.or(flat_res.ssl_result.clone()),
+                    error_message: flat_res
+                        .error_message
+                        .ok_or_else(|| de::Error::missing_field("error_message"))?,
+                    error_name: flat_res.error_name,
+                    ssl_txn_id: flat_res.ssl_txn_id,
+                })
+            } else if flat_res.ssl_result.is_some() {
+                ElavonResult::Error(ElavonErrorResponse {
+                    error_code: flat_res.ssl_result.clone(),
+                    error_message: flat_res
+                        .ssl_result_message
+                        .unwrap_or_else(|| "Transaction resulted in an error".to_string()),
+                    error_name: None,
+                    ssl_txn_id: flat_res.ssl_txn_id,
+                })
+            } else {
+                return Err(de::Error::custom(
+                    "Invalid Response from Elavon - cannot determine success or error state, missing critical fields.",
+                ));
+            }
+        };
+        Ok(Self { result })
+    }
+}
+
+impl<'de> Deserialize<'de> for ElavonIncrementalAuthResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Elavon returns error envelopes in camelCase (`<errorCode>`) but
+        // successful `ssl_*` fields in snake_case. Accept both — we use
+        // `alias` on the camelCase error variants so they can land into the
+        // canonical snake_case slot.
+        #[derive(Deserialize, Debug)]
+        #[serde(rename = "txn")]
+        struct XmlIshResponse {
+            #[serde(default, alias = "errorCode")]
+            error_code: Option<String>,
+            #[serde(default, alias = "errorMessage")]
+            error_message: Option<String>,
+            #[serde(default, alias = "errorName")]
             error_name: Option<String>,
             #[serde(default)]
             ssl_result: Option<String>,
@@ -1427,6 +1528,206 @@ impl<F> TryFrom<ResponseRouterData<ElavonPSyncResponse, Self>>
 
         Ok(Self {
             response: Ok(payments_response_data),
+            resource_common_data: PaymentFlowData {
+                status: final_status,
+                ..router_data.resource_common_data
+            },
+            ..router_data
+        })
+    }
+}
+
+// Incremental Authorization request (Elavon Converge `ccincrauth`).
+// Takes the original authorization's ssl_txn_id plus the additional increment
+// amount (ssl_amount expressed in the connector's major unit, e.g. "1.00")
+// and submits it as an XML transaction against processxml.do.
+#[skip_serializing_none]
+#[derive(Debug, Serialize)]
+pub struct ElavonIncrementalAuthRequest {
+    pub ssl_transaction_type: TransactionType,
+    pub ssl_account_id: Secret<String>,
+    pub ssl_user_id: Secret<String>,
+    pub ssl_pin: Secret<String>,
+    pub ssl_amount: StringMajorUnit,
+    pub ssl_txn_id: String,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ElavonRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for ElavonIncrementalAuthRequest
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ElavonRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+        let auth_type = ElavonAuthType::try_from(&router_data.connector_config)?;
+
+        let original_txn_id = match &router_data.request.connector_transaction_id {
+            DomainResponseId::ConnectorTransactionId(id) => id.clone(),
+            _ => {
+                return Err(report!(
+                    errors::ConnectorError::MissingConnectorTransactionID
+                ))
+                .attach_printable("Missing connector_transaction_id for Elavon IncrementalAuth")
+            }
+        };
+
+        let amount_converter = StringMajorUnitForConnector;
+        let amount = amount_converter
+            .convert(
+                router_data.request.minor_amount,
+                router_data.request.currency,
+            )
+            .map_err(|e| {
+                report!(errors::ConnectorError::AmountConversionFailed)
+                    .attach_printable(format!("Failed to convert incremental auth amount: {e}"))
+            })?;
+
+        Ok(Self {
+            ssl_transaction_type: TransactionType::CcIncrement,
+            ssl_account_id: auth_type.ssl_merchant_id,
+            ssl_user_id: auth_type.ssl_user_id,
+            ssl_pin: auth_type.ssl_pin,
+            ssl_amount: amount,
+            ssl_txn_id: original_txn_id,
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ElavonRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for XMLIncrementalAuthRequest
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        data: ElavonRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let request = ElavonIncrementalAuthRequest::try_from(data)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("Failed to create ElavonIncrementalAuthRequest")?;
+
+        let xml_content = quick_xml::se::to_string_with_root("txn", &request).map_err(|err| {
+            tracing::info!(error=?err, "XML serialization error for IncrementalAuth");
+            report!(errors::ConnectorError::RequestEncodingFailed)
+        })?;
+
+        tracing::info!(xml=?xml_content, "Generated raw XML for Elavon IncrementalAuth");
+
+        let mut result = HashMap::new();
+        result.insert(
+            "xmldata".to_string(),
+            Secret::<_, WithoutType>::new(xml_content),
+        );
+        Ok(Self(result))
+    }
+}
+
+// Response handling for IncrementalAuthorization flow.
+// Elavon returns the same `<txn>` envelope as other flows; ssl_result=="0" is
+// success. On success we remain in Authorized state (this flow only bumps the
+// authorized amount; it does not capture). On error we surface the ErrorResponse
+// and mark the attempt as Failure.
+impl<F> TryFrom<ResponseRouterData<ElavonIncrementalAuthResponse, Self>>
+    for RouterDataV2<F, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        value: ResponseRouterData<ElavonIncrementalAuthResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let ResponseRouterData {
+            response,
+            router_data,
+            http_code,
+        } = value;
+
+        let (attempt_status, error_response) =
+            get_elavon_attempt_status(&response.result, http_code);
+
+        // Incremental authorization on success keeps the payment in Authorized
+        // state (ccincrauth increases authorized amount but does not capture).
+        let final_status = match &response.result {
+            ElavonResult::Success(success_payload) => match success_payload.ssl_result {
+                SslResult::Approved => HyperswitchAttemptStatus::Authorized,
+                _ => HyperswitchAttemptStatus::Failure,
+            },
+            _ => attempt_status,
+        };
+
+        let response_data = match (&response.result, error_response) {
+            (ElavonResult::Success(payment_resp_struct), None) => {
+                Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: DomainResponseId::ConnectorTransactionId(
+                        payment_resp_struct.ssl_txn_id.clone(),
+                    ),
+                    redirection_data: None,
+                    connector_metadata: Some(
+                        serde_json::to_value(payment_resp_struct.clone())
+                            .unwrap_or(serde_json::Value::Null),
+                    ),
+                    network_txn_id: payment_resp_struct.ssl_approval_code.clone(),
+                    connector_response_reference_id: payment_resp_struct.ssl_approval_code.clone(),
+                    incremental_authorization_allowed: Some(true),
+                    mandate_reference: None,
+                    status_code: http_code,
+                })
+            }
+            (_, Some(err_resp)) => Err(err_resp),
+            (ElavonResult::Error(error_payload), None) => Err(ErrorResponse {
+                status_code: http_code,
+                code: error_payload
+                    .error_code
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                message: error_payload.error_message.clone(),
+                reason: error_payload.error_name.clone(),
+                attempt_status: Some(HyperswitchAttemptStatus::Failure),
+                connector_transaction_id: error_payload.ssl_txn_id.clone(),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            }),
+        };
+
+        Ok(Self {
+            response: response_data,
             resource_common_data: PaymentFlowData {
                 status: final_status,
                 ..router_data.resource_common_data


### PR DESCRIPTION
## Summary

**[FAILED -- DO NOT MERGE]** Attempted implementation of **INCREMENTAL_AUTH** flow for **Elavon** connector.

This implementation was generated by **GRACE** (automated connector integration pipeline) but **did not pass validation**. This PR is opened for visibility and review -- it requires manual intervention before merging.

## Failure Reason

**CONNECTOR_CREDENTIAL_ERROR (UNFIXABLE -- new credentials required).**

Elavon Converge sandbox (`api.demo.convergepay.com/VirtualMerchantDemo/processxml.do`) returns `errorCode 4025 "Invalid Credentials"` for **both Authorize and IncrementalAuthorization** with the `creds.json` values. Re-diagnosis on 2026-04-16 confirms:

- Credential mapping is correct and consistent across every Elavon flow (Authorize, PSync, Capture, Refund, RSync, IncrementalAuthorization all use the same `api_key -> ssl_merchant_id`, `key1 -> ssl_user_id`, `api_secret -> ssl_pin` pairing, wired up in `crates/types-traits/domain_types/src/router_data.rs` via the `ConnectorAuthType::SignatureKey -> ConnectorSpecificConfig::Elavon` branch).
- The XML serialization is valid (verified by direct `curl` bypassing the Rust stack: same `errorCode 4025` response).
- Elavon Converge does **not** publish shared public demo credentials -- per the developer portal, demo creds must be requested per-integrator from `convergehelpdesk@elavon.com`.
- No field swap, endpoint mismatch, or content-type issue was found. The `Authorize` flow (which has been on `main` for months) also returns 4025 with these same creds, proving this is purely a credential-validity issue and not a regression introduced by the IncrementalAuthorization PR.

## Resolution Path

1. Contact Elavon `convergehelpdesk@elavon.com` (or Elavon Solution Engineer) and request fresh Converge demo credentials (Account ID / User ID / PIN). Ensure the User is flagged as "API user" with transaction-send permission and has a freshly regenerated PIN.
2. Update `creds.json` with the new values (`api_key` = Account/Merchant ID, `key1` = User ID, `api_secret` = PIN).
3. Re-run the gRPC test on port 8100.
4. Once IncrementalAuthorization returns `AUTHORIZATION_SUCCESS`, move this PR out of draft.

## Changes (code is complete and compiles cleanly on the PR branch)

- Added `CcIncrement` variant to `TransactionType` enum (maps to Elavon Converge `ccincrauth` transaction type)
- Added `ElavonIncrementalAuthRequest` and `XMLIncrementalAuthRequest` structs in transformers.rs
- Added `ElavonIncrementalAuthResponse` with robust deserialization (handles both camelCase error fields and snake_case success fields)
- Added `TryFrom` implementations for request building and response mapping
- Registered IncrementalAuthorization in `create_all_prerequisites!` macro
- Added `macro_connector_implementation!` for IncrementalAuthorization flow using same `processxml.do` endpoint
- On success, maps to `Authorized` status (incremental auth bumps authorized amount without capturing)

## Files Modified

- `crates/integrations/connector-integration/src/connectors/elavon.rs`
- `crates/integrations/connector-integration/src/connectors/elavon/transformers.rs`

## gRPC Test Results

**Status: FAIL (CONNECTOR_CREDENTIAL_ERROR)**

<details>
<summary>grpcurl output (credentials redacted)</summary>

```
grpcurl -plaintext -max-time 60 \
  -H "x-connector: elavon" \
  -H "x-auth: signature-key" \
  -H "x-api-key: <REDACTED>" \
  -H "x-key1: <REDACTED>" \
  -H "x-api-secret: <REDACTED>" \
  -d '{"merchant_authorization_id":"test_elavon_incrauth_002","connector_transaction_id":"FAKE_TXN_123","amount":{"minor_amount":500,"currency":"USD"},"reason":"Increment for testing"}' \
  localhost:8100 types.PaymentService/IncrementalAuthorization

Response:
{
  "status": "AUTHORIZATION_FAILURE",
  "error": {
    "connectorDetails": {
      "code": "4025",
      "message": "The credentials supplied in the authorization request are invalid.",
      "reason": "Invalid Credentials"
    }
  },
  "statusCode": 200
}
```

</details>

<details>
<summary>Direct curl to Converge sandbox (bypassing Rust stack) -- same 4025</summary>

```
POST https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do
Content-Type: application/x-www-form-urlencoded
xmldata=<txn>
  <ssl_transaction_type>ccauthonly</ssl_transaction_type>
  <ssl_merchant_id><REDACTED></ssl_merchant_id>
  <ssl_user_id><REDACTED></ssl_user_id>
  <ssl_pin><REDACTED></ssl_pin>
  <ssl_amount>1.00</ssl_amount>
  ...
</txn>

<txn>
  <errorCode>4025</errorCode>
  <errorName>Invalid Credentials</errorName>
  <errorMessage>The credentials supplied in the authorization request are invalid.</errorMessage>
</txn>
```

</details>

## Error Classification

| Symptom | Root Cause | Classification |
|---------|-----------|----------------|
| Elavon returns `errorCode 4025` "Invalid Credentials" for every flow (Authorize, IncrementalAuthorization) | Credentials in `creds.json` are revoked/invalid for `api.demo.convergepay.com` | CONNECTOR_CREDENTIAL_ERROR -- UNFIXABLE in code |

## Build Status

- `cargo build --package connector-integration` passes on the PR branch (as originally reported)
- On today's `feat/grace-incremental-auth` main HEAD the connector-integration trait surface evolved (`get_auth_header` now returns `IntegrationError`, `ServerSessionAuthentication` now required, etc.) -- merging/rebasing onto main will require a trivial forward-port before re-test once real credentials are available
- Build iterations: 1 (clean first build on PR branch)

## Validation Checklist

- [x] `cargo build` passed with zero errors (on PR branch)
- [ ] grpcurl IncrementalAuthorization returned success status (2xx) -- blocked on creds
- [x] No credentials in committed source code
- [x] Only connector-specific files modified
- [x] Response deserialization works end-to-end (error response correctly parsed)
- [x] Independently reproduced 4025 via direct curl -- confirms creds are the blocker, not code

## rawConnectorRequest (masked)

```xml
<txn>
  <ssl_transaction_type>ccincrauth</ssl_transaction_type>
  <ssl_account_id><REDACTED></ssl_account_id>
  <ssl_user_id><REDACTED></ssl_user_id>
  <ssl_pin><REDACTED></ssl_pin>
  <ssl_amount>5.00</ssl_amount>
  <ssl_txn_id>FAKE_TXN_123</ssl_txn_id>
</txn>
```

## rawConnectorResponse (masked)

```xml
<txn>
  <errorCode>4025</errorCode>
  <errorName>Invalid Credentials</errorName>
  <errorMessage>The credentials supplied in the authorization request are invalid.</errorMessage>
</txn>
```

> **Note**: Re-diagnosed 2026-04-16. The code is correct and complete; the blocker is external (expired/revoked Converge sandbox credentials). Elavon does not publish shared demo credentials, so the only resolution is to request new ones from `convergehelpdesk@elavon.com`. Keeping this PR in draft until fresh credentials are obtained.
