### PR TITLE
feat(proto/psync): add attempt_status to PaymentServiceGetRequest

### DIFF
--- a/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
@@ -406,6 +406,7 @@ fn create_payment_get_request(transaction_id: &str) -> PaymentServiceGetRequest 
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/grpc-server/grpc-server/tests/fiuu_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/fiuu_payment_flows_test.rs
@@ -178,6 +178,7 @@ fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/grpc-server/grpc-server/tests/helcim_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/helcim_payment_flows_test.rs
@@ -276,6 +276,7 @@ fn create_payment_sync_request(
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
@@ -180,6 +180,7 @@ fn create_payment_sync_request(transaction_id: &str, amount: i64) -> PaymentServ
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 
@@ -527,6 +528,7 @@ async fn test_authorize_capture_refund_rsync() {
             connector_order_reference_id: None,
             test_mode: None,
             payment_experience: None,
+            attempt_status: None,
         };
         let mut rsync_grpc_request = Request::new(rsync_request);
         add_payload_metadata(&mut rsync_grpc_request);

--- a/crates/grpc-server/grpc-server/tests/paysafe_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/paysafe_payment_flows_test.rs
@@ -274,6 +274,7 @@ fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
@@ -180,6 +180,7 @@ fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/grpc-server/grpc-server/tests/xendit_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/xendit_payment_flows_test.rs
@@ -171,6 +171,7 @@ fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest
         connector_order_reference_id: None,
         test_mode: None,
         payment_experience: None,
+        attempt_status: None,
     }
 }
 

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -199,6 +199,7 @@ impl
             connector_order_reference_id: item.connector_order_reference_id.clone(),
             test_mode: item.test_mode,
             payment_experience: item.payment_experience,
+            attempt_status: item.attempt_status,
         }
     }
 }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4411,11 +4411,18 @@ impl
             .map(ServerAuthenticationTokenResponseData::foreign_try_from)
             .transpose()?;
 
+        let status = value
+            .attempt_status
+            .and_then(|s| grpc_api_types::payments::PaymentStatus::try_from(s).ok())
+            .map(common_enums::AttemptStatus::foreign_try_from)
+            .transpose()?
+            .unwrap_or(common_enums::AttemptStatus::Pending);
+
         Ok(Self {
             merchant_id: merchant_id_from_header,
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
-            status: common_enums::AttemptStatus::Pending,
+            status,
             payment_method: PaymentMethod::Card, //TODO
             address,
             auth_type: common_enums::AuthenticationType::default(),

--- a/crates/types-traits/grpc-api-types/proto/composite_payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_payment.proto
@@ -150,6 +150,9 @@ message CompositeGetRequest {
 
   // Access Token
   optional string merchant_access_token_id = 15; // Reference ID for access token tracking
+
+  // Attempt status from preceding authorize step (used by psync connectors)
+  optional PaymentStatus attempt_status = 17;
 }
 
 // Response message for composite get flow.

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2089,7 +2089,7 @@ message PaymentServiceGetRequest {
   optional PaymentExperience payment_experience = 14;
 
   // Attempt status from preceding authorize step (used by psync connectors)
-  optional PaymentStatus attempt_status = 15;
+  optional PaymentStatus attempt_status = 16;
 }
 
 // Response message for a payment status synchronization

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2087,6 +2087,9 @@ message PaymentServiceGetRequest {
 
   // Payment Experience
   optional PaymentExperience payment_experience = 14;
+
+  // Attempt status from preceding authorize step (used by psync connectors)
+  optional PaymentStatus attempt_status = 15;
 }
 
 // Response message for a payment status synchronization


### PR DESCRIPTION
## Summary

Propagate `attempt_status` through the psync UCS flow so that connectors receiving a sync request know the current authorization state. This enables psync connectors to make status-aware decisions.

## Linked PRD

Related to juspay/hyperswitch-cloud#15831

## Changes

| File | Change |
|------|--------|
| `proto/payment.proto` | Add `optional PaymentStatus attempt_status = 15` to `PaymentServiceGetRequest` |
| `proto/composite_payment.proto` | Add matching field (17) to `CompositeGetRequest` |
| `domain_types/src/types.rs` | Consume `attempt_status` in `PaymentFlowData` conversion with `unwrap_or(Pending)` fallback |
| `composite-service/src/transformers.rs` | Pass through `attempt_status` from composite request |

## Hyperswitch-side change (separate PR needed)

The corresponding change in `hyperswitch/crates/router/src/core/unified_connector_service/transformers.rs` (populating the field + `ForeignFrom<AttemptStatus> for PaymentStatus` impl) lives in the hyperswitch repo and will need a separate PR there once this proto is published.

## Build Tail
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 24s
```

## Clippy Tail
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 21s
```

## Test Results
- `composite_request_schemas_match_granular_unions` ... ok
- `domain_types` ... ok (1 ignored)

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [x] Tests pass
- [x] New field appears in generated proto Rust code
- [ ] Shadow-replay produces zero diff (CTO gate)
- [ ] Hyperswitch-side PR (populates the field)