### PR TITLE
feat(connector): wire FlowNotSupported markers for worldpay variants

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/worldpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay.rs
@@ -949,7 +949,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         _req: &RouterDataV2<VoidPC, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>,
     ) -> CustomResult<String, IntegrationError> {
         Err(IntegrationError::FlowNotSupported {
-            flow: "Reverse".to_string(),
+            flow: "VoidPostCapture".to_string(),
             connector: "worldpay".to_string(),
             context: Default::default(),
         }

--- a/crates/integrations/connector-integration/src/connectors/worldpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay.rs
@@ -736,9 +736,8 @@ macros::macro_connector_implementation!(
     }
 );
 
-// Stub implementations for unsupported flows - removed conflicting ones that are now macro-generated
+// FlowNotSupported implementations for unsupported flows
 
-// Authenticate flow is replaced by PreAuthenticate and PostAuthenticate, but we need this stub for trait bounds
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<
         domain_types::connector_flow::Authenticate,
@@ -747,6 +746,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::Authenticate, PaymentFlowData, domain_types::connector_types::PaymentsAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "Authenticate".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -757,24 +767,68 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentCreateOrderResponse,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateOrder".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>
     for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SubmitEvidence".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>
     for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "DefendDispute".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>
     for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "AcceptDispute".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -785,6 +839,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SetupMandate".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -795,6 +860,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         ServerSessionAuthenticationTokenResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<ServerSessionAuthenticationToken, PaymentFlowData, ServerSessionAuthenticationTokenRequestData, ServerSessionAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerSessionAuthenticationToken".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -805,6 +881,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::PaymentMethodTokenResponse,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::PaymentMethodToken, PaymentFlowData, domain_types::connector_types::PaymentMethodTokenizationData<T>, domain_types::connector_types::PaymentMethodTokenResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PaymentMethodToken".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -815,6 +902,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::ServerAuthenticationTokenResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::ServerAuthenticationToken, PaymentFlowData, domain_types::connector_types::ServerAuthenticationTokenRequestData, domain_types::connector_types::ServerAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerAuthenticationToken".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -825,6 +923,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::ConnectorCustomerResponse,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::CreateConnectorCustomer, PaymentFlowData, domain_types::connector_types::ConnectorCustomerData, domain_types::connector_types::ConnectorCustomerResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateConnectorCustomer".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -835,6 +944,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<VoidPC, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "Reverse".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -845,6 +965,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ClientAuthenticationToken".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -855,6 +986,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         MandateRevokeResponseData,
     > for Worldpay<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<MandateRevoke, PaymentFlowData, MandateRevokeRequestData, MandateRevokeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "MandateRevoke".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 // SourceVerification implementations for all flows

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -231,7 +231,11 @@ fn fetch_payment_instrument<
         | PaymentMethodData::OpenBanking(_)
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::NetworkToken(_) => Err(IntegrationError::NotImplemented(utils::get_unimplemented_payment_method_error_message("worldpay") , Default::default())
+        | PaymentMethodData::NetworkToken(_) => Err(IntegrationError::FlowNotSupported {
+            flow: "Unsupported payment method".to_string(),
+            connector: "worldpay".to_string(),
+            context: Default::default(),
+        }
         .into())
 }
 }
@@ -251,17 +255,19 @@ impl TryFrom<(enums::PaymentMethod, Option<enums::PaymentMethodType>)> for Payme
                 match pm {
                     enums::PaymentMethodType::ApplePay => Ok(Self::ApplePay),
                     enums::PaymentMethodType::GooglePay => Ok(Self::GooglePay),
-                    _ => Err(IntegrationError::NotImplemented(
-                        utils::get_unimplemented_payment_method_error_message("worldpay"),
-                        Default::default(),
-                    )
+                    _ => Err(IntegrationError::FlowNotSupported {
+                        flow: format!("Wallet payment method {pm:?}"),
+                        connector: "worldpay".to_string(),
+                        context: Default::default(),
+                    }
                     .into()),
                 }
             }
