### PR TITLE
parity(powertranz): fix connector_response_reference_id, capture txn ID, and partial capture error

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -129,9 +129,11 @@ pub struct PowertranzPaymentsResponse {
     #[serde(default)]
     pub approved: Option<bool>,
     pub transaction_identifier: String,
+    pub original_trxn_identifier: Option<String>,
     #[serde(rename = "IsoResponseCode")]
     pub iso_response_code: String,
     pub response_message: String,
+    pub order_identifier: String,
     /// Authorization code (present in sync responses)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_code: Option<String>,
@@ -556,14 +558,18 @@ impl<T: PaymentMethodDataTypes, F> TryFrom<ResponseRouterData<PowertranzPayments
             &response.iso_response_code,
         );
 
+        let connector_transaction_id = response
+            .original_trxn_identifier
+            .unwrap_or_else(|| response.transaction_identifier.clone());
+
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(response.transaction_identifier),
+                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(response.order_identifier),
                 incremental_authorization_allowed: None,
                 status_code: http_code,
             }),
@@ -631,24 +637,47 @@ impl<F> TryFrom<ResponseRouterData<PowertranzCaptureResponse, Self>>
             http_code,
         } = item;
 
-        // Determine payment status
         let status = get_payment_status(
             response.transaction_type,
             response.approved,
             &response.iso_response_code,
         );
 
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(response.transaction_identifier),
+        let connector_transaction_id = response
+            .original_trxn_identifier
+            .clone()
+            .unwrap_or_else(|| response.transaction_identifier.clone());
+
+        let has_error = response.errors.as_ref().is_some_and(|e| !e.is_empty())
+            || !ISO_SUCCESS_CODES.contains(&response.iso_response_code.as_str());
+
+        let response_result = if has_error {
+            let err = build_powertranz_error_response(
+                &response.errors,
+                &response.iso_response_code,
+                &response.response_message,
+                http_code,
+            );
+            Err(domain_types::router_data::ErrorResponse {
+                attempt_status: Some(status),
+                connector_transaction_id: Some(connector_transaction_id),
+                ..err
+            })
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(response.order_identifier),
                 incremental_authorization_allowed: None,
                 status_code: http_code,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response: response_result,
             resource_common_data: PaymentFlowData {
                 status,
                 ..router_data.resource_common_data


### PR DESCRIPTION
## Summary

Fix 3 parity diffs for powertranz connector to match oracle (hyperswitch) behavior in Authorize and Capture response transformers.

Refs #15820
Refs #15822

## Understanding Summary

- **Connector**: powertranz
- **Flows**: Authorize, Capture
- **Root causes**:
  1. `PowertranzPaymentsResponse` missing `order_identifier` and `original_trxn_identifier` fields
  2. Authorize + Capture always set `connector_response_reference_id: None` (oracle maps from `OrderIdentifier`)
  3. Capture always uses own `TransactionIdentifier` for connector_transaction_id (oracle prefers `OriginalTrxnIdentifier`)
  4. Capture always returns `Ok(TransactionResponse)` even for failures (oracle returns `Err(ErrorResponse)`)

## Implementation

### Change 1: Add fields to `PowertranzPaymentsResponse`
- `original_trxn_identifier: Option<String>` — present in capture/void responses, identifies the original auth txn
- `order_identifier: String` — merchant order reference echoed by PowerTranz

### Change 2: Fix Authorize response transformer
- Map `connector_response_reference_id` from `order_identifier`
- Use `original_trxn_identifier.unwrap_or_else(|| transaction_identifier)` for connector txn ID

### Change 3: Fix Capture response transformer
- Same field mappings as Authorize
- Add error handling: check for non-empty errors list or non-success ISO code
- Return `Err(ErrorResponse)` with `attempt_status` and `connector_transaction_id` for failures
- Follows same pattern as existing SetupMandate/RepeatPayment error handling

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.68s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.38s
```

## Test Results
78 lib tests passed, 0 failures. Pre-existing doctest failures in other connectors (unrelated).

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes (0 warnings)
- [x] Tests pass (78/78 lib tests)
- [x] Single file changed: `powertranz/transformers.rs`
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)