### PR TITLE
test(nuvei): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/nuvei/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/nuvei/override.json
@@ -1,5 +1,12 @@
 {
   "PaymentService/Authorize": {
+    "no3ds_auto_capture_ach_bank_transfer": {
+      "grpc_req": {
+        "metadata": {
+          "value": "{\"ach\":{\"account_number\":\"123456789\",\"routing_number\":\"021000021\",\"sec_code\":\"WEB\"}}"
+        }
+      }
+    },
     "no3ds_auto_capture_eps": {
       "assert": {
         "connector_transaction_id": null


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 86 |
| Failed  | 31 |
| Skipped | 1 |
| Total   | 118 |
| **Pass rate** | **73%** |
| Status  | Partial |

**Known remaining issues:** PSync/RSync uses fresh `clientUniqueId` instead of original → sync fails. `SetupRecurring` missing `CreateServerSessionAuthenticationToken` dependency.

> Ran via `test-prism --connector nuvei --interface grpc --report` against `fix/test-nuvei-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary
- Add metadata override for ACH bank transfer test scenario to provide account_number and routing_number that the Nuvei connector requires from request metadata

## Test plan
- [ ] ACH bank transfer scenario now passes with metadata containing ach.account_number and ach.routing_number
- [ ] Schema validation tests pass (all_supported_scenarios_match_proto_schema, all_override_entries_match_existing_scenarios_and_proto_schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
