### PR TITLE
test(cashfree): drive UPI sync to CHARGED via harness extensions + browser automation

### DIFF
--- a/browser-automation-engine/src/drivers/playwrightDriver.ts
+++ b/browser-automation-engine/src/drivers/playwrightDriver.ts
@@ -254,6 +254,12 @@ export class PlaywrightDriverFactory implements BrowserDriverFactory {
       slowMo: options.slowMoMs
     });
     const context = await browser.newContext({ viewport: options.viewport });
+    // Hide the `navigator.webdriver` flag so pages with casual bot checks
+    // (e.g. Cashfree's UPI simulator) don't refuse to enable their own
+    // submit buttons when driven by Playwright.
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => undefined });
+    });
     const page = await context.newPage();
 
     page.setDefaultTimeout(options.defaultTimeoutMs);

--- a/crates/internal/integration-tests/src/connector_specs/cashfree/browser_automation_spec.json
+++ b/crates/internal/integration-tests/src/connector_specs/cashfree/browser_automation_spec.json
@@ -1,0 +1,38 @@
+{
+  "hooks": [
+    {
+      "suite": "get",
+      "scenarios": ["sync_upi_intent"],
+      "phase": "before_request",
+      "after_dependency_suite": "authorize",
+      "after_dependency_scenario": "no3ds_auto_capture_upi_intent",
+      "endpoint_path": "redirection_data.uri.uri",
+      "rules": [
+        { "action": "waitFor", "selector": "div[data-status=\"SUCCESS\"]", "timeoutMs": 30000 },
+        { "action": "click",   "selector": "div[data-status=\"SUCCESS\"]" },
+        { "action": "fill",    "selector": "#basic-otp", "value": "111000" },
+        { "action": "evaluate", "expression": "if (typeof loadPage === 'function') loadPage();" },
+        { "action": "waitFor", "selector": "#successForm button:not([disabled])", "timeoutMs": 15000 },
+        { "action": "click",   "selector": "#successForm button" },
+        { "action": "waitFor", "urlContains": "thankyou", "timeoutMs": 30000 }
+      ]
+    },
+    {
+      "suite": "get",
+      "scenarios": ["sync_upi_qr"],
+      "phase": "before_request",
+      "after_dependency_suite": "authorize",
+      "after_dependency_scenario": "no3ds_auto_capture_upi_qr",
+      "endpoint_path": "redirection_data.uri.uri",
+      "rules": [
+        { "action": "waitFor", "selector": "div[data-status=\"SUCCESS\"]", "timeoutMs": 30000 },
+        { "action": "click",   "selector": "div[data-status=\"SUCCESS\"]" },
+        { "action": "fill",    "selector": "#basic-otp", "value": "111000" },
+        { "action": "evaluate", "expression": "if (typeof loadPage === 'function') loadPage();" },
+        { "action": "waitFor", "selector": "#successForm button:not([disabled])", "timeoutMs": 15000 },
+        { "action": "click",   "selector": "#successForm button" },
+        { "action": "waitFor", "urlContains": "thankyou", "timeoutMs": 30000 }
+      ]
+    }
+  ]
+}

