### PR TITLE
docs: add config handling blog

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -2722,6 +2722,9 @@ impl From<grpc_payment_types::PaymentServiceProxyAuthorizeRequest> for Authoriza
                         grpc_payment_types::payment_method::PaymentMethod::CardProxy(card_proxy),
                     ),
                 });
+        let threeds_completion_indicator = req
+            .threeds_completion_indicator
+            .map(|_| req.threeds_completion_indicator());
 
         Self {
             merchant_transaction_id: req.merchant_transaction_id.clone(),
@@ -2750,14 +2753,14 @@ impl From<grpc_payment_types::PaymentServiceProxyAuthorizeRequest> for Authoriza
             enable_partial_authorization: None,
             customer_acceptance: req.customer_acceptance.clone(),
             browser_info: req.browser_info,
-            billing_descriptor: None,
+            billing_descriptor: req.billing_descriptor,
             payment_experience: None,
             description: req.description.clone(),
             payment_channel: grpc_payment_types::PaymentChannel::Unspecified,
             locale: None,
             state: req.state,
-            threeds_completion_indicator: None,
-            redirection_response: None,
+            threeds_completion_indicator,
+            redirection_response: req.redirection_response,
             continue_redirection_url: None,
             l2_l3_data: req.l2_l3_data,
             setup_mandate_details: req.setup_mandate_details,
@@ -2838,7 +2841,7 @@ impl From<grpc_payment_types::PaymentServiceProxySetupRecurringRequest> for Setu
             payment_channel: None,
             complete_authorize_url: None,
             off_session: None,
-            order_category: None,
+            order_category: req.order_category,
             order_id: None,
             order_tax_amount: None,
             merchant_order_id: None,
@@ -13153,16 +13156,16 @@ pub fn tokenized_setup_recurring_to_base(
         customer_acceptance: v.customer_acceptance,
         setup_mandate_details: v.setup_mandate_details,
         setup_future_usage: v.setup_future_usage,
-        // Fields not in TokenSetupRecurringRequest - set to None/default
+        billing_descriptor: v.billing_descriptor,
+        locale: v.locale,
+        // Fields absent from TokenSetupRecurringRequest - set to None/default
         auth_type: grpc_payment_types::AuthenticationType::NoThreeDs as i32,
         authentication_data: None,
-        billing_descriptor: None,
         browser_info: None,
         complete_authorize_url: None,
         connector_testing_data: None,
         enable_partial_authorization: None,
         enrolled_for_3ds: false,
-        locale: None,
         l2_l3_data: None,
         merchant_order_id: None,
         off_session: None,
@@ -13247,10 +13250,12 @@ pub fn proxied_authorize_to_base(
         threeds_completion_indicator: v.threeds_completion_indicator,
         redirection_response: v.redirection_response,
         billing_descriptor: v.billing_descriptor,
+        setup_mandate_details: v.setup_mandate_details,
+        test_mode: v.test_mode,
         complete_authorize_url: None,
         continue_redirection_url: None,
         description: v.description,
-        // Fields not present in PaymentServiceProxyAuthorizeRequest - set to None/default
+        // Fields absent from PaymentServiceProxyAuthorizeRequest - set to None/default
         enrolled_for_3ds: None,
         enable_partial_authorization: None,
         locale: None,
@@ -13262,13 +13267,11 @@ pub fn proxied_authorize_to_base(
         order_category: v.order_category,
         order_details: Vec::new(),
         session_token: None,
-        shipping_cost: None,
+        shipping_cost: v.shipping_cost,
         order_tax_amount: None,
         statement_descriptor_name: None,
         statement_descriptor_suffix: None,
         tokenization_strategy: None,
-        setup_mandate_details: None,
-        test_mode: None,
     })
 }
 
@@ -13360,9 +13363,10 @@ pub fn proxied_setup_recurring_to_base(
         setup_mandate_details: v.setup_mandate_details,
         setup_future_usage: v.setup_future_usage,
         browser_info: v.browser_info,
-        // Fields not in ProxySetupRecurringRequest - set to None/default
-        auth_type: grpc_payment_types::AuthenticationType::NoThreeDs as i32,
-        authentication_data: None,
+        auth_type: v.auth_type,
+        authentication_data: v.authentication_data,
+        order_category: v.order_category,
+        // Fields absent from ProxySetupRecurringRequest - set to None/default
         billing_descriptor: None,
         connector_feature_data: None,
         connector_testing_data: None,
@@ -13373,7 +13377,6 @@ pub fn proxied_setup_recurring_to_base(
         l2_l3_data: None,
         merchant_order_id: None,
         off_session: None,
-        order_category: None,
         order_id: None,
         order_tax_amount: None,
         payment_channel: None,
@@ -13560,5 +13563,236 @@ impl From<connector_types::WebhookResourceReference> for grpc_api_types::payment
                 })),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        proxied_authorize_to_base, proxied_setup_recurring_to_base,
