### PR TITLE
fix(connector): [cybersource] fix clippy indexing warnings in client auth

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource.rs
@@ -1045,7 +1045,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             )));
         }
 
-        let payload = parts[1];
+        let payload = parts.get(1).ok_or_else(|| {
+            Report::new(ConnectorError::response_handling_failed(res.status_code))
+        })?;
         let decoded_bytes = Engine::decode(&BASE64_ENGINE, payload)
             .map_err(|_| ConnectorError::response_handling_failed(res.status_code))?;
         let decoded_str = String::from_utf8(decoded_bytes)
@@ -1053,12 +1055,22 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         let decoded: serde_json::Value = serde_json::from_str(&decoded_str)
             .map_err(|_| ConnectorError::response_handling_failed(res.status_code))?;
 
-        let client_library = decoded["ctx"][0]["data"]["clientLibrary"]
-            .as_str()
+        let client_library = decoded
+            .get("ctx")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.get("data"))
+            .and_then(|v| v.get("clientLibrary"))
+            .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
-        let client_library_integrity = decoded["ctx"][0]["data"]["clientLibraryIntegrity"]
-            .as_str()
+        let client_library_integrity = decoded
+            .get("ctx")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.get("data"))
+            .and_then(|v| v.get("clientLibraryIntegrity"))
+            .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
 


### PR DESCRIPTION
## Description

Fixes clippy warnings for indexing operations in the Cybersource client authentication flow.

Changes direct array indexing (`parts[1]`, `decoded["ctx"][0]["data"]`) to safe `.get()` method calls to avoid potential panics.

## Motivation and Context

Clippy warned about potential panics from direct indexing in:
- `parts[1]` - accessing JWT payload without bounds check
- `decoded["ctx"][0]["data"]["clientLibrary"]` - accessing nested JSON without safety checks

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

Build passes with no indexing warnings.

```bash
cargo check --package connector-integration
```