### PR TITLE
fix(authorizedotnet): set Failure status on CreateConnectorCustomer error paths

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -3324,9 +3324,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetCreateConnectorCustomerResponse, 
         }
 
         if new_router_data.response.is_err() {
-            let mut resource_common_data = new_router_data.resource_common_data.clone();
-            resource_common_data.status = AttemptStatus::Failure;
-            new_router_data.resource_common_data = resource_common_data;
+            new_router_data.resource_common_data.status = AttemptStatus::Failure;
         }
 
         Ok(new_router_data)

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -3323,6 +3323,12 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetCreateConnectorCustomerResponse, 
             }
         }
 
+        if new_router_data.response.is_err() {
+            let mut resource_common_data = new_router_data.resource_common_data.clone();
+            resource_common_data.status = AttemptStatus::Failure;
+            new_router_data.resource_common_data = resource_common_data;
+        }
+
         Ok(new_router_data)
     }
 }


### PR DESCRIPTION
## Summary

Set `resource_common_data.status = AttemptStatus::Failure` on error paths in the `CreateConnectorCustomer` response transformer for authorizedotnet. Previously the status was left unchanged (leaked pre-call status), which caused a parity diff with hyperswitch.

## Linked PRD

Paired fix for [hs#12102](https://github.com/juspay/hyperswitch/pull/12102) — per CTO review feedback on [GH #15708](https://github.com/juspay/hyperswitch-cloud/issues/15708).

## Understanding Summary

- **Connector**: authorizedotnet
- **Flow**: CreateConnectorCustomer
- **Root cause**: The prism transformer set `attempt_status: Some(AttemptStatus::Failure)` inside the `ErrorResponse`, but never updated `resource_common_data.status` on the `RouterDataV2`. Other transformers (Authorize, SetupMandate, Refund) all update this field.
- **Fix**: After the error-path branches, check if `response.is_err()` and set `resource_common_data.status = AttemptStatus::Failure`.

## Build Tail
```
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.67s
```

## Clippy Tail
```
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 31.63s
```

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [ ] Shadow-replay produces zero diff (CTO gate)