### PR TITLE
parity(nmi/authorize): add billing first_name and last_name

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -233,6 +233,10 @@ impl NmiMerchantDefinedField {
 #[derive(Debug, Serialize)]
 pub struct NmiBillingDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
+    first_name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     address1: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     address2: Option<Secret<String>>,
@@ -531,6 +535,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .as_ref()
                     .map(|m| NmiMerchantDefinedField::new(m.peek())),
                 billing_details: Some(NmiBillingDetails {
+                    first_name: router_data
+                        .resource_common_data
+                        .get_optional_billing_first_name(),
+                    last_name: router_data
+                        .resource_common_data
+                        .get_optional_billing_last_name(),
                     address1: router_data
                         .resource_common_data
                         .get_optional_billing_line1(),


### PR DESCRIPTION
## Summary

Add missing `first_name` and `last_name` fields to `NmiBillingDetails` so prism's NMI authorize requests match hyperswitch's wire format.

## Linked PRD

Closes https://github.com/juspay/hyperswitch-cloud/issues/15678

## Understanding Summary

- **Connector:** NMI · **Flow:** Authorize · **Category:** `missing-field`
- Hyperswitch PR #11986 (`e3f7a448cb`, Apr 27 2026) added `first_name` and `last_name` to `NmiBillingDetails`. Prism was not updated.
- The `get_optional_billing_first_name()` / `get_optional_billing_last_name()` helpers already exist in prism's `PaymentFlowData`.

## Implementation

1. **Struct** (`NmiBillingDetails` at L234): added `first_name: Option<Secret<String>>` and `last_name: Option<Secret<String>>` with `skip_serializing_if` annotations.
2. **Construction** (L533): populated both fields from `router_data.resource_common_data.get_optional_billing_first_name()` / `get_optional_billing_last_name()`.

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 51s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 57s
```

## Acceptance Criteria
- [x] `cargo build -p connector-integration` passes
- [x] `cargo clippy -p connector-integration -- -D warnings` passes
- [x] Only PRD-named file changed (1 file, 10 insertions)
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)