### PR TITLE
fix(connector): add Settled status + configurable SEC code for Cybersource BankDebit

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -2103,9 +2103,19 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     &item.router_data.request.metadata.clone(),
                 )
                 .ok();
-                let sec_code = connector_metadata
-                    .and_then(|m| m.sec_code)
-                    .unwrap_or_else(|| String::from("WEB"));
+                let sec_code = match connector_metadata.and_then(|m| m.sec_code) {
+                    Some(code) if matches!(code.as_str(), "WEB" | "CCD" | "PPD" | "TEL") => code,
+                    Some(_invalid) => {
+                        return Err(error_stack::report!(
+                            IntegrationError::InvalidDataFormat {
+                                field_name:
+                                    "metadata.sec_code: must be one of WEB, CCD, PPD, TEL",
+                                context: Default::default(),
+                            }
+                        ));
+                    }
+                    None => String::from("WEB"),
+                };
 
                 let processing_information = ProcessingInformation {
                     action_list: None,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -70,6 +70,7 @@ fn card_issuer_to_string(card_issuer: CardIssuer) -> String {
 pub struct CybersourceConnectorMetadataObject {
     pub disable_avs: Option<bool>,
     pub disable_cvn: Option<bool>,
+    pub sec_code: Option<String>,
 }
 
 impl TryFrom<&Option<pii::SecretSerdeValue>> for CybersourceConnectorMetadataObject {
@@ -1129,6 +1130,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let connector_merchant_config = CybersourceConnectorMetadataObject {
             disable_avs: auth.disable_avs,
             disable_cvn: auth.disable_cvn,
+            sec_code: None,
         };
 
         let (action_list, action_token_types, authorization_options) = if item
@@ -2097,11 +2099,14 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         },
                     }));
 
-                // ACH eCheck uses a minimal processingInformation; Cybersource's
-                // pts/v2/payments returns SERVER_ERROR if card-only fields
-                // (authorizationOptions / actionList / actionTokenTypes / capture)
-                // are sent alongside paymentType.name = "check". secCode "WEB" is
-                // the standard online-consumer-initiated SEC code for ACH debits.
+                let connector_metadata = CybersourceConnectorMetadataObject::try_from(
+                    &item.router_data.request.metadata.clone(),
+                )
+                .ok();
+                let sec_code = connector_metadata
+                    .and_then(|m| m.sec_code)
+                    .unwrap_or_else(|| String::from("WEB"));
+
                 let processing_information = ProcessingInformation {
                     action_list: None,
                     action_token_types: None,
@@ -2110,9 +2115,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     capture: None,
                     capture_options: None,
                     payment_solution: None,
-                    bank_transfer_options: Some(BankTransferOptions {
-                        sec_code: String::from("WEB"),
-                    }),
+                    bank_transfer_options: Some(BankTransferOptions { sec_code }),
                 };
 
                 let client_reference_information = ClientReferenceInformation::from(item);
@@ -2840,6 +2843,7 @@ pub enum CybersourcePaymentStatus {
     Accepted,
     Cancelled,
     StatusNotReceived,
+    Settled,
     //PartialAuthorized, not being consumed yet.
 }
 
@@ -2864,9 +2868,9 @@ pub fn map_cybersource_attempt_status(
                 common_enums::AttemptStatus::Authorized
             }
         }
-        CybersourcePaymentStatus::Succeeded | CybersourcePaymentStatus::Transmitted => {
-            common_enums::AttemptStatus::Charged
-        }
+        CybersourcePaymentStatus::Succeeded
+        | CybersourcePaymentStatus::Transmitted
+        | CybersourcePaymentStatus::Settled => common_enums::AttemptStatus::Charged,
         CybersourcePaymentStatus::Voided
         | CybersourcePaymentStatus::Reversed
         | CybersourcePaymentStatus::Cancelled => common_enums::AttemptStatus::Voided,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -2106,13 +2106,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 let sec_code = match connector_metadata.and_then(|m| m.sec_code) {
                     Some(code) if matches!(code.as_str(), "WEB" | "CCD" | "PPD" | "TEL") => code,
                     Some(_invalid) => {
-                        return Err(error_stack::report!(
-                            IntegrationError::InvalidDataFormat {
-                                field_name:
-                                    "metadata.sec_code: must be one of WEB, CCD, PPD, TEL",
-                                context: Default::default(),
-                            }
-                        ));
+                        return Err(error_stack::report!(IntegrationError::InvalidDataFormat {
+                            field_name: "metadata.sec_code: must be one of WEB, CCD, PPD, TEL",
+                            context: Default::default(),
+                        }));
                     }
                     None => String::from("WEB"),
                 };


### PR DESCRIPTION
## Summary
- **Fix 1:** Add `Settled` variant to `CybersourcePaymentStatus` enum and map it to `AttemptStatus::Charged`. Cybersource returns `"SETTLED"` for completed ACH debits — without this variant, deserialization fails since there's no `#[serde(other)]` fallback.
- **Fix 2:** Make SEC code configurable via `CybersourceConnectorMetadataObject.sec_code` instead of hardcoding `"WEB"`. Defaults to `"WEB"` when not specified, enabling `CCD` (corporate) and `TEL` (telephone) ACH flows.

Resolves technical issues identified in PR #1190 post-merge review.

## Test plan
- [ ] Verify `"SETTLED"` status deserializes correctly and maps to `Charged`
- [ ] Verify default SEC code remains `"WEB"` when no metadata is provided
- [ ] Verify custom SEC code (`"CCD"`, `"TEL"`) is used when provided in connector metadata
- [ ] Confirm no regression in existing card/wallet payment flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)