--- a/crates/internal/integration-tests/src/connector_specs/cashfree/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/cashfree/override.json
@@ -1,0 +1,70 @@
+{
+  "create_order": {
+    "create_order_basic": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 60000,
+          "currency": "INR"
+        }
+      },
+      "assert": {
+        "status": { "one_of": ["INITIATED", "REQUIRES_CUSTOMER_ACTION", "PENDING"] }
+      }
+    }
+  },
+  "authorize": {
+    "no3ds_auto_capture_upi_collect": {
+      "grpc_req": {
+        "payment_method": {
+          "upi_collect": {
+            "vpa_id": { "value": "testsuccess@gocash" }
+          }
+        }
+      },
+      "context_map": {
+        "connector_order_id": "res.connectorOrderId"
+      }
+    },
+    "no3ds_auto_capture_upi_intent": {
+      "context_map": {
+        "connector_order_id": "res.connectorOrderId"
+      }
+    },
+    "no3ds_auto_capture_upi_qr": {
+      "context_map": {
+        "connector_order_id": "res.connectorOrderId"
+      }
+    }
+  },
+  "get": {
+    "sync_upi_collect": {
+      "context_map": {
+        "connector_order_reference_id": "req.merchant_order_id"
+      },
+      "pre_request_http": {
+        "url": "https://sandbox.cashfree.com/pg/view/simulate",
+        "method": "POST",
+        "body": "{\"entity\":\"PAYMENTS\",\"entity_id\":\"{{dep_res.1.merchantTransactionId}}\",\"entity_simulation\":{\"payment_status\":\"SUCCESS\",\"payment_error_code\":\"\"}}"
+      },
+      "assert": {
+        "status": { "one_of": ["CHARGED", "AUTHORIZED"] }
+      }
+    },
+    "sync_upi_intent": {
+      "context_map": {
+        "connector_order_reference_id": "req.merchant_order_id"
+      },
+      "assert": {
+        "status": { "one_of": ["CHARGED", "AUTHORIZED"] }
+      }
+    },
+    "sync_upi_qr": {
+      "context_map": {
+        "connector_order_reference_id": "req.merchant_order_id"
+      },
+      "assert": {
+        "status": { "one_of": ["CHARGED", "AUTHORIZED"] }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/cashfree/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/cashfree/specs.json
@@ -8,5 +8,6 @@
     "void",
     "refund",
     "refund_sync"
-  ]
+  ],
+  "sync_poll_until_terminal_seconds": 60
 }

--- a/crates/internal/integration-tests/src/harness/connector_override/loader.rs
+++ b/crates/internal/integration-tests/src/harness/connector_override/loader.rs
@@ -12,6 +12,43 @@ pub struct ScenarioOverridePatch {
     pub grpc_req: Option<Value>,
     #[serde(rename = "assert", default)]
     pub assert_rules: Option<BTreeMap<String, Value>>,
+    /// Connector-specific context map patch. Keys are target paths in the
+    /// scenario request; values are `req.` / `res.` source references into the
+    /// scenario's dependency payloads. Applied AFTER the suite-level
+    /// `context_map`, so it can fill in fields the suite doesn't set.
+    #[serde(default)]
+    pub context_map: Option<BTreeMap<String, String>>,
+    /// Fire an HTTP request (fire-and-forget) before this scenario runs.
+    /// Used to drive sandbox simulators that settle a payment outside of the
+    /// normal connector API surface — e.g. Cashfree's `/pg/view/simulate`
+    /// endpoint which flips a UPI Intent payment to SUCCESS so the subsequent
+    /// sync returns `CHARGED` without browser automation.
+    #[serde(default)]
+    pub pre_request_http: Option<PreRequestHttpHook>,
+}
+
+/// Fire-and-forget HTTP call issued before the scenario's gRPC request.
+/// Body supports `{{dep_res.<index>.<json-path>}}` templating from
+/// dependency responses (e.g. pulling cf_payment_id out of the authorize
+/// response at dep_res index 1).
+#[derive(Debug, Clone, Deserialize)]
+pub struct PreRequestHttpHook {
+    pub url: String,
+    #[serde(default = "default_http_method")]
+    pub method: String,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default = "default_hook_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_http_method() -> String {
+    "POST".to_string()
+}
+fn default_hook_timeout_secs() -> u64 {
+    10
 }
 
 type SuiteOverrideFile = BTreeMap<String, ScenarioOverridePatch>;
@@ -63,6 +100,32 @@ pub fn load_scenario_override_patch(
 
     Ok(None)
 }
