### PR TITLE
fix(ci): truncate release notes to GitHub 125K release body limit

### DIFF
--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -149,6 +149,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CONNECTOR_SERVICE_CI_PAT }}
         run: |
+          if [ "$(wc -c < release-notes.md)" -gt 124000 ]; then
+            truncate -s 124000 release-notes.md
+            printf '\n\n_Full changelog available in the release artifact._\n' >> release-notes.md
+          fi
           gh release create "${{ steps.version.outputs.next_tag }}" \
             --title "${{ steps.version.outputs.next_tag }}" \
             --notes-file release-notes.md \

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -1,8 +1,8 @@
 # hyperswitch-prism
 
-**Universal Connector Service — Java/Kotlin SDK**
+**Hyperswitch Prism — Java/Kotlin SDK**
 
-A high-performance, type-safe Java/Kotlin SDK for payment processing through the Universal Connector Service. Connect to 100+ payment processors through a single, unified API.
+A high-performance, type-safe Java/Kotlin SDK for payment processing through Hyperswitch Prism. Connect to 100+ payment processors through a single, unified API.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.hyperswitch/prism.svg)](https://central.sonatype.com/artifact/io.hyperswitch/prism)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -1,8 +1,8 @@
 # hyperswitch-prism
 
-**Universal Connector Service — Node.js SDK**
+**Hyperswitch Prism — Node.js SDK**
 
-A high-performance, type-safe Node.js SDK for payment processing through the Universal Connector Service. Connect to 100+ payment processors through a single, unified API.
+A high-performance, type-safe Node.js SDK for payment processing through Hyperswitch Prism. Connect to 100+ payment processors through a single, unified API.
 
 [![npm version](https://badge.fury.io/js/hyperswitch-prism.svg)](https://www.npmjs.com/package/hyperswitch-prism)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,8 +1,8 @@
 # hyperswitch-prism
 
-**Universal Connector Service — Python SDK**
+**Hyperswitch Prism — Python SDK**
 
-A high-performance, type-safe Python SDK for payment processing through the Universal Connector Service. Connect to 100+ payment processors through a single, unified API.
+A high-performance, type-safe Python SDK for payment processing through Hyperswitch Prism. Connect to 100+ payment processors through a single, unified API.
 
 [![PyPI version](https://badge.fury.io/py/hyperswitch-prism.svg)](https://pypi.org/project/hyperswitch-prism/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary

- **fix(ci):** Truncate git-cliff release notes to GitHub's 125,000 character API limit before calling \`gh release create\`. For v0.1.0 the full history dump exceeds this limit; truncated output includes a note pointing to the full changelog in the Actions artifact.
- **docs(sdk):** Rename "Universal Connector Service" to "Hyperswitch Prism" in Python, JavaScript, and Java/Kotlin SDK READMEs (reflected on PyPI, npm, Maven Central project description pages).

## Test plan

- [ ] Trigger `release-stable-version.yml` with `dry_run=false` — verify draft release is created without HTTP 422
- [ ] Verify truncation message appears at end of release body when notes exceed 125K
- [ ] Verify SDK README pages on PyPI/npm/Maven show updated name after next publish