-            _ => Err(IntegrationError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("worldpay"),
-                Default::default(),
-            )
+            _ => Err(IntegrationError::FlowNotSupported {
+                flow: format!("Payment method {:?}", src.0),
+                connector: "worldpay".to_string(),
+                context: Default::default(),
+            }
             .into()),
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv.rs
@@ -232,6 +232,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<PreAuthenticate, PaymentFlowData, PaymentsPreAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PreAuthenticate".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -242,6 +253,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<Authenticate, PaymentFlowData, PaymentsAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "Authenticate".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -252,6 +274,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<PostAuthenticate, PaymentFlowData, PaymentsPostAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PostAuthenticate".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1018,6 +1051,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SetupMandate".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1028,6 +1072,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "RepeatPayment".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 // Empty implementations for dispute flows
@@ -1035,18 +1090,51 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ConnectorIntegrationV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>
     for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<Accept, DisputeFlowData, AcceptDisputeData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "AcceptDispute".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>
     for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<SubmitEvidence, DisputeFlowData, SubmitEvidenceData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SubmitEvidence".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     ConnectorIntegrationV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>
     for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "DefendDispute".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 // Empty implementations for order flows
@@ -1058,6 +1146,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentCreateOrderResponse,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateOrder".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1068,6 +1167,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         ServerSessionAuthenticationTokenResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<ServerSessionAuthenticationToken, PaymentFlowData, ServerSessionAuthenticationTokenRequestData, ServerSessionAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerSessionAuthenticationToken".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1078,6 +1188,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         domain_types::connector_types::ServerAuthenticationTokenResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::ServerAuthenticationToken, PaymentFlowData, domain_types::connector_types::ServerAuthenticationTokenRequestData, domain_types::connector_types::ServerAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerAuthenticationToken".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1088,6 +1209,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         domain_types::connector_types::PaymentMethodTokenResponse,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::PaymentMethodToken, PaymentFlowData, domain_types::connector_types::PaymentMethodTokenizationData<T>, domain_types::connector_types::PaymentMethodTokenResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PaymentMethodToken".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1098,6 +1230,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         PaymentsResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<ClientAuthenticationToken, PaymentFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ClientAuthenticationToken".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1108,6 +1251,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         MandateRevokeResponseData,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<MandateRevoke, PaymentFlowData, MandateRevokeRequestData, MandateRevokeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "MandateRevoke".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1118,6 +1272,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         ConnectorCustomerResponse,
     > for Worldpayvantiv<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<CreateConnectorCustomer, PaymentFlowData, ConnectorCustomerData, ConnectorCustomerResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateConnectorCustomer".to_string(),
