### PR TITLE
parity(elavon/authorize): use errorMessage for error reason

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -758,7 +758,7 @@ pub fn get_elavon_attempt_status(
                     .clone()
                     .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
                 message: error_resp.error_message.clone(),
-                reason: error_resp.error_name.clone(),
+                reason: Some(error_resp.error_message.clone()),
                 attempt_status: Some(HyperswitchAttemptStatus::Failure),
                 connector_transaction_id: error_resp.ssl_txn_id.clone(),
                 network_decline_code: None,


### PR DESCRIPTION
## Summary

Fix elavon authorize error response `reason` field to use `errorMessage` (verbose description) instead of `errorName` (short label), matching hyperswitch oracle behavior.

## Linked PRD

Closes https://github.com/juspay/hyperswitch-cloud/issues/15788

## Understanding Summary

- **Connector**: elavon
- **Flow**: authorize
- **Field**: `response.Err.reason`
- **Root cause**: Prism maps `error_name` to `reason`; oracle maps `error_message` to `reason`
- **Oracle** (HS L274-275): `reason: Some(error.error_message.clone())`
- **Prism before**: `reason: error_resp.error_name.clone()`
- **Prism after**: `reason: Some(error_resp.error_message.clone())`

## Implementation Plan

### Change 1 of 1
- **File**: `crates/integrations/connector-integration/src/connectors/elavon/transformers.rs`
- **Line 761**: `error_resp.error_name.clone()` → `Some(error_resp.error_message.clone())`

## Build Tail
```
   Compiling connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.52s
```

## Clippy Tail
```
    Checking connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.07s
```

## Test Results
No elavon-specific unit tests exist. Pre-existing doctest failures in unrelated connectors (bluesnap, stripe, etc.) are unchanged.

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [x] Tests pass (no elavon tests to regress)
- [ ] Shadow-replay produces zero diff (CTO gate)