### PR TITLE
feat(server): add config toggle for raw connector request/response storage

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -1,5 +1,7 @@
 [common]
 environment = "development"
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = false
 
 [log.console]
 enabled = true
@@ -41,9 +43,6 @@ mock_server_url = "http://localhost:3000/mockGateway"
 #
 [api_tags.tags]
 psync = "GW_TXN_SYNC"
-
-# Whether to return raw connector request/response in the response (default: true)
-return_raw_connector_data = true
 
 # Connectors that require an external API call for webhook source verification
 [webhook_source_verification_call] # comma-separated list of connector names (case-insensitive)

--- a/config/development.toml
+++ b/config/development.toml
@@ -42,6 +42,9 @@ mock_server_url = "http://localhost:3000/mockGateway"
 [api_tags.tags]
 psync = "GW_TXN_SYNC"
 
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = true
+
 # Connectors that require an external API call for webhook source verification
 [webhook_source_verification_call] # comma-separated list of connector names (case-insensitive)
 connectors_with_webhook_source_verification_call = "paypal, truelayer "

--- a/config/production.toml
+++ b/config/production.toml
@@ -20,6 +20,9 @@ idle_pool_connection_timeout = 90               # Timeout for idle pool connecti
 bypass_proxy_urls = ["localhost", "local"]
 mitm_proxy_enabled = false
 
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = true
+
 [connectors]
 peachpayments.base_url = "https://api.bankint.peachpayments.com/v/1"
 finix.base_url = "https://finix.live-payments-api.com"

--- a/config/production.toml
+++ b/config/production.toml
@@ -1,5 +1,7 @@
 [common]
 environment = "production"
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = true
 
 [log.console]
 enabled = true
@@ -19,9 +21,6 @@ port = 8080
 idle_pool_connection_timeout = 90               # Timeout for idle pool connections (defaults to 90s)
 bypass_proxy_urls = ["localhost", "local"]
 mitm_proxy_enabled = false
-
-# Whether to return raw connector request/response in the response (default: true)
-return_raw_connector_data = true
 
 [connectors]
 peachpayments.base_url = "https://api.bankint.peachpayments.com/v/1"

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -1,5 +1,7 @@
 [common]
 environment = "sandbox"
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = true
 
 [log.console]
 enabled = true
@@ -19,9 +21,6 @@ port = 8080
 idle_pool_connection_timeout = 90               # Timeout for idle pool connections (defaults to 90s)
 bypass_proxy_urls = ["localhost", "local"]
 mitm_proxy_enabled = false
-
-# Whether to return raw connector request/response in the response (default: true)
-return_raw_connector_data = true
 
 [connectors]
 peachpayments.base_url = "https://apitest.bankint.ppay.io/v/1"

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -20,6 +20,9 @@ idle_pool_connection_timeout = 90               # Timeout for idle pool connecti
 bypass_proxy_urls = ["localhost", "local"]
 mitm_proxy_enabled = false
 