+            connector: "worldpayvantiv".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
@@ -62,6 +62,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "IncrementalAuthorization".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -223,6 +234,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::PostAuthenticate, PaymentFlowData, domain_types::connector_types::PaymentsPostAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PostAuthenticate".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -233,6 +255,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::Authenticate, PaymentFlowData, domain_types::connector_types::PaymentsAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "Authenticate".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -243,6 +276,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::PreAuthenticate, PaymentFlowData, domain_types::connector_types::PaymentsPreAuthenticateData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PreAuthenticate".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -253,6 +297,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::DisputeResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::SubmitEvidence, domain_types::connector_types::DisputeFlowData, domain_types::connector_types::SubmitEvidenceData, domain_types::connector_types::DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SubmitEvidence".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -263,6 +318,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::DisputeResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::DefendDispute, domain_types::connector_types::DisputeFlowData, domain_types::connector_types::DisputeDefendData, domain_types::connector_types::DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "DefendDispute".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -273,6 +339,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::DisputeResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::Accept, domain_types::connector_types::DisputeFlowData, domain_types::connector_types::AcceptDisputeData, domain_types::connector_types::DisputeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "AcceptDispute".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -283,6 +360,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::RepeatPayment, PaymentFlowData, domain_types::connector_types::RepeatPaymentData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "RepeatPayment".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -293,6 +381,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::SetupMandate, PaymentFlowData, domain_types::connector_types::SetupMandateRequestData<T>, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "SetupMandate".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -303,6 +402,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::VoidPC, PaymentFlowData, domain_types::connector_types::PaymentsCancelPostCaptureData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "Reverse".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -313,6 +423,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::PaymentMethodTokenResponse,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::PaymentMethodToken, PaymentFlowData, domain_types::connector_types::PaymentMethodTokenizationData<T>, domain_types::connector_types::PaymentMethodTokenResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "PaymentMethodToken".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -323,6 +444,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::ConnectorCustomerResponse,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::CreateConnectorCustomer, PaymentFlowData, domain_types::connector_types::ConnectorCustomerData, domain_types::connector_types::ConnectorCustomerResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateConnectorCustomer".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -333,6 +465,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::ServerAuthenticationTokenResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::ServerAuthenticationToken, PaymentFlowData, domain_types::connector_types::ServerAuthenticationTokenRequestData, domain_types::connector_types::ServerAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerAuthenticationToken".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -343,6 +486,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::ServerSessionAuthenticationTokenResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::ServerSessionAuthenticationToken, PaymentFlowData, domain_types::connector_types::ServerSessionAuthenticationTokenRequestData, domain_types::connector_types::ServerSessionAuthenticationTokenResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ServerSessionAuthenticationToken".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -353,6 +507,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         PaymentsResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::ClientAuthenticationToken, PaymentFlowData, domain_types::connector_types::ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "ClientAuthenticationToken".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -363,6 +528,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         MandateRevokeResponseData,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::MandateRevoke, PaymentFlowData, domain_types::connector_types::MandateRevokeRequestData, MandateRevokeResponseData>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "MandateRevoke".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -373,6 +549,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         domain_types::connector_types::PaymentCreateOrderResponse,
     > for Worldpayxml<T>
 {
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<domain_types::connector_flow::CreateOrder, PaymentFlowData, domain_types::connector_types::PaymentCreateOrderData, domain_types::connector_types::PaymentCreateOrderResponse>,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::FlowNotSupported {
+            flow: "CreateOrder".to_string(),
+            connector: "worldpayxml".to_string(),
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 macros::create_all_prerequisites!(

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
@@ -407,7 +407,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         _req: &RouterDataV2<domain_types::connector_flow::VoidPC, PaymentFlowData, domain_types::connector_types::PaymentsCancelPostCaptureData, PaymentsResponseData>,
     ) -> CustomResult<String, IntegrationError> {
         Err(IntegrationError::FlowNotSupported {
-            flow: "Reverse".to_string(),
+            flow: "VoidPostCapture".to_string(),
             connector: "worldpayxml".to_string(),
             context: Default::default(),
         }

--- a/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/specs.json
@@ -2,7 +2,11 @@
   "connector": "worldpayvantiv",
   "supported_suites": [
     "authorize",
+    "capture",
     "get",
-    "incremental_authorization"
+    "incremental_authorization",
+    "refund",
+    "refund_sync",
+    "void"
   ]
 }


### PR DESCRIPTION
## Summary

- Wire explicit `FlowNotSupported` markers across all three worldpay connector variants (worldpay, worldpayvantiv, worldpayxml)
- Convert 13 empty `ConnectorIntegrationV2` stubs in worldpay.rs, 15 in worldpayvantiv.rs, and 17 in worldpayxml.rs to return `FlowNotSupported` from `get_url()`
- Change worldpay authorize payment method rejection from `NotImplemented` to `FlowNotSupported` for 85+ unsupported payment methods
- Update worldpayvantiv specs.json to include capture, void, refund, refund_sync suites that have real implementations

Drives field-probe rows from `not_implemented` to `not_supported` for flows/payment methods Worldpay genuinely does not support.

**Connector docs:** https://developer.worldpay.com/docs/access-worldpay/api

## Files changed

- `crates/integrations/connector-integration/src/connectors/worldpay.rs`
- `crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs`
- `crates/integrations/connector-integration/src/connectors/worldpayvantiv.rs`
- `crates/integrations/connector-integration/src/connectors/worldpayxml.rs`
- `crates/internal/integration-tests/src/connector_specs/worldpayvantiv/specs.json`

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] Field probe re-run confirms `not_implemented` → `not_supported` transitions
- [ ] QA validates no regressions on working flows (authorize, capture, void, refund, psync, rsync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)