### PR TITLE
test(worldpayvantiv): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
@@ -242,7 +242,7 @@
     "incremental_auth_multiple_increase": {
       "assert": {
         "status": {
-          "one_of": ["AUTHORIZATION_SUCCESS", "SUCCESS", "AUTHORIZED", "FAILED", "AUTHORIZATION_FAILURE"]
+          "one_of": ["AUTHORIZATION_SUCCESS", "SUCCESS", "AUTHORIZED"]
         }
       }
     }

--- a/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
@@ -230,5 +230,28 @@
         "error.connector_details.message": null
       }
     }
+  },
+  "PaymentService/IncrementalAuthorization": {
+    "incremental_auth_basic": {
+      "assert": {
+        "status": {
+          "one_of": ["AUTHORIZATION_SUCCESS", "SUCCESS", "AUTHORIZED"]
+        }
+      }
+    },
+    "incremental_auth_with_tip": {
+      "assert": {
+        "status": {
+          "one_of": ["AUTHORIZATION_SUCCESS", "SUCCESS", "AUTHORIZED"]
+        }
+      }
+    },
+    "incremental_auth_multiple_increase": {
+      "assert": {
+        "status": {
+          "one_of": ["AUTHORIZATION_SUCCESS", "SUCCESS", "AUTHORIZED", "FAILED", "AUTHORIZATION_FAILURE"]
+        }
+      }
+    }
   }
 }

--- a/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/worldpayvantiv/override.json
@@ -41,13 +41,6 @@
           "minor_amount": 120,
           "currency": "USD"
         }
-      },
-      "assert": {
-        "status": {
-          "one_of": ["FAILURE", "AUTHORIZATION_FAILED", "ROUTER_DECLINED", "UNRESOLVED", "PENDING"]
-        },
-        "error": null,
-        "error.connector_details.message": null
       }
     },
     "no3ds_auto_capture_ideal": {


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 19 |
| Failed  | 17 |
| Skipped | 1 |
| Total   | 37 |
| **Pass rate** | **51%** |
| Status  | Partial |

**Known remaining issues:** Framework `grpcurl` verbose output picks up connector config JSON for `NOT_SUPPORTED` gRPC errors. `add_context` overwrites intentionally invalid `connector_transaction_id` in negative tests. **Note: false positive (accepted PENDING which maps to `Sale+Approved` = charged) was caught and removed by this PR.**

> Ran via `test-prism --connector worldpayvantiv --interface grpc --report` against `fix/test-worldpayvantiv-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary
- Add `PaymentService/IncrementalAuthorization` overrides to worldpayvantiv's `override.json`
- The `AuthorizationStatus` proto enum returns `AUTHORIZATION_SUCCESS` for successful incremental auths; the global suite baseline incorrectly asserts `["SUCCESS", "AUTHORIZED"]`
- Fixes `incremental_auth_basic`, `incremental_auth_with_tip`, and `incremental_auth_multiple_increase` scenarios

## Test plan
- [x] `incremental_auth_basic`: PASS (was FAIL)
- [x] `incremental_auth_with_tip`: PASS (was FAIL)
- [x] `incremental_auth_multiple_increase`: PASS (was FAIL)
- [x] `cargo test -p integration-tests all_supported_scenarios_match_proto_schema_for_all_connectors` passes
- [x] `cargo test -p integration-tests all_override_entries_match_existing_scenarios_and_proto_schema` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
