### PR TITLE
parity(stax/authorize,psync): populate connector_response_reference_id

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -345,6 +345,7 @@ pub struct StaxPaymentResponse {
     /// mandate reference through SetupMandate so that subsequent RepeatPayment
     /// calls can reuse the same tokenized instrument.
     pub payment_method_id: Option<String>,
+    pub idempotency_id: Option<String>,
 }
 
 // Type aliases for each flow to avoid macro conflicts
@@ -410,7 +411,12 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StaxPaymentResponse, 
                 mandate_reference: None,
                 connector_metadata,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(
+                    response
+                        .idempotency_id
+                        .clone()
+                        .unwrap_or_else(|| response.id.clone()),
+                ),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
             }),
@@ -454,7 +460,12 @@ impl TryFrom<ResponseRouterData<StaxPaymentResponse, Self>>
                 mandate_reference: None,
                 connector_metadata,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(
+                    response
+                        .idempotency_id
+                        .clone()
+                        .unwrap_or_else(|| response.id.clone()),
+                ),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
             }),


### PR DESCRIPTION
## Summary

Populate `connector_response_reference_id` in Stax Authorize and PSync response transformers using `idempotency_id ?? id`, matching hyperswitch oracle behavior.

## Linked PRD

Refs #15826
Refs #15828
Refs #15827

## Understanding Summary

- **Connector:** stax
- **Flows:** Authorize, PSync
- **Field:** `response.Ok.TransactionResponse.connector_response_reference_id`
- **Root cause:** UCS `StaxPaymentResponse` struct missing `idempotency_id` field; both flow transformers hardcode `None`
- **Oracle:** Sets `Some(idempotency_id.unwrap_or(id))` at `transformers.rs:400-402`

## Changes

1. Added `idempotency_id: Option<String>` to `StaxPaymentResponse` struct
2. Authorize response transformer: `None` → `Some(idempotency_id ?? id)`
3. PSync response transformer: `None` → `Some(idempotency_id ?? id)`

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.91s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.42s
```

## Acceptance Criteria

- [x] Build passes
- [x] Clippy passes
- [x] Matches oracle behavior
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)