### PR TITLE
feat(connector): implement Reverse (VoidPostCapture) for elavon

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -18,12 +18,12 @@ buffer_limit = 100000
 
 [server]
 host = "0.0.0.0"
-port = 8094
+port = 8000
 type = "grpc"
 
 [metrics]
 host = "0.0.0.0"
-port = 8093
+port = 8080
 
 [proxy]
 idle_pool_connection_timeout = 90

--- a/config/development.toml
+++ b/config/development.toml
@@ -18,12 +18,12 @@ buffer_limit = 100000
 
 [server]
 host = "0.0.0.0"
-port = 8000
+port = 8094
 type = "grpc"
 
 [metrics]
 host = "0.0.0.0"
-port = 8080
+port = 8093
 
 [proxy]
 idle_pool_connection_timeout = 90

--- a/crates/integrations/connector-integration/src/connectors/elavon.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon.rs
@@ -5,11 +5,11 @@ use std::fmt::Debug;
 use bytes::Bytes;
 use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, RSync, Refund},
+    connector_flow::{Authorize, Capture, PSync, RSync, Refund, VoidPC},
     connector_types::{
-        ConnectorSpecifications, PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData,
+        ConnectorSpecifications, PaymentFlowData, PaymentsAuthorizeData,
+        PaymentsCancelPostCaptureData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
+        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
     },
     payment_method_data::PaymentMethodDataTypes,
     router_data::{ConnectorSpecificConfig, ErrorResponse},
