### PR TITLE
[GRACE-FAILED] feat(connector): implement INCREMENTAL_AUTH for placetopay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/placetopay.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay.rs
@@ -43,10 +43,10 @@ use interfaces::{
 use serde::Serialize;
 use std::fmt::Debug;
 use transformers::{
-    self as placetopay, PlacetopayNextActionRequest,
-    PlacetopayNextActionRequest as PlacetopayVoidRequest, PlacetopayPaymentsRequest,
-    PlacetopayPaymentsResponse as PlacetopayPSyncResponse, PlacetopayPaymentsResponse,
-    PlacetopayPaymentsResponse as PlacetopayCaptureResponse,
+    self as placetopay, PlacetopayIncrementalAuthRequest, PlacetopayIncrementalAuthResponse,
+    PlacetopayNextActionRequest, PlacetopayNextActionRequest as PlacetopayVoidRequest,
+    PlacetopayPaymentsRequest, PlacetopayPaymentsResponse as PlacetopayPSyncResponse,
+    PlacetopayPaymentsResponse, PlacetopayPaymentsResponse as PlacetopayCaptureResponse,
     PlacetopayPaymentsResponse as PlacetopayVoidResponse, PlacetopayPsyncRequest,
     PlacetopayRefundRequest, PlacetopayRefundResponse as PlacetopayRSyncResponse,
     PlacetopayRefundResponse, PlacetopayRsyncRequest,
@@ -101,6 +101,12 @@ macros::create_all_prerequisites!(
             request_body: PlacetopayRsyncRequest,
             response_body: PlacetopayRSyncResponse,
             router_data: RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ),
+        (
+            flow: IncrementalAuthorization,
+            request_body: PlacetopayIncrementalAuthRequest,
+            response_body: PlacetopayIncrementalAuthResponse,
+            router_data: RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -138,16 +144,6 @@ macros::create_all_prerequisites!(
 );
 
 // Trait implementations with generic type parameters
-
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    ConnectorIntegrationV2<
-        IncrementalAuthorization,
-        PaymentFlowData,
-        PaymentsIncrementalAuthorizationData,
-        PaymentsResponseData,
-    > for Placetopay<T>
-{
-}
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::PaymentAuthorizeV2<T> for Placetopay<T>
@@ -540,6 +536,35 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             Ok(format!("{}/query", self.connector_base_url_refunds(req)))
+        }
+    }
+);
+
+// Macro implementation for IncrementalAuthorization flow
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Placetopay,
+    curl_request: Json(PlacetopayIncrementalAuthRequest),
+    curl_response: PlacetopayIncrementalAuthResponse,
+    flow_name: IncrementalAuthorization,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentsIncrementalAuthorizationData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!("{}/transaction", self.connector_base_url_payments(req)))
         }
     }
 );

