### PR TITLE
parity(fiserv/authorize): regression test for terminalId from auth.terminal_id (PRI-25)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
@@ -1232,3 +1232,211 @@ impl<F, Req, Res> TryFrom<ResponseRouterData<FiservErrorResponse, Self>>
         Ok(router_data_out)
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::expect_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::indexing_slicing)]
+#[allow(clippy::print_stdout)]
+mod tests {
+    pub mod authorize {
+        use std::{marker::PhantomData, str::FromStr};
+
+        use common_utils::{request::RequestContent, types::MinorUnit};
+        use domain_types::{
+            connector_flow::Authorize,
+            connector_types::{
+                ConnectorEnum, PaymentFlowData, PaymentsAuthorizeData, PaymentsResponseData,
+            },
+            payment_method_data::{DefaultPCIHolder, PaymentMethodData, RawCardNumber},
+            router_data::{ConnectorSpecificConfig, ErrorResponse},
+            router_data_v2::RouterDataV2,
+            types::{ConnectorParams, Connectors},
+        };
+        use hyperswitch_masking::{ExposeInterface, Secret};
+        use interfaces::{
+            connector_integration_v2::BoxedConnectorIntegrationV2,
+            connector_types::BoxedConnector,
+        };
+
+        use crate::{connectors::Fiserv, types::ConnectorData};
+
+        // Regression guard for fiserv Authorize: `merchantDetails.terminalId`
+        // must be sourced from `ConnectorSpecificConfig::Fiserv.terminal_id`
+        // (surfaced via `FiservAuthType::terminal_id`), never from per-payment
+        // `request.metadata`. Pins against a PR-#723-class regression where
+        // `FiservSessionObject` previously read `request.metadata` and emitted
+        // `terminalId: null` whenever metadata was absent in shadow replay.
+        #[test]
+        fn terminal_id_sourced_from_auth_terminal_id() {
+            let terminal_id = "10000001".to_string();
+            let req: RouterDataV2<
+                Authorize,
+                PaymentFlowData,
+                PaymentsAuthorizeData<DefaultPCIHolder>,
+                PaymentsResponseData,
+            > = RouterDataV2 {
+                flow: PhantomData::<Authorize>,
+                resource_common_data: PaymentFlowData {
+                    vault_headers: None,
+                    merchant_id: common_utils::id_type::MerchantId::default(),
+                    customer_id: None,
+                    connector_customer: None,
+                    payment_id: "pay_fiserv_regress".to_string(),
+                    attempt_id: "attempt_fiserv_regress".to_string(),
+                    status: common_enums::AttemptStatus::Pending,
+                    payment_method: common_enums::PaymentMethod::Card,
+                    description: None,
+                    return_url: None,
+                    order_details: None,
+                    address: domain_types::payment_address::PaymentAddress::new(
+                        None, None, None, None,
+                    ),
+                    auth_type: common_enums::AuthenticationType::NoThreeDs,
+                    connector_feature_data: None,
+                    amount_captured: None,
+                    minor_amount_captured: None,
+                    minor_amount_authorized: None,
+                    access_token: None,
+                    session_token: None,
+                    reference_id: None,
+                    connector_order_id: None,
+                    preprocessing_id: None,
+                    connector_api_version: None,
+                    connector_request_reference_id: "conn_ref_fiserv_regress".to_string(),
+                    test_mode: None,
+                    connector_http_status_code: None,
+                    connectors: Connectors {
+                        fiserv: ConnectorParams {
+                            base_url: "https://cert.api.fiservapps.com/".to_string(),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    external_latency: None,
+                    connector_response_headers: None,
+                    raw_connector_response: None,
+                    raw_connector_request: None,
+                    minor_amount_capturable: None,
+                    amount: None,
+                    connector_response: None,
+                    recurring_mandate_payment_data: None,
+                    l2_l3_data: None,
+                },
+                connector_config: ConnectorSpecificConfig::Fiserv {
+                    api_key: Secret::new("test_api_key".to_string()),
+                    merchant_account: Secret::new("test_merchant_account".to_string()),
+                    api_secret: Secret::new("test_api_secret".to_string()),
+                    base_url: None,
+                    terminal_id: Some(Secret::new(terminal_id.clone())),
+                },
+                request: PaymentsAuthorizeData {
+                    authentication_data: None,
+                    connector_testing_data: None,
+                    access_token: None,
+                    payment_method_data: PaymentMethodData::Card(
+                        domain_types::payment_method_data::Card {
+                            card_number: RawCardNumber(
+                                cards::CardNumber::from_str("4111111111111111").unwrap(),
+                            ),
+                            card_cvc: Secret::new("123".to_string()),
+                            card_exp_month: Secret::new("03".to_string()),
+                            card_exp_year: Secret::new("2030".to_string()),
+                            ..Default::default()
+                        },
+                    ),
+                    amount: MinorUnit::new(1000),
+                    order_tax_amount: None,
+                    email: None,
+                    customer_name: None,
+                    currency: common_enums::Currency::USD,
+                    confirm: true,
+                    capture_method: None,
+                    integrity_object: None,
+                    router_return_url: None,
+                    webhook_url: None,
+                    complete_authorize_url: None,
+                    mandate_id: None,
+                    setup_future_usage: None,
+                    off_session: None,
+                    browser_info: None,
+                    order_category: None,
+                    session_token: None,
+                    enrolled_for_3ds: Some(false),
+                    related_transaction_id: None,
+                    payment_experience: None,
+                    payment_method_type: Some(common_enums::PaymentMethodType::Card),
+                    customer_id: None,
+                    request_incremental_authorization: Some(false),
+                    // Deliberately None to pin that terminalId does NOT depend
+                    // on request.metadata — that was the pre-PR-#723 regression class.
+                    metadata: None,
+                    minor_amount: MinorUnit::new(1000),
+                    merchant_order_id: None,
+                    shipping_cost: None,
+                    merchant_account_id: None,
+                    merchant_config_currency: None,
+                    all_keys_required: None,
+                    customer_acceptance: None,
+                    split_payments: None,
+                    request_extended_authorization: None,
+                    setup_mandate_details: None,
+                    enable_overcapture: None,
+                    connector_feature_data: None,
+                    billing_descriptor: None,
+                    enable_partial_authorization: None,
+                    locale: None,
+                    continue_redirection_url: None,
+                    redirect_response: None,
+                    threeds_method_comp_ind: None,
+                    tokenization: None,
+                    payment_channel: None,
+                },
+                response: Err(ErrorResponse::default()),
+            };
+
+            let connector: BoxedConnector<DefaultPCIHolder> = Box::new(Fiserv::new());
+            let connector_data = ConnectorData {
+                connector,
+                connector_name: ConnectorEnum::Fiserv,
+            };
+
+            let connector_integration: BoxedConnectorIntegrationV2<
+                '_,
+                Authorize,
+                PaymentFlowData,
+                PaymentsAuthorizeData<DefaultPCIHolder>,
+                PaymentsResponseData,
+            > = connector_data.connector.get_connector_integration_v2();
+
+            let request = connector_integration
+                .build_request_v2(&req)
+                .expect("fiserv Authorize build_request_v2 failed")
+                .expect("fiserv Authorize build_request_v2 returned None");
+            let body = request
+                .body
+                .as_ref()
+                .expect("fiserv Authorize request body missing");
+
+            // Use the same serialization path the HTTP layer uses on the wire.
+            // masked_serialize() would render Secret<String> as
+            // "*** alloc::string::String ***" — useless for this contract —
+            // so we read the raw JSON via RequestContent::get_inner_value.
+            let raw_json = match body {
+                RequestContent::Json(_) => body.get_inner_value().expose(),
+                other => panic!("expected JSON body, got {other:?}"),
+            };
+            let parsed: serde_json::Value = serde_json::from_str(&raw_json)
+                .expect("fiserv Authorize body is not valid JSON");
+
+            assert_eq!(
+                parsed["merchantDetails"]["terminalId"], terminal_id,
+                "fiserv Authorize merchantDetails.terminalId must be sourced from \
+                 ConnectorSpecificConfig::Fiserv.terminal_id (auth.terminal_id); \
+                 regressed to: {}",
+                parsed["merchantDetails"]["terminalId"],
+            );
+        }
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
@@ -1256,8 +1256,7 @@ mod tests {
         };
         use hyperswitch_masking::{ExposeInterface, Secret};
         use interfaces::{
-            connector_integration_v2::BoxedConnectorIntegrationV2,
-            connector_types::BoxedConnector,
+            connector_integration_v2::BoxedConnectorIntegrationV2, connector_types::BoxedConnector,
         };
 
         use crate::{connectors::Fiserv, types::ConnectorData};
@@ -1427,8 +1426,8 @@ mod tests {
                 RequestContent::Json(_) => body.get_inner_value().expose(),
                 other => panic!("expected JSON body, got {other:?}"),
             };
-            let parsed: serde_json::Value = serde_json::from_str(&raw_json)
-                .expect("fiserv Authorize body is not valid JSON");
+            let parsed: serde_json::Value =
+                serde_json::from_str(&raw_json).expect("fiserv Authorize body is not valid JSON");
 
             assert_eq!(
                 parsed["merchantDetails"]["terminalId"], terminal_id,


### PR DESCRIPTION
## Summary

Adds an inline `#[cfg(test)]` regression test in `fiserv/transformers.rs` that pins the Authorize request-body contract: `merchantDetails.terminalId` is sourced from `ConnectorSpecificConfig::Fiserv.terminal_id` (via `FiservAuthType::terminal_id`), never from per-payment `request.metadata`. Guards against a PR-#723-class regression.

## Linked PRD

Closes PRI-25.

## Understanding Summary (condensed)

- PRI-25 is a **regression test, not a fix**. The oracle-parity correction already landed on `main` via PR #723 / `a05e5e178` (Mar 24 2026), which deleted `FiservSessionObject` and wired Authorize to read `auth.terminal_id` (current L489-L492 of `fiserv/transformers.rs`).
- Scope: one file, inline `#[cfg(test)] mod tests` block, no production code or wiring changes.
- Ref pattern: `connectors/calida/test.rs::test_build_request_valid` and `connectors/adyen/test.rs::test_build_request_valid`.

## Implementation Plan (condensed)

- Appended `#[cfg(test)] mod tests { pub mod authorize { ... } }` at EOF of `crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs`.
- Builds `RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<DefaultPCIHolder>, PaymentsResponseData>` with:
  - `connector_config = ConnectorSpecificConfig::Fiserv { terminal_id: Some(Secret::new("10000001".into())), .. }`
  - `request.metadata = None` (pins that terminalId does **not** depend on per-payment metadata — the exact pre-PR-#723 regression class)
  - `PaymentMethodData::Card(..)` (fiserv Authorize only builds for `Card`; other variants return `not_implemented`)
- Serializes via `ConnectorData { .. }.connector.get_connector_integration_v2().build_request_v2(&req)`.
- Reads body via **`RequestContent::get_inner_value().expose()`** (the same path the HTTP layer uses to put bytes on the wire). `masked_serialize()` would render `Secret<String>` as `"*** alloc::string::String ***"` and defeat the assertion.
- Asserts `parsed["merchantDetails"]["terminalId"] == "10000001"`.

## Build Tail

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.32s
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, grpc-api-types v0.1.0 (/home/grace/.../grpc-api-types), multipart v0.18.0, typemap v0.3.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 6`
```

## Clippy Tail (pre-existing baseline failure — **not** caused by this PR)

```
error: indexing may panic
    --> crates/integrations/connector-integration/src/connectors/cybersource.rs:1060:40
     |
1060 |         let client_library_integrity = decoded["ctx"][0]["data"]["clientLibraryIntegrity"]
     |
     = help: consider using `.get(n)` or `.get_mut(n)` instead
...
error: could not compile `connector-integration` (lib) due to 9 previous errors
```

**Diagnostic**: all 9 clippy errors are in `cybersource.rs:1060` (introduced by commit `c1acf8158 fix(connector): [cybersource] fix Microform URL and extract mandatory client library (#1129)` — already on `main` before this branch). Verified by stashing this PR's diff and re-running clippy: same 9 errors, same locations. This PR's added test module produces zero new clippy findings. Flagged to CTO on the issue thread — this is a pre-existing baseline regression on an unrelated file, not caused by PRI-25.

## Test Results

`cargo test -p connector-integration --lib` — **79 passed, 0 failed, 0 ignored** (includes the new `connectors::fiserv::transformers::tests::authorize::terminal_id_sourced_from_auth_terminal_id`).

Targeted run:
```
test connectors::fiserv::transformers::tests::authorize::terminal_id_sourced_from_auth_terminal_id ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.00s
```

Note: `cargo test` without `--lib` attempts to run doctests and fails with 15 pre-existing `Convertor`-symbol errors across unrelated files (barclaycard, billwerk, bluesnap, cryptopay, globalpay, jpmorgan, payload, powertranz, redsys, revolut, stripe, trustpay, worldpayxml, xendit, zift). Those are out-of-scope pre-existing issues on `main`, unrelated to this PR.

## Acceptance Criteria

- [x] Build passes (`cargo build -p connector-integration`)
- [ ] Clippy passes (`cargo clippy -p connector-integration -- -D warnings`) — **blocked by pre-existing baseline failure in `cybersource.rs:1060`, unrelated to this PR; no new clippy findings from this PR's code**
- [x] Tests pass (`cargo test -p connector-integration --lib` — 79/79, includes the new test)
- [x] New test added (`fiserv::transformers::tests::authorize::terminal_id_sourced_from_auth_terminal_id`)
- [x] Single file touched (`git diff --stat` confirms one file: `.../fiserv/transformers.rs`, 208 insertions, 0 deletions)
- [ ] Shadow-replay produces zero diff (CTO gate — N/A for this ticket; PRI-25 is a regression test, no request-shape change)