+        tokenized_setup_recurring_to_base, AuthorizationRequest, SetupRecurringRequest,
+    };
+    use grpc_api_types::payments as grpc_payment_types;
+    use hyperswitch_masking::Secret;
+
+    fn secret(value: &str) -> Secret<String> {
+        Secret::new(value.to_string())
+    }
+
+    fn money() -> grpc_payment_types::Money {
+        grpc_payment_types::Money {
+            minor_amount: 100,
+            currency: grpc_payment_types::Currency::Usd as i32,
+        }
+    }
+
+    fn billing_descriptor() -> grpc_payment_types::BillingDescriptor {
+        grpc_payment_types::BillingDescriptor {
+            statement_descriptor: Some("statement".to_string()),
+            statement_descriptor_suffix: Some("suffix".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn setup_mandate_details() -> grpc_payment_types::SetupMandateDetails {
+        grpc_payment_types::SetupMandateDetails {
+            update_mandate_id: Some("mandate-update-id".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn authentication_data() -> grpc_payment_types::AuthenticationData {
+        grpc_payment_types::AuthenticationData {
+            eci: Some("05".to_string()),
+            cavv: Some("sample-cavv".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn proxy_card() -> grpc_payment_types::ProxyCardDetails {
+        grpc_payment_types::ProxyCardDetails {
+            card_number: Some(secret("4111111111111111")),
+            card_exp_month: Some(secret("12")),
+            card_exp_year: Some(secret("2030")),
+            card_cvc: Some(secret("123")),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tokenized_setup_recurring_to_base_maps_supported_proto_fields() {
+        let request = grpc_payment_types::PaymentServiceTokenSetupRecurringRequest {
+            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
+            amount: Some(money()),
+            billing_descriptor: Some(billing_descriptor()),
+            locale: Some("en-US".to_string()),
+            setup_mandate_details: Some(setup_mandate_details()),
+            ..Default::default()
+        };
+
+        let base = tokenized_setup_recurring_to_base(request);
+
+        assert_eq!(
+            base.billing_descriptor
+                .as_ref()
+                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
+            Some("statement")
+        );
+        assert_eq!(base.locale.as_deref(), Some("en-US"));
+        assert_eq!(
+            base.setup_mandate_details
+                .as_ref()
+                .and_then(|details| details.update_mandate_id.as_deref()),
+            Some("mandate-update-id")
+        );
+    }
+
+    #[test]
+    fn proxied_authorize_to_base_maps_supported_proto_fields() {
+        let request = grpc_payment_types::PaymentServiceProxyAuthorizeRequest {
+            amount: Some(money()),
+            card_proxy: Some(proxy_card()),
+            auth_type: grpc_payment_types::AuthenticationType::ThreeDs as i32,
+            authentication_data: Some(authentication_data()),
+            setup_mandate_details: Some(setup_mandate_details()),
+            billing_descriptor: Some(billing_descriptor()),
+            threeds_completion_indicator: Some(
+                grpc_payment_types::ThreeDsCompletionIndicator::Success as i32,
+            ),
+            redirection_response: Some(grpc_payment_types::RedirectionResponse {
+                params: Some("pares=abc".to_string()),
+                ..Default::default()
+            }),
+            shipping_cost: Some(250),
+            test_mode: Some(true),
+            order_category: Some("digital".to_string()),
+            ..Default::default()
+        };
+
+        let base = proxied_authorize_to_base(request).expect("proxy authorize normalization");
+
+        assert_eq!(
+            base.auth_type(),
+            grpc_payment_types::AuthenticationType::ThreeDs
+        );
+        assert_eq!(
+            base.authentication_data
+                .as_ref()
+                .and_then(|data| data.eci.as_deref()),
+            Some("05")
+        );
+        assert_eq!(
+            base.setup_mandate_details
+                .as_ref()
+                .and_then(|details| details.update_mandate_id.as_deref()),
+            Some("mandate-update-id")
+        );
+        assert_eq!(base.shipping_cost, Some(250));
+        assert_eq!(base.test_mode, Some(true));
+        assert_eq!(base.order_category.as_deref(), Some("digital"));
+        assert_eq!(
+            base.billing_descriptor
+                .as_ref()
+                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
+            Some("statement")
+        );
+        assert_eq!(
+            base.redirection_response
+                .as_ref()
+                .and_then(|response| response.params.as_deref()),
+            Some("pares=abc")
+        );
+        assert_eq!(
+            base.threeds_completion_indicator(),
+            grpc_payment_types::ThreeDsCompletionIndicator::Success
+        );
+    }
+
+    #[test]
+    fn proxy_authorize_into_authorization_request_preserves_proxy_fields() {
+        let request = grpc_payment_types::PaymentServiceProxyAuthorizeRequest {
+            amount: Some(money()),
+            card_proxy: Some(proxy_card()),
+            billing_descriptor: Some(billing_descriptor()),
+            threeds_completion_indicator: Some(
+                grpc_payment_types::ThreeDsCompletionIndicator::Success as i32,
+            ),
+            redirection_response: Some(grpc_payment_types::RedirectionResponse {
+                params: Some("pares=abc".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let auth_request: AuthorizationRequest = request.into();
+
+        assert_eq!(
+            auth_request
+                .billing_descriptor
+                .as_ref()
+                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
+            Some("statement")
+        );
+        assert_eq!(
+            auth_request.threeds_completion_indicator,
+            Some(grpc_payment_types::ThreeDsCompletionIndicator::Success)
+        );
+        assert_eq!(
+            auth_request
+                .redirection_response
+                .as_ref()
+                .and_then(|response| response.params.as_deref()),
+            Some("pares=abc")
+        );
+    }
+
+    #[test]
+    fn proxied_setup_recurring_to_base_maps_supported_proto_fields() {
+        let request = grpc_payment_types::PaymentServiceProxySetupRecurringRequest {
+            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
+            amount: Some(money()),
+            card_proxy: Some(proxy_card()),
+            auth_type: grpc_payment_types::AuthenticationType::ThreeDs as i32,
+            authentication_data: Some(authentication_data()),
+            setup_mandate_details: Some(setup_mandate_details()),
+            order_category: Some("service".to_string()),
+            ..Default::default()
+        };
+
+        let base =
+            proxied_setup_recurring_to_base(request).expect("proxy setup recurring normalization");
+
+        assert_eq!(
+            base.auth_type(),
+            grpc_payment_types::AuthenticationType::ThreeDs
+        );
+        assert_eq!(
+            base.authentication_data
+                .as_ref()
+                .and_then(|data| data.eci.as_deref()),
+            Some("05")
+        );
+        assert_eq!(base.order_category.as_deref(), Some("service"));
+        assert_eq!(
+            base.setup_mandate_details
+                .as_ref()
+                .and_then(|details| details.update_mandate_id.as_deref()),
+            Some("mandate-update-id")
+        );
+    }
+
+    #[test]
+    fn proxy_setup_recurring_into_setup_recurring_request_preserves_order_category() {
+        let request = grpc_payment_types::PaymentServiceProxySetupRecurringRequest {
+            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
+            amount: Some(money()),
+            card_proxy: Some(proxy_card()),
+            order_category: Some("service".to_string()),
+            ..Default::default()
+        };
+
+        let setup_request: SetupRecurringRequest = request.into();
+
+        assert_eq!(setup_request.order_category.as_deref(), Some("service"));
     }
 }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -2637,11 +2637,14 @@ pub struct SetupRecurringRequest {
     pub metadata: Option<Secret<String>>,
     pub connector_feature_data: Option<Secret<String>>,
     pub state: Option<grpc_payment_types::ConnectorState>,
+    pub session_token: Option<String>,
     pub setup_mandate_details: Option<grpc_payment_types::SetupMandateDetails>,
     pub customer_acceptance: Option<grpc_payment_types::CustomerAcceptance>,
     pub auth_type: AuthenticationType,
     pub authentication_data: Option<grpc_payment_types::AuthenticationData>,
     pub setup_future_usage: grpc_payment_types::FutureUsage,
+    pub request_incremental_authorization: bool,
+    pub enable_partial_authorization: Option<bool>,
     pub browser_info: Option<grpc_payment_types::BrowserInformation>,
     pub billing_descriptor: Option<grpc_payment_types::BillingDescriptor>,
     pub locale: Option<String>,
@@ -2651,7 +2654,9 @@ pub struct SetupRecurringRequest {
     pub order_category: Option<String>,
     pub order_id: Option<String>,
     pub order_tax_amount: Option<i64>,
+    pub shipping_cost: Option<i64>,
     pub merchant_order_id: Option<String>,
+    pub connector_testing_data: Option<Secret<String>>,
     pub l2_l3_data: Option<grpc_payment_types::L2l3Data>,
 }
 
@@ -2663,6 +2668,10 @@ impl From<grpc_payment_types::PaymentServiceAuthorizeRequest> for AuthorizationR
         let tokenization_strategy = req
             .tokenization_strategy
             .map(|_| req.tokenization_strategy());
+        let payment_experience = req.payment_experience.map(|_| req.payment_experience());
+        let threeds_completion_indicator = req
+            .threeds_completion_indicator
+            .map(|_| req.threeds_completion_indicator());
         Self {
             merchant_transaction_id: req.merchant_transaction_id.clone(),
             amount: req.amount,
@@ -2691,13 +2700,13 @@ impl From<grpc_payment_types::PaymentServiceAuthorizeRequest> for AuthorizationR
             customer_acceptance: req.customer_acceptance.clone(),
             browser_info: req.browser_info.clone(),
             billing_descriptor: req.billing_descriptor.clone(),
-            payment_experience: Some(req.payment_experience()),
+            payment_experience,
             description: req.description.clone(),
             payment_channel: req.payment_channel(),
             locale: req.locale.clone(),
             state: req.state.clone(),
             tokenization_strategy,
-            threeds_completion_indicator: Some(req.threeds_completion_indicator()),
+            threeds_completion_indicator,
             redirection_response: req.redirection_response,
             continue_redirection_url: req.continue_redirection_url,
             l2_l3_data: req.l2_l3_data,
@@ -2789,6 +2798,7 @@ impl From<grpc_payment_types::PaymentServiceSetupRecurringRequest> for SetupRecu
             metadata: req.metadata,
             connector_feature_data: req.connector_feature_data,
             state: req.state,
+            session_token: req.session_token,
             setup_mandate_details: req.setup_mandate_details,
             customer_acceptance: req.customer_acceptance,
             authentication_data: req.authentication_data,
@@ -2798,10 +2808,14 @@ impl From<grpc_payment_types::PaymentServiceSetupRecurringRequest> for SetupRecu
             payment_channel: req.payment_channel,
             complete_authorize_url: req.complete_authorize_url,
             off_session: req.off_session,
+            request_incremental_authorization: req.request_incremental_authorization,
+            enable_partial_authorization: req.enable_partial_authorization,
             order_category: req.order_category,
             order_id: req.order_id,
             order_tax_amount: req.order_tax_amount,
+            shipping_cost: req.shipping_cost,
             merchant_order_id: req.merchant_order_id,
+            connector_testing_data: req.connector_testing_data,
             l2_l3_data: req.l2_l3_data,
         }
     }
@@ -2832,9 +2846,12 @@ impl From<grpc_payment_types::PaymentServiceProxySetupRecurringRequest> for Setu
             metadata: req.metadata,
             connector_feature_data: None,
             state: req.state,
+            session_token: None,
             setup_mandate_details: req.setup_mandate_details,
             customer_acceptance: req.customer_acceptance,
             authentication_data: req.authentication_data,
+            request_incremental_authorization: false,
+            enable_partial_authorization: None,
             browser_info: req.browser_info,
             billing_descriptor: None,
             locale: None,
@@ -2844,7 +2861,9 @@ impl From<grpc_payment_types::PaymentServiceProxySetupRecurringRequest> for Setu
             order_category: req.order_category,
             order_id: None,
             order_tax_amount: None,
+            shipping_cost: None,
             merchant_order_id: None,
+            connector_testing_data: None,
             l2_l3_data: None,
         }
     }
@@ -3294,14 +3313,19 @@ impl<
             mandate_id: None,
             off_session: value.off_session,
             order_category: value.order_category,
-            session_token: None,
+            session_token: value.session_token,
             access_token,
             customer_acceptance: customer_acceptance
                 .map(mandates::CustomerAcceptance::foreign_try_from)
                 .transpose()?,
             enrolled_for_3ds: value.enrolled_for_3ds,
             related_transaction_id: None,
-            payment_experience: None,
+            payment_experience: match value.payment_experience {
+                Some(grpc_payment_types::PaymentExperience::Unspecified) | None => None,
+                Some(payment_experience) => Some(
+                    common_enums::PaymentExperience::foreign_try_from(payment_experience)?,
+                ),
+            },
             customer_id: value
                 .customer
                 .and_then(|customer| customer.id)
@@ -3320,7 +3344,9 @@ impl<
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
                 .transpose()?,
             merchant_order_id: value.merchant_order_id,
-            order_tax_amount: None,
+            order_tax_amount: value
+                .order_tax_amount
+                .map(common_utils::types::MinorUnit::new),
             shipping_cost,
             merchant_account_id,
             integrity_object: None,
@@ -3416,6 +3442,21 @@ impl<
             .billing_descriptor
             .map(|descriptor| BillingDescriptor::from((&descriptor, None, None)));
 
+        let payment_channel = value
+            .payment_channel
+            .map(grpc_payment_types::PaymentChannel::try_from)
+            .transpose()
+            .ok()
+            .flatten()
+            .filter(|channel| !matches!(channel, grpc_payment_types::PaymentChannel::Unspecified))
+            .map(common_enums::PaymentChannel::foreign_try_from)
+            .transpose()?;
+
+        let connector_testing_data = value
+            .connector_testing_data
+            .map(|m| ForeignTryFrom::foreign_try_from((m, "connector_testing_data")))
+            .transpose()?;
+
         Ok(Self {
             currency: common_enums::Currency::foreign_try_from(amount.currency())?,
             payment_method_data,
@@ -3456,7 +3497,7 @@ impl<
                     })
                 })?,
             )?,
-            request_incremental_authorization: false,
+            request_incremental_authorization: value.request_incremental_authorization,
             metadata: value
                 .metadata
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
@@ -3465,9 +3506,7 @@ impl<
             capture_method: None,
             merchant_order_id: value.merchant_order_id,
             minor_amount: Some(common_utils::types::MinorUnit::new(amount.minor_amount)),
-            shipping_cost: value
-                .order_tax_amount
-                .map(common_utils::types::MinorUnit::new),
+            shipping_cost: value.shipping_cost.map(common_utils::types::MinorUnit::new),
             customer_id: value
                 .customer
                 .and_then(|customer| customer.connector_customer_id)
@@ -3481,10 +3520,10 @@ impl<
                     },
                 })?,
             integrity_object: None,
-            payment_channel: None,
-            enable_partial_authorization: None,
+            payment_channel,
+            enable_partial_authorization: value.enable_partial_authorization,
             locale: value.locale.clone(),
-            connector_testing_data: None,
+            connector_testing_data,
         })
     }
 }
@@ -4169,13 +4208,27 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card,
+            payment_method: PaymentMethod::foreign_try_from(
+                value.payment_method.clone().unwrap_or_default(),
+            )?,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
             connector_request_reference_id: extract_connector_request_reference_id(
                 &value.merchant_transaction_id,
             ),
-            customer_id: None,
+            customer_id: value
+                .customer
+                .clone()
+                .and_then(|customer| customer.id)
+                .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
+                .transpose()
+                .change_context(IntegrationError::InvalidDataFormat {
+                    field_name: "unknown",
+                    context: IntegrationErrorContext {
+                        additional_context: Some("Failed to parse Customer Id".to_string()),
+                        ..Default::default()
+                    },
+                })?,
             connector_customer: value
                 .customer
                 .and_then(|customer| customer.connector_customer_id),
@@ -4188,11 +4241,11 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
             amount: None,
             access_token,
             session_token: value.session_token,
-            reference_id: None,
+            reference_id: value.merchant_order_id.clone(),
             connector_order_id: None,
             preprocessing_id: None,
             connector_api_version: None,
-            test_mode: None,
+            test_mode: value.test_mode,
             connector_http_status_code: None,
             external_latency: None,
             connectors,
@@ -4255,12 +4308,26 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
             connector_request_reference_id: extract_connector_request_reference_id(&Some(
                 value.merchant_recurring_payment_id.clone(),
             )),
-            customer_id: None,
-            connector_customer: None,
+            customer_id: value
+                .customer
+                .clone()
+                .and_then(|customer| customer.id)
+                .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
+                .transpose()
+                .change_context(IntegrationError::InvalidDataFormat {
+                    field_name: "unknown",
+                    context: IntegrationErrorContext {
+                        additional_context: Some("Failed to parse Customer Id".to_string()),
+                        ..Default::default()
+                    },
+                })?,
+            connector_customer: value
+                .customer
+                .and_then(|customer| customer.connector_customer_id),
             description: None,
             return_url: value.return_url.clone(),
             connector_feature_data,
@@ -4269,9 +4336,9 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             minor_amount_capturable: None,
             amount: None,
             access_token,
-            session_token: None,
-            reference_id: None,
-            connector_order_id: None,
+            session_token: value.session_token,
+            reference_id: value.order_id.clone(),
+            connector_order_id: value.order_id,
             preprocessing_id: None,
             connector_api_version: None,
             test_mode: None,
@@ -8535,7 +8602,10 @@ impl
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            auth_type: common_enums::AuthenticationType::foreign_try_from(
+                grpc_api_types::payments::AuthenticationType::try_from(value.auth_type)
+                    .unwrap_or_default(),
+            )?,
             connector_request_reference_id: value.merchant_recurring_payment_id,
             customer_id: value
                 .customer
@@ -8639,13 +8709,21 @@ impl<
 
         let setup_future_usage = value.setup_future_usage();
 
-        let setup_mandate_details = MandateData {
-            update_mandate_id: None,
-            customer_acceptance: Some(mandates::CustomerAcceptance::foreign_try_from(
-                customer_acceptance.clone(),
+        let payment_channel = match value.payment_channel() {
+            grpc_payment_types::PaymentChannel::Unspecified => None,
+            _ => Some(common_enums::PaymentChannel::foreign_try_from(
+                value.payment_channel(),
             )?),
-            mandate_type: None,
         };
+
+        let mut setup_mandate_details = value
+            .setup_mandate_details
+            .map(MandateData::foreign_try_from)
+            .transpose()?
+            .unwrap_or_default();
+        setup_mandate_details.customer_acceptance = Some(
+            mandates::CustomerAcceptance::foreign_try_from(customer_acceptance.clone())?,
+        );
 
         let billing_descriptor =
             value
@@ -8659,13 +8737,6 @@ impl<
                     statement_descriptor_suffix: descriptor.statement_descriptor_suffix.clone(),
                     reference: descriptor.reference.clone(),
                 });
-
-        let payment_channel = match value.payment_channel() {
-            grpc_payment_types::PaymentChannel::Unspecified => None,
-            _ => Some(common_enums::PaymentChannel::foreign_try_from(
-                value.payment_channel(),
-            )?),
-        };
 
         Ok(Self {
             currency: amount.currency,
@@ -8699,16 +8770,16 @@ impl<
                 .map(<Option<common_enums::PaymentMethodType>>::foreign_try_from)
                 .transpose()?
                 .flatten(),
-            request_incremental_authorization: false,
+            request_incremental_authorization: value.request_incremental_authorization,
             metadata: value
                 .metadata
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
                 .transpose()?,
-            complete_authorize_url: None,
+            complete_authorize_url: value.complete_authorize_url.clone(),
             capture_method: None,
             integrity_object: None,
             minor_amount: Some(amount.amount),
-            shipping_cost: None,
+            shipping_cost: value.shipping_cost.map(common_utils::types::MinorUnit::new),
             customer_id: value
                 .customer
                 .and_then(|customer| customer.id)
@@ -13563,236 +13634,5 @@ impl From<connector_types::WebhookResourceReference> for grpc_api_types::payment
                 })),
             },
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        proxied_authorize_to_base, proxied_setup_recurring_to_base,
-        tokenized_setup_recurring_to_base, AuthorizationRequest, SetupRecurringRequest,
-    };
-    use grpc_api_types::payments as grpc_payment_types;
-    use hyperswitch_masking::Secret;
-
-    fn secret(value: &str) -> Secret<String> {
-        Secret::new(value.to_string())
-    }
-
-    fn money() -> grpc_payment_types::Money {
-        grpc_payment_types::Money {
-            minor_amount: 100,
-            currency: grpc_payment_types::Currency::Usd as i32,
-        }
-    }
-
-    fn billing_descriptor() -> grpc_payment_types::BillingDescriptor {
-        grpc_payment_types::BillingDescriptor {
-            statement_descriptor: Some("statement".to_string()),
-            statement_descriptor_suffix: Some("suffix".to_string()),
-            ..Default::default()
-        }
-    }
-
-    fn setup_mandate_details() -> grpc_payment_types::SetupMandateDetails {
-        grpc_payment_types::SetupMandateDetails {
-            update_mandate_id: Some("mandate-update-id".to_string()),
-            ..Default::default()
-        }
-    }
-
-    fn authentication_data() -> grpc_payment_types::AuthenticationData {
-        grpc_payment_types::AuthenticationData {
-            eci: Some("05".to_string()),
-            cavv: Some("sample-cavv".to_string()),
-            ..Default::default()
-        }
-    }
-
-    fn proxy_card() -> grpc_payment_types::ProxyCardDetails {
-        grpc_payment_types::ProxyCardDetails {
-            card_number: Some(secret("4111111111111111")),
-            card_exp_month: Some(secret("12")),
-            card_exp_year: Some(secret("2030")),
-            card_cvc: Some(secret("123")),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn tokenized_setup_recurring_to_base_maps_supported_proto_fields() {
-        let request = grpc_payment_types::PaymentServiceTokenSetupRecurringRequest {
-            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
-            amount: Some(money()),
-            billing_descriptor: Some(billing_descriptor()),
-            locale: Some("en-US".to_string()),
-            setup_mandate_details: Some(setup_mandate_details()),
-            ..Default::default()
-        };
-
-        let base = tokenized_setup_recurring_to_base(request);
-
-        assert_eq!(
-            base.billing_descriptor
-                .as_ref()
-                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
-            Some("statement")
-        );
-        assert_eq!(base.locale.as_deref(), Some("en-US"));
-        assert_eq!(
-            base.setup_mandate_details
-                .as_ref()
-                .and_then(|details| details.update_mandate_id.as_deref()),
-            Some("mandate-update-id")
-        );
-    }
-
-    #[test]
-    fn proxied_authorize_to_base_maps_supported_proto_fields() {
-        let request = grpc_payment_types::PaymentServiceProxyAuthorizeRequest {
-            amount: Some(money()),
-            card_proxy: Some(proxy_card()),
-            auth_type: grpc_payment_types::AuthenticationType::ThreeDs as i32,
-            authentication_data: Some(authentication_data()),
-            setup_mandate_details: Some(setup_mandate_details()),
-            billing_descriptor: Some(billing_descriptor()),
-            threeds_completion_indicator: Some(
-                grpc_payment_types::ThreeDsCompletionIndicator::Success as i32,
-            ),
-            redirection_response: Some(grpc_payment_types::RedirectionResponse {
-                params: Some("pares=abc".to_string()),
-                ..Default::default()
-            }),
-            shipping_cost: Some(250),
-            test_mode: Some(true),
-            order_category: Some("digital".to_string()),
-            ..Default::default()
-        };
-
-        let base = proxied_authorize_to_base(request).expect("proxy authorize normalization");
-
-        assert_eq!(
-            base.auth_type(),
-            grpc_payment_types::AuthenticationType::ThreeDs
-        );
-        assert_eq!(
-            base.authentication_data
-                .as_ref()
-                .and_then(|data| data.eci.as_deref()),
-            Some("05")
-        );
-        assert_eq!(
-            base.setup_mandate_details
-                .as_ref()
-                .and_then(|details| details.update_mandate_id.as_deref()),
-            Some("mandate-update-id")
-        );
-        assert_eq!(base.shipping_cost, Some(250));
-        assert_eq!(base.test_mode, Some(true));
-        assert_eq!(base.order_category.as_deref(), Some("digital"));
-        assert_eq!(
-            base.billing_descriptor
-                .as_ref()
-                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
-            Some("statement")
-        );
-        assert_eq!(
-            base.redirection_response
-                .as_ref()
-                .and_then(|response| response.params.as_deref()),
-            Some("pares=abc")
-        );
-        assert_eq!(
-            base.threeds_completion_indicator(),
-            grpc_payment_types::ThreeDsCompletionIndicator::Success
-        );
-    }
-
-    #[test]
-    fn proxy_authorize_into_authorization_request_preserves_proxy_fields() {
-        let request = grpc_payment_types::PaymentServiceProxyAuthorizeRequest {
-            amount: Some(money()),
-            card_proxy: Some(proxy_card()),
-            billing_descriptor: Some(billing_descriptor()),
-            threeds_completion_indicator: Some(
-                grpc_payment_types::ThreeDsCompletionIndicator::Success as i32,
-            ),
-            redirection_response: Some(grpc_payment_types::RedirectionResponse {
-                params: Some("pares=abc".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let auth_request: AuthorizationRequest = request.into();
-
-        assert_eq!(
-            auth_request
-                .billing_descriptor
-                .as_ref()
-                .and_then(|descriptor| descriptor.statement_descriptor.as_deref()),
-            Some("statement")
-        );
-        assert_eq!(
-            auth_request.threeds_completion_indicator,
-            Some(grpc_payment_types::ThreeDsCompletionIndicator::Success)
-        );
-        assert_eq!(
-            auth_request
-                .redirection_response
-                .as_ref()
-                .and_then(|response| response.params.as_deref()),
-            Some("pares=abc")
-        );
-    }
-
-    #[test]
-    fn proxied_setup_recurring_to_base_maps_supported_proto_fields() {
-        let request = grpc_payment_types::PaymentServiceProxySetupRecurringRequest {
-            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
-            amount: Some(money()),
-            card_proxy: Some(proxy_card()),
-            auth_type: grpc_payment_types::AuthenticationType::ThreeDs as i32,
-            authentication_data: Some(authentication_data()),
-            setup_mandate_details: Some(setup_mandate_details()),
-            order_category: Some("service".to_string()),
-            ..Default::default()
-        };
-
-        let base =
-            proxied_setup_recurring_to_base(request).expect("proxy setup recurring normalization");
-
-        assert_eq!(
-            base.auth_type(),
-            grpc_payment_types::AuthenticationType::ThreeDs
-        );
-        assert_eq!(
-            base.authentication_data
-                .as_ref()
-                .and_then(|data| data.eci.as_deref()),
-            Some("05")
-        );
-        assert_eq!(base.order_category.as_deref(), Some("service"));
-        assert_eq!(
-            base.setup_mandate_details
-                .as_ref()
-                .and_then(|details| details.update_mandate_id.as_deref()),
-            Some("mandate-update-id")
-        );
-    }
-
-    #[test]
-    fn proxy_setup_recurring_into_setup_recurring_request_preserves_order_category() {
-        let request = grpc_payment_types::PaymentServiceProxySetupRecurringRequest {
-            merchant_recurring_payment_id: "merchant-recurring-id".to_string(),
-            amount: Some(money()),
-            card_proxy: Some(proxy_card()),
-            order_category: Some("service".to_string()),
-            ..Default::default()
-        };
-
-        let setup_request: SetupRecurringRequest = request.into();
-
-        assert_eq!(setup_request.order_category.as_deref(), Some("service"));
     }
 }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -1530,7 +1530,14 @@ impl<
                         email: match interac.email {
                             Some(ref email_str) => Some(
                                 Email::try_from(email_str.clone().expose()).change_context(
-                                    IntegrationError::InvalidDataFormat { field_name: "unknown", context: IntegrationErrorContext { additional_context: Some("Invalid email for Interac".to_string()), ..Default::default() } },
+                                    IntegrationError::InvalidDataFormat {
+                                        field_name: "payment_method.interac.email",
+                                        context: IntegrationErrorContext {
+                                            additional_context: Some("Invalid email format for Interac payment method".to_string()),
+                                            suggested_action: Some("Provide a valid email address for Interac".to_string()),
+                                            doc_url: None,
+                                        },
+                                    },
                                 )?,
                             ),
                             None => None,
@@ -1562,7 +1569,14 @@ impl<
                         email: match online_banking_finland.email {
                                 Some(ref email_str) => Some(
                                     Email::try_from(email_str.clone().expose()).change_context(
-                                        IntegrationError::InvalidDataFormat { field_name: "unknown", context: IntegrationErrorContext { additional_context: Some("Invalid email".to_string()), ..Default::default() } },
+                                        IntegrationError::InvalidDataFormat {
+                                            field_name: "payment_method.online_banking_finland.email",
+                                            context: IntegrationErrorContext {
+                                                additional_context: Some("Invalid email format for Online Banking Finland".to_string()),
+                                                suggested_action: Some("Provide a valid email address for Online Banking Finland".to_string()),
+                                                doc_url: None,
+                                            },
+                                        },
                                     )?,
                                 ),
                                 None => None,
@@ -2637,14 +2651,11 @@ pub struct SetupRecurringRequest {
     pub metadata: Option<Secret<String>>,
     pub connector_feature_data: Option<Secret<String>>,
     pub state: Option<grpc_payment_types::ConnectorState>,
-    pub session_token: Option<String>,
     pub setup_mandate_details: Option<grpc_payment_types::SetupMandateDetails>,
     pub customer_acceptance: Option<grpc_payment_types::CustomerAcceptance>,
     pub auth_type: AuthenticationType,
     pub authentication_data: Option<grpc_payment_types::AuthenticationData>,
     pub setup_future_usage: grpc_payment_types::FutureUsage,
-    pub request_incremental_authorization: bool,
-    pub enable_partial_authorization: Option<bool>,
     pub browser_info: Option<grpc_payment_types::BrowserInformation>,
     pub billing_descriptor: Option<grpc_payment_types::BillingDescriptor>,
     pub locale: Option<String>,
@@ -2654,9 +2665,7 @@ pub struct SetupRecurringRequest {
     pub order_category: Option<String>,
     pub order_id: Option<String>,
     pub order_tax_amount: Option<i64>,
-    pub shipping_cost: Option<i64>,
     pub merchant_order_id: Option<String>,
-    pub connector_testing_data: Option<Secret<String>>,
     pub l2_l3_data: Option<grpc_payment_types::L2l3Data>,
 }
 
@@ -2668,10 +2677,6 @@ impl From<grpc_payment_types::PaymentServiceAuthorizeRequest> for AuthorizationR
         let tokenization_strategy = req
             .tokenization_strategy
             .map(|_| req.tokenization_strategy());
-        let payment_experience = req.payment_experience.map(|_| req.payment_experience());
-        let threeds_completion_indicator = req
-            .threeds_completion_indicator
-            .map(|_| req.threeds_completion_indicator());
         Self {
             merchant_transaction_id: req.merchant_transaction_id.clone(),
             amount: req.amount,
@@ -2700,13 +2705,13 @@ impl From<grpc_payment_types::PaymentServiceAuthorizeRequest> for AuthorizationR
             customer_acceptance: req.customer_acceptance.clone(),
             browser_info: req.browser_info.clone(),
             billing_descriptor: req.billing_descriptor.clone(),
-            payment_experience,
+            payment_experience: Some(req.payment_experience()),
             description: req.description.clone(),
             payment_channel: req.payment_channel(),
             locale: req.locale.clone(),
             state: req.state.clone(),
             tokenization_strategy,
-            threeds_completion_indicator,
+            threeds_completion_indicator: Some(req.threeds_completion_indicator()),
             redirection_response: req.redirection_response,
             continue_redirection_url: req.continue_redirection_url,
             l2_l3_data: req.l2_l3_data,
@@ -2731,9 +2736,6 @@ impl From<grpc_payment_types::PaymentServiceProxyAuthorizeRequest> for Authoriza
                         grpc_payment_types::payment_method::PaymentMethod::CardProxy(card_proxy),
                     ),
                 });
-        let threeds_completion_indicator = req
-            .threeds_completion_indicator
-            .map(|_| req.threeds_completion_indicator());
 
         Self {
             merchant_transaction_id: req.merchant_transaction_id.clone(),
@@ -2762,14 +2764,14 @@ impl From<grpc_payment_types::PaymentServiceProxyAuthorizeRequest> for Authoriza
             enable_partial_authorization: None,
             customer_acceptance: req.customer_acceptance.clone(),
             browser_info: req.browser_info,
-            billing_descriptor: req.billing_descriptor,
+            billing_descriptor: None,
             payment_experience: None,
             description: req.description.clone(),
             payment_channel: grpc_payment_types::PaymentChannel::Unspecified,
             locale: None,
             state: req.state,
-            threeds_completion_indicator,
-            redirection_response: req.redirection_response,
+            threeds_completion_indicator: None,
+            redirection_response: None,
             continue_redirection_url: None,
             l2_l3_data: req.l2_l3_data,
             setup_mandate_details: req.setup_mandate_details,
@@ -2798,7 +2800,6 @@ impl From<grpc_payment_types::PaymentServiceSetupRecurringRequest> for SetupRecu
             metadata: req.metadata,
             connector_feature_data: req.connector_feature_data,
             state: req.state,
-            session_token: req.session_token,
             setup_mandate_details: req.setup_mandate_details,
             customer_acceptance: req.customer_acceptance,
             authentication_data: req.authentication_data,
@@ -2808,14 +2809,10 @@ impl From<grpc_payment_types::PaymentServiceSetupRecurringRequest> for SetupRecu
             payment_channel: req.payment_channel,
             complete_authorize_url: req.complete_authorize_url,
             off_session: req.off_session,
-            request_incremental_authorization: req.request_incremental_authorization,
-            enable_partial_authorization: req.enable_partial_authorization,
             order_category: req.order_category,
             order_id: req.order_id,
             order_tax_amount: req.order_tax_amount,
-            shipping_cost: req.shipping_cost,
             merchant_order_id: req.merchant_order_id,
-            connector_testing_data: req.connector_testing_data,
             l2_l3_data: req.l2_l3_data,
         }
     }
@@ -2846,24 +2843,19 @@ impl From<grpc_payment_types::PaymentServiceProxySetupRecurringRequest> for Setu
             metadata: req.metadata,
             connector_feature_data: None,
             state: req.state,
-            session_token: None,
             setup_mandate_details: req.setup_mandate_details,
             customer_acceptance: req.customer_acceptance,
             authentication_data: req.authentication_data,
-            request_incremental_authorization: false,
-            enable_partial_authorization: None,
             browser_info: req.browser_info,
             billing_descriptor: None,
             locale: None,
             payment_channel: None,
             complete_authorize_url: None,
             off_session: None,
-            order_category: req.order_category,
+            order_category: None,
             order_id: None,
             order_tax_amount: None,
-            shipping_cost: None,
             merchant_order_id: None,
-            connector_testing_data: None,
             l2_l3_data: None,
         }
     }
@@ -2934,43 +2926,26 @@ impl ForeignTryFrom<grpc_api_types::payments::ProxyCardDetails>
     fn foreign_try_from(
         card: grpc_api_types::payments::ProxyCardDetails,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
+        // Derive card_network from the proto field only.
+        // NOTE: card.card_number is a vault token (e.g. "token_123456"), NOT a real card BIN,
+        // so BIN-based issuer detection is not possible here. The caller must populate the card_network proto field
+
+        let card_network = card.card_network.and_then(|n| {
+            grpc_api_types::payments::CardNetwork::try_from(n)
+                .ok()
+                .and_then(|cn| CardNetwork::foreign_try_from(cn).ok())
+        });
+
         Ok(payment_method_data::Card {
-            card_number: RawCardNumber(card.card_number.ok_or(
-                IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
-                    context: IntegrationErrorContext {
-                        additional_context: Some("Missing card number".to_string()),
-                        ..Default::default()
-                    },
-                },
-            )?),
-            card_exp_month: card
-                .card_exp_month
-                .ok_or(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
-                    context: IntegrationErrorContext {
-                        additional_context: Some("Missing Card Expiry Month".to_string()),
-                        ..Default::default()
-                    },
-                })?,
-            card_exp_year: card
-                .card_exp_year
-                .ok_or(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
-                    context: IntegrationErrorContext {
-                        additional_context: Some("Missing Card Expiry Year".to_string()),
-                        ..Default::default()
-                    },
-                })?,
-            card_cvc: card.card_cvc.ok_or(IntegrationError::InvalidDataFormat {
-                field_name: "unknown",
-                context: IntegrationErrorContext {
-                    additional_context: Some("Missing CVC".to_string()),
-                    ..Default::default()
-                },
-            })?,
+            card_number: RawCardNumber(
+                //card number token is already stored in token_data , so we can update the value to internal transformation value.
+                "{{$card_number}}".to_string().into(),
+            ),
+            card_exp_month: "{{$card_exp_month}}".to_string().into(),
+            card_exp_year: "{{$card_exp_year}}".to_string().into(),
+            card_cvc: "{{$card_cvc}}".to_string().into(),
             card_issuer: card.card_issuer,
-            card_network: None,
+            card_network,
             card_type: card.card_type,
             card_issuing_country: card.card_issuing_country_alpha2,
             bank_code: card.bank_code,
@@ -3187,10 +3162,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -3313,29 +3291,25 @@ impl<
             mandate_id: None,
             off_session: value.off_session,
             order_category: value.order_category,
-            session_token: value.session_token,
+            session_token: None,
             access_token,
             customer_acceptance: customer_acceptance
                 .map(mandates::CustomerAcceptance::foreign_try_from)
                 .transpose()?,
             enrolled_for_3ds: value.enrolled_for_3ds,
             related_transaction_id: None,
-            payment_experience: match value.payment_experience {
-                Some(grpc_payment_types::PaymentExperience::Unspecified) | None => None,
-                Some(payment_experience) => Some(
-                    common_enums::PaymentExperience::foreign_try_from(payment_experience)?,
-                ),
-            },
+            payment_experience: None,
             customer_id: value
                 .customer
                 .and_then(|customer| customer.id)
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             request_incremental_authorization: value.request_incremental_authorization,
@@ -3344,9 +3318,7 @@ impl<
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
                 .transpose()?,
             merchant_order_id: value.merchant_order_id,
-            order_tax_amount: value
-                .order_tax_amount
-                .map(common_utils::types::MinorUnit::new),
+            order_tax_amount: None,
             shipping_cost,
             merchant_account_id,
             integrity_object: None,
@@ -3442,21 +3414,6 @@ impl<
             .billing_descriptor
             .map(|descriptor| BillingDescriptor::from((&descriptor, None, None)));
 
-        let payment_channel = value
-            .payment_channel
-            .map(grpc_payment_types::PaymentChannel::try_from)
-            .transpose()
-            .ok()
-            .flatten()
-            .filter(|channel| !matches!(channel, grpc_payment_types::PaymentChannel::Unspecified))
-            .map(common_enums::PaymentChannel::foreign_try_from)
-            .transpose()?;
-
-        let connector_testing_data = value
-            .connector_testing_data
-            .map(|m| ForeignTryFrom::foreign_try_from((m, "connector_testing_data")))
-            .transpose()?;
-
         Ok(Self {
             currency: common_enums::Currency::foreign_try_from(amount.currency())?,
             payment_method_data,
@@ -3497,7 +3454,7 @@ impl<
                     })
                 })?,
             )?,
