### PR TITLE
fix(events): stringify post-transformation CKH field names

### DIFF
--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -530,7 +530,7 @@ pub(crate) fn process_event_with_config(
     }
 
     // Stringify JSON object fields that CKH expects as String columns
-    for field in &["request_data", "response_data", "error"] {
+    for field in &["request", "masked_response", "error"] {
         if let Some(obj) = result.as_object_mut() {
             if let Some(val) = obj.get(*field) {
                 if val.is_object() || val.is_array() {


### PR DESCRIPTION
Stringify block was targeting UCS internal field names (request_data, response_data) but transformations rename these to CKH column names (request, masked_response) before stringify runs. Fix targets the correct post-transformation field names so CKH String columns receive stringified JSON instead of objects.

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
