### PR TITLE
fix(connector): add Auth-Token-Type HMAC header for authipay authorize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/authipay.rs
@@ -54,6 +54,7 @@ pub(crate) mod headers {
     pub(crate) const CONTENT_TYPE: &str = "Content-Type";
     pub(crate) const API_KEY: &str = "Api-Key";
     pub(crate) const CLIENT_REQUEST_ID: &str = "Client-Request-Id";
+    pub(crate) const AUTH_TOKEN_TYPE: &str = "Auth-Token-Type";
     pub(crate) const TIMESTAMP: &str = "Timestamp";
     pub(crate) const MESSAGE_SIGNATURE: &str = "Message-Signature";
 }
@@ -307,6 +308,10 @@ macros::create_all_prerequisites!(
                 (
                     headers::CLIENT_REQUEST_ID.to_string(),
                     client_request_id.into(),
+                ),
+                (
+                    headers::AUTH_TOKEN_TYPE.to_string(),
+                    "HMAC".to_string().into(),
                 ),
                 (headers::TIMESTAMP.to_string(), timestamp.into()),
                 (

--- a/data/field_probe/authipay.json
+++ b/data/field_probe/authipay.json
@@ -124,6 +124,7 @@
           "method": "Post",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -498,6 +499,7 @@
           "method": "Post",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -574,6 +576,7 @@
           "method": "Get",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -637,6 +640,7 @@
           "method": "Post",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -680,6 +684,7 @@
           "method": "Post",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -703,6 +708,7 @@
           "method": "Get",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
@@ -756,6 +762,7 @@
           "method": "Post",
           "headers": {
             "api-key": "probe_key",
+            "auth-token-type": "HMAC",
             "client-request-id": "00000000-0000-0000-0000-000000000000",
             "content-type": "application/json",
             "message-signature": "cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",


### PR DESCRIPTION
## Summary
Add the missing `Auth-Token-Type: HMAC` header to prism's authipay connector to match hyperswitch oracle behavior.

## Linked PRD
Closes https://github.com/juspay/hyperswitch-cloud/issues/15723 (PRD-2)

## Understanding Summary

- **Connector:** authipay
- **Flow:** authorize (all flows affected via shared `build_headers_with_signature`)
- **Field path:** `header.auth-token-type`
- **Root cause:** missing-field — header present in oracle, absent in prism

**Oracle:** `build_headers` in hyperswitch's `authipay.rs:L136` explicitly includes `("Auth-Token-Type", "HMAC")` in the headers vec.

**Prism:** `build_headers_with_signature` in prism's `authipay.rs:L298-316` returns 5 headers but omits `Auth-Token-Type`. The header was never included when the connector was implemented.

## Implementation Plan

### Change 1: Add header constant (L57)
Added `pub(crate) const AUTH_TOKEN_TYPE: &str = "Auth-Token-Type"` to the `headers` module for consistency with the existing constants pattern.

### Change 2: Add header to vec (L312-315)
Added `(headers::AUTH_TOKEN_TYPE.to_string(), "HMAC".to_string().into())` to the headers vec after `Client-Request-Id` to match oracle ordering.

## Build Tail
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 45.88s
```

## Clippy Tail
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 11s
```
No clippy warnings.

## Test Results
- authipay-specific tests: 0 passed, 0 failed (no authipay unit tests exist)
- 14 pre-existing doc test failures in unrelated connectors (barclaycard, billwerk, bluesnap, etc.) — none related to authipay

## Acceptance Criteria
- [x] Build passes (`cargo build -p connector-integration`)
- [x] Clippy passes (`cargo clippy -p connector-integration -- -D warnings`)
- [x] Tests pass (no authipay-specific test regressions)
- [ ] Shadow-replay produces zero diff for `header.auth-token-type` (CTO gate)