### PR TITLE
proto: [TEST] add optional Money.display_amount — should PASS buf breaking check

### DIFF
--- a/.github/git-cliff-changelog.toml
+++ b/.github/git-cliff-changelog.toml
@@ -71,8 +71,9 @@ commit_parsers = [
     { message = "^(?i)(docs)", group = "<!-- 6 -->Documentation" },
     { message = "^(?i)(chore\\(version\\)): (V|v)[\\d]+\\.[\\d]+\\.[\\d]+", skip = true },
     { message = "^(?i)(chore\\(version\\)): [0-9]{4}\\.[0-9]{2}\\.[0-9]{2}(\\.[0-9]+)?(-.+)?", skip = true },
-    { message = "^(?i)(chore)", group = "<!-- 7 -->Miscellaneous Tasks" },
-    { message = "^(?i)(build)", group = "<!-- 8 -->Build System / Dependencies" },
+    { message = "^(?i)(proto)", group = "<!-- 7 -->Proto / API Contract" },
+    { message = "^(?i)(chore)", group = "<!-- 8 -->Miscellaneous Tasks" },
+    { message = "^(?i)(build)", group = "<!-- 9 -->Build System / Dependencies" },
     { message = "^(?i)(ci)", skip = true },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ permissions:
 # Job dependency graph:
 #
 #   changes ─┬─ typos              (always, ~8s)
-#            ├─ proto-checks       (PR only if proto changed: buf lint + buf breaking)
 #            ├─ auto-fix           (PR only: format + generate + docs → bot commit if needed)
 #            │   ├─ check          (if rust changed AND auto-fix didn't push, ~11min)
 #            │   ├─ test           (parallel with check, ~15min)
@@ -146,59 +145,6 @@ jobs:
   # buf breaking — vs PR base branch; git fetch ensures refs/heads/<base> exists for buf's local clone.
   # --against-config aligns module root with protos under crates/types-traits/grpc-api-types/proto.
   #
-  # Intentional breaking removals after consumers migrated: label proto-breaking-approved + migration PR link.
-  proto-checks:
-    name: Proto checks (lint + breaking)
-    needs: changes
-    if: >-
-      github.event_name == 'pull_request' &&
-      !github.event.pull_request.draft &&
-      needs.changes.outputs.proto == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install buf
-        uses: bufbuild/buf-action@v1
-        with:
-          setup_only: true
-
-      - name: buf lint
-        run: buf lint
-
-      - name: buf breaking change check
-        id: buf-breaking
-        continue-on-error: true
-        run: |
-          BASE_REF="${GITHUB_BASE_REF:?GITHUB_BASE_REF is not set — this job must run on pull_request events only}"
-          git fetch origin "refs/heads/${BASE_REF}:refs/heads/${BASE_REF}"
-          buf breaking --against ".git#branch=${BASE_REF}" --against-config scripts/ci/buf-breaking-baseline.yaml
-
-      - name: Breaking change approved via label
-        if: steps.buf-breaking.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
-        run: |
-          echo "::warning::Breaking proto changes approved via 'proto-breaking-approved' label. Checklist: (1) PR description links the consumer migration PR (HS / Euler). (2) Migration PR is already merged and deployed to all active envs. (3) Removed field numbers are listed under 'reserved' in the proto."
-
-      - name: Fail on unapproved breaking change
-        if: steps.buf-breaking.outcome == 'failure' && !contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
-        run: |
-          echo "::error::Breaking proto changes detected and not approved."
-          echo ""
-          echo "Options:"
-          echo "  1. Keep changes backward-compatible:"
-          echo "       Add the new field alongside the old one; mark old as [deprecated=true]."
-          echo "       Remove it in a follow-up PR once consumers have migrated."
-          echo ""
-          echo "  2. Intentional removal (consumers already migrated):"
-          echo "       Add the 'proto-breaking-approved' label to this PR."
-          echo "       Use 'proto!:' as the PR title type."
-          echo "       Link the consumer migration PR in the PR description."
-          echo "       Ensure removed field numbers appear under 'reserved'."
-          exit 1
-
   clippy:
     name: Clippy check
     needs: changes
@@ -775,14 +721,13 @@ jobs:
   ci-gate:
     name: CI Result
     if: always()
-    needs: [typos, proto-checks, clippy, formatting, auto-fix, check, test, sdk-test]
+    needs: [typos, clippy, formatting, auto-fix, check, test, sdk-test]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate CI results
         run: |
           echo "Job results:"
           echo "  typos:         ${{ needs.typos.result }}"
-          echo "  proto-checks:  ${{ needs.proto-checks.result }}"
           echo "  clippy:        ${{ needs.clippy.result }}"
           echo "  formatting:    ${{ needs.formatting.result }}"
           echo "  auto-fix:      ${{ needs.auto-fix.result }}"
@@ -801,7 +746,6 @@ jobs:
 
           results=(
             "${{ needs.typos.result }}"
-            "${{ needs.proto-checks.result }}"
             "${{ needs.clippy.result }}"
             "${{ needs.formatting.result }}"
             "${{ needs.auto-fix.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,23 +169,6 @@ jobs:
       - name: buf lint
         run: buf lint
 
-      - name: Check PR title for proto scope
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          # Proto changes must use conventional commit type "proto" or "proto!".
-          # proto:  backward-compatible change (new field, deprecation marker, etc.)
-          # proto!: intentional breaking removal — requires proto-breaking-approved label too.
-          if echo "$PR_TITLE" | grep -qE '^proto(\(.+\))?!?:'; then
-            echo "PR title uses correct proto type: $PR_TITLE"
-          else
-            echo "::error::PR title must start with 'proto:' or 'proto!:' when proto files are changed."
-            echo "  Examples:"
-            echo "    proto: add merchant_refund_id field to RefundRequest"
-            echo "    proto!: remove deprecated connector_state from WebhookRequest"
-            exit 1
-          fi
-
       - name: buf breaking change check
         id: buf-breaking
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ permissions:
 # Job dependency graph:
 #
 #   changes ─┬─ typos              (always, ~8s)
+#            ├─ proto-checks       (PR only if proto changed: buf lint + buf breaking)
 #            ├─ auto-fix           (PR only: format + generate + docs → bot commit if needed)
 #            │   ├─ check          (if rust changed AND auto-fix didn't push, ~11min)
 #            │   ├─ test           (parallel with check, ~15min)
@@ -137,6 +138,83 @@ jobs:
         uses: crate-ci/typos@master
         with:
           config: ./.typos.toml
+
+  # ── Proto checks (lint + breaking) ───────────────────────────────────────
+  # Pull requests only (proto paths changed, non-draft). merge_group/push rely on PR gate.
+  #
+  # buf lint — MINIMAL preset + legacy-layout exceptions (see buf.yaml)
+  # buf breaking — vs PR base branch; git fetch ensures refs/heads/<base> exists for buf's local clone.
+  # --against-config aligns module root with protos under crates/types-traits/grpc-api-types/proto.
+  #
+  # Intentional breaking removals after consumers migrated: label proto-breaking-approved + migration PR link.
+  proto-checks:
+    name: Proto checks (lint + breaking)
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      !github.event.pull_request.draft &&
+      needs.changes.outputs.proto == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: buf lint
+        run: buf lint
+
+      - name: Check PR title for proto scope
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Proto changes must use conventional commit type "proto" or "proto!".
+          # proto:  backward-compatible change (new field, deprecation marker, etc.)
+          # proto!: intentional breaking removal — requires proto-breaking-approved label too.
+          if echo "$PR_TITLE" | grep -qE '^proto(\(.+\))?!?:'; then
+            echo "PR title uses correct proto type: $PR_TITLE"
+          else
+            echo "::error::PR title must start with 'proto:' or 'proto!:' when proto files are changed."
+            echo "  Examples:"
+            echo "    proto: add merchant_refund_id field to RefundRequest"
+            echo "    proto!: remove deprecated connector_state from WebhookRequest"
+            exit 1
+          fi
+
+      - name: buf breaking change check
+        id: buf-breaking
+        continue-on-error: true
+        run: |
+          BASE_REF="${GITHUB_BASE_REF:?GITHUB_BASE_REF is not set — this job must run on pull_request events only}"
+          git fetch origin "refs/heads/${BASE_REF}:refs/heads/${BASE_REF}"
+          buf breaking --against ".git#branch=${BASE_REF}" --against-config scripts/ci/buf-breaking-baseline.yaml
+
+      - name: Breaking change approved via label
+        if: steps.buf-breaking.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
+        run: |
+          echo "::warning::Breaking proto changes approved via 'proto-breaking-approved' label. Checklist: (1) PR description links the consumer migration PR (HS / Euler). (2) Migration PR is already merged and deployed to all active envs. (3) Removed field numbers are listed under 'reserved' in the proto."
+
+      - name: Fail on unapproved breaking change
+        if: steps.buf-breaking.outcome == 'failure' && !contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
+        run: |
+          echo "::error::Breaking proto changes detected and not approved."
+          echo ""
+          echo "Options:"
+          echo "  1. Keep changes backward-compatible:"
+          echo "       Add the new field alongside the old one; mark old as [deprecated=true]."
+          echo "       Remove it in a follow-up PR once consumers have migrated."
+          echo ""
+          echo "  2. Intentional removal (consumers already migrated):"
+          echo "       Add the 'proto-breaking-approved' label to this PR."
+          echo "       Use 'proto!:' as the PR title type."
+          echo "       Link the consumer migration PR in the PR description."
+          echo "       Ensure removed field numbers appear under 'reserved'."
+          exit 1
 
   clippy:
     name: Clippy check
@@ -714,18 +792,20 @@ jobs:
   ci-gate:
     name: CI Result
     if: always()
-    needs: [typos, clippy, formatting, auto-fix, check, test, sdk-test]
+    needs: [typos, proto-checks, clippy, formatting, auto-fix, check, test, sdk-test]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate CI results
         run: |
           echo "Job results:"
-          echo "  typos:       ${{ needs.typos.result }}"
-          echo "  formatting:  ${{ needs.formatting.result }}"
-          echo "  auto-fix:    ${{ needs.auto-fix.result }}"
-          echo "  check:       ${{ needs.check.result }}"
-          echo "  test:        ${{ needs.test.result }}"
-          echo "  sdk-test:    ${{ needs.sdk-test.result }}"
+          echo "  typos:         ${{ needs.typos.result }}"
+          echo "  proto-checks:  ${{ needs.proto-checks.result }}"
+          echo "  clippy:        ${{ needs.clippy.result }}"
+          echo "  formatting:    ${{ needs.formatting.result }}"
+          echo "  auto-fix:      ${{ needs.auto-fix.result }}"
+          echo "  check:         ${{ needs.check.result }}"
+          echo "  test:          ${{ needs.test.result }}"
+          echo "  sdk-test:      ${{ needs.sdk-test.result }}"
           echo "  auto-fix pushed: ${{ needs.auto-fix.outputs.pushed }}"
           echo ""
 
@@ -738,6 +818,8 @@ jobs:
 
           results=(
             "${{ needs.typos.result }}"
+            "${{ needs.proto-checks.result }}"
+            "${{ needs.clippy.result }}"
             "${{ needs.formatting.result }}"
             "${{ needs.auto-fix.result }}"
             "${{ needs.check.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,6 @@ jobs:
         with:
           config: ./.typos.toml
 
-  # ── Proto checks (lint + breaking) ───────────────────────────────────────
-  # Pull requests only (proto paths changed, non-draft). merge_group/push rely on PR gate.
-  #
-  # buf lint — MINIMAL preset + legacy-layout exceptions (see buf.yaml)
-  # buf breaking — vs PR base branch; git fetch ensures refs/heads/<base> exists for buf's local clone.
-  # --against-config aligns module root with protos under crates/types-traits/grpc-api-types/proto.
-  #
   clippy:
     name: Clippy check
     needs: changes

--- a/.github/workflows/proto-checks.yml
+++ b/.github/workflows/proto-checks.yml
@@ -1,0 +1,63 @@
+name: Proto checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    paths:
+      - '**.proto'
+
+concurrency:
+  group: proto-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  proto-checks:
+    name: Proto checks (lint + breaking)
+    if: "!github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: buf lint
+        run: buf lint
+
+      - name: buf breaking change check
+        id: buf-breaking
+        continue-on-error: true
+        run: |
+          BASE_REF="${GITHUB_BASE_REF:?GITHUB_BASE_REF is not set — this job must run on pull_request events only}"
+          git fetch origin "refs/heads/${BASE_REF}:refs/heads/${BASE_REF}"
+          buf breaking --against ".git#branch=${BASE_REF}" --against-config scripts/ci/buf-breaking-baseline.yaml
+
+      - name: Breaking change approved via label
+        if: steps.buf-breaking.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
+        run: |
+          echo "::warning::Breaking proto changes approved via 'proto-breaking-approved' label. Checklist: (1) PR description links the consumer migration PR (HS / Euler). (2) Migration PR is already merged and deployed to all active envs. (3) Removed field numbers are listed under 'reserved' in the proto."
+
+      - name: Fail on unapproved breaking change
+        if: steps.buf-breaking.outcome == 'failure' && !contains(github.event.pull_request.labels.*.name, 'proto-breaking-approved')
+        run: |
+          echo "::error::Breaking proto changes detected and not approved."
+          echo ""
+          echo "Options:"
+          echo "  1. Keep changes backward-compatible:"
+          echo "       Add the new field alongside the old one; mark old as [deprecated=true]."
+          echo "       Remove it in a follow-up PR once consumers have migrated."
+          echo ""
+          echo "  2. Intentional removal (consumers already migrated):"
+          echo "       Add the 'proto-breaking-approved' label to this PR."
+          echo "       Use 'proto!:' as the PR title type."
+          echo "       Link the consumer migration PR in the PR description."
+          echo "       Ensure removed field numbers appear under 'reserved'."
+          exit 1

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,17 +1,17 @@
 version: v2
 deps:
   - buf.build/googleapis/googleapis
+# Module root must match import paths (bare filenames like payment_methods.proto).
 modules:
-  - path: .
-    excludes:
-      - examples/example-hs-grpc/proto
+  - path: crates/types-traits/grpc-api-types/proto
 lint:
   use:
-    - STANDARD
-  ignore_only:
-    ENUM_VALUE_PREFIX:
-      - crates/types-traits/grpc-api-types/proto
-    ENUM_ZERO_VALUE_SUFFIX:
-      - crates/types-traits/grpc-api-types/proto 
-    SERVICE_SUFFIX:
-      - crates/types-traits/grpc-api-types/proto/health_check.proto
+    - MINIMAL
+  except:
+    # Legacy flat layout: package types + grpc.health.v1 share one directory.
+    - DIRECTORY_SAME_PACKAGE
+    - PACKAGE_DIRECTORY_MATCH
+
+breaking:
+  use:
+    - FILE

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,12 @@
+[commit_types]
+feat     = { changelog_title = "<!-- 0 -->Features" }
+fix      = { changelog_title = "<!-- 1 -->Bug Fixes" }
+perf     = { changelog_title = "<!-- 2 -->Performance" }
+refactor = { changelog_title = "<!-- 3 -->Refactors" }
+test     = { changelog_title = "<!-- 4 -->Testing" }
+docs     = { changelog_title = "<!-- 5 -->Documentation" }
+proto    = { changelog_title = "<!-- 6 -->Proto / API Contract" }
+chore    = { changelog_title = "<!-- 7 -->Miscellaneous Tasks" }
+build    = { changelog_title = "<!-- 8 -->Build System / Dependencies" }
+revert   = { changelog_title = "<!-- 9 -->Reverts" }
+ci       = { changelog_title = "Continuous Integration", omit_from_changelog = true }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2368,6 +2368,8 @@ message PaymentServiceCaptureRequest {
   // Environment Configuration
   optional bool test_mode = 10;
 
+  // Additional Context
+  optional string merchant_order_id = 11;
 }
 
 // Response message for a payment capture operation

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2370,6 +2370,8 @@ message PaymentServiceCaptureRequest {
 
   // Additional Context
   optional string merchant_order_id = 11;
+  // Text shown on the customer's bank statement for this capture
+  optional string statement_descriptor = 12;
 }
 
 // Response message for a payment capture operation

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -58,6 +58,7 @@ option go_package = "github.com/juspay/connector-service/crates/types-traits/grp
 message Money {
   int64 minor_amount = 1; // Amount in minor units (e.g., 1000 = $10.00)
   Currency currency = 2; // ISO 4217 currency code (e.g., "USD", "EUR")
+  optional string display_amount = 3; // Human-readable formatted amount (e.g., "$10.00")
 }
 
 // Permissions wraps a repeated string field to allow optional presence

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2368,10 +2368,6 @@ message PaymentServiceCaptureRequest {
   // Environment Configuration
   optional bool test_mode = 10;
 
-  // Additional Context
-  optional string merchant_order_id = 11;
-  // Text shown on the customer's bank statement for this capture
-  optional string statement_descriptor = 12;
 }
 
 // Response message for a payment capture operation

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2368,8 +2368,6 @@ message PaymentServiceCaptureRequest {
   // Environment Configuration
   optional bool test_mode = 10;
 
-  // Additional Context
-  optional string merchant_order_id = 11;
 }
 
 // Response message for a payment capture operation

--- a/scripts/ci/buf-breaking-baseline.yaml
+++ b/scripts/ci/buf-breaking-baseline.yaml
@@ -1,0 +1,11 @@
+# --against-config for buf breaking: tells buf where the proto module root is in the baseline
+# branch (same path as buf.yaml). Required because buf reads the baseline via file://…/.git
+# and needs an explicit module config to resolve bare imports like import "payment.proto".
+version: v2
+deps:
+  - buf.build/googleapis/googleapis
+modules:
+  - path: crates/types-traits/grpc-api-types/proto
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
## Purpose

Temporary test PR for [#1224](https://github.com/juspay/hyperswitch-prism/pull/1224).

Proves the `proto-checks.yml` workflow **passes** when a purely additive proto change (new optional field) is made.

## Change

Adds `optional string display_amount = 3` to the `Money` message in `payment.proto`. New optional fields are non-breaking — existing compiled consumers ignore unknown fields.

## Expected CI result

- `buf lint` → pass
- `buf breaking` → **PASS** (no breaking changes detected)
- Overall check → green

> **Do not merge.** Delete this branch after verifying the check output.