### PR TITLE
parity(tsys/authorize): remove extra status check in SaleResponse

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -417,26 +417,10 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<TsysAuthorizeResponse
                 ),
             },
             TsysPaymentsResponse::SaleResponse(resp) => match resp {
-                TsysResponseTypes::SuccessResponse(sale_response) => {
-                    // Check if the status is actually PASS or FAIL
-                    match sale_response.status {
-                        TsysPaymentStatus::Pass => (
-                            Ok(get_payments_response(sale_response, item.http_code)),
-                            AttemptStatus::Charged,
-                        ),
-                        TsysPaymentStatus::Fail => {
-                            let error_resp = TsysErrorResponse {
-                                status: sale_response.status,
-                                response_code: sale_response.response_code,
-                                response_message: sale_response.response_message,
-                            };
-                            (
-                                Err(get_error_response(&error_resp, item.http_code)),
-                                AttemptStatus::Failure,
-                            )
-                        }
-                    }
-                }
+                TsysResponseTypes::SuccessResponse(sale_response) => (
+                    Ok(get_payments_response(sale_response, item.http_code)),
+                    AttemptStatus::Charged,
+                ),
                 TsysResponseTypes::ErrorResponse(error_response) => (
                     Err(get_error_response(&error_response, item.http_code)),
                     AttemptStatus::Failure,


### PR DESCRIPTION
## Summary

Remove the extra `match sale_response.status` branch in the prism tsys authorize SaleResponse handler so it matches oracle (hyperswitch) behavior: any response that deserializes as `SuccessResponse` (has `transactionID`) maps to `Ok(TransactionResponse)` + `Charged`, regardless of the `PASS`/`FAIL` status field.

Refs #15829

## Understanding Summary

- **Connector**: tsys
- **Flow**: authorize (SaleResponse path — auto-capture)
- **Root cause**: Prism added an explicit `match sale_response.status` that the oracle doesn't have. A FAIL response with `transactionID` deserializes as `SuccessResponse` (serde untagged), but prism re-classified it as `Err(ErrorResponse)` + `Failure`.
- **Oracle behavior**: `SuccessResponse` → always `Ok(TransactionResponse)` + `Charged` (L312-321 in oracle)
- **Fix**: Remove the inner status match, align with oracle

## Implementation

**File**: `crates/integrations/connector-integration/src/connectors/tsys/transformers.rs`

Removed the `match sale_response.status { Pass => ..., Fail => ... }` block in the `SaleResponse` arm. Now `SuccessResponse` unconditionally maps to `Ok` + `Charged`, matching the oracle.

1 file changed, 4 insertions, 20 deletions.

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.71s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.30s
```

## Test Results
No tsys-specific tests exist. Pre-existing doctest failures in unrelated connectors (billwerk, axisbank, etc.) are unchanged.

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes (no warnings)
- [x] Tests pass (no regressions)
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)