### PR TITLE
test(bankofamerica): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/bankofamerica/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/bankofamerica/override.json
@@ -1,4 +1,17 @@
 {
+  "PaymentService/Authorize": {
+    "no3ds_fail_payment": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_exp_year": {
+              "value": "98"
+            }
+          }
+        }
+      }
+    }
+  },
   "PaymentService/Void": {
     "void_authorized_payment": {
       "grpc_req": {


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 33 |
| Failed  | 29 |
| Skipped | 1 |
| Total   | 63 |
| **Pass rate** | **52%** |
| Status  | Partial |

**Known remaining issues:** `SetupMandate` hardcodes `bill_to: None` (BoA requires billing address). TSS PSync/RSync returns 404 immediately after txn (sandbox eventual consistency). 16 non-card PMs `NOT_IMPLEMENTED`.

> Ran via `test-prism --connector bankofamerica --interface grpc --report` against `fix/test-bankofamerica-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary
- Override `no3ds_fail_payment` with expiry year `98` (1998, expired) to trigger Bank of America decline
- Preserves existing Void scenario amount overrides (6000 USD)

## Test plan
- [ ] Run `test-prism --connector bankofamerica` and verify `no3ds_fail_payment` returns FAILURE/AUTHORIZATION_FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
