### PR TITLE
test(mollie): harden integration test overrides

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/mollie/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/mollie/override.json
@@ -1,1 +1,63 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4543474002249996"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_credit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4543474002249996"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "2223000010479399"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_manual_capture_debit_card": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "2223000010479399"
+            }
+          }
+        }
+      }
+    },
+    "no3ds_fail_payment": {
+      "grpc_req": {
+        "payment_method": {
+          "card": {
+            "card_number": {
+              "value": "4543474002249996"
+            }
+          }
+        },
+        "amount": {
+          "minor_amount": 100600,
+          "currency": "EUR"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- TEST-RESULTS-START -->
## 📊 Fresh Test Results (2026-05-12)

| Metric | Value |
|---|---|
| Passed  | 68 |
| Failed  | 37 |
| Skipped | 1 |
| Total   | 106 |
| **Pass rate** | **64%** |
| Status  | Partial |

**Known remaining issues:** Global `suite_spec.json` for Capture/Void/Refund/Get doesn't propagate tokenize token via `context_map` → Authorize returns `AUTHENTICATION_PENDING`. Capture transformer requires `description` missing from gRPC request.

> Ran via `test-prism --connector mollie --interface grpc --report` against `fix/test-mollie-*` branch.
<!-- TEST-RESULTS-END -->

---

## Summary
- Override credit card scenarios with Mollie sandbox VISA `4543474002249996`
- Override debit card scenarios with MC `2223000010479399`
- Override `no3ds_fail_payment` with magic amount EUR 1006.00 (100600 minor units) which Mollie sandbox treats as `refused_by_issuer`

## Test plan
- [ ] Run `test-prism --connector mollie` and verify card authorize scenarios pass
- [ ] Verify `no3ds_fail_payment` returns FAILURE/AUTHORIZATION_FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
