### PR TITLE
feat(proto): add payment_method_type to PaymentServiceGetRequest for PSync

### DIFF
--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -199,6 +199,7 @@ impl
             connector_order_reference_id: item.connector_order_reference_id.clone(),
             test_mode: item.test_mode,
             payment_experience: item.payment_experience,
+            payment_method_type: item.payment_method_type,
         }
     }
 }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5569,6 +5569,11 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceGetRequest> for Paym
             )?),
         };
 
+        let payment_method_type =
+            <Option<common_enums::PaymentMethodType>>::foreign_try_from(
+                value.payment_method_type(),
+            )?;
+
         let connector_feature_data = value
             .connector_feature_data
             .map(|m| ForeignTryFrom::foreign_try_from((m, "connector metadata")))
@@ -5581,7 +5586,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceGetRequest> for Paym
             connector_feature_data,
             sync_type,
             mandate_id: None,
-            payment_method_type: None,
+            payment_method_type,
             currency,
             payment_experience,
             amount: common_utils::types::MinorUnit::new(amount.minor_amount),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5569,10 +5569,9 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceGetRequest> for Paym
             )?),
         };
 
-        let payment_method_type =
-            <Option<common_enums::PaymentMethodType>>::foreign_try_from(
-                value.payment_method_type(),
-            )?;
+        let payment_method_type = <Option<common_enums::PaymentMethodType>>::foreign_try_from(
+            value.payment_method_type(),
+        )?;
 
         let connector_feature_data = value
             .connector_feature_data

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2087,6 +2087,9 @@ message PaymentServiceGetRequest {
 
   // Payment Experience
   optional PaymentExperience payment_experience = 14;
+
+  // Payment Method Type (e.g., Card, GooglePay, ApplePay)
+  optional PaymentMethodType payment_method_type = 15;
 }
 
 // Response message for a payment status synchronization


### PR DESCRIPTION
## Summary

- Adds `optional PaymentMethodType payment_method_type = 15` to the `PaymentServiceGetRequest` proto message
- Updates `PaymentsSyncData::foreign_try_from` to extract the field instead of hardcoding `None`
- Fixes `connector_response` being `null` for ALL connectors' PSync flows (not just adyen)

## Root Cause

The `PaymentServiceGetRequest` proto was missing `payment_method_type`. This caused `PaymentsSyncData.payment_method_type` to always be `None`, so `get_adyen_response()` (and equivalent handlers in other connectors) could never build `ConnectorResponseData::with_auth_code(auth_code, pmt)` — the `pmt.and_then(...)` always returned `None`.

## Changes

| File | Change |
|------|--------|
| `proto/payment.proto` | Add `optional PaymentMethodType payment_method_type = 15` to `PaymentServiceGetRequest` |
| `domain_types/src/types.rs` | Extract `payment_method_type` from proto in `PaymentsSyncData::foreign_try_from` |

## Companion Change

Hyperswitch router-side change (populates the field in PSync GRPC requests): branch `parity/adyen/psync-connector-response-payment-method-type` on `juspay/hyperswitch`

## Test plan

- [ ] `cargo check -p grpc-api-types` passes
- [ ] `cargo check -p domain_types` passes
- [ ] Verify adyen PSync returns `connector_response.additional_payment_method_data.Card.auth_code` (non-null)
- [ ] Verify no regression for PSync flows on other connectors

Refs: GH #15778, PRI-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)