### PR TITLE
test(powertranz): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/powertranz/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/powertranz/override.json
@@ -1,1 +1,244 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_debit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "threeds_manual_capture_credit_card": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_fail_payment": {
+      "grpc_req": {
+        "merchant_transaction_id": "mti_auto_generate"
+      }
+    }
+  },
+  "PaymentService/SetupRecurring": {
+    "PaymentService/SetupRecurring": {
+      "grpc_req": {
+        "merchant_recurring_payment_id": "mrpi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "setup_recurring": {
+      "grpc_req": {
+        "merchant_recurring_payment_id": "mrpi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "setup_recurring_with_order_context": {
+      "grpc_req": {
+        "merchant_recurring_payment_id": "mrpi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    },
+    "setup_recurring_with_webhook": {
+      "grpc_req": {
+        "merchant_recurring_payment_id": "mrpi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_cvc": {
+              "value": "123"
+            }
+          }
+        }
+      }
+    }
+  },
+  "RecurringPaymentService/Charge": {
+    "RecurringPaymentService/Charge": {
+      "grpc_req": {
+        "merchant_charge_id": "mchi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_exp_month": {
+              "value": "08"
+            },
+            "card_exp_year": {
+              "value": "30"
+            },
+            "card_cvc": {
+              "value": "123"
+            },
+            "card_holder_name": {
+              "value": "John Doe"
+            }
+          }
+        }
+      }
+    },
+    "recurring_charge": {
+      "grpc_req": {
+        "merchant_charge_id": "mchi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_exp_month": {
+              "value": "08"
+            },
+            "card_exp_year": {
+              "value": "30"
+            },
+            "card_cvc": {
+              "value": "123"
+            },
+            "card_holder_name": {
+              "value": "John Doe"
+            }
+          }
+        }
+      }
+    },
+    "recurring_charge_low_amount": {
+      "grpc_req": {
+        "merchant_charge_id": "mchi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_exp_month": {
+              "value": "08"
+            },
+            "card_exp_year": {
+              "value": "30"
+            },
+            "card_cvc": {
+              "value": "123"
+            },
+            "card_holder_name": {
+              "value": "John Doe"
+            }
+          }
+        }
+      }
+    },
+    "recurring_charge_with_order_context": {
+      "grpc_req": {
+        "merchant_charge_id": "mchi_auto_generate",
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4012000000020006"
+            },
+            "card_exp_month": {
+              "value": "08"
+            },
+            "card_exp_year": {
+              "value": "30"
+            },
+            "card_cvc": {
+              "value": "123"
+            },
+            "card_holder_name": {
+              "value": "John Doe"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/powertranz/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/powertranz/specs.json
@@ -9,5 +9,6 @@
     "RefundService/Get",
     "PaymentService/SetupRecurring",
     "PaymentService/Void"
-  ]
+  ],
+  "request_id_source_field": "merchant_transaction_id"
 }


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 51 |
| Failed  | 16 |
| Skipped | 1 |
| Total   | 68 |
| **Pass rate** | **75%** |
| Status  | Partial |

**Known remaining issues:** Decline not surfaced in transformer (always returns `Ok`). 15 unsupported PMs.

> Ran via `test-prism --connector powertranz --interface grpc --report` against `fix/test-powertranz-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary

- Fixed root cause of all PowerTranz card payment test failures: `merchant_transaction_id` (and equivalent fields for SetupRecurring/RecurringCharge flows) were pruned before auto-generation ran, resulting in an empty `OrderIdentifier` being sent to PowerTranz which rejected every request with "Missing field(s): OrderIdentifier" (ISO 97)
- Fixed by setting these fields to sentinel values like `"mti_auto_generate"` which survive the pruning step (not exact `"auto_generate"`) but are still resolved to unique UUIDs by `resolve_auto_generate`
- Overrode card number to PowerTranz sandbox test card `4012000000020006` / CVC `123` across all card scenarios
- Added full card fields (exp_month, exp_year, card_holder_name) to RecurringPaymentService/Charge overrides

## Test Results

- PaymentService/Authorize: 5/22 pass (5 card scenarios), 15 non-card PMs rejected by connector code (NOT_SUPPORTED), 1 decline error-field UCS code bug, 1 GPay skip
- PaymentService/Capture: 6/6 pass (100%)
- PaymentService/Get: 10/10 pass (100%)
- RecurringPaymentService/Charge: 5/5 pass (100%)
- PaymentService/Refund: 6/6 pass (100%)
- RefundService/Get: 9/9 pass (100%)
- PaymentService/SetupRecurring: 4/4 pass (100%)
- PaymentService/Void: 6/6 pass (100%)

## Known Remaining Issues (UCS Code Bugs - REPORT_TO_MASTER)

1. 15 non-card payment methods (ACH, Affirm, Afterpay, Alipay, BACS, Bancontact, EPS, Giropay, iDEAL, Klarna, Przelewy24, SEPA, UPI Collect, UPI Intent, UPI QR) return `FailedPrecondition: NOT_SUPPORTED` — connector code explicitly rejects these payment methods
2. `no3ds_fail_payment`: Authorize transformer always returns `Ok(PaymentsResponseData)` on decline without populating the error field — assertion `error: expected field to exist` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