@@ -20,13 +20,14 @@ use domain_types::{
 use hyperswitch_masking::Maskable;
 use interfaces::{
     api::ConnectorCommon, connector_integration_v2::ConnectorIntegrationV2, connector_types,
-    decode::BodyDecoding, verification::SourceVerification,
+    connector_types::PaymentVoidPostCaptureV2, decode::BodyDecoding,
+    verification::SourceVerification,
 };
 use serde::Serialize;
 use transformers::{
     self as elavon, ElavonCaptureResponse, ElavonPSyncResponse, ElavonPaymentsResponse,
-    ElavonRSyncResponse, ElavonRefundResponse, XMLCaptureRequest, XMLElavonRequest,
-    XMLPSyncRequest, XMLRSyncRequest, XMLRefundRequest,
+    ElavonRSyncResponse, ElavonRefundResponse, ElavonVoidPCResponse, XMLCaptureRequest,
+    XMLElavonRequest, XMLPSyncRequest, XMLRSyncRequest, XMLRefundRequest, XMLVoidPCRequest,
 };
 
 use super::macros;
@@ -75,6 +76,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::PaymentCapture for Elavon<T>
+{
+}
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    PaymentVoidPostCaptureV2 for Elavon<T>
 {
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -218,6 +223,12 @@ macros::create_all_prerequisites!(
             request_body: XMLRSyncRequest,
             response_body: ElavonRSyncResponse,
             router_data: RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
+        ),
+        (
+            flow: VoidPC,
+            request_body: XMLVoidPCRequest,
+            response_body: ElavonVoidPCResponse,
+            router_data: RouterDataV2<VoidPC, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -408,6 +419,39 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type],
+    connector: Elavon,
+    curl_request: FormUrlEncoded(XMLVoidPCRequest),
+    curl_response: ElavonVoidPCResponse,
+    flow_name: VoidPC,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentsCancelPostCaptureData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    preprocess_response: true,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<VoidPC, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<VoidPC, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(format!(
+                "{}processxml.do",
+                req.resource_common_data.connectors.elavon.base_url
+            ))
+        }
+    }
+);
+
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> ConnectorSpecifications
     for Elavon<T>
 {
@@ -422,7 +466,6 @@ macros::macro_connector_flow_status_impls!(
         SetupMandate,
         PaymentMethodToken,
         MandateRevoke,
-        VoidPC,
         RepeatPayment,
     ],
     not_supported: [

--- a/crates/integrations/connector-integration/src/connectors/elavon.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon.rs
@@ -78,8 +78,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::PaymentCapture for Elavon<T>
 {
 }
-impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
-    PaymentVoidPostCaptureV2 for Elavon<T>
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> PaymentVoidPostCaptureV2
+    for Elavon<T>
 {
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -12,8 +12,8 @@ use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, VoidPC},
     connector_types::{
         MandateReference, PaymentFlowData, PaymentsAuthorizeData, PaymentsCancelPostCaptureData,
-        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData,
-        RefundsData, RefundsResponseData, ResponseId as DomainResponseId,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
+        RefundSyncData, RefundsData, RefundsResponseData, ResponseId as DomainResponseId,
     },
     payment_address::PaymentAddress,
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -9,11 +9,11 @@ use common_utils::{
     types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
 use domain_types::{
-    connector_flow::{Authorize, Capture, PSync, RSync, Refund},
+    connector_flow::{Authorize, Capture, PSync, RSync, Refund, VoidPC},
     connector_types::{
-        MandateReference, PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData, ResponseId as DomainResponseId,
+        MandateReference, PaymentFlowData, PaymentsAuthorizeData, PaymentsCancelPostCaptureData,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData,
+        RefundsData, RefundsResponseData, ResponseId as DomainResponseId,
     },
     payment_address::PaymentAddress,
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
@@ -68,6 +68,7 @@ pub enum TransactionType {
     CcComplete,
     CcReturn,
     TxnQuery,
+    CcVoid,
 }
 
 impl Serialize for TransactionType {
@@ -81,6 +82,7 @@ impl Serialize for TransactionType {
             Self::CcComplete => "cccomplete",
             Self::CcReturn => "ccreturn",
             Self::TxnQuery => "txnquery",
+            Self::CcVoid => "ccvoid",
         };
         serializer.serialize_str(value)
     }
@@ -284,7 +286,7 @@ pub struct XMLElavonRequest(pub HashMap<String, Secret<String, WithoutType>>);
 #[derive(Debug, Serialize)]
 pub struct XMLPSyncRequest(pub HashMap<String, Secret<String, WithoutType>>);
 
-// Define dedicated types for Capture, Refund, and RSync XML requests
+// Define dedicated types for Capture, Refund, RSync, and VoidPC XML requests
 #[derive(Debug, Serialize)]
 pub struct XMLCaptureRequest(pub HashMap<String, Secret<String, WithoutType>>);
 
@@ -293,6 +295,9 @@ pub struct XMLRefundRequest(pub HashMap<String, Secret<String, WithoutType>>);
 
 #[derive(Debug, Serialize)]
 pub struct XMLRSyncRequest(pub HashMap<String, Secret<String, WithoutType>>);
+
+#[derive(Debug, Serialize)]
+pub struct XMLVoidPCRequest(pub HashMap<String, Secret<String, WithoutType>>);
 
 // TryFrom implementation to convert from the router data to XMLElavonRequest
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1467,6 +1472,273 @@ impl<F> TryFrom<ResponseRouterData<ElavonPSyncResponse, Self>>
 
         Ok(Self {
             response: Ok(payments_response_data),
+            resource_common_data: PaymentFlowData {
+                status: final_status,
+                ..router_data.resource_common_data
+            },
+            ..router_data
+        })
+    }
+}
+
+// ============================================================
+// VoidPC (VoidPostCapture / Reverse) flow
+// ============================================================
+
+/// Request struct for VoidPC (ccvoid).
+/// No amount field — ccvoid always voids the full captured amount.
+#[skip_serializing_none]
+#[derive(Debug, Serialize)]
+pub struct ElavonVoidPCRequest {
+    pub ssl_transaction_type: TransactionType,
+    pub ssl_account_id: Secret<String>,
+    pub ssl_user_id: Secret<String>,
+    pub ssl_pin: Secret<String>,
+    pub ssl_txn_id: String,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ElavonRouterData<
+            RouterDataV2<
+                VoidPC,
+                PaymentFlowData,
+                PaymentsCancelPostCaptureData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for ElavonVoidPCRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: ElavonRouterData<
+            RouterDataV2<
+                VoidPC,
+                PaymentFlowData,
+                PaymentsCancelPostCaptureData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+        let auth_type = ElavonAuthType::try_from(&router_data.connector_config)?;
+        let connector_transaction_id = router_data.request.connector_transaction_id.clone();
+
+        Ok(Self {
+            ssl_transaction_type: TransactionType::CcVoid,
+            ssl_account_id: auth_type.ssl_merchant_id,
+            ssl_user_id: auth_type.ssl_user_id,
+            ssl_pin: auth_type.ssl_pin,
+            ssl_txn_id: connector_transaction_id,
+        })
+    }
+}
+
+/// XML form wrapper for VoidPC request — same pattern as all other Elavon XML flows.
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        ElavonRouterData<
+            RouterDataV2<
+                VoidPC,
+                PaymentFlowData,
+                PaymentsCancelPostCaptureData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for XMLVoidPCRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        data: ElavonRouterData<
+            RouterDataV2<
+                VoidPC,
+                PaymentFlowData,
+                PaymentsCancelPostCaptureData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let request = ElavonVoidPCRequest::try_from(data)
+            .change_context(IntegrationError::RequestEncodingFailed {
+                context: Default::default(),
+            })
+            .attach_printable("Failed to create ElavonVoidPCRequest")?;
+
+        let xml_content = quick_xml::se::to_string_with_root("txn", &request).map_err(|err| {
+            tracing::info!(error=?err, "XML serialization error for VoidPC");
+            error_stack::report!(IntegrationError::RequestEncodingFailed {
+                context: Default::default()
+            })
+        })?;
+
+        let mut result = HashMap::new();
+        result.insert(
+            "xmldata".to_string(),
+            Secret::<_, WithoutType>::new(xml_content),
+        );
+
+        Ok(Self(result))
+    }
+}
+
+/// Response type for VoidPC — same ElavonResult shape as other payment response types.
+#[derive(Debug, Clone, Serialize)]
+pub struct ElavonVoidPCResponse {
+    pub result: ElavonResult,
+}
+
+impl<'de> Deserialize<'de> for ElavonVoidPCResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Debug)]
+        #[serde(rename = "txn")]
+        struct XmlIshResponse {
+            #[serde(default, rename = "errorCode")]
+            error_code: Option<String>,
+            #[serde(default, rename = "errorMessage")]
+            error_message: Option<String>,
+            #[serde(default, rename = "errorName")]
+            error_name: Option<String>,
+            #[serde(default)]
+            ssl_result: Option<String>,
+            #[serde(default)]
+            ssl_txn_id: Option<String>,
+            #[serde(default)]
+            ssl_result_message: Option<String>,
+            #[serde(default)]
+            ssl_token: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_token_response: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_approval_code: Option<String>,
+            #[serde(default)]
+            ssl_transaction_type: Option<String>,
+            #[serde(default)]
+            ssl_cvv2_response: Option<Secret<String>>,
+            #[serde(default)]
+            ssl_avs_response: Option<String>,
+        }
+
+        let flat_res = XmlIshResponse::deserialize(deserializer)?;
+
+        let result = if flat_res.ssl_result.as_deref() == Some("0") {
+            ElavonResult::Success(PaymentResponse {
+                ssl_result: SslResult::try_from(
+                    flat_res
+                        .ssl_result
+                        .ok_or_else(|| de::Error::missing_field("ssl_result"))?,
+                )
+                .map_err(de::Error::custom)?,
+                ssl_txn_id: flat_res
+                    .ssl_txn_id
+                    .ok_or_else(|| de::Error::missing_field("ssl_txn_id"))?,
+                ssl_result_message: flat_res
+                    .ssl_result_message
+                    .ok_or_else(|| de::Error::missing_field("ssl_result_message"))?,
+                ssl_token: flat_res.ssl_token,
+                ssl_approval_code: flat_res.ssl_approval_code,
+                ssl_transaction_type: flat_res.ssl_transaction_type.clone(),
+                ssl_cvv2_response: flat_res.ssl_cvv2_response,
+                ssl_avs_response: flat_res.ssl_avs_response,
+                ssl_token_response: flat_res.ssl_token_response.map(|s| s.expose()),
+            })
+        } else if flat_res.error_message.is_some() {
+            ElavonResult::Error(ElavonErrorResponse {
+                error_code: flat_res.error_code.or(flat_res.ssl_result.clone()),
+                error_message: flat_res
+                    .error_message
+                    .ok_or_else(|| de::Error::missing_field("error_message"))?,
+                error_name: flat_res.error_name,
+                ssl_txn_id: flat_res.ssl_txn_id,
+            })
+        } else if flat_res.ssl_result.is_some() {
+            ElavonResult::Error(ElavonErrorResponse {
+                error_code: flat_res.ssl_result.clone(),
+                error_message: flat_res
+                    .ssl_result_message
+                    .unwrap_or_else(|| "VoidPC transaction resulted in an error".to_string()),
+                error_name: None,
+                ssl_txn_id: flat_res.ssl_txn_id,
+            })
+        } else {
+            return Err(de::Error::custom(
+                "Invalid VoidPC Response from Elavon - cannot determine success or error state, missing critical fields.",
+            ));
+        };
+
+        Ok(Self { result })
+    }
+}
+
+/// Response TryFrom for VoidPC flow.
+/// Maps a successful ccvoid response to AttemptStatus::VoidPostCaptureInitiated.
+impl<F> TryFrom<ResponseRouterData<ElavonVoidPCResponse, Self>>
+    for RouterDataV2<F, PaymentFlowData, PaymentsCancelPostCaptureData, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        value: ResponseRouterData<ElavonVoidPCResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let ResponseRouterData {
+            response,
+            router_data,
+            http_code,
+        } = value;
+
+        tracing::info!(response=?response, "Processing Elavon VoidPC response");
+
+        let (attempt_status, error_response) =
+            get_elavon_attempt_status(&response.result, http_code);
+
+        // Override the attempt status for a successful void — use VoidPostCaptureInitiated
+        let final_status = match &response.result {
+            ElavonResult::Success(_) => HyperswitchAttemptStatus::VoidPostCaptureInitiated,
+            _ => attempt_status,
+        };
+
+        let response_data = match (&response.result, error_response) {
+            (ElavonResult::Success(payment_resp_struct), None) => {
+                Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: DomainResponseId::ConnectorTransactionId(
+                        payment_resp_struct.ssl_txn_id.clone(),
+                    ),
+                    redirection_data: None,
+                    connector_metadata: None,
+                    network_txn_id: payment_resp_struct.ssl_approval_code.clone(),
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    mandate_reference: None,
+                    status_code: http_code,
+                })
+            }
+            (_, Some(err_resp)) => Err(err_resp),
+            (ElavonResult::Error(error_payload), None) => Err(ErrorResponse {
+                status_code: http_code,
+                code: error_payload
+                    .error_code
+                    .clone()
+                    .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                message: error_payload.error_message.clone(),
+                reason: error_payload.error_name.clone(),
+                attempt_status: Some(HyperswitchAttemptStatus::Failure),
+                connector_transaction_id: error_payload.ssl_txn_id.clone(),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            }),
+        };
+
+        Ok(Self {
+            response: response_data,
             resource_common_data: PaymentFlowData {
                 status: final_status,
                 ..router_data.resource_common_data

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -1699,42 +1699,34 @@ impl<F> TryFrom<ResponseRouterData<ElavonVoidPCResponse, Self>>
         let (attempt_status, error_response) =
             get_elavon_attempt_status(&response.result, http_code);
 
-        // Override the attempt status for a successful void — use VoidPostCaptureInitiated
-        let final_status = match &response.result {
-            ElavonResult::Success(_) => HyperswitchAttemptStatus::VoidPostCaptureInitiated,
-            _ => attempt_status,
-        };
-
-        let response_data = match (&response.result, error_response) {
-            (ElavonResult::Success(payment_resp_struct), None) => {
-                Ok(PaymentsResponseData::TransactionResponse {
-                    resource_id: DomainResponseId::ConnectorTransactionId(
-                        payment_resp_struct.ssl_txn_id.clone(),
-                    ),
-                    redirection_data: None,
-                    connector_metadata: None,
-                    network_txn_id: payment_resp_struct.ssl_approval_code.clone(),
-                    connector_response_reference_id: None,
-                    incremental_authorization_allowed: None,
-                    mandate_reference: None,
+        let (final_status, response_data) = match (&response.result, error_response) {
+            (ElavonResult::Success(payment_resp_struct), None) => (
+                HyperswitchAttemptStatus::VoidedPostCapture,
+                Ok(PaymentsResponseData::PostCaptureVoidResponse {
+                    post_capture_void_status: common_enums::PostCaptureVoidStatus::Succeeded,
+                    connector_reference_id: payment_resp_struct.ssl_approval_code.clone(),
+                    description: None,
                     status_code: http_code,
-                })
-            }
-            (_, Some(err_resp)) => Err(err_resp),
-            (ElavonResult::Error(error_payload), None) => Err(ErrorResponse {
-                status_code: http_code,
-                code: error_payload
-                    .error_code
-                    .clone()
-                    .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
-                message: error_payload.error_message.clone(),
-                reason: error_payload.error_name.clone(),
-                attempt_status: Some(HyperswitchAttemptStatus::Failure),
-                connector_transaction_id: error_payload.ssl_txn_id.clone(),
-                network_decline_code: None,
-                network_advice_code: None,
-                network_error_message: None,
-            }),
+                }),
+            ),
+            (_, Some(err_resp)) => (attempt_status, Err(err_resp)),
+            (ElavonResult::Error(error_payload), None) => (
+                attempt_status,
+                Err(ErrorResponse {
+                    status_code: http_code,
+                    code: error_payload
+                        .error_code
+                        .clone()
+                        .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                    message: error_payload.error_message.clone(),
+                    reason: error_payload.error_name.clone(),
+                    attempt_status: Some(HyperswitchAttemptStatus::Failure),
+                    connector_transaction_id: error_payload.ssl_txn_id.clone(),
+                    network_decline_code: None,
+                    network_advice_code: None,
+                    network_error_message: None,
+                }),
+            ),
         };
 
         Ok(Self {

--- a/data/field_probe/elavon.json
+++ b/data/field_probe/elavon.json
@@ -694,8 +694,9 @@
       "default": {
         "status": "supported",
         "proto_request": {
+          "connector_transaction_id": "probe_connector_txn_001",
           "merchant_reverse_id": "probe_reverse_001",
-          "connector_transaction_id": "probe_connector_txn_001"
+          "cancellation_reason": "requested_by_customer"
         },
         "sample": {
           "url": "https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do",

--- a/data/field_probe/elavon.json
+++ b/data/field_probe/elavon.json
@@ -3,7 +3,8 @@
   "flows": {
     "authenticate": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "authenticate flow not supported by elavon connector"
       }
     },
     "authorize": {
@@ -502,37 +503,44 @@
     },
     "create_client_authentication_token": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "client_authentication_token flow not supported by elavon connector"
       }
     },
     "create_customer": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "create_connector_customer flow not supported by elavon connector"
       }
     },
     "create_order": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "create_order flow not supported by elavon connector"
       }
     },
     "create_server_authentication_token": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "server_authentication_token flow not supported by elavon connector"
       }
     },
     "create_server_session_authentication_token": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "server_session_authentication_token flow not supported by elavon connector"
       }
     },
     "dispute_accept": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "accept_dispute flow not supported by elavon connector"
       }
     },
     "dispute_defend": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "defend_dispute flow not supported by elavon connector"
       }
     },
     "dispute_get": {
@@ -542,7 +550,8 @@
     },
     "dispute_submit_evidence": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "submit_evidence flow not supported by elavon connector"
       }
     },
     "eligibility": {
@@ -579,7 +588,8 @@
     },
     "incremental_authorization": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "incremental_authorization flow not supported by elavon connector"
       }
     },
     "parse_event": {
@@ -589,12 +599,14 @@
     },
     "post_authenticate": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "post_authenticate flow not supported by elavon connector"
       }
     },
     "pre_authenticate": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_supported",
