### PR TITLE
fix(hardening): test overrides for nmi and payload connectors

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/globalpay/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/globalpay/specs.json
@@ -4,6 +4,7 @@
     "PaymentService/Authorize",
     "PaymentService/Capture",
     "MerchantAuthenticationService/CreateClientAuthenticationToken",
+    "MerchantAuthenticationService/CreateServerAuthenticationToken",
     "PaymentService/Get",
     "RecurringPaymentService/Charge",
     "PaymentService/Refund",

--- a/crates/internal/integration-tests/src/connector_specs/nmi/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/nmi/override.json
@@ -1,1 +1,128 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_debit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4751271111111118"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_debit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4751271111111118"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_credit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4532111111111112"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_credit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4532111111111112"
+            }
+          }
+        }
+      }
+    }
+  },
+  "PaymentService/SetupRecurring": {
+    "PaymentService/SetupRecurring": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      }
+    },
+    "setup_recurring": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      }
+    },
+    "setup_recurring_with_order_context": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      }
+    },
+    "setup_recurring_with_webhook": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      }
+    }
+  },
+  "RecurringPaymentService/Charge": {
+    "RecurringPaymentService/Charge": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "08",
+            "card_exp_year": "30",
+            "card_cvc": "999"
+          }
+        }
+      }
+    },
+    "recurring_charge": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "08",
+            "card_exp_year": "30",
+            "card_cvc": "999"
+          }
+        }
+      }
+    },
+    "recurring_charge_low_amount": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "08",
+            "card_exp_year": "30",
+            "card_cvc": "999"
+          }
+        }
+      }
+    },
+    "recurring_charge_with_order_context": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "08",
+            "card_exp_year": "30",
+            "card_cvc": "999"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/payload/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/payload/override.json
@@ -1,82 +1,10 @@
 {
-  "PaymentService/Authorize": {
-    "no3ds_auto_capture_credit_card": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "no3ds_auto_capture_debit_card": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    }
-  },
-  "PaymentService/Get": {
-    "sync_payment": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "sync_payment_with_handle_response": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    }
-  },
-  "PaymentService/Refund": {
-    "refund_full_amount": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "refund_partial_amount": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "refund_with_reason": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    }
-  },
-  "RefundService/Get": {
-    "refund_sync": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "RefundService/Get": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    },
-    "refund_sync_with_reason": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      }
-    }
-  },
   "PaymentService/SetupRecurring": {
     "PaymentService/SetupRecurring": {
       "grpc_req": {
         "amount": {
           "minor_amount": 0
         }
-      },
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
       }
     },
     "setup_recurring": {
@@ -84,10 +12,6 @@
         "amount": {
           "minor_amount": 0
         }
-      },
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
       }
     },
     "setup_recurring_with_order_context": {
@@ -95,10 +19,6 @@
         "amount": {
           "minor_amount": 0
         }
-      },
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
       }
     },
     "setup_recurring_with_webhook": {
@@ -106,19 +26,11 @@
         "amount": {
           "minor_amount": 0
         }
-      },
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
       }
     }
   },
   "RecurringPaymentService/Charge": {
     "RecurringPaymentService/Charge": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -131,10 +43,6 @@
       }
     },
     "recurring_charge": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -147,10 +55,6 @@
       }
     },
     "recurring_charge_low_amount": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -163,10 +67,6 @@
       }
     },
     "recurring_charge_with_order_context": {
-      "pre_request_http": {
-        "url": "http://10.255.255.1",
-        "timeout_secs": 31
-      },
       "grpc_req": {
         "payment_method": {
           "card": {

--- a/crates/internal/integration-tests/src/connector_specs/payload/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/payload/override.json
@@ -1,6 +1,9 @@
 {
   "PaymentService/SetupRecurring": {
     "PaymentService/SetupRecurring": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "amount": {
           "minor_amount": 0
@@ -8,6 +11,9 @@
       }
     },
     "setup_recurring": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "amount": {
           "minor_amount": 0
@@ -15,6 +21,9 @@
       }
     },
     "setup_recurring_with_order_context": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "amount": {
           "minor_amount": 0
@@ -22,6 +31,9 @@
       }
     },
     "setup_recurring_with_webhook": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "amount": {
           "minor_amount": 0
@@ -31,6 +43,9 @@
   },
   "RecurringPaymentService/Charge": {
     "RecurringPaymentService/Charge": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -43,6 +58,9 @@
       }
     },
     "recurring_charge": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -55,6 +73,9 @@
       }
     },
     "recurring_charge_low_amount": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -67,6 +88,9 @@
       }
     },
     "recurring_charge_with_order_context": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      },
       "grpc_req": {
         "payment_method": {
           "card": {
@@ -76,6 +100,64 @@
             "card_cvc": "123"
           }
         }
+      }
+    }
+  },
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    }
+  },
+  "PaymentService/Get": {
+    "sync_payment": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "sync_payment_with_handle_response": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    }
+  },
+  "PaymentService/Refund": {
+    "refund_full_amount": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "refund_partial_amount": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "refund_with_reason": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    }
+  },
+  "RefundService/Get": {
+    "refund_sync": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "RefundService/Get": {
+      "pre_request_http": {
+        "timeout_secs": 31
+      }
+    },
+    "refund_sync_with_reason": {
+      "pre_request_http": {
+        "timeout_secs": 31
       }
     }
   }

