### PR TITLE
docs(blogs): add payment processor integration blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prism supports **multiple connectors** with varying levels of payment method and
 | ⚠ | Implementation in progress or partial |
 | ? | Implementation needs validation against live environment |
 
-**[View Complete Connector Coverage →](./docs-generated/all_connector.md)**
+**[View Complete Connector Coverage →](https://github.com/juspay/hyperswitch-prism/blob/main/docs-generated/all_connector.md)**
 
 ## What Prism does not do (yet)?
 - **Built-in vault or tokenization service.** This is a design choice. You may bring your own vault, or use the payment processor's vault.

--- a/docs/blogs/how-does-payment-processor-lock-in-starts-in-your-code.md
+++ b/docs/blogs/how-does-payment-processor-lock-in-starts-in-your-code.md
@@ -1,0 +1,52 @@
+# How does payment processor lock-in start in your code?
+
+[stripe lockin](https://ibb.co/WpWd8CpS)
+
+## Prioritizing product market fit
+A payment integration is roughly five operations: authorize, capture, refund, parse a webhook and resolve a 3DS challenge. Additionally including references for idempotency, PCI vault tokens, orders and customers. This is pretty much the shape of the payments domain every payment processor exposes, but each one names the fields differently, returns different state machines, and signs webhooks differently.
+
+It makes sense for most startups to begin with Stripe. The documentation is excellent, the APIs are well designed, and enable shipping a working checkout in a few hours.
+To the downside, whenever the developer adds npm install stripe to the code and writes business logic against paymentIntent.status, every piece of code branches on that library and status, becoming tightly coupled to Stripe's specific lifecycle.
+## Payments for business growth
+Let's say the startup expands to Brazil and discovers Pix-via-Stripe doesn't quite cover subscription payments. Or expands to Europe and runs into local-acquirer requirements and Strong Customer Authentication (SCA) requirements. Or worse, the transaction patterns may differ from the primary market of operation (as it's a new market); the payment processor might treat it as a fraud signal and all the payouts get frozen suddenly.
+
+Now, the need for a secondary processor becomes a survival strategy for the startup.
+
+## It all started in the code
+Nobody would have instructed the startup (or the developer) to build a unified/vendor-neutral layer before integrating with Stripe. Treating Stripe as the unified layer when adding payment acceptance becomes a bottleneck.
+
+Let's look at this from another perspective. The same startup might have built a vendor-agnostic tech stack with
+- JDBC for **relational database connections** with the underlying infrastructure managed by a cloud provider (AWS or GCP or Azure)
+- OpenTelemetry for accessing **monitoring frameworks**. The underlying providers may be Datadog or New Relic or any other provider
+- Keycloak for managing access by connecting to **multiple identity providers**
+- LiteLLM for connecting to **multiple LLM providers for optionality**
+
+*If every layer in the tech stack deserves a vendor-neutral layer, why not the same for payments?*
+
+[library for payments?](https://ibb.co/m56xhK3v)
+
+## A lightweight payments library to solve for payment integrations
+Payments orchestration platforms like **Juspay Hyperswitch, Spreedly, Primer, and Ixopay** abstract multiple payment processors behind a unified API. Juspay Hyperswitch adds auth-rate-based routing across payment processors in the US and Europe, Primer leads with payments observability across payment processors, Spreedly leads with a vault-first model in the US, Ixopay focuses on European acquirers.
+
+But, the reality is most startups (and developers) do not need a full orchestration platform which optimizes payments. They don't have the time to think about payments. All they need is redundancy, to activate when needed. Such redundancy cannot be locked into a SaaS platform.
+An orchestration platform owns routing decisions, payment integrations, retry policies as a service. Whereas an integration library owns request/response translation and webhook normalization, in your process, in your code.
+Hence, developers need an **open-source, vendor agnostic, and stateless payment integration library**. Something that could be `npm install`-ed or `pip install`-ed into the code, and pointed at any payment processor to start accepting payments. If there is a new market expansion, simply point the library at a different payment processor and it works.
+
+## Past work in this area
+
+This used to be solved by open source community libraries. **ActiveMerchant**, born inside Shopify, gave Ruby developers a unified payment interface for over a decade. **OmniPay** did the same for PHP. Both are still maintained, both still loved. However, they are language-specific, community-paced, and forever a step behind payment processor specification drift.
+
+Hyperswitch Prism is a payments library, that eliminates the shortcomings of the previous initiatives with:
+
+- **One unified payment specification**, but language-agnostic: With first-class bindings generated for JavaScript, Python, Go, Rust, Java, PHP, Ruby.
+- **Hardened by production traffic** and regular testing: Fixtures and edge cases captured from real merchant volume, not the developer documentation alone. Every change is regressed on past behaviour.
+- **Kept up-to-date**: Payment processor changelogs, regulator bulletins, and webhook drift watched continuously and the library is kept up to date by the team powering Juspay hyperswitch.
+
+Hyperswitch Prism is extracted from the product grade payment orchestrator **Juspay hyperswitch**, as a payment integration library to plug and switch payment processors. Prism is maintained by the same team as Juspay hyperswitch, and actively used on production by leading global businesses.
+
+## How to avoid payment processor lock-in from day one?
+Choose the right payments integration library if you need redundancy and clean payment processor boundaries in your code. It is free, open source and well maintained by a team of payment domain experts on behalf of global enterprises.
+
+And go for payment orchestration as a service, only if you additionally need authorization-rate uplift, vault portability, or retry-as-a-service.
+
+In the next post, you will be shown how to integrate Stripe and Global Payments without code duplication and without additional compliance burden.

--- a/docs/blogs/integrating-stripe-and-globalpayments-using-a-unified-payments-library.md
+++ b/docs/blogs/integrating-stripe-and-globalpayments-using-a-unified-payments-library.md
@@ -1,0 +1,229 @@
+# Integrating Stripe & Global Payments using a Unified Payments Integration library
+
+Most businesses integrate Stripe directly into the codebase, treating it as the unified payments layer. When the need for a second processor arises (due to new market expansion, or frozen payouts, or local compliance), it would be too late to discover that Stripe is wired through every call site creating a vendor lock-in at code level. While other layers of the stack would generally have vendor-neutral interfaces (JDBC, OpenTelemetry, Keycloak, LiteLLM), payments generally doesn't.
+
+This is a guide for implementing a unified payment integration that can point to multiple payment processors.
+
+
+## Use case for multiple payment processor integrations
+
+A business accepting cards in both the US and the EU usually faces the same shape of problem: Stripe is the natural choice for USD acceptance, Global Payments is a strong choice for EUR acceptance, and the business ends up shipping two integrations within the same codebase - one wrapping Stripe Payment Intents, another wrapping GP-API. The impact will be: every new operation (capture, void, recurring charge) gets implemented twice. Refund mappings diverge. Status enumerations get hard to match in reconciliations.
+
+A unified payment integration library collapses that surface to one. Your code compiles against one request schema, ships one payment service, and chooses the underlying processor at config time rather than at code time. 
+
+This piece walks through that pattern of implementation for Stripe and Global Payments as the two connectors, and currency-based routing.
+
+![demo store with Stripe and Globalpayments](https://iili.io/Bt2zo37.gif)
+
+## Five step integration with the Hyperswitch Prism unified payments library
+
+The flow is the same regardless of which payment processor handles the order. Each step below maps directly to a section in the Prism docs ([Installation and Configuration](https://docs.hyperswitch.io/integrations/prism/getting-started/installation), [First Payment](https://docs.hyperswitch.io/integrations/prism/getting-started/first-payment)) — adapted here for two connectors instead of one, with currency as a selector.
+
+### 1. Install the payments library
+
+Install the SDK in the language of your app's payment service. 
+Node.js shown below, and equivalent commands exist for Python (`pip install hyperswitch-prism`), Java (Maven `io.hyperswitch:prism`), and PHP (`composer require hyperswitch-prism`).
+
+```bash
+npm install hyperswitch-prism
+```
+
+### 2. Configure the payment processor clients
+
+Each payment processor is treated as a connector by the library. Every connector gets its own `ConnectorConfig`, and each `ConnectorConfig` produces its own `PaymentClient`. In this case the two clients will be Stripe and Global Payments. 
+
+Note that Stripe takes a single `apiKey`, but Global Payments takes `appId`, `appKey`, and `baseUrl`.
+
+```typescript
+import { PaymentClient, MerchantAuthenticationClient, types } from 'hyperswitch-prism';
+
+const stripeConfig: types.IConnectorConfig = {
+  connectorConfig: {
+    stripe: {
+      apiKey: { value: process.env.STRIPE_API_KEY! },
+      baseUrl: 'https://api.stripe.com',
+    },
+  },
+};
+
+const globalpayConfig: types.IConnectorConfig = {
+  connectorConfig: {
+    globalpay: {
+      appId: { value: process.env.GP_APP_ID! },
+      appKey: { value: process.env.GP_APP_KEY! },
+      baseUrl: 'https://apis.globalpay.com',
+    },
+  },
+};
+
+const stripeClient = new PaymentClient(stripeConfig);
+const globalpayClient = new PaymentClient(globalpayConfig);
+
+// Currency-based connector selection — your routing rule.
+function clientFor(currency: types.Currency) {
+  return currency === types.Currency.USD ? stripeClient : globalpayClient;
+}
+```
+
+The connector identifier is fixed at config time and lives inside the client. `clientFor(currency)` is the only line of code that knows about the currency rule. Every subsequent step calls a method on whichever client `clientFor` returned — the request shape and method names are identical across both.
+
+### 3. Generate Session Token
+
+Your backend should request the library for a client-side authentication token before the customer interacts with the hosted form. This is what Stripe's docs call a Payment Intent `client_secret` and what Global Payments calls a session ID. The library normalises the call but returns the connector's native field on `response.sessionData.connectorSpecific.<connector>`.
+
+```typescript
+async function createClientToken(order: { id: string; amount: number; currency: types.Currency }) {
+  const config = order.currency === types.Currency.USD ? stripeConfig : globalpayConfig;
+  const authClient = new MerchantAuthenticationClient(config);
+
+  const response = await authClient.createClientAuthenticationToken({
+    merchantClientSessionId: `sess_${order.id}`,
+    payment: {
+      amount: { minorAmount: order.amount, currency: order.currency },
+    },
+    testMode: true,
+  });
+
+  // Stripe returns clientSecret; Global Payments returns its own session field.
+  if (order.currency === types.Currency.USD) {
+    return response.sessionData?.connectorSpecific?.stripe?.clientSecret?.value;
+  }
+  return response.sessionData?.connectorSpecific?.globalpay;
+}
+```
+
+The token is scoped to the connector. So, it is important to use the token created against `stripeConfig` to bootstrap a Stripe Payment Element, and a token created against `globalpayConfig` to bootstrap a Global Payments Hosted Payment Page. Your frontend cannot mix them.
+
+### 4. Open the Hosted checkout from your frontend
+
+Your frontend should use the client token to initialise the payment processor (PSP) hosted form, so that the customer enters their card directly into the PSP's surface. The form returns a connector-issued payment-method token to your frontend. 
+This is where PCI scope sits with the PSP — the PAN is captured by Stripe's Payment Element or Global Payments' Hosted Payment Page, never traverses your origin, and is never touched by the payment integration library.
+
+```html
+<!-- USD orders: Stripe Payment Element -->
+<script src="https://js.stripe.com/v3/"></script>
+<div id="card-element"></div>
+<button id="submit">Pay</button>
+
+<script>
+  const stripe = Stripe(window.STRIPE_PUBLISHABLE_KEY); // pk_xxx
+  const elements = stripe.elements({ clientSecret });   // from step 3
+  elements.create('card').mount('#card-element');
+
+  document.getElementById('submit').addEventListener('click', async () => {
+    const { error, paymentMethod } = await stripe.createPaymentMethod({
+      type: 'card',
+      card: elements.getElement('card'),
+    });
+    if (error) return console.error(error.message);
+    // POST paymentMethod.id ("pm_1234...") to your backend → step 5
+  });
+</script>
+```
+
+For EUR orders, the same shape applies with Global Payments' Hosted Payment Page (HPP). You can embed the GP HPP using the session field returned in step 3, and the HPP posts back a Global Payments payment-method token reference. Your backend now holds a token (`pm_xxx` for Stripe, a GP payment-token for Global Payments) and the order's `merchantTransactionId`. 
+
+### 5. Authorize the payment
+
+Your backend calls `tokenAuthorize` on whichever client `clientFor(order.currency)` returns. The same function works against either connector - Stripe or Global payments.
+
+```typescript
+async function chargeOrder(order: {
+  id: string;
+  amount: number;
+  currency: types.Currency;
+  connectorToken: string; // from step 4
+}) {
+  const client = clientFor(order.currency); 
+  // chooses the right client based on currency
+
+  const auth = await client.tokenAuthorize({
+    merchantTransactionId: order.id,
+    merchantOrderId: `order_${order.id}`,
+    amount: { minorAmount: order.amount, currency: order.currency },
+    connectorToken: { value: order.connectorToken },
+    address: { billingAddress: {} },
+    captureMethod: types.CaptureMethod.AUTOMATIC,
+    returnUrl: 'https://merchant.example/return',
+    testMode: true,
+  });
+
+  if (auth.status === types.PaymentStatus.FAILURE) {
+    throw new PaymentDeclined(auth.error?.code, auth.error?.message);
+  }
+
+  // Persist (merchantTransactionId, connector, connectorTransactionId) together.
+  // Now onwards every downstream operation reads `connector` from this row, not the routing rule.
+  await orders.markPaid(order.id, {
+    connector: order.currency === types.Currency.USD ? 'stripe' : 'globalpay',
+    connectorTransactionId: auth.connectorTransactionId,
+  });
+
+  return auth;
+}
+```
+
+The request shape is identical across the two connectors. The `connectorToken` value is the only payload field that carries connector lineage, and your backend treats it as opaque. The `connector` string persisted alongside the transaction is what makes every downstream operation deterministic — refunds, captures, voids, recurring charges read the connector from storage, never recompute it from the routing rule.
+
+## Integrating with AI agents?
+Point your agent to [this skill file](https://github.com/juspay/hyperswitch-prism/blob/main/.skills/demo-integration/SKILL.md) of payments integration library from your application codebase, and answer the followup questions with your integration requirements.
+
+![prism integration skill](https://s13.gifyu.com/images/b7Wxe.gif)
+
+## Extending to more operations - Capture, Refund, Recurring charges
+
+Once the charge has settled, every follow-up operation against that transaction goes through the same `PaymentClient` shape — only the config changes based on which connector originated it.
+
+```typescript
+async function refundOrder(orderRef: { connector: 'stripe' | 'globalpay'; connectorTransactionId: string; amount: number; currency: types.Currency }) {
+  const config = orderRef.connector === 'stripe' ? stripeConfig : globalpayConfig;
+  const client = new PaymentClient(config);
+
+  return client.refund({
+    merchantRefundId: `ref_${Date.now()}`,
+    connectorTransactionId: orderRef.connectorTransactionId,
+    refundAmount: { minorAmount: orderRef.amount, currency: orderRef.currency },
+    paymentAmount: orderRef.amount,
+    reason: 'customer_request',
+  });
+}
+```
+
+For a subscription business, the recurring charge runs through `RecurringPaymentClient` against the same canonical schema:
+
+```typescript
+import { RecurringPaymentClient, types } from 'hyperswitch-prism';
+
+const recurringClient = new RecurringPaymentClient(stripeConfig);
+const charge = await recurringClient.charge({
+  connectorRecurringPaymentId: { /* mandate reference returned at setup */ },
+  amount: { minorAmount: 1999, currency: types.Currency.USD },
+  paymentMethod: { token: { token: { value: subscriber.connectorPaymentMethodToken } } },
+  connectorCustomerId: subscriber.connectorCustomerId,
+  offSession: true,
+  returnUrl: 'https://merchant.example/recurring-return',
+});
+```
+
+The mandate is set up for the first time via `paymentClient.setupRecurring(...)` against whichever connector owns the customer relationship. The recurring `charge` call uses the same response status enum (`PaymentStatus`) the one-shot `authorize` call returns. Subscription dunning logic does not need a connector branch.
+
+
+## Important points to note
+- Your app owns currency-based routing logic. The library owns the request-response transformation and the API call to the payment processor once the routing decision is made.
+- The PCI scope sits with the payment processor. Neither your app nor the library will handle the raw card data. 
+- Your app will need to persist some information for the flows to be managed after authorize. The `connector` is a very important field because it encodes the historical fact of where the transaction lives. Every other future operation (refund, capture, etc.) shall read from the table below.
+
+    ```sql
+    CREATE TABLE order_payments (
+      merchant_transaction_id   TEXT PRIMARY KEY,
+      connector                 TEXT NOT NULL,           -- 'stripe' | 'globalpay'
+      connector_transaction_id  TEXT NOT NULL,           -- pi_xxx | GP-API GUID
+      connector_customer_id     TEXT,                    -- for recurring
+      recurring_payment_id      TEXT,                    -- mandate reference
+      currency                  TEXT NOT NULL,
+      minor_amount              BIGINT NOT NULL,
+      status                    INT NOT NULL             -- types.PaymentStatus enum value
+    );
+    ```
+
+The canonical schema of the payment integration library - `PaymentService.Authorize`, `PaymentService.TokenAuthorize`, `PaymentService.Refund`, `PaymentService.Capture`, `PaymentService.Void`, `RecurringPaymentService.Charge`. It becomes the unified grammar to interact with any payment processor. Adding a third connector to the integration above is a matter of adding one more `ConnectorConfig` and extending the currency selector. The application code does not change.


### PR DESCRIPTION
## Description
Adds two new blog posts to the `docs/blogs/` folder:

- **How Does Payment Processor Lock-in Starts in Your Code** — Explores how vendor lock-in creeps into payment integrations at the code level
- **Integrating Stripe and GlobalPayments Using a Unified Payments Library** — Practical guide showing how Prism enables switching between payment processors with minimal code changes

## Motivation and Context
These blog posts provide educational content about payment processor lock-in and demonstrate Prism's value proposition as a unified, stateless connector library. Documentation-only change with no code modifications.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?
Documentation-only change. Verified markdown formatting renders correctly.