### PR TITLE
test(stax): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/stax/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/stax/override.json
@@ -1,1 +1,22 @@
-{}
+{
+  "CustomerService/Create": {
+    "create_customer": {
+      "grpc_req": {
+        "email": {
+          "value": "stax.test@sandbox.example.com"
+        },
+        "customer_name": "Stax Test User",
+        "phone_number": "+19794113855"
+      }
+    },
+    "CustomerService/Create": {
+      "grpc_req": {
+        "email": {
+          "value": "stax.test@sandbox.example.com"
+        },
+        "customer_name": "Stax Test User",
+        "phone_number": "+19794113855"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 44 |
| Failed  | 111 |
| Skipped | 1 |
| Total   | 156 |
| **Pass rate** | **28%** |
| Status  | Partial |

**Known remaining issues:** `StaxTokenResponse { pub id: Secret<String> }` — struct fails to deserialize actual Stax HTTP 200 token response → cascades to all dependent suites. Needs connector code fix.

> Ran via `test-prism --connector stax --interface grpc --report` against `fix/test-stax-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary

- Fixed `CustomerService/Create` test scenarios for Stax connector (0% → 100% pass rate)
- Root cause: global scenario uses `"auto_generate"` sentinels for `email`, `customer_name`, and `phone_number` at top level; `prune_all_default_top_level_keys` treats `"auto_generate"` as a default leaf and prunes these keys before `resolve_auto_generate` runs — so Stax's CreateCustomer API receives no email, returning "Missing required field: email"
- Fix: added concrete values in `override.json` for both `create_customer` and `CustomerService/Create` scenario keys under the `CustomerService/Create` suite

## Test plan

- [ ] `CustomerService/Create` suite: 2/2 PASS
- [ ] Downstream failures (Tokenize, Authorize, Capture, etc.) remain as UCS code bugs (separate issue — `StaxTokenResponse` deserialization mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
