### PR TITLE
feat: update method to non optional string, req, res as string instead of json object  as per ckh

### DIFF
--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -212,6 +212,13 @@ impl<T: ApiEventMetric> ApiEventMetric for &T {
 
 impl ApiEventMetric for TimeRange {}
 
+fn serialize_method<S: serde::Serializer>(
+    method: &Option<String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(method.as_deref().unwrap_or(""))
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Event {
     pub request_id: String,
@@ -219,7 +226,8 @@ pub struct Event {
     pub flow_type: FlowName,
     pub connector: String,
     pub url: Option<String>,
-    /// HTTP verb for outbound connector calls; `None` for gRPC-only audit events.
+    /// HTTP verb for outbound connector calls; empty string for gRPC-only audit events.
+    #[serde(serialize_with = "serialize_method")]
     pub method: Option<String>,
     pub stage: EventStage,
     pub latency_ms: Option<u64>,
@@ -273,6 +281,13 @@ impl Event {
                     .insert("service_name".to_string(), masked_name);
             },
         );
+    }
+
+    pub fn add_tenant_id(&mut self, tenant_id: &str) {
+        MaskedSerdeValue::from_masked_optional(&tenant_id.to_string(), "tenant_id").map(|masked| {
+            self.additional_fields
+                .insert("tenant_id".to_string(), masked);
+        });
     }
 
     pub fn set_grpc_error_response(&mut self, tonic_error: &tonic::Status) {
@@ -510,6 +525,18 @@ pub(crate) fn process_event_with_config(
                     error = %e,
                     "Failed to set extraction, continuing with event processing"
                 );
+            }
+        }
+    }
+
+    // Stringify JSON object fields that CKH expects as String columns
+    for field in &["request_data", "response_data", "error"] {
+        if let Some(obj) = result.as_object_mut() {
+            if let Some(val) = obj.get(*field) {
+                if val.is_object() || val.is_array() {
+                    let stringified = val.to_string();
+                    obj.insert(field.to_string(), serde_json::Value::String(stringified));
+                }
             }
         }
     }

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -290,6 +290,7 @@ pub struct EventProcessingParams<'a> {
     pub reference_id: &'a Option<String>,
     pub resource_id: &'a Option<String>,
     pub shadow_mode: bool,
+    pub tenant_id: &'a str,
 }
 
 #[cfg(feature = "injector-client")]