+
+/// Loads the optional `pre_request_http` hook for a scenario override.
+pub fn load_scenario_pre_request_http(
+    connector: &str,
+    suite: &str,
+    scenario: &str,
+) -> Result<Option<PreRequestHttpHook>, ScenarioError> {
+    Ok(load_scenario_override_patch(connector, suite, scenario)?
+        .and_then(|patch| patch.pre_request_http))
+}
+
+/// Loads optional per-connector `context_map` patch for a given scenario.
+///
+/// Used to inject dependency-derived fields into the effective request for
+/// connectors whose sync/flow transformers require fields the default suite
+/// context_map doesn't set (e.g. PhonePe reads `connector_order_reference_id`
+/// from the sync request as its `merchant_order_id`).
+pub fn load_scenario_override_context_map(
+    connector: &str,
+    suite: &str,
+    scenario: &str,
+) -> Result<Option<BTreeMap<String, String>>, ScenarioError> {
+    Ok(load_scenario_override_patch(connector, suite, scenario)?
+        .and_then(|patch| patch.context_map))
+}
+
 
 /// Path to `<connector>/webhook_payload.json` under connector override root.
 pub fn connector_webhook_payload_file_path(connector: &str) -> PathBuf {

--- a/crates/internal/integration-tests/src/harness/connector_override/loader.rs
+++ b/crates/internal/integration-tests/src/harness/connector_override/loader.rs
@@ -126,7 +126,6 @@ pub fn load_scenario_override_context_map(
         .and_then(|patch| patch.context_map))
 }
 