+        "error": "pre_authenticate flow not supported by elavon connector"
       }
     },
     "proxy_authorize": {
@@ -634,17 +646,20 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: setup_mandate flow for elavon"
       }
     },
     "recurring_charge": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: repeat_payment flow for elavon"
       }
     },
     "recurring_revoke": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: mandate_revoke flow for elavon"
       }
     },
     "refund": {
@@ -710,7 +725,8 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: setup_mandate flow for elavon"
       }
     },
     "token_authorize": {
@@ -721,12 +737,14 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: setup_mandate flow for elavon"
       }
     },
     "tokenize": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: payment_method_token flow for elavon"
       }
     },
     "verify_redirect": {
@@ -736,7 +754,8 @@
     },
     "void": {
       "default": {
-        "status": "not_implemented"
+        "status": "not_implemented",
+        "error": "This feature is not implemented: void flow for elavon"
       }
     }
   }

--- a/data/field_probe/elavon.json
+++ b/data/field_probe/elavon.json
@@ -694,9 +694,8 @@
       "default": {
         "status": "supported",
         "proto_request": {
-          "connector_transaction_id": "probe_connector_txn_001",
           "merchant_reverse_id": "probe_reverse_001",
-          "cancellation_reason": "requested_by_customer"
+          "connector_transaction_id": "probe_connector_txn_001"
         },
         "sample": {
           "url": "https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do",

--- a/data/field_probe/elavon.json
+++ b/data/field_probe/elavon.json
@@ -3,8 +3,7 @@
   "flows": {
     "authenticate": {
       "default": {
-        "status": "not_supported",
-        "error": "authenticate flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "authorize": {
@@ -503,44 +502,37 @@
     },
     "create_client_authentication_token": {
       "default": {
-        "status": "not_supported",
-        "error": "client_authentication_token flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "create_customer": {
       "default": {
-        "status": "not_supported",
-        "error": "create_connector_customer flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "create_order": {
       "default": {
-        "status": "not_supported",
-        "error": "create_order flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "create_server_authentication_token": {
       "default": {
-        "status": "not_supported",
-        "error": "server_authentication_token flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "create_server_session_authentication_token": {
       "default": {
-        "status": "not_supported",
-        "error": "server_session_authentication_token flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "dispute_accept": {
       "default": {
-        "status": "not_supported",
-        "error": "accept_dispute flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "dispute_defend": {
       "default": {
-        "status": "not_supported",
-        "error": "defend_dispute flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "dispute_get": {
@@ -550,8 +542,7 @@
     },
     "dispute_submit_evidence": {
       "default": {
-        "status": "not_supported",
-        "error": "submit_evidence flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "eligibility": {
@@ -588,8 +579,7 @@
     },
     "incremental_authorization": {
       "default": {
-        "status": "not_supported",
-        "error": "incremental_authorization flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "parse_event": {
@@ -599,14 +589,12 @@
     },
     "post_authenticate": {
       "default": {
-        "status": "not_supported",
-        "error": "post_authenticate flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "pre_authenticate": {
       "default": {
-        "status": "not_supported",
-        "error": "pre_authenticate flow not supported by elavon connector"
+        "status": "not_implemented"
       }
     },
     "proxy_authorize": {
@@ -646,20 +634,17 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for elavon"
+        "status": "not_implemented"
       }
     },
     "recurring_charge": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: repeat_payment flow for elavon"
+        "status": "not_implemented"
       }
     },
     "recurring_revoke": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: mandate_revoke flow for elavon"
+        "status": "not_implemented"
       }
     },
     "refund": {
@@ -707,14 +692,25 @@
     },
     "reverse": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: void_post_capture flow for elavon"
+        "status": "supported",
+        "proto_request": {
+          "merchant_reverse_id": "probe_reverse_001",
+          "connector_transaction_id": "probe_connector_txn_001"
+        },
+        "sample": {
+          "url": "https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do",
+          "method": "Post",
+          "headers": {
+            "content-type": "application/x-www-form-urlencoded",
+            "via": "HyperSwitch"
+          },
+          "body": "xmldata=%3Ctxn%3E%3Cssl_transaction_type%3Eccvoid%3C%2Fssl_transaction_type%3E%3Cssl_account_id%3Eprobe_merchant%3C%2Fssl_account_id%3E%3Cssl_user_id%3Eprobe_user%3C%2Fssl_user_id%3E%3Cssl_pin%3Eprobe_pin%3C%2Fssl_pin%3E%3Cssl_txn_id%3Eprobe_connector_txn_001%3C%2Fssl_txn_id%3E%3C%2Ftxn%3E"
+        }
       }
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for elavon"
+        "status": "not_implemented"
       }
     },
     "token_authorize": {
@@ -725,14 +721,12 @@
     },
     "token_setup_recurring": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for elavon"
+        "status": "not_implemented"
       }
     },
     "tokenize": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: payment_method_token flow for elavon"
+        "status": "not_implemented"
       }
     },
     "verify_redirect": {
@@ -742,8 +736,7 @@
     },
     "void": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: void flow for elavon"
+        "status": "not_implemented"
       }
     }
   }

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -141,7 +141,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Datatrans](connectors/datatrans.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ |
 | [dLocal](connectors/dlocal.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ✓ | ⚠ | x | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | ⚠ | x | x | x | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ |
 | [Easebuzz](connectors/easebuzz.md) | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ |
-| [Elavon](connectors/elavon.md) | ✓ | ⚠ | ⚠ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
+| [Elavon](connectors/elavon.md) | ✓ | ⚠ | ✓ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Finix](connectors/finix.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | x | ⚠ | ? | ✓ | ? | x | ? | ✓ | x | ✓ | ✓ | ✓ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ |
 | [Fiserv](connectors/fiserv.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | x | ✓ | x | x | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Fiservcommercehub](connectors/fiservcommercehub.md) | ✓ | ✓ | x | ⚠ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ? | ⚠ | ⚠ | x | ✓ | x | x | ⚠ | ✓ | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |

--- a/docs-generated/connectors/elavon.md
+++ b/docs-generated/connectors/elavon.md
@@ -131,7 +131,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/elavon/elavon.py#L116) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L106) · [Rust](../../examples/elavon/elavon.rs#L150)
+**Examples:** [Python](../../examples/elavon/elavon.py#L122) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L113) · [Rust](../../examples/elavon/elavon.rs#L158)
 
 ### Card Payment (Authorize + Capture)
 
@@ -145,19 +145,19 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/elavon/elavon.py#L135) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L122) · [Rust](../../examples/elavon/elavon.rs#L166)
+**Examples:** [Python](../../examples/elavon/elavon.py#L141) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L129) · [Rust](../../examples/elavon/elavon.rs#L174)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/elavon/elavon.py#L160) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L144) · [Rust](../../examples/elavon/elavon.rs#L189)
+**Examples:** [Python](../../examples/elavon/elavon.py#L166) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L151) · [Rust](../../examples/elavon/elavon.rs#L197)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/elavon/elavon.py#L185) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L166) · [Rust](../../examples/elavon/elavon.rs#L212)
+**Examples:** [Python](../../examples/elavon/elavon.py#L191) · [JavaScript](../../examples/elavon/elavon.js) · [Kotlin](../../examples/elavon/elavon.kt#L173) · [Rust](../../examples/elavon/elavon.rs#L220)
 
 ## API Reference
 
@@ -169,6 +169,7 @@ Retrieve current payment status from the connector.
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
+| [PaymentService.Reverse](#paymentservicereverse) | Payments | `PaymentServiceReverseRequest` |
 
 ### Payments
 
@@ -302,7 +303,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L217) · [Kotlin](../../examples/elavon/elavon.kt#L184) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L224) · [Kotlin](../../examples/elavon/elavon.kt#L191) · [Rust](../../examples/elavon/elavon.rs)
 
 #### PaymentService.Capture
 
@@ -313,7 +314,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L226) · [Kotlin](../../examples/elavon/elavon.kt#L196) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L233) · [Kotlin](../../examples/elavon/elavon.kt#L203) · [Rust](../../examples/elavon/elavon.rs)
 
 #### PaymentService.Get
 
@@ -324,7 +325,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L235) · [Kotlin](../../examples/elavon/elavon.kt#L206) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L242) · [Kotlin](../../examples/elavon/elavon.kt#L213) · [Rust](../../examples/elavon/elavon.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -335,7 +336,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L244) · [Kotlin](../../examples/elavon/elavon.kt#L214) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L251) · [Kotlin](../../examples/elavon/elavon.kt#L221) · [Rust](../../examples/elavon/elavon.rs)
 
 #### PaymentService.Refund
 
@@ -346,7 +347,18 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L253) · [Kotlin](../../examples/elavon/elavon.kt#L243) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L260) · [Kotlin](../../examples/elavon/elavon.kt#L250) · [Rust](../../examples/elavon/elavon.rs)
+
+#### PaymentService.Reverse
+
+Reverse a captured payment in full. Initiates a complete refund when you need to cancel a settled transaction rather than just an authorization.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceReverseRequest` |
+| **Response** | `PaymentServiceReverseResponse` |
+
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L278) · [Kotlin](../../examples/elavon/elavon.kt#L272) · [Rust](../../examples/elavon/elavon.rs)
 
 ### Refunds
 
@@ -359,4 +371,4 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L262) · [Kotlin](../../examples/elavon/elavon.kt#L253) · [Rust](../../examples/elavon/elavon.rs)
+**Examples:** [Python](../../examples/elavon/elavon.py) · [TypeScript](../../examples/elavon/elavon.ts#L269) · [Kotlin](../../examples/elavon/elavon.kt#L260) · [Rust](../../examples/elavon/elavon.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -211,7 +211,7 @@ connector_id: elavon
 doc: docs/connectors/elavon.md
 scenarios: checkout_autocapture, checkout_card, refund, get_payment
 payment_methods: Card
-flows: authorize, capture, get, proxy_authorize, refund, refund_get
+flows: authorize, capture, get, proxy_authorize, refund, refund_get, reverse
 examples_python: examples/elavon/elavon.py
 
 ## Finix

--- a/examples/elavon/elavon.kt
+++ b/examples/elavon/elavon.kt
@@ -22,7 +22,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.ElavonConfig
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "get", "proxy_authorize", "refund", "refund_get")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "get", "proxy_authorize", "refund", "refund_get", "reverse")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -98,6 +98,13 @@ private fun buildRefundRequest(connectorTransactionIdStr: String): PaymentServic
             currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
         }
         reason = "customer_request"  // Reason for the refund.
+    }.build()
+}
+
+private fun buildReverseRequest(connectorTransactionIdStr: String): PaymentServiceReverseRequest {
+    return PaymentServiceReverseRequest.newBuilder().apply {
+        merchantReverseId = "probe_reverse_001"  // Identification.
+        connectorTransactionId = connectorTransactionIdStr
     }.build()
 }
 
@@ -261,6 +268,14 @@ fun refundGet(txnId: String, config: ConnectorConfig = _defaultConfig) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.Reverse
+fun reverse(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = buildReverseRequest("probe_connector_txn_001")
+    val response = client.reverse(request)
+    println("Status: ${response.status.name}")
+}
+
 
 fun main(args: Array<String>) {
     val txnId = "order_001"
@@ -276,6 +291,7 @@ fun main(args: Array<String>) {
         "proxyAuthorize" -> proxyAuthorize(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, get, proxyAuthorize, refund, refundGet")
+        "reverse" -> reverse(txnId)
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, get, proxyAuthorize, refund, refundGet, reverse")
     }
 }

--- a/examples/elavon/elavon.py
+++ b/examples/elavon/elavon.py
@@ -11,7 +11,7 @@ from payments import PaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "capture", "get", "proxy_authorize", "refund", "refund_get"]
+SUPPORTED_FLOWS = ["authorize", "capture", "get", "proxy_authorize", "refund", "refund_get", "reverse"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -112,6 +112,12 @@ def _build_refund_get_request():
         merchant_refund_id="probe_refund_001",  # Identification.
         connector_transaction_id="probe_connector_txn_001",
         refund_id="probe_refund_id_001",  # Deprecated.
+    )
+
+def _build_reverse_request(connector_transaction_id: str):
+    return payment_pb2.PaymentServiceReverseRequest(
+        merchant_reverse_id="probe_reverse_001",  # Identification.
+        connector_transaction_id=connector_transaction_id,
     )
 async def process_checkout_autocapture(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """One-step Payment (Authorize + Capture)
@@ -247,6 +253,15 @@ async def process_refund_get(merchant_transaction_id: str, config: sdk_config_pb
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
+
+
+async def process_reverse(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.Reverse"""
+    payment_client = PaymentClient(config)
+
+    reverse_response = await payment_client.reverse(_build_reverse_request("probe_connector_txn_001"))
+
+    return {"status": reverse_response.status}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "checkout_autocapture"

--- a/examples/elavon/elavon.rs
+++ b/examples/elavon/elavon.rs
@@ -21,6 +21,7 @@ pub const SUPPORTED_FLOWS: &[&str] = &[
     "proxy_authorize",
     "refund",
     "refund_get",
+    "reverse",
 ];
 
 #[allow(dead_code)]
@@ -160,6 +161,14 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
         merchant_refund_id: Some("probe_refund_001".to_string()), // Identification.
         connector_transaction_id: "probe_connector_txn_001".to_string(),
         refund_id: "probe_refund_id_001".to_string(), // Deprecated.
+        ..Default::default()
+    }
+}
+
+pub fn build_reverse_request(connector_transaction_id: &str) -> PaymentServiceReverseRequest {
+    PaymentServiceReverseRequest {
+        merchant_reverse_id: Some("probe_reverse_001".to_string()), // Identification.
+        connector_transaction_id: connector_transaction_id.to_string(),
         ..Default::default()
     }
 }
@@ -396,6 +405,22 @@ pub async fn process_refund_get(
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.Reverse
+#[allow(dead_code)]
+pub async fn process_reverse(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client
+        .reverse(
+            build_reverse_request("probe_connector_txn_001"),
+            &HashMap::new(),
+            None,
+        )
+        .await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 #[allow(dead_code)]
 #[tokio::main]
 async fn main() {
@@ -413,8 +438,9 @@ async fn main() {
         "process_get" => process_get(&client, "txn_001").await,
         "process_proxy_authorize" => process_proxy_authorize(&client, "txn_001").await,
         "process_refund_get" => process_refund_get(&client, "txn_001").await,
+        "process_reverse" => process_reverse(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_get_payment, process_authorize, process_capture, process_get, process_proxy_authorize, process_refund_get", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_get_payment, process_authorize, process_capture, process_get, process_proxy_authorize, process_refund_get, process_reverse", flow);
             return;
         }
     };

--- a/examples/elavon/elavon.ts
+++ b/examples/elavon/elavon.ts
@@ -7,7 +7,7 @@
 
 import { PaymentClient, RefundClient, types } from 'hyperswitch-prism';
 const { Environment, AuthenticationType, CaptureMethod, CardNetwork, Currency } = types;
-export const SUPPORTED_FLOWS = ["authorize", "capture", "get", "proxy_authorize", "refund", "refund_get"];
+export const SUPPORTED_FLOWS = ["authorize", "capture", "get", "proxy_authorize", "refund", "refund_get", "reverse"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -115,6 +115,13 @@ function _buildRefundGetRequest(): types.IRefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"  // Deprecated.
+    };
+}
+
+function _buildReverseRequest(connectorTransactionId: string): types.IPaymentServiceReverseRequest {
+    return {
+        "merchantReverseId": "probe_reverse_001",  // Identification.
+        "connectorTransactionId": connectorTransactionId
     };
 }
 
@@ -267,10 +274,19 @@ async function refundGet(merchantTransactionId: string, config: types.IConnector
     return refundResponse;
 }
 
+// Flow: PaymentService.Reverse
+async function reverse(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const reverseResponse = await paymentClient.reverse(_buildReverseRequest('probe_connector_txn_001'));
+
+    return reverseResponse;
+}
+
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, get, proxyAuthorize, refund, refundGet, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, get, proxyAuthorize, refund, refundGet, reverse, _buildAuthorizeRequest, _buildCaptureRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildReverseRequest
 };
 
 // CLI runner


### PR DESCRIPTION
"## Summary\n\nImplementation of **Reverse (VoidPostCapture)** flow for **ELAVON** connector using the `ccvoid` transaction type.\n\n- Added `CcVoid` variant to `TransactionType` enum (serializes to `\"ccvoid\"`)\n- Added `ElavonVoidPCRequest` struct and `XMLVoidPCRequest` wrapper\n- Added `ElavonVoidPCResponse` with custom `Deserialize` (same pattern as `ElavonPaymentsResponse`)\n- Added `TryFrom` implementations for request and response\n- Added `VoidPC` entry to `create_all_prerequisites!` macro\n- Replaced empty `ConnectorIntegrationV2<VoidPC>` impl with full `macro_connector_implementation!` including correct `get_url` pointing to `processxml.do`\n- Updated `data/field_probe/elavon.json` to mark `reverse` as supported with `ccvoid` sample request\n\n## grpcurl Test Output\n\n### Step 1: Authorize (to verify connectivity)\n\n```bash\ngrpcurl -plaintext \\\n  -H \"x-connector: elavon\" \\\n  -H \"x-auth: signature-key\" \\\n  -H \"x-api-key: <REDACTED>\" \\\n  -H \"x-key1: <REDACTED>\" \\\n  -H \"x-api-secret: <REDACTED>\" \\\n  -H \"x-merchant-id: test_merchant\" \\\n  -H \"x-tenant-id: default\" \\\n  -H \"x-request-id: test_auth_001\" \\\n  -d '{\n    \"merchant_transaction_id\": \"grpcurl_auth_TEST001\",\n    \"amount\": {\"minor_amount\": 1000, \"currency\": \"USD\"},\n    \"payment_method\": {\"card\": {\n      \"card_number\": {\"value\": \"4124939999999990\"},\n      \"card_exp_month\": {\"value\": \"12\"},\n      \"card_exp_year\": {\"value\": \"2050\"},\n      \"card_cvc\": {\"value\": \"123\"},\n      \"card_holder_name\": {\"value\": \"Test User\"}\n    }},\n    \"address\": {\"billing_address\": {\n      \"first_name\": {\"value\": \"John\"},\n      \"last_name\": {\"value\": \"Doe\"},\n      \"line1\": {\"value\": \"123 Main St\"},\n      \"city\": {\"value\": \"Austin\"},\n      \"state\": {\"value\": \"TX\"},\n      \"zip_code\": {\"value\": \"78701\"},\n      \"country_alpha2_code\": \"US\"\n    }},\n    \"capture_method\": \"MANUAL\",\n    \"auth_type\": \"NO_THREE_DS\"\n  }' \\\n  localhost:8000 types.PaymentService/Authorize\n```\n\n**Response:**\n```json\n{\n  \"status\": \"FAILURE\",\n  \"error\": {\n    \"issuerDetails\": {\n      \"networkDetails\": {}\n    },\n    \"connectorDetails\": {\n      \"code\": \"4025\",\n      \"message\": \"The credentials supplied in the authorization request are invalid.\",\n      \"reason\": \"Invalid Credentials\"\n    }\n  },\n  \"statusCode\": 200\n}\n```\n\n### Step 2: Reverse (VoidPostCapture) \u2014 core flow under test\n\n```bash\ngrpcurl -plaintext \\\n  -H \"x-connector: elavon\" \\\n  -H \"x-auth: signature-key\" \\\n  -H \"x-api-key: <REDACTED>\" \\\n  -H \"x-key1: <REDACTED>\" \\\n  -H \"x-api-secret: <REDACTED>\" \\\n  -H \"x-merchant-id: test_merchant\" \\\n  -H \"x-tenant-id: default\" \\\n  -H \"x-request-id: test_reverse_001\" \\\n  -d '{\n    \"merchant_reverse_id\": \"grpcurl_reverse_001\",\n    \"connector_transaction_id\": \"DUMMY_TXN_ID_FOR_TEST\",\n    \"cancellation_reason\": \"requested_by_customer\"\n  }' \\\n  localhost:8000 types.PaymentService/Reverse\n```\n\n**Response:**\n```json\n{\n  \"status\": \"FAILURE\",\n  \"error\": {\n    \"connectorDetails\": {\n      \"code\": \"4025\",\n      \"message\": \"The credentials supplied in the authorization request are invalid.\",\n      \"reason\": \"Invalid Credentials\"\n    }\n  },\n  \"statusCode\": 200\n}\n```\n\n### Server log confirmation\n\nThe server logs confirm the VoidPostCapture flow correctly routes to Elavon's endpoint:\n\n```\nflow_type: \"VoidPostCapture\"\nrequest.url: https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do\nrequest.method: POST\nrequest.headers: {(\"via\", \"HyperSwitch\"), (\"Content-Type\", \"application/x-www-form-urlencoded\")}\nresponse_data: {\"result\":{\"errorCode\":\"4025\",\"errorMessage\":\"The credentials supplied in the authorization request are invalid.\",\"errorName\":\"Invalid Credentials\"}}\nlatency_ms: 441\nstatus_code: 200\n```\n\n**Note on error 4025**: Both Authorize and Reverse return `errorCode: 4025` (Invalid Credentials) from Elavon's sandbox server. This is expected \u2014 the sandbox credentials in `creds.json` are expired (external credential issue, not a code defect). The response is HTTP 200 from Elavon's API at `https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do`, confirming the request reaches Elavon correctly and the `ssl_transaction_type=ccvoid` payload is transmitted. The transformer correctly parses the error response via `ElavonVoidPCResponse`.\n\n## Build\n\n**Build**: PASS (zero errors)\n\n## Files Modified\n\n- `crates/integrations/connector-integration/src/connectors/elavon.rs`\n- `crates/integrations/connector-integration/src/connectors/elavon/transformers.rs`\n- `data/field_probe/elavon.json`\n- `docs-generated/` (auto-generated: elavon.md, all_connector.md, llms.txt \u2014 elavon entries only)\n- `examples/elavon/` (auto-generated SDK examples)\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\n"