@@ -785,7 +786,7 @@ fn create_event(
 
     let mut event = Event {
         request_id: request_id.to_string(),
-        timestamp: chrono::Utc::now().timestamp().into(),
+        timestamp: chrono::Utc::now().timestamp_millis().into(),
         flow_type: event_params.flow_name,
         connector: event_params.connector_name.to_string(),
         url,
@@ -805,6 +806,7 @@ fn create_event(
     event.add_resource_id(event_params.resource_id.as_deref());
     event.add_service_type(event_params.service_type);
     event.add_service_name(event_params.service_name);
+    event.add_tenant_id(event_params.tenant_id);
 
     event
 }

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -109,6 +109,7 @@ impl DisputeService for Disputes {
                         reference_id,
                         resource_id,
                         shadow_mode,
+                        tenant_id,
                         ..
                     } = request_data.extracted_metadata;
                     let connector_data: ConnectorData<DefaultPCIHolder> =
@@ -158,6 +159,7 @@ impl DisputeService for Disputes {
                         reference_id: &reference_id,
                         resource_id: &resource_id,
                         shadow_mode,
+                        tenant_id: &tenant_id,
                     };
 
                     let response = Box::pin(
@@ -325,6 +327,7 @@ impl DisputeService for Disputes {
                         reference_id,
                         resource_id,
                         shadow_mode,
+                        tenant_id,
                         ..
                     } = request_data.extracted_metadata;
 
@@ -376,6 +379,7 @@ impl DisputeService for Disputes {
                         reference_id: &reference_id,
                         resource_id: &resource_id,
                         shadow_mode,
+                        tenant_id: &tenant_id,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -221,6 +221,7 @@ async fn verify_webhook_source_external(
         reference_id: &metadata_payload.reference_id,
         resource_id: &metadata_payload.resource_id,
         shadow_mode: metadata_payload.shadow_mode,
+        tenant_id: &metadata_payload.tenant_id,
     };
 
     match Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -102,6 +102,7 @@ struct EventParams<'a> {
     reference_id: &'a Option<String>,
     resource_id: &'a Option<String>,
     shadow_mode: bool,
+    tenant_id: &'a str,
 }
 
 /// Helper function for converting CardDetails to TokenData with structured types
@@ -417,6 +418,7 @@ impl CustomerService for Customer {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        tenant_id: &metadata_payload.tenant_id,
                     };
 
                     let response = Box::pin(
@@ -543,6 +545,7 @@ impl Payments {
             reference_id: &metadata_payload.reference_id,
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
+            tenant_id: &metadata_payload.tenant_id,
         };
 
         // Execute connector processing - ONLY the authorize call
@@ -661,6 +664,7 @@ impl Payments {
             reference_id: &metadata_payload.reference_id,
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
+            tenant_id: &metadata_payload.tenant_id,
         };
 
         let response = Box::pin(
@@ -1044,6 +1048,7 @@ impl PaymentService for Payments {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        tenant_id: &metadata_payload.tenant_id,
                     };
 
                     let consume_or_trigger_flow = match payload.handle_response {
@@ -2174,6 +2179,7 @@ impl PaymentMethod {
             reference_id: &metadata_payload.reference_id,
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
+            tenant_id: &metadata_payload.tenant_id,
         };
 
         let response = Box::pin(
@@ -2280,6 +2286,7 @@ impl MerchantAuthentication {
             reference_id: event_params.reference_id,
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
+            tenant_id: event_params.tenant_id,
         };
 
         // Execute connector processing
@@ -2392,6 +2399,7 @@ impl MerchantAuthentication {
             reference_id: event_params.reference_id,
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
+            tenant_id: event_params.tenant_id,
         };
 
         let response = Box::pin(
@@ -2564,6 +2572,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        tenant_id: &metadata_payload.tenant_id,
                     };
 
                     let session_response = Box::pin(self.handle_session_token(
@@ -2679,6 +2688,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        tenant_id: &metadata_payload.tenant_id,
                     };
 
                     // Reuse the existing handle_access_token function which now uses
@@ -2864,6 +2874,7 @@ impl RecurringPaymentService for RecurringPayments {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        tenant_id: &metadata_payload.tenant_id,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -357,7 +357,7 @@ fn create_and_emit_grpc_event<R>(
 {
     let mut grpc_event = Event {
         request_id: metadata_payload.map_or("unknown".to_string(), |md| md.request_id.clone()),
-        timestamp: chrono::Utc::now().timestamp().into(),
+        timestamp: chrono::Utc::now().timestamp_millis().into(),
         flow_type: flow_name,
         connector: metadata_payload.map_or("unknown".to_string(), |md| md.connector.to_string()),
         url: None,
@@ -380,6 +380,11 @@ fn create_and_emit_grpc_event<R>(
         .add_resource_id(metadata_payload.and_then(|metadata| metadata.resource_id.as_deref()));
     grpc_event.add_service_type(service_type_str(&config.server.type_));
     grpc_event.add_service_name(service_name);
+    grpc_event.add_tenant_id(
+        metadata_payload
+            .map(|md| md.tenant_id.as_str())
+            .unwrap_or("public"),
+    );
 
     match grpc_response {
         Ok(response) => grpc_event.set_grpc_success_response(response.get_ref()),
@@ -550,6 +555,7 @@ macro_rules! implement_connector_operation {
                 reference_id: &metadata_payload.reference_id,
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
+                tenant_id: &metadata_payload.tenant_id,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -677,6 +683,7 @@ macro_rules! implement_connector_operation {
                 reference_id: &metadata_payload.reference_id,
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
+                tenant_id: &metadata_payload.tenant_id,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -800,6 +807,7 @@ macro_rules! implement_connector_operation {
                 reference_id: &metadata_payload.reference_id,
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
+                tenant_id: &metadata_payload.tenant_id,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,

--- a/crates/types-traits/ucs_interface_common/src/metadata.rs
+++ b/crates/types-traits/ucs_interface_common/src/metadata.rs
@@ -149,7 +149,7 @@ pub fn tenant_id_from_metadata(
 ) -> CustomResult<String, IntegrationError> {
     parse_metadata(metadata, consts::X_TENANT_ID)
         .map(|s| s.to_string())
-        .or_else(|_| Ok("DefaultTenantId".to_string()))
+        .or_else(|_| Ok("public".to_string()))
 }
 
 pub fn reference_id_from_metadata(
@@ -267,7 +267,7 @@ mod tests {
     fn tenant_id_defaults_when_missing() {
         let metadata = MetadataMap::new();
         let tenant_id = tenant_id_from_metadata(&metadata).expect("should not fail");
-        assert_eq!(tenant_id, "DefaultTenantId");
+        assert_eq!(tenant_id, "public");
     }
 
     #[test]


### PR DESCRIPTION
## Align UCS connector event emission with ClickHouse schema

Fixes field format mismatches between UCS-emitted events and the CKH `connector_events` table:

- **`method`**: changed from `Option<String>` (serialized as `null`) to always emit `""` for gRPC-only events — CKH `LowCardinality(String)` is non-nullable
- **`request`/`response`/`error`**: stringify JSON object fields before emission — CKH expects `String` columns, matching HS's `ConnectorEvent.request` / `masked_response` behavior
- **`created_at`**: fix gRPC event path using `.timestamp()` (seconds) → `.timestamp_millis()` — CKH `DateTime64(3)` expects milliseconds, consistent with HS's `unix_timestamp_nanos() / 1_000_000`
- **`tenant_id`**: propagate through `EventProcessingParams` and emit in both HTTP and gRPC event paths; fallback to `"public"` (matching HS's `TenantId("public")`)