### PR TITLE
test(billwerk): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/billwerk/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/billwerk/override.json
@@ -1,1 +1,87 @@
-{}
+{
+  "PaymentMethodService/Tokenize": {
+    "tokenize_credit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "3530111333300000"
+            },
+            "card_exp_month": {
+              "value": "03"
+            },
+            "card_exp_year": {
+              "value": "2030"
+            },
+            "card_cvc": {
+              "value": "737"
+            }
+          }
+        }
+      }
+    },
+    "tokenize_debit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "3530111333300000"
+            },
+            "card_exp_month": {
+              "value": "03"
+            },
+            "card_exp_year": {
+              "value": "2030"
+            },
+            "card_cvc": {
+              "value": "737"
+            }
+          }
+        }
+      }
+    },
+    "tokenize_with_metadata": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "3530111333300000"
+            },
+            "card_exp_month": {
+              "value": "03"
+            },
+            "card_exp_year": {
+              "value": "2030"
+            },
+            "card_cvc": {
+              "value": "737"
+            }
+          }
+        }
+      }
+    }
+  },
+  "MerchantAuthenticationService/CreateClientAuthenticationToken": {
+    "create_sdk_session_apple_pay": {
+      "grpc_req": {
+        "customer": {
+          "id": "billwerk_test_customer_01"
+        }
+      }
+    },
+    "create_sdk_session_google_pay": {
+      "grpc_req": {
+        "customer": {
+          "id": "billwerk_test_customer_01"
+        }
+      }
+    },
+    "create_sdk_session_with_taxes": {
+      "grpc_req": {
+        "customer": {
+          "id": "billwerk_test_customer_01"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 42 |
| Failed  | 72 |
| Skipped | 1 |
| Total   | 115 |
| **Pass rate** | **37%** |
| Status  | Partial |

**Known remaining issues:** `connector_request_reference_id` contains `/` which Billwerk rejects in the `handle` field (must match `^[a-zA-Z0-9_\.\-@]*$`). Framework: gRPC error responses block `error.must_exist` assertion evaluation.

> Ran via `test-prism --connector billwerk --interface grpc --report` against `fix/test-billwerk-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary

- Override tokenize card numbers to JCB test card (3530111333300000) — the Billwerk test account credentials do not have Visa/Mastercard enabled (returns `card-type-not-supported`), but JCB is accepted
- Override `customer.id` for `MerchantAuthenticationService/CreateClientAuthenticationToken` scenarios with a static value (`billwerk_test_customer_01`) to prevent the auto_generate sentinel from being pruned before auto-generation, which caused the customer handle to be missing from the request entirely

## Test Results

Before: 0/115 passing
After: 42/115 passing (36%)

Remaining failures are real connector bugs (not test data issues):
- All `PaymentService/Authorize` and dependent flows fail because the `connector_request_reference_id` contains forward slashes (`/`) which Billwerk's API rejects in the `handle` field (must match `^[a-zA-Z0-9_\\.\\-@]*$`)
- `tokenize_fail_expired_card` and `tokenize_fail_invalid_card_number` fail due to framework behavior where `execution_error` path bypasses `assert.error.must_exist` evaluation

## Test plan
- [x] Schema validation: `all_override_entries_match_existing_scenarios_and_proto_schema` passes
- [x] Schema validation: `all_supported_scenarios_match_proto_schema_for_all_connectors` passes
- [x] `PaymentMethodService/Tokenize`: 3/5 pass (tokenize_credit_card, tokenize_debit_card, tokenize_with_metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
