### PR TITLE
feat(connector): [AXISBANK] implement webhooks for axisbank

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/axisbank.rs
+++ b/crates/integrations/connector-integration/src/connectors/axisbank.rs
@@ -5,13 +5,19 @@ use self::transformers::{
     extract_merchant_identifiers_from_metadata, AxisbankAuthConfig, AxisbankPaymentsRequest,
     AxisbankPaymentsResponse, AxisbankRefundRequest, AxisbankRefundResponse,
     AxisbankRefundSyncRequest, AxisbankRefundSyncResponse, AxisbankSyncRequest,
-    AxisbankSyncResponse,
+    AxisbankSyncResponse, AxisbankWebhookTypeProbe,
 };
 use super::macros;
 use crate::types::ResponseRouterData;
 use common_enums as enums;
-use common_utils::{errors::CustomResult, events, ext_traits::BytesExt, types::StringMajorUnit};
-use domain_types::errors::{ConnectorError, IntegrationError, IntegrationErrorContext};
+use common_utils::{
+    errors::CustomResult,
+    events,
+    ext_traits::ByteSliceExt,
+    types::StringMajorUnit,
+};
+use domain_types::connector_types::EventType;
+use domain_types::errors::{ConnectorError, IntegrationError, IntegrationErrorContext, WebhookError};
 use domain_types::{
     connector_flow::{
         Accept, Authenticate, Authorize, Capture, ClientAuthenticationToken,
@@ -22,7 +28,8 @@ use domain_types::{
     },
     connector_types::{
         AcceptDisputeData, ClientAuthenticationTokenRequestData, ConnectorCustomerData,
-        ConnectorCustomerResponse, ConnectorSpecifications, DisputeDefendData, DisputeFlowData,
+        ConnectorCustomerResponse, ConnectorSpecifications, ConnectorWebhookSecrets,
+        DisputeDefendData, DisputeFlowData,
         DisputeResponseData, MandateRevokeRequestData, MandateRevokeResponseData,
         PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
         PaymentMethodTokenResponse, PaymentMethodTokenizationData, PaymentVoidData,
@@ -30,6 +37,7 @@ use domain_types::{
         PaymentsCaptureData, PaymentsIncrementalAuthorizationData, PaymentsPostAuthenticateData,
         PaymentsPreAuthenticateData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
         RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
+        RequestDetails, ResponseId, RefundWebhookDetailsResponse, WebhookDetailsResponse,
         ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
         ServerSessionAuthenticationTokenRequestData, ServerSessionAuthenticationTokenResponseData,
         SetupMandateRequestData, SubmitEvidenceData, VerifyWebhookSourceFlowData,
@@ -43,6 +51,7 @@ use domain_types::{
     types::Connectors,
 };
 use error_stack::ResultExt;
+use base64::Engine as _;
 use hyperswitch_masking::Maskable;
 use interfaces::{
     api::ConnectorCommon, connector_integration_v2::ConnectorIntegrationV2, connector_types,
@@ -50,6 +59,29 @@ use interfaces::{
 };
 use serde::Serialize;
 use tracing::error;
+
+/// Recursively sort all JSON object keys alphabetically.
+///
+/// Required for Axis Bank webhook signature verification: the spec states that
+/// the callback JSON body keys must be alphabetically sorted before signing.
+fn sort_json_keys_alphabetically(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut sorted: serde_json::Map<String, serde_json::Value> =
+                serde_json::Map::new();
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                sorted.insert(key.clone(), sort_json_keys_alphabetically(&map[key]));
+            }
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(sort_json_keys_alphabetically).collect())
+        }
+        other => other.clone(),
+    }
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     connector_types::ConnectorServiceTrait<T> for Axisbank<T>
@@ -192,6 +224,225 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     connector_types::IncomingWebhook for Axisbank<T>
 {
+    /// Extract the RSA-PSS-SHA256 signature from the `x-merchant-payload-signature` header.
+    fn get_webhook_source_verification_signature(
+        &self,
+        request: &RequestDetails,
+        _connector_webhook_secret: &ConnectorWebhookSecrets,
+    ) -> Result<Vec<u8>, error_stack::Report<WebhookError>> {
+        use crate::connectors::juspay_upi_stack::constants::X_MERCHANT_PAYLOAD_SIGNATURE;
+
+        let signature_b64 = request
+            .headers
+            .get(X_MERCHANT_PAYLOAD_SIGNATURE)
+            .ok_or(WebhookError::WebhookSignatureNotFound)
+            .attach_printable("Missing x-merchant-payload-signature header in Axis Bank callback")?;
+
+        base64::engine::general_purpose::STANDARD
+            .decode(signature_b64)
+            .or_else(|_| {
+                common_utils::consts::BASE64_ENGINE_URL_SAFE_NO_PAD.decode(signature_b64)
+            })
+            .change_context(WebhookError::WebhookSignatureNotFound)
+            .attach_printable("Failed to base64-decode Axis Bank webhook signature")
+    }
+
+    /// Construct the signing message: alphabetically-sorted JSON body bytes.
+    ///
+    /// Per Axis Bank spec, the callback signature is computed over the JSON body
+    /// with keys sorted alphabetically.
+    fn get_webhook_source_verification_message(
+        &self,
+        request: &RequestDetails,
+        _connector_webhook_secret: &ConnectorWebhookSecrets,
+    ) -> Result<Vec<u8>, error_stack::Report<WebhookError>> {
+        let body_value: serde_json::Value = serde_json::from_slice(&request.body)
+            .change_context(WebhookError::WebhookBodyDecodingFailed)
+            .attach_printable("Failed to parse Axis Bank webhook body as JSON")?;
+
+        // Sort JSON keys alphabetically (as required by Axis Bank spec)
+        let sorted_json = sort_json_keys_alphabetically(&body_value);
+
+        serde_json::to_vec(&sorted_json)
+            .change_context(WebhookError::WebhookBodyDecodingFailed)
+            .attach_printable("Failed to serialize sorted Axis Bank webhook body")
+    }
+
+    /// Verify the webhook signature using RSA-PSS-SHA256 and Juspay's public key.
+    fn verify_webhook_source(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        connector_account_details: Option<ConnectorSpecificConfig>,
+    ) -> Result<bool, error_stack::Report<WebhookError>> {
+        let connector_config = connector_account_details
+            .ok_or(WebhookError::WebhookVerificationSecretNotFound)
+            .attach_printable("Axis Bank connector_account_details missing for webhook verification")?;
+
+        let auth = AxisbankAuthConfig::try_from(&connector_config)
+            .change_context(WebhookError::WebhookSourceVerificationFailed)
+            .attach_printable("Failed to extract AxisbankAuthConfig for webhook verification")?;
+
+        let dummy_secret = ConnectorWebhookSecrets {
+            secret: Vec::new(),
+            additional_secret: None,
+        };
+
+        let signature = self.get_webhook_source_verification_signature(&request, &dummy_secret)?;
+        let message = self.get_webhook_source_verification_message(&request, &dummy_secret)?;
+
+        let signature_b64 =
+            common_utils::consts::BASE64_ENGINE_URL_SAFE_NO_PAD.encode(&signature);
+        let message_str = String::from_utf8_lossy(&message);
+        crate::connectors::juspay_upi_stack::crypto::verify_jws_signature_pss(
+            &signature_b64,
+            &message_str,
+            &auth.juspay_public_key,
+        )
+        .change_context(WebhookError::WebhookSourceVerificationFailed)
+        .attach_printable("RSA-PSS-SHA256 verification failed for Axis Bank webhook")
+    }
+
+    /// Determine the event type from the webhook body.
+    ///
+    /// Axis Bank sends two callback types:
+    /// - Payment callback: has `merchantRequestId`, `gatewayResponseCode`, `type`
+    /// - Refund callback: has `refundRequestId`
+    fn get_event_type(
+        &self,
+        request: RequestDetails,
+    ) -> Result<EventType, error_stack::Report<WebhookError>> {
+        use transformers::webhook_gateway_code_to_attempt_status;
+
+        let probe: AxisbankWebhookTypeProbe = serde_json::from_slice(&request.body)
+            .change_context(WebhookError::WebhookEventTypeNotFound)
+            .attach_printable("Failed to probe Axis Bank webhook type")?;
+
+        if probe.refund_request_id.is_some() {
+            // Refund callback
+            let callback: axisbank::RefundCallbackPayload = serde_json::from_slice(&request.body)
+                .change_context(WebhookError::WebhookEventTypeNotFound)
+                .attach_printable("Failed to parse Axis Bank refund callback")?;
+
+            let status = transformers::webhook_gateway_code_to_refund_status(
+                &callback.refund_type,
+                &callback.gateway_response_code,
+                &callback.gateway_response_status,
+            );
+
+            match status {
+                common_enums::RefundStatus::Success => Ok(EventType::RefundSuccess),
+                common_enums::RefundStatus::Failure
+                | common_enums::RefundStatus::TransactionFailure => Ok(EventType::RefundFailure),
+                common_enums::RefundStatus::Pending
+                | common_enums::RefundStatus::ManualReview => Ok(EventType::RefundFailure),
+            }
+        } else {
+            // Payment callback
+            let callback: axisbank::PayCallbackPayload = serde_json::from_slice(&request.body)
+                .change_context(WebhookError::WebhookEventTypeNotFound)
+                .attach_printable("Failed to parse Axis Bank payment callback")?;
+
+            let attempt_status =
+                webhook_gateway_code_to_attempt_status(&callback.gateway_response_code);
+
+            match attempt_status {
+                common_enums::AttemptStatus::Charged => Ok(EventType::PaymentIntentSuccess),
+                common_enums::AttemptStatus::Failure
+                | common_enums::AttemptStatus::AuthorizationFailed
+                | common_enums::AttemptStatus::AuthenticationFailed => {
+                    Ok(EventType::PaymentIntentFailure)
+                }
+                _ => Ok(EventType::PaymentIntentProcessing),
+            }
+        }
+    }
+
+    /// Process a payment webhook and return standardised `WebhookDetailsResponse`.
+    fn process_payment_webhook(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+        _event_context: Option<domain_types::connector_types::EventContext>,
+    ) -> Result<WebhookDetailsResponse, error_stack::Report<WebhookError>> {
+        use transformers::webhook_gateway_code_to_attempt_status;
+
+        let callback: axisbank::PayCallbackPayload = serde_json::from_slice(&request.body)
+            .change_context(WebhookError::WebhookBodyDecodingFailed)
+            .attach_printable("Failed to parse Axis Bank payment callback body")?;
+
+        let status = webhook_gateway_code_to_attempt_status(&callback.gateway_response_code);
+
+        let resource_id = if !callback.gateway_transaction_id.is_empty() {
+            Some(ResponseId::ConnectorTransactionId(
+                callback.gateway_transaction_id.clone(),
+            ))
+        } else {
+            Some(ResponseId::EncodedData(
+                callback.merchant_request_id.clone(),
+            ))
+        };
+
+        Ok(WebhookDetailsResponse {
+            resource_id,
+            status,
+            connector_response_reference_id: callback.gateway_reference_id.clone(),
+            mandate_reference: None,
+            error_code: None,
+            error_message: None,
+            error_reason: None,
+            raw_connector_response: Some(String::from_utf8_lossy(&request.body).to_string()),
+            status_code: 200,
+            response_headers: None,
+            amount_captured: None,
+            minor_amount_captured: None,
+            network_txn_id: None,
+            payment_method_update: None,
+        })
+    }
+
+    /// Process a refund webhook and return standardised `RefundWebhookDetailsResponse`.
+    fn process_refund_webhook(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+    ) -> Result<RefundWebhookDetailsResponse, error_stack::Report<WebhookError>> {
+        let callback: axisbank::RefundCallbackPayload = serde_json::from_slice(&request.body)
+            .change_context(WebhookError::WebhookBodyDecodingFailed)
+            .attach_printable("Failed to parse Axis Bank refund callback body")?;
+
+        let status = transformers::webhook_gateway_code_to_refund_status(
+            &callback.refund_type,
+            &callback.gateway_response_code,
+            &callback.gateway_response_status,
+        );
+
+        Ok(RefundWebhookDetailsResponse {
+            connector_refund_id: Some(callback.refund_request_id.clone()),
+            status,
+            connector_response_reference_id: Some(callback.original_merchant_request_id.clone()),
+            error_code: None,
+            error_message: None,
+            raw_connector_response: Some(String::from_utf8_lossy(&request.body).to_string()),
+            status_code: 200,
+            response_headers: None,
+        })
+    }
+
+    /// Return the raw webhook body as the resource object (for logging/debugging).
+    fn get_webhook_resource_object(
+        &self,
+        request: RequestDetails,
+    ) -> Result<Box<dyn hyperswitch_masking::ErasedMaskSerialize>, error_stack::Report<WebhookError>>
+    {
+        let body: serde_json::Value = serde_json::from_slice(&request.body)
+            .change_context(WebhookError::WebhookResourceObjectNotFound)
+            .attach_printable("Failed to parse Axis Bank webhook body as resource object")?;
+
+        Ok(Box::new(body))
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -535,7 +786,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 
     fn get_supported_webhook_flows(&self) -> Option<&'static [enums::EventClass]> {
-        None
+        static SUPPORTED: &[enums::EventClass] = &[
+            enums::EventClass::Payments,
+            enums::EventClass::Refunds,
+        ];
+        Some(SUPPORTED)
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/axisbank/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/axisbank/transformers.rs
@@ -34,6 +34,10 @@ use serde::Serialize;
 pub use crate::connectors::juspay_upi_stack::crypto::get_current_timestamp_ms;
 pub use crate::connectors::juspay_upi_stack::transformers::build_error_response;
 pub use crate::connectors::juspay_upi_stack::transformers::extract_merchant_identifiers_from_metadata;
+pub use crate::connectors::juspay_upi_stack::transformers::{map_refund_status, map_transaction_status};
+pub use crate::connectors::juspay_upi_stack::types::{
+    GatewayResponseCode, OuterResponseCode, PayCallbackPayload, RefundCallbackPayload,
+};
 
 /// Auth configuration for Axis Bank.
 /// This struct extracts Axis-specific fields from ConnectorSpecificConfig.
@@ -312,4 +316,39 @@ impl TryFrom<ResponseRouterData<AxisbankRefundSyncResponse, Self>>
     ) -> Result<Self, Self::Error> {
         handle_rsync_response(resp.response, resp.http_code, resp.router_data)
     }
+}
+
+// ============================================================
+// WEBHOOK — Helper types and status mapping
+// ============================================================
+
+/// Distinguishes a payment callback from a refund callback by probing field presence.
+///
+/// A payment callback always has `merchantRequestId` and `gatewayTransactionId`.
+/// A refund callback always has `refundRequestId` (absent in payment callbacks).
+#[derive(Debug, serde::Deserialize)]
+pub struct AxisbankWebhookTypeProbe {
+    #[serde(rename = "refundRequestId")]
+    pub refund_request_id: Option<String>,
+}
+
+/// Map an Axis Bank gateway response code (from a payment callback) to `AttemptStatus`.
+///
+/// Axis Bank uses the same `gatewayResponseCode` values as in PSync responses,
+/// so we reuse the shared `GatewayResponseCode` + `map_transaction_status` logic.
+pub fn webhook_gateway_code_to_attempt_status(
+    gateway_response_code: &str,
+) -> common_enums::AttemptStatus {
+    use crate::connectors::juspay_upi_stack::types::OuterResponseCode;
+    // Payment callbacks do not carry the outer responseCode; map directly from gateway code.
+    map_transaction_status(OuterResponseCode::Success, Some(gateway_response_code))
+}
+
+/// Map an Axis Bank gateway response code (from a refund callback) to `RefundStatus`.
+pub fn webhook_gateway_code_to_refund_status(
+    refund_type: &str,
+    gateway_response_code: &str,
+    gateway_response_status: &str,
+) -> common_enums::RefundStatus {
+    map_refund_status(refund_type, gateway_response_code, gateway_response_status)
 }


### PR DESCRIPTION
## Summary

Implement **IncomingWebhook** flow for the **AxisBank** connector (Juspay UPI Merchant Stack).

This PR adds full webhook handling support for Axis Bank's UPI payment callbacks, covering both payment completion and refund status callbacks. The implementation is not yet tested against a live sandbox — opening as **draft** for review.

## Background

Axis Bank is part of the Juspay UPI Merchant Stack family. The existing connector implements Authorize, PSync, Refund, and RSync flows. This PR adds the IncomingWebhook flow so that Axis Bank can asynchronously notify the platform of payment and refund status changes via callbacks.

## Changes

### `axisbank.rs`
- Filled in the previously empty `connector_types::IncomingWebhook for Axisbank<T>` impl block with:
  - `get_webhook_source_verification_signature` — extracts `x-merchant-payload-signature` header and base64-decodes it
  - `get_webhook_source_verification_message` — parses body as JSON and sorts keys alphabetically (required by Axis Bank spec before signing)
  - `verify_webhook_source` — verifies callback authenticity using RSA-PSS-SHA256 with Juspay's public key via the shared `verify_jws_signature_pss()` utility
  - `get_event_type` — detects payment vs refund callback by probing for `refundRequestId` field; maps `gatewayResponseCode` to `EventType`
  - `process_payment_webhook` — parses `PayCallbackPayload`, maps `gatewayResponseCode` → `AttemptStatus`, returns `WebhookDetailsResponse`
  - `process_refund_webhook` — parses `RefundCallbackPayload`, maps gateway code → `RefundStatus`, returns `RefundWebhookDetailsResponse`
  - `get_webhook_resource_object` — returns raw body as `serde_json::Value` for logging
- Updated `get_supported_webhook_flows()` to advertise `[EventClass::Payments, EventClass::Refunds]`
- Added helper `sort_json_keys_alphabetically()` for deterministic message construction

### `axisbank/transformers.rs`
- Re-exported shared types: `map_refund_status`, `map_transaction_status`, `GatewayResponseCode`, `OuterResponseCode`, `PayCallbackPayload`, `RefundCallbackPayload`
- Added `AxisbankWebhookTypeProbe` struct — minimal probe to distinguish payment vs refund callbacks
- Added `webhook_gateway_code_to_attempt_status()` — maps gateway code to `AttemptStatus` using shared logic
- Added `webhook_gateway_code_to_refund_status()` — maps gateway code + refund type to `RefundStatus` using shared logic

## Files Modified

- `crates/integrations/connector-integration/src/connectors/axisbank.rs`
- `crates/integrations/connector-integration/src/connectors/axisbank/transformers.rs`

## Webhook Contract (from Axis Bank tech spec)

### Payment Callback
- **Endpoint**: Merchant-configured callback URL
- **Signature header**: `x-merchant-payload-signature` (RSA-PSS-SHA256, signed by Juspay)
- **Key fields**: `merchantRequestId`, `gatewayTransactionId`, `gatewayResponseCode` (`00` = success), `amount`, `type` (`MERCHANT_CREDITED_VIA_PAY`)

### Refund Callback
- **Key fields**: `refundRequestId`, `originalMerchantRequestId`, `gatewayResponseCode`, `refundType` (`UDIR`/`OFFLINE`)

### Gateway Response Code Mapping
| Code | Payment Status | Refund Status |
|------|---------------|---------------|
| `00` | Charged | Success |
| `01` | Pending | Pending |
| `ZA` | Failure | Failure |
| `RB` | Pending (deemed) | Pending |
| Others | Failure | Failure |

## Validation Checklist

- [x] `cargo check` passes with zero errors
- [x] No credentials in committed source code
- [x] Only connector-specific files modified (`axisbank.rs`, `axisbank/transformers.rs`)
- [x] Branch based on latest `main`
- [ ] Tested against Axis Bank sandbox (pending — draft PR)
- [ ] grpcurl webhook simulation test (pending)

## Notes

- Dispute webhooks are **not implemented** — Axis Bank UPI Stack does not support dispute/chargeback callbacks
- The `verify_webhook_source` method uses `juspay_public_key` from the connector config (not the merchant webhook secret) — this matches the Axis Bank spec where Juspay signs callbacks with their own private key
- All status mapping reuses the shared `juspay_upi_stack` utilities already used by PSync and RSync flows