### PR TITLE
fix(connector): [Trustly] Fix country handling in the request

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
@@ -288,19 +288,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         .change_context(errors::IntegrationError::AmountConversionFailed {
                             context: Default::default(),
                         })?,
-                    country: item
-                        .router_data
-                        .resource_common_data
-                        .get_billing_country()
-                        .unwrap_or(
-                            item.router_data
-                                .resource_common_data
-                                .get_optional_shipping_country()
-                                .ok_or(errors::IntegrationError::MissingRequiredField {
-                                    field_name: "country",
-                                    context: Default::default(),
-                                })?,
-                        ),
+                    country: match item.router_data.resource_common_data.get_billing_country() {
+                        Ok(country) => country,
+                        Err(_) => item
+                            .router_data
+                            .resource_common_data
+                            .get_optional_shipping_country()
+                            .ok_or(errors::IntegrationError::MissingRequiredField {
+                                field_name: "country",
+                                context: Default::default(),
+                            })?,
+                    },
                     currency: item.router_data.request.currency,
                     email: item
                         .router_data


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Earlier when country was passed inside billing details, it would still check for it inside shipping details. This was because of use of unwrap_or. This PR fixes this.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