-            request_incremental_authorization: value.request_incremental_authorization,
+            request_incremental_authorization: false,
             metadata: value
                 .metadata
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
@@ -3506,7 +3463,9 @@ impl<
             capture_method: None,
             merchant_order_id: value.merchant_order_id,
             minor_amount: Some(common_utils::types::MinorUnit::new(amount.minor_amount)),
-            shipping_cost: value.shipping_cost.map(common_utils::types::MinorUnit::new),
+            shipping_cost: value
+                .order_tax_amount
+                .map(common_utils::types::MinorUnit::new),
             customer_id: value
                 .customer
                 .and_then(|customer| customer.connector_customer_id)
@@ -3520,10 +3479,10 @@ impl<
                     },
                 })?,
             integrity_object: None,
-            payment_channel,
-            enable_partial_authorization: value.enable_partial_authorization,
+            payment_channel: None,
+            enable_partial_authorization: None,
             locale: value.locale.clone(),
-            connector_testing_data,
+            connector_testing_data: None,
         })
     }
 }
@@ -4125,10 +4084,11 @@ impl ForeignTryFrom<(PaymentServiceAuthorizeRequest, Connectors, &MaskedMetadata
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.connector_customer_id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid connector customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             connector_customer: value
@@ -4208,27 +4168,13 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::foreign_try_from(
-                value.payment_method.clone().unwrap_or_default(),
-            )?,
+            payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
+            auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: extract_connector_request_reference_id(
                 &value.merchant_transaction_id,
             ),
-            customer_id: value
-                .customer
-                .clone()
-                .and_then(|customer| customer.id)
-                .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
-                .transpose()
-                .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
-                    context: IntegrationErrorContext {
-                        additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
-                    },
-                })?,
+            customer_id: None,
             connector_customer: value
                 .customer
                 .and_then(|customer| customer.connector_customer_id),
