### PR TITLE
refactor(connector): ppro webhooks fix.

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/ppro.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro.rs
@@ -473,7 +473,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 charge.payment_charge_id.clone(),
             )),
             status,
-            connector_response_reference_id: Some(charge.payment_charge_id),
+            connector_response_reference_id: charge
+                .merchant_payment_charge_reference
+                .or(Some(charge.payment_charge_id)),
             error_code,
             error_message,
             error_reason,

--- a/crates/integrations/connector-integration/src/connectors/ppro.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro.rs
@@ -474,8 +474,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             )),
             status,
             connector_response_reference_id: charge
-                .merchant_payment_charge_reference
-                .or(Some(charge.payment_charge_id)),
+                .merchant_payment_charge_reference,
             error_code,
             error_message,
             error_reason,

--- a/crates/integrations/connector-integration/src/connectors/ppro.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro.rs
@@ -473,8 +473,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 charge.payment_charge_id.clone(),
             )),
             status,
-            connector_response_reference_id: charge
-                .merchant_payment_charge_reference,
+            connector_response_reference_id: charge.merchant_payment_charge_reference,
             error_code,
             error_message,
             error_reason,

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -684,6 +684,8 @@ pub struct PproWebhookChargeData {
     pub payment_charge_id: String,
     pub payment_charge_status: PproPaymentStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant_payment_charge_reference: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<PproFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refund_id: Option<String>,


### PR DESCRIPTION
## Description
Added the merchant_payment_charge_reference field to the PproWebhookChargeData struct in transformers.rs and updated the webhook processing logic in ppro.rs to use this field as the connector_response_reference_id when present. This ensures the correct merchant transaction ID is returned in webhook responses.

## Motivation and Context
Previously, the webhook response was returning the connector’s internal charge ID instead of the actual merchant transaction ID, making it difficult for upstream systems to correlate events. This change fixes that by correctly mapping and returning the merchant’s reference.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

