### PR TITLE
parity(worldpayvantiv/psync): suppress connector_response_reference_id

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
@@ -1778,11 +1778,7 @@ impl TryFrom<ResponseRouterData<VantivSyncResponse, Self>>
             mandate_reference: None,
             connector_metadata: None,
             network_txn_id: None,
-            connector_response_reference_id: item
-                .response
-                .payment_detail
-                .as_ref()
-                .and_then(|detail| detail.merchant_txn_id.clone()),
+            connector_response_reference_id: None,
             incremental_authorization_allowed: None,
             status_code: item.http_code,
         };


### PR DESCRIPTION
## Summary

Suppress `connector_response_reference_id` in worldpayvantiv PSync responses to match hyperswitch oracle behavior, which always returns `None` for this field.

Refs #15834

## Understanding Summary

- **Connector**: worldpayvantiv
- **Flow**: PSync (payment sync / query)
- **Field**: `response.Ok.TransactionResponse.connector_response_reference_id`
- **Root cause**: UCS extracts `merchantTxnId` from the query API JSON and maps it to `connector_response_reference_id`, while HS intentionally sets this to `None` in PSync responses.
- **Oracle behavior** (HS `transformers.rs:605`): `connector_response_reference_id: None`
- **Prism behavior** (UCS `transformers.rs:1781-1785`): extracts `merchant_txn_id` from `payment_detail`
- **Collateral impact**: None — `merchant_txn_id` is still used for status determination via `determine_attempt_status_for_psync()`, unaffected by this change.

## Implementation

Single change in `crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs`:
- Replaced the `merchant_txn_id` extraction with `None` in the PSync `TryFrom` implementation.

## Build Tail
```
   Compiling connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.19s
```

## Clippy Tail
```
    Checking connector-integration v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.73s
```

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [x] No out-of-scope files changed (1 file, 1 insertion, 5 deletions)
- [ ] Shadow-replay produces zero diff (CTO gate)