@@ -4241,11 +4187,11 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
             amount: None,
             access_token,
             session_token: value.session_token,
-            reference_id: value.merchant_order_id.clone(),
+            reference_id: None,
             connector_order_id: None,
             preprocessing_id: None,
             connector_api_version: None,
-            test_mode: value.test_mode,
+            test_mode: None,
             connector_http_status_code: None,
             external_latency: None,
             connectors,
@@ -4308,26 +4254,12 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
+            auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: extract_connector_request_reference_id(&Some(
                 value.merchant_recurring_payment_id.clone(),
             )),
-            customer_id: value
-                .customer
-                .clone()
-                .and_then(|customer| customer.id)
-                .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
-                .transpose()
-                .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
-                    context: IntegrationErrorContext {
-                        additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
-                    },
-                })?,
-            connector_customer: value
-                .customer
-                .and_then(|customer| customer.connector_customer_id),
+            customer_id: None,
+            connector_customer: None,
             description: None,
             return_url: value.return_url.clone(),
             connector_feature_data,
@@ -4336,9 +4268,9 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             minor_amount_capturable: None,
             amount: None,
             access_token,
-            session_token: value.session_token,
-            reference_id: value.order_id.clone(),
-            connector_order_id: value.order_id,
+            session_token: None,
+            reference_id: None,
+            connector_order_id: None,
             preprocessing_id: None,
             connector_api_version: None,
             test_mode: None,
