### PR TITLE
parity(globalpay/authorize): remove extra fields cvv_indicator, name

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
@@ -355,8 +355,6 @@ pub struct GlobalpayPaymentsRequest<T: PaymentMethodDataTypes> {
 
 #[derive(Debug, Serialize)]
 pub struct GlobalpayPaymentMethod<T: PaymentMethodDataTypes> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<Secret<String>>,
     pub entry_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card: Option<GlobalpayCard<T>>,
@@ -375,8 +373,6 @@ pub struct GlobalpayCard<T: PaymentMethodDataTypes> {
     pub expiry_month: Secret<String>,
     pub expiry_year: Secret<String>,
     pub cvv: Secret<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvv_indicator: Option<String>,
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -415,22 +411,13 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     },
                 )?;
 
-                // Determine cvv_indicator based on whether CVV is provided
-                let cvv_indicator = if card_data.card_cvc.peek().is_empty() {
-                    Some("NOT_PRESENT".to_string())
-                } else {
-                    Some("PRESENT".to_string())
-                };
-
                 GlobalpayPaymentMethod {
-                    name: item.request.customer_name.clone().map(Secret::new),
                     entry_mode: constants::ENTRY_MODE_ECOM.to_string(),
                     card: Some(GlobalpayCard {
                         number: card_data.card_number.clone(),
                         expiry_month: card_data.card_exp_month.clone(),
                         expiry_year: expiry_year_2digit,
                         cvv: card_data.card_cvc.clone(),
-                        cvv_indicator,
                     }),
                     apm: None,
                     id: None,
@@ -448,7 +435,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 };
 
                 GlobalpayPaymentMethod {
-                    name: item.request.customer_name.clone().map(Secret::new),
                     entry_mode: constants::ENTRY_MODE_ECOM.to_string(),
                     card: None,
                     apm: Some(GlobalpayApm {
@@ -462,7 +448,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 let token = t.token.clone();
 
                 GlobalpayPaymentMethod {
-                    name: item.request.customer_name.clone().map(Secret::new),
                     entry_mode: constants::ENTRY_MODE_ECOM.to_string(),
                     card: None,
                     apm: None,

--- a/data/field_probe/globalpay.json
+++ b/data/field_probe/globalpay.json
@@ -131,7 +131,7 @@
             "via": "HyperSwitch",
             "x-gp-version": "2021-03-22"
           },
-          "body": "{\"account_name\":\"transaction_processing\",\"channel\":\"CNP\",\"amount\":\"1000\",\"currency\":\"USD\",\"reference\":\"probe_txn_001\",\"country\":\"US\",\"capture_mode\":\"AUTO\",\"payment_method\":{\"entry_mode\":\"ECOM\",\"card\":{\"number\":\"4111111111111111\",\"expiry_month\":\"03\",\"expiry_year\":\"30\",\"cvv\":\"737\",\"cvv_indicator\":\"PRESENT\"}}}"
+          "body": "{\"account_name\":\"transaction_processing\",\"channel\":\"CNP\",\"amount\":\"1000\",\"currency\":\"USD\",\"reference\":\"probe_txn_001\",\"country\":\"US\",\"capture_mode\":\"AUTO\",\"payment_method\":{\"entry_mode\":\"ECOM\",\"card\":{\"number\":\"4111111111111111\",\"expiry_month\":\"03\",\"expiry_year\":\"30\",\"cvv\":\"737\"}}}"
         }
       },
       "CashappQr": {
@@ -679,7 +679,7 @@
             "via": "HyperSwitch",
             "x-gp-version": "2021-03-22"
           },
-          "body": "{\"account_name\":\"transaction_processing\",\"channel\":\"CNP\",\"amount\":\"1000\",\"currency\":\"USD\",\"reference\":\"probe_proxy_txn_001\",\"country\":\"US\",\"capture_mode\":\"AUTO\",\"payment_method\":{\"entry_mode\":\"ECOM\",\"card\":{\"number\":\"4111111111111111\",\"expiry_month\":\"03\",\"expiry_year\":\"30\",\"cvv\":\"123\",\"cvv_indicator\":\"PRESENT\"}}}"
+          "body": "{\"account_name\":\"transaction_processing\",\"channel\":\"CNP\",\"amount\":\"1000\",\"currency\":\"USD\",\"reference\":\"probe_proxy_txn_001\",\"country\":\"US\",\"capture_mode\":\"AUTO\",\"payment_method\":{\"entry_mode\":\"ECOM\",\"card\":{\"number\":\"4111111111111111\",\"expiry_month\":\"03\",\"expiry_year\":\"30\",\"cvv\":\"123\"}}}"
         }
       }
     },


### PR DESCRIPTION
## Summary

Remove `cvv_indicator` from `GlobalpayCard` and `name` from `GlobalpayPaymentMethod` in prism's globalpay authorize transformer. Both fields are absent from the hyperswitch oracle and produce wire-format divergence.

## Linked PRD

Closes https://github.com/juspay/hyperswitch-cloud/issues/15627 (PRD-A only)

## Understanding Summary

- **Connector:** globalpay | **Flow:** authorize
- **Field paths:** `payment_method.card.cvv_indicator`, `payment_method.name`
- **Root cause:** missing-field (extra field in prism, absent from oracle)
- **Oracle:** `Card` struct (requests.rs L83-89) has no `cvv_indicator`; `CommonPaymentMethodData` (L56-61) has no `name`
- **Prism divergence:** `GlobalpayCard` had `cvv_indicator: Option<String>` (PRESENT/NOT_PRESENT); `GlobalpayPaymentMethod` had `name: Option<Secret<String>>` (customer_name)
- **Why oracle is correct:** Hyperswitch is ground truth; its wire format defines parity target
- **Collateral:** All globalpay card/redirect/token authorize flows use these structs — removing fields is desired for all

## Implementation Plan

7 changes in one file:
1. Remove `cvv_indicator` field from `GlobalpayCard<T>` struct
2. Remove `cvv_indicator` variable assignment (CVV presence check)
3. Remove `cvv_indicator` from `GlobalpayCard` initializer
4. Remove `name` field from `GlobalpayPaymentMethod<T>` struct
5. Remove `name` from Card branch initializer
6. Remove `name` from BankRedirect branch initializer
7. Remove `name` from Token branch initializer

## Build Tail
```
   Compiling connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 05s
```

## Clippy Tail
```
    Checking connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
```

## Test Results
```
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(15 pre-existing doctest failures across all connectors — unrelated to this change)

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [x] Tests pass
- [x] New test added (if applicable) — N/A, acceptance criteria #5 deferred since it requires test infrastructure setup
- [ ] Shadow-replay produces zero diff (CTO gate)