--- a/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
@@ -1,10 +1,10 @@
 use common_utils::types::MinorUnit;
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, RSync, Void},
+    connector_flow::{Authorize, Capture, IncrementalAuthorization, PSync, RSync, Void},
     connector_types::{
         PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData, ResponseId,
+        PaymentsIncrementalAuthorizationData, PaymentsResponseData, PaymentsSyncData,
+        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, ResponseId,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
@@ -588,6 +588,126 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
             response: Ok(RefundsResponseData {
                 connector_refund_id: item.response.internal_reference.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.status.status),
+                status_code: item.http_code,
+            }),
+            ..item.router_data
+        })
+    }
+}
+
+// ============================================================================
+// IncrementalAuthorization flow
+// ============================================================================
+//
+// PlacetoPay uses the /transaction endpoint with the "reauthorize" action to
+// perform incremental authorizations. The request includes the auth block,
+// the internal_reference from the original authorization, the action, and
+// the new total amount.
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlacetopayIncrementalAuthRequest {
+    auth: PlacetopayAuth,
+    internal_reference: u64,
+    action: PlacetopayNextAction,
+    amount: PlacetopayAmount,
+}
+
+// Response from the /transaction endpoint for incremental authorization.
+// Same shape as PlacetopayPaymentsResponse but kept as a distinct type to
+// allow a separate TryFrom implementation producing IncrementalAuthorizationResponse.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlacetopayIncrementalAuthResponse {
+    status: PlacetopayStatusResponse,
+    internal_reference: u64,
+    authorization: Option<Secret<String>>,
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        PlacetopayRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for PlacetopayIncrementalAuthRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+    fn try_from(
+        item: PlacetopayRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let auth = PlacetopayAuth::try_from(&item.router_data.connector_config)?;
+        let internal_reference = item
+            .router_data
+            .request
+            .connector_transaction_id
+            .get_connector_transaction_id()
+            .change_context(IntegrationError::MissingConnectorTransactionID {
+                context: Default::default(),
+            })?
+            .parse::<u64>()
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })?;
+        let action = PlacetopayNextAction::Checkout;
+        let amount = PlacetopayAmount {
+            currency: item.router_data.request.currency,
+            total: item.router_data.request.minor_amount,
+        };
+        Ok(Self {
+            auth,
+            internal_reference,
+            action,
+            amount,
+        })
+    }
+}
+
+impl TryFrom<ResponseRouterData<PlacetopayIncrementalAuthResponse, Self>>
+    for RouterDataV2<
+        IncrementalAuthorization,
+        PaymentFlowData,
+        PaymentsIncrementalAuthorizationData,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<PlacetopayIncrementalAuthResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let authorization_status = match item.response.status.status {
+            PlacetopayTransactionStatus::Approved | PlacetopayTransactionStatus::Ok => {
+                common_enums::AuthorizationStatus::Success
+            }
+            PlacetopayTransactionStatus::Pending
+            | PlacetopayTransactionStatus::PendingValidation
+            | PlacetopayTransactionStatus::PendingProcess => {
+                common_enums::AuthorizationStatus::Processing
+            }
+            PlacetopayTransactionStatus::Failed
+            | PlacetopayTransactionStatus::Rejected
+            | PlacetopayTransactionStatus::Error => common_enums::AuthorizationStatus::Failure,
+        };
+
+        Ok(Self {
+            response: Ok(PaymentsResponseData::IncrementalAuthorizationResponse {
+                status: authorization_status,
+                connector_authorization_id: Some(
+                    item.response.internal_reference.to_string(),
+                ),
                 status_code: item.http_code,
             }),
             ..item.router_data

--- a/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
@@ -94,6 +94,13 @@ pub struct PlacetopayPaymentsRequest<
     T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
 > {
     auth: PlacetopayAuth,
+    // Action controls capture behaviour:
+    //   - "checkout" (default): immediately captures funds (status CHARGED)
+    //   - "checkin":            pre-authorization hold (status AUTHORIZED) that
+    //                           can later be incremented via "reauthorization"
+    //                           and finalized via "checkout"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action: Option<PlacetopayNextAction>,
     payment: PlacetopayPayment,
     instrument: PlacetopayInstrument<T>,
     ip_address: Secret<String, common_utils::pii::IpAddress>,
@@ -173,6 +180,13 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             },
         };
 
+        // Manual capture => pre-authorization ("checkin"); Automatic (or None)
+        // falls back to the default behaviour (immediate capture, action omitted).
+        let action = match item.router_data.request.capture_method {
+            Some(common_enums::CaptureMethod::Manual) => Some(PlacetopayNextAction::Checkin),
+            _ => None,
+        };
+
         match item.router_data.request.payment_method_data.clone() {
             PaymentMethodData::Card(req_card) => {
                 let card = PlacetopayCard {
@@ -186,6 +200,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     ip_address,
                     user_agent,
                     auth,
+                    action,
                     payment,
                     instrument: PlacetopayInstrument {
                         card: card.to_owned(),
@@ -386,6 +401,12 @@ pub enum PlacetopayNextAction {
     Void,
     Process,
     Checkout,
+    // Pre-authorization only. Reserves funds without capturing. Required when
+    // the merchant wants to later issue "reauthorization" (incremental auth).
+    Checkin,
+    // Modifies a previously-held (checkin) amount. For Transerver Retail, the
+    // new amount must be strictly greater than the previously held amount.
+    Reauthorization,
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -599,18 +620,41 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
 // IncrementalAuthorization flow
 // ============================================================================
 //
-// PlacetoPay uses the /transaction endpoint with the "reauthorize" action to
-// perform incremental authorizations. The request includes the auth block,
-// the internal_reference from the original authorization, the action, and
-// the new total amount.
+// PlacetoPay exposes incremental authorization via the "reauthorization" action
+// on the /gateway/transaction endpoint. Per PlacetoPay's docs, a prior "checkin"
+// pre-authorization is required, and both `internalReference` and
+// `authorization` (the auth code returned by the original checkin's
+// `preAuthorization` node) must be supplied. The amount must be wrapped in a
+// `payment` object, not passed as a top-level `amount`.
+//
+// Example request body:
+// {
+//   "auth": { ... WSSE ... },
+//   "internalReference": 30,
+//   "authorization": "235263",
+//   "action": "reauthorization",
+//   "payment": {
+//     "reference": "REAUTH_12345",
+//     "description": "Modified authorization",
+//     "amount": { "currency": "USD", "total": 15 }
+//   }
+// }
+//
+// The caller must pass the original checkin's `authorization` code back to us
+// via the request's `connector_feature_data` (a JSON string). That field is
+// populated by Hyperswitch from the original authorize response's
+// `connector_metadata`, which for PlacetoPay is set to the authorization code
+// in the Authorize TryFrom below.
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlacetopayIncrementalAuthRequest {
     auth: PlacetopayAuth,
     internal_reference: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    authorization: Option<Secret<String>>,
     action: PlacetopayNextAction,
-    amount: PlacetopayAmount,
+    payment: PlacetopayPayment,
 }
 
 // Response from the /transaction endpoint for incremental authorization.
@@ -621,6 +665,7 @@ pub struct PlacetopayIncrementalAuthRequest {
 pub struct PlacetopayIncrementalAuthResponse {
     status: PlacetopayStatusResponse,
     internal_reference: u64,
+    #[allow(dead_code)]
     authorization: Option<Secret<String>>,
 }
 
@@ -662,16 +707,44 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;
-        let action = PlacetopayNextAction::Checkout;
-        let amount = PlacetopayAmount {
-            currency: item.router_data.request.currency,
-            total: item.router_data.request.minor_amount,
+
+        // Pull the original checkin's `authorization` code from
+        // connector_feature_data. PlacetoPay accepts either a raw string or a
+        // JSON string, so handle both serde shapes.
+        let authorization = item
+            .router_data
+            .request
+            .connector_feature_data
+            .clone()
+            .and_then(|v| match v.expose() {
+                serde_json::Value::String(s) => Some(Secret::new(s)),
+                other => other.as_str().map(|s| Secret::new(s.to_string())),
+            });
+
+        let action = PlacetopayNextAction::Reauthorization;
+        let payment = PlacetopayPayment {
+            reference: item
+                .router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            description: item
+                .router_data
+                .request
+                .reason
+                .clone()
+                .unwrap_or_else(|| "Incremental authorization".to_string()),
+            amount: PlacetopayAmount {
+                currency: item.router_data.request.currency,
+                total: item.router_data.request.minor_amount,
+            },
         };
         Ok(Self {
             auth,
             internal_reference,
+            authorization,
             action,
-            amount,
+            payment,
         })
     }
 }


### PR DESCRIPTION
## Summary

**[STILL FAILED -- CODE CORRECTED, BLOCKED ON MERCHANT ENTITLEMENT]**
Implementation of **IncrementalAuthorization** flow for **placetopay** connector.

This PR was originally generated by GRACE. The first attempt used the wrong
endpoint/action and failed. The request shape has now been corrected to match
PlacetoPay's official documentation, but end-to-end validation remains blocked
because the shared sandbox merchant credentials do not have the Transerver
Retail / pre-authorization feature enabled.

## Fix in this PR (commit `d41af543b`)

The original attempt issued `action: "checkout"` against `/gateway/transaction`
with a top-level `amount` field — which PlacetoPay correctly rejects. Per
PlacetoPay docs (`docs.placetopay.dev/en/gateway/transaction-types`):

| Step | Endpoint | Action |
| --- | --- | --- |
| Pre-auth (hold funds) | `POST /gateway/process` | `"checkin"` |
| Incremental auth | `POST /gateway/transaction` | `"reauthorization"` |
| Final capture | `POST /gateway/transaction` | `"checkout"` |

Code changes:

1. **Authorize flow** (`PlacetopayPaymentsRequest`): added optional `action`
   field. When `capture_method = Manual`, emit `"action": "checkin"` so
   PlacetoPay holds funds without auto-capturing. `Automatic` omits the field
   (default `/gateway/process` behaviour).

2. **IncrementalAuthorization flow** (`PlacetopayIncrementalAuthRequest`):
   * action → `"reauthorization"` (not `"checkout"`)
   * amount moved inside a `payment` object (matches docs)
   * includes `authorization` field pulled from
     `connector_feature_data` — the auth code returned by the original checkin
     response

3. Added `Checkin` and `Reauthorization` variants to `PlacetopayNextAction`.

## Validation

Build: **PASS** (zero errors)

gRPC test results against the provided sandbox merchant
(`creds.json::placetopay`):

### Attempt A: Authorize with `capture_method=MANUAL` → emits `action: checkin`

Request body (masked):
```json
POST https://test.placetopay.com/rest/gateway/process
{
  "auth": { "...WSSE..." },
  "action": "checkin",
  "payment": {"reference":"...","description":"...","amount":{"currency":"USD","total":10000}},
  "instrument": {"card":{"number":"411076**********","expiration":"***","cvv":"***"}},
  "ipAddress":"...","userAgent":"Mozilla/5.0"
}
```

Response: **HTTP 400 — `La acción "checkin" no es soportada por este servicio`**
("The 'checkin' action is not supported by this service")

This error is a **merchant-side feature gate**: `checkin` is only enabled
for Transerver Retail / pre-authorization merchants. The shared sandbox
credentials do not have this capability.

### Attempt B: Authorize with `capture_method=AUTOMATIC` (default) then reauthorization

- Authorize: **PASS** (status `CHARGED`, status code 200,
  `connectorTransactionId: 1599747784`, authorization `000000`)
- IncrementalAuthorization request (shape now correct):

```json
POST https://test.placetopay.com/rest/gateway/transaction
{
  "auth": { "...WSSE..." },
  "internalReference": 1599747784,
  "authorization": "000000",
  "action": "reauthorization",
  "payment": {"reference":"test_p2p_incr_auth_fixed_003","description":"Additional charges for hotel room service","amount":{"currency":"USD","total":15000}}
}
```

Response: **HTTP 400 — `La transacción no puede ser procesada`**

Same outcome as before because the parent transaction was not created via
`checkin`. Per the docs: *"A CHECKIN request must be made before processing
a REAUTHORIZATION."*

## Conclusion

The code change is correct per PlacetoPay's official documentation. The PR
should be merged only once a sandbox merchant with Transerver Retail /
pre-authorization capability is available for testing, or once production
merchants that need this flow have enrolled in pre-authorization with
PlacetoPay.

Nothing in the connector code can bypass the merchant-level feature gate.

## Files Modified

- `crates/integrations/connector-integration/src/connectors/placetopay.rs`
- `crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs`

## Validation Checklist

- [x] `cargo build` passed with zero errors
- [ ] grpcurl IncrementalAuthorization returned success status (2xx) — blocked on merchant entitlement
- [x] Request/response shapes match official PlacetoPay documentation
- [x] No credentials committed in source code
- [x] Only connector-specific files modified
