### PR TITLE
docs(grace): tighten hardening and test workflow guidance

### DIFF
--- a/grace/workflow/1_orchestrator.md
+++ b/grace/workflow/1_orchestrator.md
@@ -170,6 +170,7 @@ Per-connector results:
 4. **Fix ONLY tests**: If test fails due to test bug → create fix branch, fix test. If fails due to real connector bug → report FAILED (don't fix connector code).
 5. **Fully autonomous**: Never ask questions. Make decisions and proceed.
 6. **Your subagent**: The **Test Suite Agent** (`3_test.md`). You can deploy multiple subagents within the "Test Suite Agent" subagent based on the requirement.
+7. **Do not assume suite chaining**: In hardening mode, suites such as `CreateOrder`, `Authorize`, and session-token flows may be standalone test entrypoints. Determine expected behavior from the actual suite request and latest report output, not from an assumed runtime chain.
 
 ---
 
@@ -206,7 +207,12 @@ pwd && ls crates/internal/integration-tests/README.md
 cargo build -p integration-tests
 # Check credentials exist
 cat creds.json | head -20
+# Clear stale listeners that can break grpc-server startup
+lsof -ti:8000 | xargs kill -9 2>/dev/null || true
+lsof -ti:8080 | xargs kill -9 2>/dev/null || true
 ```
+
+**Important startup note:** a stale listener on `8080` (metrics) can make `test-prism` look like it is failing readiness on `8000`. If startup fails, inspect and clear both ports before concluding the connector run is blocked.
 
 **Credentials Check (REQUIRED per connector):**
 
@@ -232,6 +238,8 @@ For each connector in `CONNECTOR_LIST`, spawn ONE Test Suite Agent:
 ```
 delegate_task(
   subagent_type="general",
+  load_skills=[],
+  run_in_background=false,
   description="Run test suite for {CONNECTOR}",
   prompt="Read and follow the workflow defined in grace/workflow/3_test.md
 

--- a/grace/workflow/1_orchestrator.md
+++ b/grace/workflow/1_orchestrator.md
@@ -229,6 +229,8 @@ lsof -ti:8080 | xargs kill -9 2>/dev/null || true
 - Web: https://hyperswitch-prism-testing.netlify.app/
 - Latest JSON: https://integ.hyperswitch.io/connector-service/reports/grpc/report_latest.json
 
+**Debugging Test Failures:** See `grace/workflow/3_test.md` for detailed investigation procedures, common failure patterns, and debugging commands.
+
 ---
 
 ### STEP 2: PROCESS EACH CONNECTOR

--- a/grace/workflow/3_test.md
+++ b/grace/workflow/3_test.md
@@ -43,6 +43,14 @@ cat creds.json | jq '.${CONNECTOR}'
 
 ## Phase 1: Run Tests
 
+**Before the first run (and again on any readiness failure), clear stale listeners on BOTH ports:**
+
+```bash
+# test-prism waits for gRPC on 8000, but stale listeners on 8080 can also kill startup
+lsof -ti:8000 | xargs kill -9 2>/dev/null || true
+lsof -ti:8080 | xargs kill -9 2>/dev/null || true
+```
+
 **Run with timeout (5-10 minutes per connector):**
 
 ```bash
@@ -60,6 +68,12 @@ test-prism --connector {CONNECTOR} --suite authorize
 ```
 
 **Capture the full output** — save test results for analysis.
+
+**Read the latest report carefully:**
+
+- `crates/internal/integration-tests/report.json` accumulates entries across runs
+- Always inspect the latest block for the scenario you just reran (usually near the end of the file)
+- Do NOT justify a fix from an older matching scenario block
 
 **View results in UI:**
 
@@ -106,12 +120,20 @@ test-prism --connector {CONNECTOR} --suite authorize
 
 **Determine failure type:**
 
+**Before classifying a failure, verify the actual suite entrypoint and request shape:**
+
+- Confirm whether the failing suite is a standalone entrypoint (for example `PaymentService/CreateOrder`) or a scenario dependency
+- Do NOT assume `CreateOrder`, `Authorize`, or session-token flows are chained together unless the scenario explicitly wires them together
+- Check the request payload before deciding what should exist in the response; for example, payment-method-specific fields may be the reason `session_data` appears in one scenario and not another
+
 1. **Test Bug — POSITIVE Override Issue (FIX):**
    - Test uses wrong field names → fix the test data
    - Missing required fields in test data → add field
    - Test assertion logic is wrong → fix assertion to match expected behavior
    - Missing connector config in test → add config
    - **Key: The fix makes the test correct, not just asserts failure**
+   - Removing an invalid success-only assertion is allowed only when the real failing payload remains visible after the change
+   - Widening a status assertion is allowed only when the latest report block AND connector/UCS mapping both support that status
    - **→ FIX IMMEDIATELY, DO NOT WAIT → RERUN → THEN proceed**
    - **→ FIX NOW, proceed to Phase 3 immediately**
 
@@ -222,6 +244,7 @@ gh pr label add "grace" --repo juspay/hyperswitch-prism
 
 - **ALWAYS check creds first** — no creds = SKIPPED
 - **Set timeout** — 5-10 minutes per connector
+- **If server readiness fails, inspect both 8000 and 8080** — stale metrics listeners can look like a gRPC 8000 problem
 - **Positive overrides only** — fix assertions, not just assert failure
 - **NEVER touch UCS core** — only test files
 - **NEVER touch framework core** — only connector_specs/

--- a/grace/workflow/3_test.md
+++ b/grace/workflow/3_test.md
@@ -84,7 +84,49 @@ test-prism --connector {CONNECTOR} --suite authorize
 
 ## Phase 2: Analyze Results
 
+**Research the failure before classifying it. Do NOT guess.**
+
+Use this checklist for every failing scenario:
+
+1. Read the **latest** matching block in `crates/internal/integration-tests/report.json`.
+2. Inspect the connector's **effective request** with:
+
+```bash
+UCS_DEBUG_EFFECTIVE_REQ=1 test-prism --connector {CONNECTOR} --interface {TEST_MODE} --report
+```
+
+3. Compare the base scenario with the connector override:
+   - Base: `crates/internal/integration-tests/src/global_suites/<suite>_suite/scenario.json`
+   - Override: `crates/internal/integration-tests/src/connector_specs/{CONNECTOR}/override.json`
+4. Read the harness docs/code that explain what the runner really sends:
+   - `crates/internal/integration-tests/docs/connector-overrides.md`
+   - `crates/internal/integration-tests/docs/code-walkthrough.md`
+   - `crates/internal/integration-tests/src/harness/connector_override/mod.rs`
+   - `crates/internal/integration-tests/src/harness/scenario_api.rs`
+5. Read the connector implementation to identify:
+   - required request fields sourced from scenario input
+   - fields sourced from creds/config/header generation instead of `override.json`
+   - explicitly unsupported payment methods / flows
+   - strict response parsing that can fail after the request is sent
+6. Use local reference material when available:
+   - integration-test docs/files under `crates/internal/integration-tests/docs/*`, `src/*`, `README.md`, `TESTING_PLAN.md`, `test_suite.sh`
+
+**Important facts while analyzing:**
+
+- `override.json` is merged into the effective `grpc_req` **before** execution.
+- `test-prism --interface grpc` sends the harness-built request through gRPC/grpcurl.
+- You may add request fields via `override.json` **only if** they are valid in the proto request shape and sourced from scenario input.
+- `override.json` cannot directly fix:
+  - connector config / creds-derived fields
+  - generated headers or request-reference IDs
+  - connector code branches that return `NotSupported` / `NotImplemented`
+  - response deserialization mismatches after the connector responds
+  - harness/core dependency propagation bugs
+- Downstream suites (`Capture`, `Get`, `Refund`, `Void`) can use authorize-derived IDs **only if** authorize succeeded and the prior response exposes the ID in a path the harness can reuse. If authorize fails, omits the ID, or returns it in an unmapped shape, later suites will still fail with missing transaction/refund IDs.
+- Treat known connector behavior from references as real evidence. Example: Payload duplicate-sensitive flows need a delay window; NMI SetupMandate must be exactly zero amount.
+
 ### If ALL tests pass:
+
 - Result: **HARDENED**
 - The connector is now fully tested and can move to "Tested" status in docs
 
@@ -108,10 +150,12 @@ test-prism --connector {CONNECTOR} --suite authorize
 - **You MUST make a test change between retries.** Never rerun tests without changing test data. No change = same result = STOP → return FAILED.
 
 **MANDATORY SEQUENCE:**
+
 1. **First:** Identify fixable issues (test data, credentials)
 2. **Second:** For each fixable issue → FIX IT in override.json/creds.json → RERUN tests
 3. **Third:** Only after reruns pass → return HARDENED
 4. **Fourth:** Only if CANNOT fix → return FAILED with evidence of attempted fixes
+
 - If test fails due to test data (positive override) → FIX IT NOW, don't ask
 - If test fails due to connector code bug → FAILED (report)
 - If test fails due to framework bug → REPORT_TO_MASTER (stop)
@@ -125,6 +169,10 @@ test-prism --connector {CONNECTOR} --suite authorize
 - Confirm whether the failing suite is a standalone entrypoint (for example `PaymentService/CreateOrder`) or a scenario dependency
 - Do NOT assume `CreateOrder`, `Authorize`, or session-token flows are chained together unless the scenario explicitly wires them together
 - Check the request payload before deciding what should exist in the response; for example, payment-method-specific fields may be the reason `session_data` appears in one scenario and not another
+- For missing required fields, verify whether the field comes from:
+  - scenario request data (`override.json` can help), or
+  - connector config / generated headers / request-reference plumbing (`override.json` cannot help)
+- For missing `connector_transaction_id`, verify the upstream authorize/latest dependency response before changing a downstream scenario. Missing downstream IDs are often symptoms of an earlier failure, not independent override bugs.
 
 1. **Test Bug — POSITIVE Override Issue (FIX):**
    - Test uses wrong field names → fix the test data
@@ -196,6 +244,26 @@ git checkout -b fix/test-{connector}-{issue}
   - `specs.json` — connector-specific specs
   - Scenario JSON files in the connector spec folder
 
+**How to update `override.json` safely:**
+
+1. Start from the base global scenario and patch only the connector-specific delta.
+2. Follow `crates/internal/integration-tests/docs/connector-overrides.md` exactly:
+   - key shape is `suite -> scenario -> { grpc_req, assert }`
+   - `grpc_req` uses JSON Merge Patch semantics
+   - `null` removes a key
+3. Prefer **leaf-field** edits over replacing whole nested objects.
+4. Use `crates/internal/integration-tests/src/connector_specs/stripe/override.json` as the reference style.
+5. Do not use `override.json` to hide a real connector failure. The request must remain truthful.
+6. If the connector code shows the field comes from creds/config/header generation, stop — that is **not** an override fix.
+7. If the connector code explicitly rejects the PM/flow, stop — that is **not** an override fix.
+
+**Validate override changes before rerunning the connector:**
+
+```bash
+cargo test -p integration-tests all_supported_scenarios_match_proto_schema_for_all_connectors
+cargo test -p integration-tests all_override_entries_match_existing_scenarios_and_proto_schema
+```
+
 **Verify fix:**
 
 ```bash
@@ -209,6 +277,7 @@ test-prism --connector {CONNECTOR} --report
 - Push: `git push -u origin fix/test-{connector}-{issue}`
 
 **MANDATORY: After pushing, CREATE PR:**
+
 ```
 # Create PR after pushing
 gh pr create --title "fix({CONNECTOR}): positive override test fixes" --body "- Test fixes applied for {connector}" --repo juspay/hyperswitch-prism

--- a/grace/workflow/3_test.md
+++ b/grace/workflow/3_test.md
@@ -64,7 +64,10 @@ test-prism --connector {CONNECTOR} --interface {TEST_MODE} --report
 **Or for a specific suite:**
 
 ```bash
-test-prism --connector {CONNECTOR} --suite authorize
+# IMPORTANT: Suite names use FORWARD SLASHES, not underscores
+# WRONG: test-prism --connector nmi --suite PaymentService_Authorize
+# RIGHT: test-prism --connector nmi --suite PaymentService/Authorize
+test-prism --connector {CONNECTOR} --suite PaymentService/Authorize
 ```
 
 **Capture the full output** — save test results for analysis.
@@ -74,6 +77,11 @@ test-prism --connector {CONNECTOR} --suite authorize
 - `crates/internal/integration-tests/report.json` accumulates entries across runs
 - Always inspect the latest block for the scenario you just reran (usually near the end of the file)
 - Do NOT justify a fix from an older matching scenario block
+- **Markdown reports** are generated at `crates/internal/integration-tests/test_report/connectors/{connector}/` — these provide human-readable summaries with exact request/response pairs for each scenario
+- **To debug failures**, examine:
+  1. The markdown report in `test_report/connectors/{connector}/{suite}.md` for request/response details
+  2. The JSON report for raw proto payloads
+  3. The connector transformer code in `crates/integrations/connector-integration/src/connectors/{connector}/` to understand expected fields
 
 **View results in UI:**
 
@@ -129,6 +137,63 @@ UCS_DEBUG_EFFECTIVE_REQ=1 test-prism --connector {CONNECTOR} --interface {TEST_M
 
 - Result: **HARDENED**
 - The connector is now fully tested and can move to "Tested" status in docs
+
+### Debugging Failed Tests - Where to Look
+
+When tests fail, follow this investigation order:
+
+1. **Check Markdown Reports** (immediate visibility):
+
+   ```bash
+   # Find the connector's markdown report
+   ls -la crates/internal/integration-tests/test_report/connectors/{CONNECTOR}/
+
+   # Read specific suite report
+   cat crates/internal/integration-tests/test_report/connectors/{CONNECTOR}/paymentservice-authorize.md
+   ```
+
+   These reports show:
+   - Exact gRPC request sent
+   - Exact gRPC response received
+   - Assertion failures with field-level detail
+
+2. **Check JSON Report** (raw payloads):
+
+   ```bash
+   cat crates/internal/integration-tests/report.json | jq '.[-10:]'
+   ```
+
+   Shows the raw proto serialization for debugging override issues
+
+3. **Check Connector Code** (why request fails):
+
+   ```bash
+   # Find connector transformer
+   ls crates/integrations/connector-integration/src/connectors/{CONNECTOR}/
+
+   # Read the transformer to understand expected fields
+   cat crates/integrations/connector-integration/src/connectors/{CONNECTOR}/transformers.rs
+   ```
+
+   Look for:
+   - Required fields that must come from scenario input (vs creds/config)
+   - Explicit `NotSupported` or `NotImplemented` branches
+   - Payment method type checking that rejects certain PMs
+   - Response parsing that can fail if connector returns unexpected shape
+
+4. **Debug Request with Effective Req**:
+
+   ```bash
+   UCS_DEBUG_EFFECTIVE_REQ=1 test-prism --connector {CONNECTOR} --suite {SUITE} --report
+   ```
+
+   Shows exactly what the harness builds before sending to gRPC server
+
+5. **Check Override JSON** (verify test data):
+   ```bash
+   cat crates/internal/integration-tests/src/connector_specs/{CONNECTOR}/override.json
+   ```
+   Compare against base scenario to ensure override is valid
 
 ### If tests FAIL:
 


### PR DESCRIPTION
## Summary
- tighten hardening workflow guidance based on Nuvei test-suite debugging
- add startup and report-reading safeguards to the test workflow
- clarify suite-entrypoint validation before classifying failures or changing overrides

## Changes
- `grace/workflow/1_orchestrator.md`
  - add hardening guidance to avoid assuming suite chaining
  - clear stale listeners on `8000` and `8080` during pre-flight
  - document the 8080 metrics-port trap that can look like an 8000 readiness failure
  - fix the delegate example to include required task params
- `grace/workflow/3_test.md`
  - clear stale listeners on both ports before first run and on readiness failures
  - note that `report.json` accumulates entries across runs, so the latest block must be inspected
  - verify the actual suite entrypoint and request shape before deciding expected response fields
  - tighten safe-override guidance so invalid success-only assertions can be removed without masking real failures

## Why
These updates capture workflow gaps found during the Nuvei hardening pass and make the hardening/test process more reliable for future connectors.