### PR TITLE
test(multisafepay): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/multisafepay/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/multisafepay/override.json
@@ -1,1 +1,104 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_cc_auto",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_dc_auto",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_cc_man",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_debit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_dc_man",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "threeds_manual_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_3ds_cc_man",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_fail_payment": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_fail",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_alipay": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_alipay",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_ideal": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_ideal",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_giropay": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_giropay",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_eps": {
+      "grpc_req": {
+        "merchant_transaction_id": "msp_no3ds_eps",
+        "customer": {
+          "email": {
+            "value": "test@example.com"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/multisafepay/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/multisafepay/specs.json
@@ -6,5 +6,6 @@
     "PaymentService/Get",
     "PaymentService/Refund",
     "RefundService/Get"
-  ]
+  ],
+  "request_id_source_field": "merchant_transaction_id"
 }


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 8 |
| Failed  | 41 |
| Skipped | 1 |
| Total   | 50 |
| **Pass rate** | **16%** |
| Status  | Partial — connector-code fixes required |

### Why pass rate is capped (connector-code root cause)

The override alone cannot lift this above ~16%. The transformer at
`crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs`
has two issues that block the remaining suites:

**1. `response.success` is deserialized but never read.** In
`MultisafepayPaymentsResponse::try_from` for `Authorize`, status mapping
runs through `MultisafepayPaymentStatus -> AttemptStatus` only — the
`pub success: bool` field is dropped on the floor. So a declined
response like `{"success": false, "data": {"status": "Initialized"}}`
gets routed to the success path. The connector should branch on
`!item.response.success` first and emit
`Err(ErrorResponse { attempt_status: Some(AttemptStatus::Failure), ... })`.

**2. `Initialized -> AuthenticationPending` is misleading for direct flows.**
MultiSafepay's sandbox returns `status: Initialized` for newly created
orders regardless of whether 3DS is involved. The current mapping
`Initialized -> AuthenticationPending` implies a 3DS-style auth challenge,
which is wrong for direct card auto-capture. Either:

- Remap `Initialized -> Pending` (semantically more accurate — the order
  exists, awaiting customer payment), letting the harness's
  poll-to-terminal logic carry it forward; **or**
- Add a follow-up GET to `/orders/{id}` to resolve to a terminal
  `Completed`/`Declined` state before returning.

### What override.json fixes

Only the missing test data the connector doesn't generate by default:

- `customer.email` injected to prevent the framework's `auto_generate`
  sentinel from being pruned (otherwise `MissingRequiredField: email`)
- `merchant_transaction_id` per scenario so MultiSafepay receives a
  valid non-empty `order_id`

### What override.json does NOT fix

- Direct card decline mapping (needs `success: false` routing — see #1 above)
- Direct card success mapping (needs status remap — see #2 above)
- All dependent suites (Capture/Void/Get/Refund) that cascade from
  the broken Authorize step

These remaining failures are tracked as connector-level work, out of
MODE B scope.

> Ran via `test-prism --connector multisafepay --interface grpc --report`.
<!-- TEST-RESULTS-END -->

---

---

## Summary

- Add `customer.email` override (`test@example.com`) for all supported Authorize scenarios to prevent the field from being pruned (global scenario has `auto_generate` which gets pruned before reaching the connector, causing `MissingRequiredField: email`)
- Add `merchant_transaction_id` per scenario so MultSafepay receives a valid, non-empty `order_id` (the server populates `connector_request_reference_id` from `merchant_transaction_id` in the request body; when absent/pruned, it defaults to `""` → MultSafepay returns HTTP 404 for empty order IDs)
- Add `request_id_source_field: "merchant_transaction_id"` to specs.json to align header reference ID with the body field

## Root Causes Fixed

1. **Missing email**: `customer` block in global scenario has all `auto_generate`/empty values → `prune_all_default_top_level_keys` removes the entire `customer` block → `item.request.email` is `None` → `MissingRequiredField: email`
2. **Empty order_id**: `merchant_transaction_id` is `"auto_generate"` in the global scenario → pruned before sending → server's `connector_request_reference_id` = `""` → MultSafepay rejects empty `order_id` with HTTP 404

## Test plan

- [x] Validated with `cargo test -p integration-tests all_override_entries_match_existing_scenarios_and_proto_schema`
- [x] Validated with `cargo test -p integration-tests all_supported_scenarios_match_proto_schema_for_all_connectors`
- [x] Ran `test-prism --connector multisafepay --suite PaymentService/Authorize` — redirect-based flows (alipay, ideal, giropay, eps, threeds_manual_capture_credit_card) now PASS
- [x] Remaining failures are real connector behavior issues (not test data bugs): direct card payments return HTTP 200 + `success: false` which the connector maps to `AUTHENTICATION_PENDING` instead of `FAILURE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)