### PR TITLE
fix(cashfree): align PSync URL builder with Razorpay's connector_order_id pattern

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cashfree.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree.rs
@@ -413,13 +413,18 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<PSync, PaymentFlowData, PaymentsSyncData, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            // Cashfree PSync URL uses the merchant order_id, not cf_payment_id.
-            // Try reference_id (connector_order_reference_id from gRPC) first,
-            // then connector_request_reference_id (merchant_transaction_id).
+            // Cashfree PSync URL is keyed by the merchant order id, not by
+            // cf_payment_id. Match Razorpay's pattern (`razorpay.rs:582`) by
+            // preferring `connector_order_id` — the proto-level slot for an
+            // order id carried over from CreateOrder/Authorize — and only
+            // falling back to the legacy `reference_id` /
+            // `connector_request_reference_id` paths for callers that haven't
+            // populated it.
             let order_id = req
                 .resource_common_data
-                .reference_id
+                .connector_order_id
                 .as_ref()
+                .or(req.resource_common_data.reference_id.as_ref())
                 .unwrap_or(&req.resource_common_data.connector_request_reference_id);
             let base_url = self.connector_base_url(req);
             Ok(format!("{base_url}pg/orders/{order_id}/payments"))


### PR DESCRIPTION
## Summary

Cashfree's PSync URL is keyed by the merchant order id (`pg/orders/{order_id}/payments`), not by `cf_payment_id`. The current code reads that order id from `resource_common_data.reference_id`, which is populated indirectly via the sync request's `connector_order_reference_id` proto field. This forces every caller (including the integration tests) to inject `connector_order_reference_id` just so cashfree's URL builder can find the value, even though the identifier is conceptually a `connector_order_id`.

Razorpay handles the same situation in `razorpay.rs:582` by reading `resource_common_data.connector_order_id` directly. This PR brings cashfree's PSync URL builder in line with that pattern.

## Change

Single file: `crates/integrations/connector-integration/src/connectors/cashfree.rs`.

Sync URL fallback chain becomes:

1. `req.resource_common_data.connector_order_id` — preferred. Same field razorpay reads. Propagated by the standard authorize-suite context_map (`connector_order_id: res.connectorOrderId`) so this is the natural slot.
2. `req.resource_common_data.reference_id` — kept for callers that still populate `connector_order_reference_id` on the sync request.
3. `req.resource_common_data.connector_request_reference_id` — last-resort header echo (unchanged).

No proto changes. No struct changes. No other connectors touched.

## Why this matters

Reviewer feedback on PR #1161 flagged that the test-side per-connector context_map machinery only existed because cashfree was forcing tests to populate `connector_order_reference_id`. After this change, cashfree's PSync naturally reads `connector_order_id`, which is the field already wired through the authorize-suite's standard context_map from CreateOrder's response. The test-side override on PR #1161 can then be simplified in a follow-up.

## Test plan

- [x] `cargo build -p grpc-server --bin grpc-server` — clean.
- [ ] Run cashfree UPI authorize + sync end-to-end and confirm sync still reaches the same `pg/orders/{order_id}/payments` URL.
- [ ] Confirm no behavioural regression for existing callers that populate `connector_order_reference_id` (the second fallback preserves their path).