-
 /// Path to `<connector>/webhook_payload.json` under connector override root.
 pub fn connector_webhook_payload_file_path(connector: &str) -> PathBuf {
     connector_override_root()

--- a/crates/internal/integration-tests/src/harness/connector_override/mod.rs
+++ b/crates/internal/integration-tests/src/harness/connector_override/mod.rs
@@ -105,7 +105,6 @@ pub fn connector_override_context_map(
     loader::load_scenario_override_context_map(connector, suite, scenario)
 }
 
-
 /// Applies connector override patches to request payload and assertions.
 pub fn apply_connector_overrides(
     connector: &str,

--- a/crates/internal/integration-tests/src/harness/connector_override/mod.rs
+++ b/crates/internal/integration-tests/src/harness/connector_override/mod.rs
@@ -85,6 +85,27 @@ impl OverrideRegistry {
     }
 }
 
+pub use loader::PreRequestHttpHook;
+
+/// Returns the optional `pre_request_http` hook spec for a scenario.
+pub fn connector_pre_request_http_hook(
+    connector: &str,
+    suite: &str,
+    scenario: &str,
+) -> Result<Option<PreRequestHttpHook>, ScenarioError> {
+    loader::load_scenario_pre_request_http(connector, suite, scenario)
+}
+
+/// Returns the connector's per-scenario `context_map` override, if any.
+pub fn connector_override_context_map(
+    connector: &str,
+    suite: &str,
+    scenario: &str,
+) -> Result<Option<BTreeMap<String, String>>, ScenarioError> {
+    loader::load_scenario_override_context_map(connector, suite, scenario)
+}
+
+
 /// Applies connector override patches to request payload and assertions.
 pub fn apply_connector_overrides(
     connector: &str,

--- a/crates/internal/integration-tests/src/harness/scenario_api.rs
+++ b/crates/internal/integration-tests/src/harness/scenario_api.rs
@@ -4351,7 +4351,6 @@ fn execute_single_scenario_with_context(
         apply_context_map(&connector_entries, &mut effective_req);
     }
 
-
     // Fallback generation for unresolved non-context placeholders.
     resolve_auto_generate(&mut effective_req)?;
 

--- a/crates/internal/integration-tests/src/harness/scenario_api.rs
+++ b/crates/internal/integration-tests/src/harness/scenario_api.rs
@@ -23,8 +23,9 @@ use uuid::Uuid;
 use crate::harness::{
     auto_gen::resolve_auto_generate,
     connector_override::{
-        apply_connector_overrides, context_deferred_paths_for_connector,
-        normalize_tonic_request_for_connector, transform_response_for_connector,
+        apply_connector_overrides, connector_override_context_map, connector_pre_request_http_hook,
+        context_deferred_paths_for_connector, normalize_tonic_request_for_connector,
+        transform_response_for_connector, PreRequestHttpHook,
     },
     credentials::{creds_file_path, load_connector_config},
     metadata::add_connector_metadata,
@@ -4022,6 +4023,166 @@ fn append_follow_up_trace(existing: &mut Option<String>, heading: &str, payload:
     *existing = Some(merged);
 }
 
+/// Templates `{{dep_res.<index>.<json-path>}}` placeholders in a string
+/// using the list of dependency responses. Unknown placeholders are left as-is
+/// so the caller can see what didn't resolve.
+fn template_with_dep_res(template: &str, dependency_res: &[Value]) -> String {
+    let mut out = template.to_string();
+    while let Some(start) = out.find("{{dep_res.") {
+        let Some(end) = out[start..].find("}}") else {
+            break;
+        };
+        let end_abs = start + end;
+        let inner = &out[start + 10..end_abs];
+        let (idx_str, rest) = match inner.find('.') {
+            Some(dot) => (&inner[..dot], &inner[dot + 1..]),
+            None => (inner, ""),
+        };
+        let replacement = idx_str
+            .parse::<usize>()
+            .ok()
+            .and_then(|i| dependency_res.get(i))
+            .and_then(|res| {
+                if rest.is_empty() {
+                    res.as_str().map(|s| s.to_string())
+                } else {
+                    lookup_json_path_with_case_fallback(res, rest)
+                        .and_then(|v| v.as_str().map(|s| s.to_string()))
+                }
+            })
+            .unwrap_or_default();
+        out.replace_range(start..end_abs + 2, &replacement);
+    }
+    out
+}
+
+/// Fires the configured pre-request HTTP hook. Fire-and-forget: network
+/// errors are logged (when debug env is set) but do not fail the scenario.
+#[allow(clippy::print_stdout)]
+fn fire_pre_request_http_hook(hook: &PreRequestHttpHook, dependency_res: &[Value]) {
+    let url = template_with_dep_res(&hook.url, dependency_res);
+    let body = hook
+        .body
+        .as_ref()
+        .map(|b| template_with_dep_res(b, dependency_res));
+    let method = hook.method.to_uppercase();
+
+    let mut cmd = Command::new("curl");
+    cmd.arg("-sS")
+        .arg("-m")
+        .arg(hook.timeout_secs.to_string())
+        .arg("-X")
+        .arg(&method)
+        .arg(&url);
+    for (k, v) in &hook.headers {
+        cmd.arg("-H").arg(format!("{k}: {v}"));
+    }
+    if let Some(body) = body.as_ref() {
+        cmd.arg("-H")
+            .arg("Content-Type: application/json")
+            .arg("-d")
+            .arg(body);
+    }
+    let output = cmd.output();
+    if std::env::var("UCS_DEBUG_PRE_REQUEST_HOOK").as_deref() == Ok("1") {
+        match output {
+            Ok(out) => println!(
+                "[suite_run_test] pre_request_http → status={} body={}",
+                out.status,
+                String::from_utf8_lossy(&out.stdout)
+                    .chars()
+                    .take(300)
+                    .collect::<String>()
+            ),
+            Err(e) => println!("[suite_run_test] pre_request_http error: {e}"),
+        }
+    }
+}
+
+/// For the `get`/sync suite only: if the connector spec has
+/// `sync_poll_until_terminal_seconds` set and the response status is still
+/// non-terminal (e.g. `PENDING`), re-issue the sync call every 5s until a
+/// terminal status arrives or the budget elapses. Mutates `response_json` in
+/// place with the final body.
+///
+/// Used for connectors whose sandbox auto-settles after a delay — e.g.
+/// Cashfree's `testsuccess@gocash` UPI collect transitions from
+/// `NOT_ATTEMPTED` to `SUCCESS` at ~30s.
+fn maybe_poll_sync_until_terminal(
+    suite: &str,
+    scenario: &str,
+    connector: &str,
+    options: SuiteRunOptions<'_>,
+    effective_req: &Value,
+    response_json: &mut Value,
+    grpc_request: &mut Option<String>,
+    grpc_response: &mut Option<String>,
+) {
+    if suite != "get" || options.backend != ExecutionBackend::Grpcurl {
+        return;
+    }
+    let Some(spec) = load_connector_spec(connector) else {
+        return;
+    };
+    let Some(budget_secs) = spec.sync_poll_until_terminal_seconds else {
+        return;
+    };
+
+    let is_terminal = |status: &str| {
+        matches!(
+            status,
+            "CHARGED" | "AUTHORIZED" | "VOIDED" | "FAILURE" | "REJECTED" | "CANCELLED" | "EXPIRED"
+        )
+    };
+    let current_status = |body: &Value| {
+        lookup_json_path_with_case_fallback(body, "status")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string())
+    };
+
+    if let Some(status) = current_status(response_json) {
+        if is_terminal(&status) {
+            return;
+        }
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(budget_secs);
+    let poll_interval = Duration::from_secs(5);
+
+    while std::time::Instant::now() < deadline {
+        thread::sleep(poll_interval);
+
+        let trace = match execute_grpcurl_request_from_payload_with_trace(
+            suite,
+            scenario,
+            effective_req,
+            options.endpoint,
+            Some(connector),
+            options.merchant_id,
+            options.tenant_id,
+            options.plaintext,
+        ) {
+            Ok(trace) if trace.success => trace,
+            _ => continue,
+        };
+
+        let Ok(mut next_json) = serde_json::from_str::<Value>(&trace.response_body) else {
+            continue;
+        };
+        transform_response_for_connector(connector, suite, scenario, &mut next_json);
+
+        *response_json = next_json;
+        *grpc_request = Some(trace.request_command);
+        *grpc_response = Some(trace.response_output);
+
+        if let Some(status) = current_status(response_json) {
+            if is_terminal(&status) {
+                break;
+            }
+        }
+    }
+}
+
 fn maybe_sync_complete_authorize_pending(
     suite: &str,
     connector: &str,
@@ -4163,6 +4324,34 @@ fn execute_single_scenario_with_context(
     // Apply any explicit dependency path mappings from suite_spec.json.
     apply_context_map(explicit_context_entries, &mut effective_req);
 
+    // Per-connector context_map patch from `<connector>/override.json`.
+    // Lets a single connector inject dependency-derived fields without
+    // changing the suite-level context_map shared by all connectors.
+    //
+    // Applied against ALL dependencies (not only those with an explicit
+    // suite-level context_map), so a connector can reach into the req/res of
+    // a dep that the global spec didn't wire through.  For each dependency,
+    // `apply_context_map` silently skips keys that don't resolve, so listing
+    // the same mapping against every dep is safe.
+    if let Ok(Some(connector_map)) = connector_override_context_map(connector, suite, scenario) {
+        let connector_entries: Vec<ExplicitContextEntry> = dependency_reqs
+            .iter()
+            .zip(dependency_res.iter())
+            .map(|(req, res)| {
+                (
+                    connector_map
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    req.clone(),
+                    res.clone(),
+                )
+            })
+            .collect();
+        apply_context_map(&connector_entries, &mut effective_req);
+    }
+
+
     // Fallback generation for unresolved non-context placeholders.
     resolve_auto_generate(&mut effective_req)?;
 
@@ -4184,6 +4373,13 @@ fn execute_single_scenario_with_context(
         dependency_entries,
         &mut effective_req,
     )?;
+
+    // Fire any connector-specific `pre_request_http` hook (e.g. Cashfree's
+    // `/pg/view/simulate` to flip a UPI Intent payment to SUCCESS before
+    // sync). Dependency responses are available for body templating.
+    if let Ok(Some(hook)) = connector_pre_request_http_hook(connector, suite, scenario) {
+        fire_pre_request_http_hook(&hook, dependency_res);
+    }
 
     let (response, mut grpc_request, mut grpc_response) = match options.backend {
         ExecutionBackend::Grpcurl => {
@@ -4240,6 +4436,17 @@ fn execute_single_scenario_with_context(
     })?;
 
     transform_response_for_connector(connector, suite, scenario, &mut response_json);
+
+    maybe_poll_sync_until_terminal(
+        suite,
+        scenario,
+        connector,
+        options,
+        &effective_req,
+        &mut response_json,
+        &mut grpc_request,
+        &mut grpc_response,
+    );
 
     maybe_sync_complete_authorize_pending(
         suite,

--- a/crates/internal/integration-tests/src/harness/scenario_types.rs
+++ b/crates/internal/integration-tests/src/harness/scenario_types.rs
@@ -252,6 +252,13 @@ pub struct ConnectorSuiteSpec {
     /// Max length for auto-generated reference IDs (default: no truncation).
     #[serde(default)]
     pub request_id_length: Option<usize>,
+    /// When set, `get`/sync scenarios re-issue the sync call until the status
+    /// reaches a terminal value (`CHARGED`, `FAILURE`, `VOIDED`, etc.) or this
+    /// many seconds elapse. Use for connectors whose sandbox auto-settles UPI
+    /// payments after a delay (e.g. Cashfree settles `testsuccess@gocash` at
+    /// ~30s). Default: no polling (status returned on first call is final).
+    #[serde(default)]
+    pub sync_poll_until_terminal_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary

Wires Cashfree's UPI flows (Collect, Intent, QR) end-to-end through the existing integration-test harness so **sync** actually reaches a terminal `CHARGED` status against Cashfree's sandbox — without manual phone interaction, without hard-coded sleeps, and without any connector-code changes.

Three commits, all additive and opt-in per connector:

| Commit | What it adds |
| --- | --- |
| `feat(test-suite): harness extensions for slow-sandbox sync + pre-request HTTP hooks` | Generic harness features: `sync_poll_until_terminal_seconds`, `pre_request_http`, per-connector `context_map`. |
| `fix(browser-automation): hide navigator.webdriver so simulator pages work` | One-line Playwright init script; lets connector sandbox simulator pages proceed normally when driven by the bundled `browser-automation-engine`. |
| `test(cashfree): wire UPI flows end-to-end to CHARGED in sandbox` | Cashfree `specs.json` / `override.json` / `browser_automation_spec.json` that use the three mechanisms above to drive Collect (via direct sandbox API) and Intent/QR (via browser automation) to CHARGED. |

**This PR explicitly does NOT contain Cashfree connector-code fixes** — those ship separately in PR #1151.

## Harness extensions

Three new primitives, each driven entirely from connector-side JSON; zero effect on connectors that don't opt in.

### 1. `sync_poll_until_terminal_seconds` — new field on `ConnectorSuiteSpec`

For connectors whose sandbox auto-settles after a delay. Re-issues the sync call every 5 seconds until a terminal status arrives (`CHARGED` / `AUTHORIZED` / `VOIDED` / `FAILURE` / `REJECTED` / `CANCELLED` / `EXPIRED`) or the budget elapses.

```json
// connector_specs/<c>/specs.json
{
  "sync_poll_until_terminal_seconds": 60
}
```

### 2. `pre_request_http` — new field on `ScenarioOverridePatch`

Fire-and-forget HTTP call issued right before the scenario's gRPC request. Useful for poking sandbox-only endpoints (e.g. simulators) without routing through the connector API surface. Body and URL support `{{dep_res.<index>.<json-path>}}` templating so values from earlier dependencies can be plugged in.

```json
// connector_specs/<c>/override.json
{
  "get": {
    "sync_upi_collect": {
      "pre_request_http": {
        "url": "https://sandbox.example.com/pg/view/simulate",
        "method": "POST",
        "body": "{\"entity\":\"PAYMENTS\",\"entity_id\":\"{{dep_res.1.merchantTransactionId}}\",\"entity_simulation\":{\"payment_status\":\"SUCCESS\"}}"
      }
    }
  }
}
```

### 3. Per-connector `context_map` now applies to ALL dependencies

Previously only worked for dependencies that carried a suite-level `context_map`. Now iterates over every dep so a connector can reach into req/res of any dependency the global suite didn't wire through. Keys that don't resolve are silently skipped — safe to spray across all deps.

## Browser-automation engine fix

One additional `addInitScript` in the Playwright driver:

```ts
await context.addInitScript(() => {
  Object.defineProperty(navigator, "webdriver", { get: () => undefined });
});
```

Some sandbox simulator pages guard their internal state machine based on `navigator.webdriver`. Overriding the getter lets our tests drive those pages. No effect on the existing Stripe/PayPal/NexiXPay redirect specs, which worked fine before and continue to.

## Cashfree wiring

```
crates/internal/integration-tests/src/connector_specs/cashfree/
├── specs.json                      # enable 60s sync polling
├── override.json                   # test VPA, context_map, pre_request_http for Collect
└── browser_automation_spec.json    # NEW — Playwright hooks for Intent / QR simulators
```

Strategy per scenario:

| Scenario | Driven by | Why |
| --- | --- | --- |
| `sync_upi_collect` | `pre_request_http` | Collect has no redirect page; flips the payment by hitting Cashfree's sandbox `/pg/view/simulate` endpoint directly. |
| `sync_upi_intent` | `browser_automation_spec.json` | Opens the simulator URL, clicks SUCCESS, submits — same flow a real user would follow. |
| `sync_upi_qr` | `browser_automation_spec.json` | Same as Intent; Cashfree's V3 API returns the same simulator URL for both. |

## Test plan

### Prerequisites

```bash
# Rust harness + grpc-server
cargo build -p grpc-server --bin grpc-server -p integration-tests --bin suite_run_test

# Browser automation engine (one-time per machine)
cd browser-automation-engine
npm install
npm run install:browsers
npm run build
cd ..
```

### Run (three terminals)

```bash
# Terminal 1 — grpc server
./target/debug/grpc-server

# Terminal 2 — browser automation engine
#   (If port 3000 is taken on your machine, override via PORT/UCS_BROWSER_AUTOMATION_PORT)
cd browser-automation-engine && PORT=3333 npm run dev

# Terminal 3 — tests
UCS_BROWSER_AUTOMATION_PORT=3333 \
cargo run -p integration-tests --bin suite_run_test -- \
  --connector cashfree --suite get --endpoint localhost:8000 2>&1 \
  | grep -E 'sync_upi|no3ds_auto_capture_upi|summary'
```

### Expected harness output

```
[suite_run_test] pre_request_http → status=exit status: 0 body={"simulation_id":"sim_...","entity":"PAYMENTS","entity_id":"<cf_payment_id>","entity_simulation":{"payment_status":"SUCCESS","payment_error_code":""}}
[suite_run_test] assertion result for 'no3ds_auto_capture_upi_collect': PASS
[suite_run_test] assertion result for 'sync_upi_collect': PASS
[suite_run_test] assertion result for 'no3ds_auto_capture_upi_intent': PASS
[suite_run_test] assertion result for 'sync_upi_intent': PASS
[suite_run_test] assertion result for 'no3ds_auto_capture_upi_qr': PASS
[suite_run_test] assertion result for 'sync_upi_qr': PASS
[suite_run_test] summary suite=get connector=cashfree passed=9 failed=4
```

(The 4 failures are `sync_payment` / `sync_payment_with_handle_response` and their card-authorize deps — Cashfree doesn't implement card payments. Unrelated to this PR.)

### Manual verification via grpcurl (no credentials shown — substitute your own in `creds.json`)

**1. CreateOrder**

```bash
grpcurl -plaintext \
  -H "x-connector-config: <JSON config from creds.json>" \
  -H 'x-merchant-id: test_merchant' -H 'x-tenant-id: default' \
  -H 'x-request-id: r0' -H 'x-connector-request-reference-id: cf_test_order_1' \
  -d '{
    "merchant_order_id": "cf_test_order_1",
    "amount": {"minor_amount": 60000, "currency": "INR"},
    "webhook_url": "https://example.com/webhook",
    "test_mode": true
  }' \
  localhost:8000 types.PaymentService/CreateOrder
```

Example response:
```json
{
  "merchantOrderId": "cf_test_order_1",
  "connectorOrderId": "session_<random>",
  "status": "PENDING",
  "statusCode": 200
}
```

**2. Authorize (UPI Intent)**

```bash
grpcurl -plaintext \
  -H "x-connector-config: <JSON config from creds.json>" \
  -H 'x-merchant-id: test_merchant' -H 'x-tenant-id: default' \
  -H 'x-request-id: r1' -H 'x-connector-request-reference-id: mti_test_intent_1' \
  -d '{
    "merchant_transaction_id": "mti_test_intent_1",
    "amount": {"minor_amount": 60000, "currency": "INR"},
    "payment_method": {"upi_intent": {}},
    "capture_method": "AUTOMATIC",
    "auth_type": "NO_THREE_DS",
    "customer": {"name":"Test","email":{"value":"t@example.com"},"id":"c1","phone_number":"+919999999999"},
    "address": {"billing_address": {
      "first_name":{"value":"Test"},"last_name":{"value":"User"},
      "line1":{"value":"1 St"},"city":{"value":"Mumbai"},"state":{"value":"MH"},
      "zip_code":{"value":"400001"},"country_alpha2_code":"IN",
      "email":{"value":"t@example.com"},"phone_number":{"value":"9999999999"},
      "phone_country_code":"+91"
    }},
    "browser_info": {"ip_address":"127.0.0.1","user_agent":"manual"},
    "return_url": "https://example.com/r",
    "webhook_url": "https://example.com/w",
    "test_mode": true,
    "session_token": "<connectorOrderId from CreateOrder>",
    "connector_order_id": "<connectorOrderId from CreateOrder>"
  }' \
  localhost:8000 types.PaymentService/Authorize
```

Example response:
```json
{
  "merchantTransactionId": "<cf_payment_id>",
  "status": "AUTHENTICATION_PENDING",
  "statusCode": 200,
  "redirectionData": {
    "uri": {
      "uri": "https://payments-test.cashfree.com/pgbillpayuiapi/simulator/<cf_payment_id>?txnId=...&amount=600.00&..."
    }
  }
}
```

(The `redirection_data.uri.uri` is the simulator URL the browser hook drives.)

**3. Sync (the harness fires the simulator automatically — for manual test see step 4)**

```bash
grpcurl -plaintext \
  -H "x-connector-config: <JSON config from creds.json>" \
  -H 'x-merchant-id: test_merchant' -H 'x-tenant-id: default' \
  -H 'x-request-id: r2' -H 'x-connector-request-reference-id: cf_test_order_1' \
  -d '{
    "merchant_transaction_id": "cf_test_order_1",
    "connector_transaction_id": "cf_test_order_1",
    "connector_order_reference_id": "cf_test_order_1",
    "amount": {"minor_amount": 60000, "currency": "INR"}
  }' \
  localhost:8000 types.PaymentService/Get
```

Example response **before** the user (or simulator) completes the payment:
```json
{
  "connectorTransactionId": "cf_test_order_1",
  "status": "PENDING",
  "statusCode": 200
}
```

Example response **after** the simulator fires (what the harness's test path sees):
```json
{
  "connectorTransactionId": "cf_test_order_1",
  "merchantTransactionId": "<cf_payment_id>",
  "status": "CHARGED",
  "statusCode": 200
}
```

**4. (Manual only) Flip a UPI Intent payment to SUCCESS without the harness**

```bash
curl -sS -X POST 'https://sandbox.cashfree.com/pg/view/simulate' \
  -H 'Content-Type: application/json' \
  -d '{
    "entity": "PAYMENTS",
    "entity_id": "<cf_payment_id from Authorize response merchantTransactionId>",
    "entity_simulation": {
      "payment_status": "SUCCESS",
      "payment_error_code": ""
    }
  }'
```

Re-run step 3 and `status` will be `CHARGED`.

## Dependencies

- Depends on the connector-fix PR #1151 for the Cashfree connector transformer cleanup (not included here).
- This PR does not modify any connector Rust code.
- No credentials are committed. `testsuccess@gocash` is Cashfree's documented sandbox test VPA, not a real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)