### PR TITLE
parity(authipay/authorize): remove extra body fields

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
@@ -144,9 +144,7 @@ pub enum AuthipayRequestType {
 #[serde(rename_all = "camelCase")]
 pub struct AuthipayPaymentsRequest<T: PaymentMethodDataTypes> {
     pub request_type: AuthipayRequestType,
-    pub merchant_transaction_id: String,
     pub transaction_amount: TransactionAmount,
-    pub order: OrderDetails,
     pub payment_method: PaymentMethod<T>,
 }
 
@@ -154,12 +152,6 @@ pub struct AuthipayPaymentsRequest<T: PaymentMethodDataTypes> {
 pub struct TransactionAmount {
     pub total: FloatMajorUnit,
     pub currency: common_enums::Currency,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderDetails {
-    pub order_id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -174,8 +166,6 @@ pub struct PaymentCard<T: PaymentMethodDataTypes> {
     pub number: RawCardNumber<T>,
     pub expiry_date: ExpiryDate,
     pub security_code: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub holder: Option<Secret<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -228,7 +218,6 @@ impl<T: PaymentMethodDataTypes>
                         year: year_yy,
                     },
                     security_code: Some(card_data.card_cvc.clone()),
-                    holder: item.request.customer_name.clone().map(Secret::new),
                 };
                 PaymentMethod { payment_card }
             }
@@ -247,31 +236,16 @@ impl<T: PaymentMethodDataTypes>
             .map(|cm| matches!(cm, common_enums::CaptureMethod::Manual))
             .unwrap_or(false);
 
-        // Generate unique merchant transaction ID using connector request reference ID
-        let merchant_transaction_id = item
-            .resource_common_data
-            .connector_request_reference_id
-            .clone();
-
-        // Create order details with same ID
-        let order = OrderDetails {
-            order_id: merchant_transaction_id.clone(),
-        };
-
         if is_manual_capture {
             Ok(Self {
                 request_type: AuthipayRequestType::PaymentCardPreAuthTransaction,
-                merchant_transaction_id,
                 transaction_amount,
-                order,
                 payment_method,
             })
         } else {
             Ok(Self {
                 request_type: AuthipayRequestType::PaymentCardSaleTransaction,
-                merchant_transaction_id,
                 transaction_amount,
-                order,
                 payment_method,
             })
         }

--- a/data/field_probe/authipay.json
+++ b/data/field_probe/authipay.json
@@ -130,7 +130,7 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"requestType\":\"PaymentCardSaleTransaction\",\"merchantTransactionId\":\"probe_txn_001\",\"transactionAmount\":{\"total\":10.0,\"currency\":\"USD\"},\"order\":{\"orderId\":\"probe_txn_001\"},\"paymentMethod\":{\"paymentCard\":{\"number\":\"4111111111111111\",\"expiryDate\":{\"month\":\"03\",\"year\":\"30\"},\"securityCode\":\"737\"}}}"
+          "body": "{\"requestType\":\"PaymentCardSaleTransaction\",\"transactionAmount\":{\"total\":10.0,\"currency\":\"USD\"},\"paymentMethod\":{\"paymentCard\":{\"number\":\"4111111111111111\",\"expiryDate\":{\"month\":\"03\",\"year\":\"30\"},\"securityCode\":\"737\"}}}"
         }
       },
       "CashappQr": {
@@ -643,7 +643,7 @@
             "timestamp": "0000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"requestType\":\"PaymentCardSaleTransaction\",\"merchantTransactionId\":\"probe_proxy_txn_001\",\"transactionAmount\":{\"total\":10.0,\"currency\":\"USD\"},\"order\":{\"orderId\":\"probe_proxy_txn_001\"},\"paymentMethod\":{\"paymentCard\":{\"number\":\"4111111111111111\",\"expiryDate\":{\"month\":\"03\",\"year\":\"30\"},\"securityCode\":\"123\"}}}"
+          "body": "{\"requestType\":\"PaymentCardSaleTransaction\",\"transactionAmount\":{\"total\":10.0,\"currency\":\"USD\"},\"paymentMethod\":{\"paymentCard\":{\"number\":\"4111111111111111\",\"expiryDate\":{\"month\":\"03\",\"year\":\"30\"},\"securityCode\":\"123\"}}}"
         }
       }
     },


### PR DESCRIPTION
## Summary

Remove three extra body fields (`merchantTransactionId`, `order`, `paymentMethod.paymentCard.holder`) from prism's authipay Authorize request that the hyperswitch oracle never sends.

## Linked PRD

Closes https://github.com/juspay/hyperswitch-cloud/issues/15723 (PRD-1 / PRD-B)

## Understanding Summary

- **Connector:** authipay | **Flow:** authorize
- **Root cause:** Prism's authipay connector was scaffolded from the fiservemea template, which includes `merchantTransactionId`, `order`, and `holder`. Hyperswitch's oracle has none of these fields.
- **Oracle struct** (`AuthipayPaymentsRequest`): only `request_type`, `transaction_amount`, `payment_method`
- **Oracle `Card` struct**: only `number`, `security_code`, `expiry_date` — no `holder`
- **Collateral:** none — these structs are only used in the Authorize flow

## Implementation Plan

### Changes (1 file, 26 deletions)

1. **`AuthipayPaymentsRequest`** — removed `merchant_transaction_id: String` and `order: OrderDetails` fields
2. **`OrderDetails` struct** — removed entirely (only referenced by `AuthipayPaymentsRequest`)
3. **`PaymentCard`** — removed `holder: Option<Secret<String>>` field and its `skip_serializing_if` attribute
4. **TryFrom impl** — removed `holder` binding, `merchant_transaction_id` binding, `order` binding, and their references in both struct-construction arms

## Build Tail

```
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Clippy Tail

```
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Test Results

No authipay-specific tests exist. All pre-existing test failures are in unrelated connectors (doctest compilation errors in barclaycard, billwerk, etc.).

## Acceptance Criteria

- [x] Build passes (`cargo build -p connector-integration`)
- [x] Clippy passes (`cargo clippy -p connector-integration -- -D warnings`)
- [x] Tests pass (no authipay tests exist; pre-existing failures are unrelated)
- [ ] Shadow-replay produces zero diff for `merchantTransactionId`, `order`, `paymentMethod.paymentCard.holder` (CTO gate)