--- a/crates/internal/integration-tests/src/connector_specs/payload/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/payload/override.json
@@ -1,1 +1,182 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    }
+  },
+  "PaymentService/Get": {
+    "sync_payment": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "sync_payment_with_handle_response": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    }
+  },
+  "PaymentService/Refund": {
+    "refund_full_amount": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "refund_partial_amount": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "refund_with_reason": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    }
+  },
+  "RefundService/Get": {
+    "refund_sync": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "RefundService/Get": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "refund_sync_with_reason": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    }
+  },
+  "PaymentService/SetupRecurring": {
+    "PaymentService/SetupRecurring": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      },
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "setup_recurring": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      },
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "setup_recurring_with_order_context": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      },
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    },
+    "setup_recurring_with_webhook": {
+      "grpc_req": {
+        "amount": {
+          "minor_amount": 0
+        }
+      },
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      }
+    }
+  },
+  "RecurringPaymentService/Charge": {
+    "RecurringPaymentService/Charge": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      },
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "12",
+            "card_exp_year": "2030",
+            "card_cvc": "123"
+          }
+        }
+      }
+    },
+    "recurring_charge": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      },
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "12",
+            "card_exp_year": "2030",
+            "card_cvc": "123"
+          }
+        }
+      }
+    },
+    "recurring_charge_low_amount": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      },
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "12",
+            "card_exp_year": "2030",
+            "card_cvc": "123"
+          }
+        }
+      }
+    },
+    "recurring_charge_with_order_context": {
+      "pre_request_http": {
+        "url": "http://10.255.255.1",
+        "timeout_secs": 31
+      },
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "12",
+            "card_exp_year": "2030",
+            "card_cvc": "123"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/harness/connector_override/loader.rs
+++ b/crates/internal/integration-tests/src/harness/connector_override/loader.rs
@@ -27,7 +27,12 @@ pub struct ScenarioOverridePatch {
 /// response at dep_res index 1).
 #[derive(Debug, Clone, Deserialize)]
 pub struct PreRequestHttpHook {
-    pub url: String,
+    /// When `Some`, fire an HTTP request to the URL before the scenario runs.
+    /// When `None`, the hook degenerates to a pure sleep of `timeout_secs`
+    /// seconds — useful for waiting out sandbox-side dedup/rate windows
+    /// without needing an unreachable URL as a sleep vehicle.
+    #[serde(default)]
+    pub url: Option<String>,
     #[serde(default = "default_http_method")]
     pub method: String,
     #[serde(default)]

--- a/crates/internal/integration-tests/src/harness/scenario_api.rs
+++ b/crates/internal/integration-tests/src/harness/scenario_api.rs
@@ -4206,9 +4206,23 @@ fn template_with_dep_res(template: &str, dependency_res: &[Value]) -> String {
 
 /// Fires the configured pre-request HTTP hook. Fire-and-forget: network
 /// errors are logged (when debug env is set) but do not fail the scenario.
+///
+/// When `hook.url` is `None`, the hook degenerates to a pure sleep of
+/// `timeout_secs` seconds — used to wait out sandbox-side dedup/rate windows.
 #[allow(clippy::print_stdout)]
 fn fire_pre_request_http_hook(hook: &PreRequestHttpHook, dependency_res: &[Value]) {
-    let url = template_with_dep_res(&hook.url, dependency_res);
+    let Some(url_template) = hook.url.as_ref() else {
+        thread::sleep(Duration::from_secs(hook.timeout_secs));
+        if std::env::var("UCS_DEBUG_PRE_REQUEST_HOOK").as_deref() == Ok("1") {
+            println!(
+                "[suite_run_test] pre_request_http → slept {}s (no url)",
+                hook.timeout_secs
+            );
+        }
+        return;
+    };
+
+    let url = template_with_dep_res(url_template, dependency_res);
     let body = hook
         .body
         .as_ref()


### PR DESCRIPTION
## Summary

Test data overrides to harden NMI and Payload connectors for the integration test suite.

### Changes

**NMI (override.json):**
- Add test card overrides: Credit `4532111111111112`, Debit `4751271111111118`
- Add zero-amount for `PaymentService/SetupRecurring` (NMI sandbox requirement)
- Add card injections for `RecurringPaymentService/Charge`

**Payload (override.json):**
- Add 31s `pre_request_http` delays for duplicate-sensitive flows (Authorize, Get, Refund, SetupRecurring, Charge)
- Add zero-amount for `PaymentService/SetupRecurring`
- Add card injections for `RecurringPaymentService/Charge`

**GlobalPay (specs.json):**
- Add `MerchantAuthenticationService/CreateServerAuthenticationToken` to supported suites

### Test Results

- **NMI**: 4/21 authorize scenarios pass (card scenarios) - APM failures expected (not supported by connector)
- **Payload**: 22.7% authorize (cards work), 100% for other suites - APM failures expected
- **GlobalPay**: Still 0% - requires code fix for recurring payment bug
- **JPMorgan**: 0% - likely credentials/sandbox issue

### Files Changed

- `crates/internal/integration-tests/src/connector_specs/nmi/override.json`
- `crates/internal/integration-tests/src/connector_specs/payload/override.json`
- `crates/internal/integration-tests/src/connector_specs/globalpay/specs.json`

---

## Update — `pre_request_http` framework change

### Why

The `pre_request_http` hook in the integration-test harness previously required a `url` string. To insert a fixed wait between scenarios (e.g. to wait out a sandbox's duplicate-request window), override authors had to point `url` at an unrouteable IP and let `curl` hit the `timeout_secs` value — a sleep dressed as an HTTP call. That left a fake URL in `override.json`, plus per-scenario curl shell-out cost.

### What changed

- `crates/internal/integration-tests/src/harness/connector_override/loader.rs` — `PreRequestHttpHook::url` is now `Option<String>` instead of `String`.
- `crates/internal/integration-tests/src/harness/scenario_api.rs` — `fire_pre_request_http_hook` branches on `url`:
  - `Some(url)` → existing behavior (templated `curl -sS -m timeout_secs -X method url ...`); fire-and-forget, errors logged only with `UCS_DEBUG_PRE_REQUEST_HOOK=1`.
  - `None` → `thread::sleep(Duration::from_secs(timeout_secs))` and return.
- `crates/internal/integration-tests/src/connector_specs/payload/override.json` — replaced the prior URL-based sleep hack with the new shape:

  ```json
  "pre_request_http": { "timeout_secs": 31 }
  ```

### Backwards compatibility

- Existing override files that supply a `url` (e.g. `cashfree/override.json`) parse and behave identically — `url: Some(...)` enters the original code path unchanged.
- The schema validation unit test `all_override_entries_match_existing_scenarios_and_proto_schema` passes.
- Default values for `method`, `headers`, `body`, `timeout_secs` are unchanged.

### Scenarios touched (payload)

Sleep restored on the dedup-sensitive scenarios via the new shape:

- `PaymentService/Authorize` — `no3ds_auto_capture_credit_card`, `no3ds_auto_capture_debit_card`
- `PaymentService/Get` — `sync_payment`, `sync_payment_with_handle_response`
- `PaymentService/Refund` — `refund_full_amount`, `refund_partial_amount`, `refund_with_reason`
- `RefundService/Get` — `refund_sync`, `RefundService/Get`, `refund_sync_with_reason`
- `PaymentService/SetupRecurring` — all 4 scenarios
- `RecurringPaymentService/Charge` — all 4 scenarios