@@ -7927,10 +7859,16 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "payment_context.customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some(
+                                "Invalid email format in payment context customer".to_string(),
+                            ),
+                            suggested_action: Some(
+                                "Provide a valid email address in payment_context.customer.email"
+                                    .to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -8505,10 +8443,11 @@ impl
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             connector_customer: value
@@ -8602,10 +8541,7 @@ impl
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::foreign_try_from(
-                grpc_api_types::payments::AuthenticationType::try_from(value.auth_type)
-                    .unwrap_or_default(),
-            )?,
+            auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: value.merchant_recurring_payment_id,
             customer_id: value
                 .customer
@@ -8614,10 +8550,11 @@ impl
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             connector_customer: value
@@ -8676,10 +8613,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -8709,21 +8649,13 @@ impl<
 
         let setup_future_usage = value.setup_future_usage();
 
-        let payment_channel = match value.payment_channel() {
-            grpc_payment_types::PaymentChannel::Unspecified => None,
-            _ => Some(common_enums::PaymentChannel::foreign_try_from(
-                value.payment_channel(),
+        let setup_mandate_details = MandateData {
+            update_mandate_id: None,
+            customer_acceptance: Some(mandates::CustomerAcceptance::foreign_try_from(
+                customer_acceptance.clone(),
             )?),
+            mandate_type: None,
         };
-
-        let mut setup_mandate_details = value
-            .setup_mandate_details
-            .map(MandateData::foreign_try_from)
-            .transpose()?
-            .unwrap_or_default();
-        setup_mandate_details.customer_acceptance = Some(
-            mandates::CustomerAcceptance::foreign_try_from(customer_acceptance.clone())?,
-        );
 
         let billing_descriptor =
             value
@@ -8737,6 +8669,13 @@ impl<
                     statement_descriptor_suffix: descriptor.statement_descriptor_suffix.clone(),
                     reference: descriptor.reference.clone(),
                 });
+
+        let payment_channel = match value.payment_channel() {
+            grpc_payment_types::PaymentChannel::Unspecified => None,
+            _ => Some(common_enums::PaymentChannel::foreign_try_from(
+                value.payment_channel(),
+            )?),
+        };
 
         Ok(Self {
             currency: amount.currency,
@@ -8770,16 +8709,16 @@ impl<
                 .map(<Option<common_enums::PaymentMethodType>>::foreign_try_from)
                 .transpose()?
                 .flatten(),
-            request_incremental_authorization: value.request_incremental_authorization,
+            request_incremental_authorization: false,
             metadata: value
                 .metadata
                 .map(|m| ForeignTryFrom::foreign_try_from((m, "metadata")))
                 .transpose()?,
-            complete_authorize_url: value.complete_authorize_url.clone(),
+            complete_authorize_url: None,
             capture_method: None,
             integrity_object: None,
             minor_amount: Some(amount.amount),
-            shipping_cost: value.shipping_cost.map(common_utils::types::MinorUnit::new),
+            shipping_cost: None,
             customer_id: value
                 .customer
                 .and_then(|customer| customer.id)
@@ -8787,10 +8726,11 @@ impl<
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             billing_descriptor,
@@ -9027,10 +8967,11 @@ impl ForeignTryFrom<&grpc_api_types::payments::Customer> for CustomerInfo {
             .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
             .transpose()
             .change_context(IntegrationError::InvalidDataFormat {
-                field_name: "unknown",
+                field_name: "customer.id",
                 context: IntegrationErrorContext {
                     additional_context: Some("Failed to parse Customer Id".to_string()),
-                    ..Default::default()
+                    suggested_action: Some("Provide a valid customer ID".to_string()),
+                    doc_url: None,
                 },
             })?;
 
@@ -9038,10 +8979,60 @@ impl ForeignTryFrom<&grpc_api_types::payments::Customer> for CustomerInfo {
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
+                        },
+                    })
+                })?)
+            }
+            None => None,
+        };
+
+        Ok(Self {
+            customer_id,
+            customer_email,
+            customer_name: value.name.clone().map(Into::into),
+            customer_phone_number: value.phone_number.clone().map(Into::into),
+            customer_phone_country_code: value.phone_country_code.clone(),
+        })
+    }
+}
+
+impl ForeignTryFrom<&grpc_api_types::payouts::Customer> for CustomerInfo {
+    type Error = IntegrationError;
+    fn foreign_try_from(
+        value: &grpc_api_types::payouts::Customer,
+    ) -> Result<Self, error_stack::Report<Self::Error>> {
+        let customer_id = value
+            .id
+            .clone()
+            .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
+            .transpose()
+            .change_context(IntegrationError::InvalidDataFormat {
+                field_name: "customer.id",
+                context: IntegrationErrorContext {
+                    additional_context: Some("Failed to parse Customer Id".to_string()),
+                    suggested_action: Some("Provide a valid customer ID".to_string()),
+                    doc_url: None,
+                },
+            })?;
+
+        let customer_email: Option<Email> = match value.email {
+            Some(ref email_str) => {
+                Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
+                    error_stack::Report::new(IntegrationError::InvalidDataFormat {
+                        field_name: "customer.email",
+                        context: IntegrationErrorContext {
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -10370,10 +10361,11 @@ impl
                 .map(|customer_id| CustomerId::try_from(Cow::from(customer_id)))
                 .transpose()
                 .change_context(IntegrationError::InvalidDataFormat {
-                    field_name: "unknown",
+                    field_name: "customer.id",
                     context: IntegrationErrorContext {
                         additional_context: Some("Failed to parse Customer Id".to_string()),
-                        ..Default::default()
+                        suggested_action: Some("Provide a valid customer ID".to_string()),
+                        doc_url: None,
                     },
                 })?,
             connector_customer: value.customer.and_then(|c| c.id),
@@ -10645,10 +10637,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -11935,10 +11930,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -12034,10 +12032,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -12149,10 +12150,13 @@ impl<
             Some(ref email_str) => {
                 Some(Email::try_from(email_str.clone().expose()).map_err(|_| {
                     error_stack::Report::new(IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
+                        field_name: "customer.email",
                         context: IntegrationErrorContext {
-                            additional_context: Some("Invalid email".to_string()),
-                            ..Default::default()
+                            additional_context: Some("Invalid customer email format".to_string()),
+                            suggested_action: Some(
+                                "Provide a valid email address in customer.email".to_string(),
+                            ),
+                            doc_url: None,
                         },
                     })
                 })?)
@@ -13227,16 +13231,16 @@ pub fn tokenized_setup_recurring_to_base(
         customer_acceptance: v.customer_acceptance,
         setup_mandate_details: v.setup_mandate_details,
         setup_future_usage: v.setup_future_usage,
-        billing_descriptor: v.billing_descriptor,
-        locale: v.locale,
-        // Fields absent from TokenSetupRecurringRequest - set to None/default
+        // Fields not in TokenSetupRecurringRequest - set to None/default
         auth_type: grpc_payment_types::AuthenticationType::NoThreeDs as i32,
         authentication_data: None,
+        billing_descriptor: None,
         browser_info: None,
         complete_authorize_url: None,
         connector_testing_data: None,
         enable_partial_authorization: None,
         enrolled_for_3ds: false,
+        locale: None,
         l2_l3_data: None,
         merchant_order_id: None,
         off_session: None,
@@ -13321,12 +13325,10 @@ pub fn proxied_authorize_to_base(
         threeds_completion_indicator: v.threeds_completion_indicator,
         redirection_response: v.redirection_response,
         billing_descriptor: v.billing_descriptor,
-        setup_mandate_details: v.setup_mandate_details,
-        test_mode: v.test_mode,
         complete_authorize_url: None,
         continue_redirection_url: None,
         description: v.description,
-        // Fields absent from PaymentServiceProxyAuthorizeRequest - set to None/default
+        // Fields not present in PaymentServiceProxyAuthorizeRequest - set to None/default
         enrolled_for_3ds: None,
         enable_partial_authorization: None,
         locale: None,
@@ -13338,11 +13340,13 @@ pub fn proxied_authorize_to_base(
         order_category: v.order_category,
         order_details: Vec::new(),
         session_token: None,
-        shipping_cost: v.shipping_cost,
+        shipping_cost: None,
         order_tax_amount: None,
         statement_descriptor_name: None,
         statement_descriptor_suffix: None,
         tokenization_strategy: None,
+        setup_mandate_details: None,
+        test_mode: None,
     })
 }
 
@@ -13434,10 +13438,9 @@ pub fn proxied_setup_recurring_to_base(
         setup_mandate_details: v.setup_mandate_details,
         setup_future_usage: v.setup_future_usage,
         browser_info: v.browser_info,
-        auth_type: v.auth_type,
-        authentication_data: v.authentication_data,
-        order_category: v.order_category,
-        // Fields absent from ProxySetupRecurringRequest - set to None/default
+        // Fields not in ProxySetupRecurringRequest - set to None/default
+        auth_type: grpc_payment_types::AuthenticationType::NoThreeDs as i32,
+        authentication_data: None,
         billing_descriptor: None,
         connector_feature_data: None,
         connector_testing_data: None,
@@ -13448,6 +13451,7 @@ pub fn proxied_setup_recurring_to_base(
         l2_l3_data: None,
         merchant_order_id: None,
         off_session: None,
+        order_category: None,
         order_id: None,
         order_tax_amount: None,
         payment_channel: None,

--- a/docs/blogs/config-handling-blog.md
+++ b/docs/blogs/config-handling-blog.md
@@ -1,0 +1,217 @@
+# Every Integration Wants Something Different
+
+*How to keep your core clean when the outside world refuses to be consistent.*
+
+---
+
+## A Problem Every Backend Engineer Hits
+
+At some point, you build a system that needs to talk to multiple external services. Maybe it's payment providers, cloud storage buckets, notification services, or data warehouses. The business logic is the same across all of them. But every single one has a different idea of what "connecting" looks like.
+
+One wants an API key. Another wants a key and a secret. A third wants a username and password. A fourth wants a signed certificate.
+
+None of them are wrong. They just aren't consistent with each other.
+
+So the question becomes: where does all that difference live in your system?
+
+---
+
+## Where It Usually Goes Wrong
+
+The path of least resistance is to pass the raw config straight through and let the core figure it out. It works fine for the first integration. By the third it starts getting messy. By the tenth, your core is full of conditionals like this:
+
+```javascript
+function processRequest(config, payload) {
+  if (config.provider === "stripe") {
+    headers["Authorization"] = `Bearer ${config.apiKey}`;
+
+  } else if (config.provider === "adyen") {
+    headers["X-API-Key"] = config.apiKey;
+    body["merchantAccount"] = config.merchantAccount;
+
+  } else if (config.provider === "braintree") {
+    const token = btoa(`${config.publicKey}:${config.privateKey}`);
+    headers["Authorization"] = `Basic ${token}`;
+  }
+
+  // ... keeps growing with every new integration
+}
+```
+
+Now the core knows the internal shape of every integration's credentials. Adding a new integration means touching the core. Rotating a credential means hunting through the core to find every reference. Testing the core means setting up mocks for every integration's config shape.
+
+> The core didn't get complex because the business logic got complex. It got complex because integration details had no other place to go.
+
+---
+
+## The Pattern: Absorb at the Boundary
+
+The fix is simple in concept. Integration-specific config belongs at the boundary, not in the core.
+
+The boundary is the place where your system first receives external input. It is the only place that should know about integration-specific shapes. Its job is to take all that variation, absorb it, and hand the core one consistent type regardless of which integration is being used.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│   Integration A     Integration B     Integration C        │
+│   { api_key }       { key + secret }  { user + pass }      │
+│                                                             │
+│        (each caller speaks a completely different language) │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      The Boundary                           │
+│                                                             │
+│         absorbs all variation, translates everything        │
+│               into one single canonical form                │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Canonical Config                          │
+│                                                             │
+│       one consistent shape, the only thing                  │
+│               the core ever sees                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Here is what that changes in practice:
+
+| | Without a boundary | With a boundary |
+|---|---|---|
+| Core receives | Raw integration config | One canonical type |
+| Adding an integration | Touches core logic | Adds a boundary variant only |
+| Credential rotation | Trace through the entire core | Update the boundary |
+| Core tests | Need every integration's config | Independent of integrations |
+
+---
+
+## The Hard Part: When Config Changes Per Request
+
+Static config is the easy case. The harder case is when a caller wants to override something at request time. Maybe they want to point an integration at a staging environment, or use a different endpoint for one specific request.
+
+The tempting fix is to pass the override straight into the core and handle it there. But the moment you do that, the boundary breaks. The core starts needing to know that integration A has a `disputeUrl` field and integration B has a `secondaryEndpoint` field. You are back to the same problem.
+
+The right approach is to keep overrides behind the boundary too. The boundary accepts the override in the integration's own language, extracts what is relevant, merges it into the canonical form, and only then passes it to the core.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Request arrives with an integration-specific override   │
+│  e.g. "use this staging URL for this request"            │
+└─────────────────────────┬────────────────────────────────┘
+                          │
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                    The Boundary                          │
+│                                                          │
+│  1. Accept override in the integration's own language    │
+│  2. Extract only what is relevant                        │
+│  3. Merge into the canonical form                        │
+└─────────────────────────┬────────────────────────────────┘
+                          │
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│         Core receives the merged canonical config        │
+│                                                          │
+│    No knowledge of the override.                         │
+│    No knowledge of which integration was called.         │
+└──────────────────────────────────────────────────────────┘
+```
+
+The core gets a clean, merged config. It never knows an override happened.
+
+---
+
+## How Prism Does This Across 60+ Payment Connectors
+
+[Prism](https://hyperswitch.io) is a payment infrastructure layer that routes transactions across 60+ payment connectors including Stripe, Adyen, Braintree, Razorpay, and many more. Every connector has a different credential shape. This is exactly the problem from above, running in production at scale.
+
+### The vocabulary problem
+
+Here is a sample of what a few real connectors expect:
+
+| Connector | Credential fields |
+|---|---|
+| Stripe | `api_key` |
+| Adyen | `api_key` + `merchant_account` + optional `review_key` |
+| Authorize.net | `name` + `transaction_key` |
+| Bluesnap | `username` + `password` |
+| Braintree | `public_key` + `private_key` + optional `merchant_account_id` |
+| Revolut | `secret_api_key` + optional `signing_secret` |
+
+Same concept across all of them: authenticate with this connector. Six completely different shapes.
+
+### The boundary in Prism
+
+Prism defines a typed enum with one variant per connector. The caller sends credentials in their connector's own language. Prism parses it into the enum at the boundary. From that point on, the rest of the system never sees connector-specific field names:
+
+```rust
+// One variant per connector, each capturing exactly what that connector needs
+enum ConnectorConfig {
+    Stripe          { api_key: Secret },
+    Adyen           { api_key: Secret, merchant_account: Secret, review_key: Option<Secret> },
+    Authorizedotnet { name: Secret, transaction_key: Secret },
+    Bluesnap        { username: Secret, password: Secret },
+    Braintree       { public_key: Secret, private_key: Secret, merchant_account_id: Option<Secret> },
+    Revolut         { secret_api_key: Secret, signing_secret: Option<Secret> },
+    // ... 60+ more
+}
+```
+
+### What the core sees
+
+The core works with a completely different type. A flat struct with just URLs. No credentials, no connector-specific field names:
+
+```rust
+// What the core always receives, regardless of which connector is being used
+struct ConnectorEndpoints {
+    base_url:      String,
+    dispute_url:   Option<String>,
+    secondary_url: Option<String>,
+}
+```
+
+Every connector collapses to this same shape before the core touches it. The core reads `endpoints.base_url`. It has no idea which connector is on the other end or what credentials were used to get there.
+
+### Overrides in Prism
+
+When a caller wants to override a URL at request time, they include it in their connector config. Prism pulls it out at the boundary, translates it to the canonical field name, and merges it into `ConnectorEndpoints` before anything reaches the core.
+
+The comment in the source code says it plainly:
+
+> "This is the only path by which URL overrides in ConnectorConfig should influence request execution."
+
+There is no side door. Every connector-specific value, whether it is a credential or a URL override, goes through the boundary and gets translated before the core sees it.
+
+---
+
+## What You Get From This
+
+The payoff shows up in everyday engineering work.
+
+Adding a new connector means adding a variant to the boundary enum and writing a translator. The core stays untouched.
+
+Rotating a credential means updating the boundary. You do not need to trace where it flows through the rest of the system.
+
+Testing the core means testing against the canonical type. No integration-specific mock setup needed.
+
+Debugging is cleaner too. Integration-specific problem? Look at the boundary. Flow problem? Look at the core. The separation tells you exactly where to look.
+
+In Prism's case, 60+ connectors and the core has never needed a conditional for any of them. The boundary does the work so the core does not have to.
+
+---
+
+## Final Thought
+
+The outside world will never be consistent. Every integration you connect will have a different shape, a different auth scheme, a different set of fields it cares about.
+
+That is fine, as long as your system has one place where all that inconsistency gets absorbed and translated. The core should never know what is on the other side of that boundary.
+
+The pattern itself is not complicated. The discipline to maintain it, to not let one quick fix bypass the boundary, is the hard part. But once it holds, adding integration number 61 costs exactly as much as adding integration number 1.
+
+That is the foundation [Prism](https://hyperswitch.io) is built on. And it applies to any system that talks to more than one external service.
+
+---
+
+[System Design](https://medium.com/tag/system-design) · [Backend Engineering](https://medium.com/tag/backend-engineering) · [API Design](https://medium.com/tag/api-design) · [Software Architecture](https://medium.com/tag/software-architecture) · [Payment Infrastructure](https://medium.com/tag/payment-infrastructure)

--- a/docs/blogs/config-handling-blog.md
+++ b/docs/blogs/config-handling-blog.md
@@ -213,5 +213,3 @@ The pattern itself is not complicated. The discipline to maintain it, to not let
 That is the foundation [Prism](https://hyperswitch.io) is built on. And it applies to any system that talks to more than one external service.
 
 ---
-
-[System Design](https://medium.com/tag/system-design) · [Backend Engineering](https://medium.com/tag/backend-engineering) · [API Design](https://medium.com/tag/api-design) · [Software Architecture](https://medium.com/tag/software-architecture) · [Payment Infrastructure](https://medium.com/tag/payment-infrastructure)


### PR DESCRIPTION
## Summary

- Adds a new blog post `docs/blogs/config-handling-blog.md`
- Explains how Prism handles connector-specific config at the boundary so the core never sees integration-specific credentials
- Covers the boundary pattern, the override chain, and real connector examples (Stripe, Adyen, Braintree etc.)
- Written for a general engineering audience, uses Prism as the real-world proof point

## Test plan

- [ ] Read through the blog for accuracy
- [ ] Verify it renders correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)