### PR TITLE
fix(authorizedotnet/authorize): map HeldForReview to Unresolved

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2343,7 +2343,7 @@ fn get_hs_status(
                 match trans_res.response_code {
                     AuthorizedotnetPaymentStatus::Declined
                     | AuthorizedotnetPaymentStatus::Error => AttemptStatus::Failure,
-                    AuthorizedotnetPaymentStatus::HeldForReview => AttemptStatus::Pending,
+                    AuthorizedotnetPaymentStatus::HeldForReview => AttemptStatus::Unresolved,
                     AuthorizedotnetPaymentStatus::RequiresAction => {
                         AttemptStatus::AuthenticationPending
                     }


### PR DESCRIPTION
## Summary

Aligns UCS authorize.net HeldForReview (responseCode 4) status mapping with hyperswitch oracle PR #11890, changing from `Pending` to `Unresolved`.

## Linked PRD

Refs juspay/hyperswitch-cloud#15783

## Understanding Summary

- **Connector**: authorizedotnet
- **Flow**: authorize
- **Field**: `status`
- **Root cause**: Oracle PR #11890 (merged 2026-04-28) changed `HeldForReview` → `Unresolved` for FDS merchant-action-required semantics. UCS was not updated.
- **Oracle**: `get_payment_status()` maps `HeldForReview` → `enums::AttemptStatus::Unresolved`
- **Prism (before)**: `get_hs_status()` mapped `HeldForReview` → `AttemptStatus::Pending`

## Implementation Plan

Single-line change in `get_hs_status()`:
```rust
// Before
AuthorizedotnetPaymentStatus::HeldForReview => AttemptStatus::Pending,
// After
AuthorizedotnetPaymentStatus::HeldForReview => AttemptStatus::Unresolved,
```

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.56s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
```

## Test Results
78 lib tests passed, 0 failed. (Pre-existing doctest failures in unrelated connectors — stripe, barclaycard, etc.)

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes (no warnings)
- [x] Tests pass
- [x] No out-of-scope changes (`git diff --stat` shows 1 file, 1 insertion, 1 deletion)
- [ ] Shadow-replay produces zero diff (CTO gate)