### PR TITLE
chore(cybersource): fix clippy indexing_slicing regression (PRI-31)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource.rs
@@ -1039,13 +1039,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         // Decode JWT payload to extract client library info
         let parts: Vec<&str> = capture_context_jwt.split('.').collect();
-        if parts.len() < 2 {
-            return Err(Report::new(ConnectorError::response_handling_failed(
-                res.status_code,
-            )));
-        }
-
-        let payload = parts[1];
+        let payload = parts
+            .get(1)
+            .copied()
+            .ok_or_else(|| ConnectorError::response_handling_failed(res.status_code))?;
         let decoded_bytes = Engine::decode(&BASE64_ENGINE, payload)
             .map_err(|_| ConnectorError::response_handling_failed(res.status_code))?;
         let decoded_str = String::from_utf8(decoded_bytes)
@@ -1053,12 +1050,20 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         let decoded: serde_json::Value = serde_json::from_str(&decoded_str)
             .map_err(|_| ConnectorError::response_handling_failed(res.status_code))?;
 
-        let client_library = decoded["ctx"][0]["data"]["clientLibrary"]
-            .as_str()
+        let client_library = decoded
+            .get("ctx")
+            .and_then(|v| v.get(0))
+            .and_then(|v| v.get("data"))
+            .and_then(|v| v.get("clientLibrary"))
+            .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
-        let client_library_integrity = decoded["ctx"][0]["data"]["clientLibraryIntegrity"]
-            .as_str()
+        let client_library_integrity = decoded
+            .get("ctx")
+            .and_then(|v| v.get(0))
+            .and_then(|v| v.get("data"))
+            .and_then(|v| v.get("clientLibraryIntegrity"))
+            .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
 


### PR DESCRIPTION
## Summary

Clears the 9 clippy `indexing_slicing` errors in `connector-integration` that currently make `cargo clippy -p connector-integration -- -D warnings` fail on `main`. Introduced by PR #1129 (commit `c1acf8158`). Repo-hygiene only — no behavioural change to Cybersource Microform `ClientAuthenticationToken` handling.

## Linked PRD

Tracks PRI-31 (Paperclip). CTO routed to ConnectorEngineer as Option A — "between-parity hygiene ticket".

## Understanding Summary (condensed)

- **Connector / flow**: Cybersource, `ClientAuthenticationToken` (Microform capture-context JWT decoder).
- **Lint**: `clippy::indexing_slicing`, enforced via `-D warnings` locally. CI does not currently gate on clippy, so this is a contributor-UX regression, not a merge-blocker.
- **Baseline** (verified on fresh `main`): 9 errors = **1 at line 1048** (`parts[1]`) + **4 at line 1056** + **4 at line 1060** (chained `decoded[...]` indexing). All introduced by the same commit `c1acf8158`.
- **Oracle**: N/A (repo-hygiene, not a parity gap).

My first Understanding Summary on the PRD thread miscounted the baseline and excluded line 1048; I posted a [plan revision](../../issues/PRI-31) with the corrected baseline before executing.

## Implementation Plan (condensed)

**File**: `crates/integrations/connector-integration/src/connectors/cybersource.rs` (only file changed).

### Site A — line 1048 (`parts[1]`)
Replace `if parts.len() < 2 { return Err(Report::new(...)) }` + `parts[1]` with a single `.get(1).copied().ok_or_else(|| ConnectorError::response_handling_failed(...))?`. Same error on malformed JWT; matches the `.map_err(|_| ConnectorError::...)?` idiom already used on the next three lines.

### Sites B & C — lines 1056 and 1060 (`decoded[...][...]` chains)
Replace chained `decoded["ctx"][0]["data"]["clientLibrary"]` (and `clientLibraryIntegrity`) with `.get("ctx").and_then(|v| v.get(0)).and_then(|v| v.get("data")).and_then(|v| v.get(key)).and_then(|v| v.as_str()).unwrap_or_default().to_string()`. `.unwrap_or_default()` continues to yield `""` for any missing segment; matches the `.get(key).and_then(|v| v.as_str())` idiom already used 18 lines earlier in the same function for `captureContext`.

Diff: +16 / −11 across one file.

## Build Tail

```
   Compiling connector-integration v0.1.0 (/home/grace/Connecter-service1/hyperswitch-prism/crates/integrations/connector-integration)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.86s
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, grpc-api-types v0.1.0 (/home/grace/Connecter-service1/hyperswitch-prism/crates/types-traits/grpc-api-types), multipart v0.18.0, typemap v0.3.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 6`
```

(`future-incompat` warning is pre-existing in the workspace and unrelated to this change.)

## Clippy Tail

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, grpc-api-types v0.1.0 (/home/grace/Connecter-service1/hyperswitch-prism/crates/types-traits/grpc-api-types), multipart v0.18.0, typemap v0.3.3
```

Exit 0. Baseline on `main` was exit 101 with 9 `indexing_slicing` errors.

## Test Results

```
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

(`cargo test -p connector-integration --lib`; the crate does not currently use `nextest`.)

## Acceptance Criteria

- [x] `cargo build -p connector-integration` passes
- [x] `cargo clippy -p connector-integration -- -D warnings` exits 0 on this branch (PRD acceptance criterion)
- [x] No behavioural change to Microform client-library extraction (semantic equivalence of error path + `Option`→`unwrap_or_default()` chain)
- [x] Single-file hygiene fix
- [x] All library tests pass (78/78)
- [x] `cargo fmt --check` clean
- [ ] Shadow-replay produces zero diff (CTO gate — not applicable here since flow is Microform JWT decoding with no payment wire traffic; flagged for CTO to confirm whether it still needs a gate tick)