+# Whether to return raw connector request/response in the response (default: true)
+return_raw_connector_data = true
+
 [connectors]
 peachpayments.base_url = "https://apitest.bankint.ppay.io/v/1"
 finix.base_url = "https://finix.sandbox-payments-api.com"

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -162,7 +162,7 @@ where
     Resp: Clone + 'static + std::fmt::Debug,
     ResourceCommonData: Clone + RawConnectorRequestResponse + ConnectorResponseHeaders,
 {
-    let return_raw = event_params.map_or(true, |p| p.return_raw_connector_data);
+    let return_raw = event_params.is_none_or(|p| p.return_raw_connector_data);
     match response {
         Ok(body) => {
             let response = match body {

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -162,6 +162,7 @@ where
     Resp: Clone + 'static + std::fmt::Debug,
     ResourceCommonData: Clone + RawConnectorRequestResponse + ConnectorResponseHeaders,
 {
+    let return_raw = event_params.map_or(true, |p| p.return_raw_connector_data);
     match response {
         Ok(body) => {
             let response = match body {
@@ -170,7 +171,7 @@ where
                     tracing::Span::current()
                         .record("status_code", tracing::field::display(status_code));
 
-                    if all_keys_required.unwrap_or(true) {
+                    if all_keys_required.unwrap_or(true) && return_raw {
                         let raw_response_string = strip_bom_and_convert_to_string(&body.response);
                         updated_router_data
                             .resource_common_data
@@ -217,7 +218,7 @@ where
                             .inc();
                     }
 
-                    if all_keys_required.unwrap_or(true) {
+                    if all_keys_required.unwrap_or(true) && return_raw {
                         let raw_response_string = strip_bom_and_convert_to_string(&body.response);
                         updated_router_data
                             .resource_common_data
@@ -289,6 +290,7 @@ pub struct EventProcessingParams<'a> {
     pub resource_id: &'a Option<String>,
     pub shadow_mode: bool,
     pub tenant_id: &'a str,
+    pub return_raw_connector_data: bool,
 }
 
 #[cfg(feature = "injector-client")]
@@ -355,7 +357,7 @@ where
 
             let mut updated_router_data = router_data.clone();
             updated_router_data = match &connector_request {
-                Some(request) => {
+                Some(request) if event_params.return_raw_connector_data => {
                     updated_router_data
                         .resource_common_data
                         .set_raw_connector_request(Some(
@@ -363,7 +365,7 @@ where
                         ));
                     updated_router_data
                 }
-                None => updated_router_data,
+                _ => updated_router_data,
             };
             connector_request = connector_request.map(|mut req| {
                 if event_params.shadow_mode {

--- a/crates/common/ucs_env/src/configs.rs
+++ b/crates/common/ucs_env/src/configs.rs
@@ -42,6 +42,8 @@ pub struct Config {
     pub webhook_source_verification_call: WebhookSourceVerificationCall,
     #[serde(default)]
     pub connector_request_kafka: ConnectorRequestKafkaConfig,
+    #[serde(default = "default_true")]
+    pub return_raw_connector_data: bool,
     /// Superposition configuration for connector URL resolution
     /// This is loaded at startup from config/superposition.toml
     #[serde(skip)]
@@ -67,6 +69,10 @@ fn default_lineage_header() -> String {
 
 fn default_lineage_prefix() -> String {
     consts::LINEAGE_FIELD_PREFIX.to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Test mode configuration for mock server integration

--- a/crates/common/ucs_env/src/configs.rs
+++ b/crates/common/ucs_env/src/configs.rs
@@ -42,8 +42,6 @@ pub struct Config {
     pub webhook_source_verification_call: WebhookSourceVerificationCall,
     #[serde(default)]
     pub connector_request_kafka: ConnectorRequestKafkaConfig,
-    #[serde(default = "default_true")]
-    pub return_raw_connector_data: bool,
     /// Superposition configuration for connector URL resolution
     /// This is loaded at startup from config/superposition.toml
     #[serde(skip)]
@@ -174,19 +172,22 @@ impl ApiTagConfig {
 #[derive(Clone, Deserialize, Debug, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct Common {
     pub environment: consts::Env,
+    #[serde(default = "default_true")]
+    pub return_raw_connector_data: bool,
 }
 
 impl Default for Common {
     fn default() -> Self {
         Self {
             environment: consts::Env::Development,
+            return_raw_connector_data: true,
         }
     }
 }
 
 impl Common {
     pub fn validate(&self) -> Result<(), config::ConfigError> {
-        let Self { environment } = self;
+        let environment = &self.environment;
         match environment {
             consts::Env::Development | consts::Env::Production | consts::Env::Sandbox => Ok(()),
         }

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -160,7 +160,7 @@ impl DisputeService for Disputes {
                         resource_id: &resource_id,
                         shadow_mode,
                         tenant_id: &tenant_id,
-                        return_raw_connector_data: config.return_raw_connector_data,
+                        return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
                     let response = Box::pin(
@@ -381,7 +381,7 @@ impl DisputeService for Disputes {
                         resource_id: &resource_id,
                         shadow_mode,
                         tenant_id: &tenant_id,
-                        return_raw_connector_data: config.return_raw_connector_data,
+                        return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -160,6 +160,7 @@ impl DisputeService for Disputes {
                         resource_id: &resource_id,
                         shadow_mode,
                         tenant_id: &tenant_id,
+                        return_raw_connector_data: config.return_raw_connector_data,
                     };
 
                     let response = Box::pin(
@@ -380,6 +381,7 @@ impl DisputeService for Disputes {
                         resource_id: &resource_id,
                         shadow_mode,
                         tenant_id: &tenant_id,
+                        return_raw_connector_data: config.return_raw_connector_data,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -298,6 +298,7 @@ async fn verify_webhook_source_external(
         resource_id: &metadata_payload.resource_id,
         shadow_mode: metadata_payload.shadow_mode,
         tenant_id: &metadata_payload.tenant_id,
+        return_raw_connector_data: config.return_raw_connector_data,
     };
 
     match Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -298,7 +298,7 @@ async fn verify_webhook_source_external(
         resource_id: &metadata_payload.resource_id,
         shadow_mode: metadata_payload.shadow_mode,
         tenant_id: &metadata_payload.tenant_id,
-        return_raw_connector_data: config.return_raw_connector_data,
+        return_raw_connector_data: config.common.return_raw_connector_data,
     };
 
     match Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -419,6 +419,7 @@ impl CustomerService for Customer {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
+                        return_raw_connector_data: config.return_raw_connector_data,
                     };
 
                     let response = Box::pin(
@@ -546,6 +547,7 @@ impl Payments {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
+            return_raw_connector_data: config.return_raw_connector_data,
         };
 
         // Execute connector processing - ONLY the authorize call
@@ -665,6 +667,7 @@ impl Payments {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
+            return_raw_connector_data: config.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -1049,6 +1052,7 @@ impl PaymentService for Payments {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
+                        return_raw_connector_data: config.return_raw_connector_data,
                     };
 
                     // handle_response field removed from proto (field 5 reserved)
@@ -2176,6 +2180,7 @@ impl PaymentMethod {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
+            return_raw_connector_data: config.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -2283,6 +2288,7 @@ impl MerchantAuthentication {
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
             tenant_id: event_params.tenant_id,
+            return_raw_connector_data: config.return_raw_connector_data,
         };
 
         // Execute connector processing
@@ -2396,6 +2402,7 @@ impl MerchantAuthentication {
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
             tenant_id: event_params.tenant_id,
+            return_raw_connector_data: config.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -2871,6 +2878,7 @@ impl RecurringPaymentService for RecurringPayments {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
+                        return_raw_connector_data: config.return_raw_connector_data,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -419,7 +419,7 @@ impl CustomerService for Customer {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
-                        return_raw_connector_data: config.return_raw_connector_data,
+                        return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
                     let response = Box::pin(
@@ -547,7 +547,7 @@ impl Payments {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
-            return_raw_connector_data: config.return_raw_connector_data,
+            return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
         // Execute connector processing - ONLY the authorize call
@@ -667,7 +667,7 @@ impl Payments {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
-            return_raw_connector_data: config.return_raw_connector_data,
+            return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -1052,7 +1052,7 @@ impl PaymentService for Payments {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
-                        return_raw_connector_data: config.return_raw_connector_data,
+                        return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
                     // handle_response field removed from proto (field 5 reserved)
@@ -2180,7 +2180,7 @@ impl PaymentMethod {
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
             tenant_id: &metadata_payload.tenant_id,
-            return_raw_connector_data: config.return_raw_connector_data,
+            return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -2288,7 +2288,7 @@ impl MerchantAuthentication {
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
             tenant_id: event_params.tenant_id,
-            return_raw_connector_data: config.return_raw_connector_data,
+            return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
         // Execute connector processing
@@ -2402,7 +2402,7 @@ impl MerchantAuthentication {
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
             tenant_id: event_params.tenant_id,
-            return_raw_connector_data: config.return_raw_connector_data,
+            return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
         let response = Box::pin(
@@ -2878,7 +2878,7 @@ impl RecurringPaymentService for RecurringPayments {
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
                         tenant_id: &metadata_payload.tenant_id,
-                        return_raw_connector_data: config.return_raw_connector_data,
+                        return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -556,7 +556,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
-                return_raw_connector_data: config.return_raw_connector_data,
+                return_raw_connector_data: config.common.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -685,7 +685,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
-                return_raw_connector_data: config.return_raw_connector_data,
+                return_raw_connector_data: config.common.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -810,7 +810,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
-                return_raw_connector_data: config.return_raw_connector_data,
+                return_raw_connector_data: config.common.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -556,6 +556,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
+                return_raw_connector_data: config.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -684,6 +685,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
+                return_raw_connector_data: config.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,
@@ -808,6 +810,7 @@ macro_rules! implement_connector_operation {
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
                 tenant_id: &metadata_payload.tenant_id,
+                return_raw_connector_data: config.return_raw_connector_data,
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,


### PR DESCRIPTION
## Description

Adds a `return_raw_connector_data` config flag (default: `true`) that controls whether `raw_connector_request` and `raw_connector_response` are populated and returned in the response.

When set to `false`, both fields are omitted — useful for environments where returning raw gateway payloads is undesirable.

## Motivation and Context

Euler http has no use case of using raw_connector_data, but the sensitive data in http response is getting flagged 

### Additional Changes
- [x] This PR modifies application configuration/environment variables

Config key added to `development.toml`, `sandbox.toml`, and `production.toml`:
```toml
return_raw_connector_data = true  # set to false to disable
```

## How did you test it?

tested with config as false through http server, and didnt get raw_connector_req or raw_connector_res
<img width="1161" height="420" alt="image" src="https://github.com/user-attachments/assets/113cf99e-8bc3-4c03-8ac6-895350265a8a" />
