### PR TITLE
parity(forte/psync): write connector_metadata through in generate_payment_sync_response

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -6123,7 +6123,7 @@ pub fn generate_payment_sync_response(
             PaymentsResponseData::TransactionResponse {
                 resource_id,
                 redirection_data,
-                connector_metadata: _,
+                connector_metadata,
                 network_txn_id,
                 connector_response_reference_id,
                 incremental_authorization_allowed,
@@ -6185,7 +6185,7 @@ pub fn generate_payment_sync_response(
                     email: None,
                     connector_customer_id: None,
                     merchant_order_id: None,
-                    metadata: None,
+                    metadata: convert_connector_metadata_to_secret_string(connector_metadata),
                     status_code: status_code as u32,
                     raw_connector_response,
                     response_headers: router_data_v2


### PR DESCRIPTION
## Summary

Write `connector_metadata` through in `generate_payment_sync_response` instead of discarding it, fixing the forte PSync parity diff where `connector_metadata` returned `null` instead of `{"auth_id": "<authorization_code>"}`.

## Linked PRD

Refs juspay/hyperswitch-cloud#15798

## Paired HS PR

https://github.com/juspay/hyperswitch/pull/12110 (HS side — reads proto field 21 `metadata` for `connector_metadata`)

## Understanding Summary

- The forte connector layer in UCS already correctly populates `connector_metadata` with `ForteMeta { auth_id }` in the PSync response
- The router-level `generate_payment_sync_response` in `crates/types-traits/domain_types/src/types.rs` was discarding it (`connector_metadata: _`) and hardcoding `metadata: None`
- The authorize response function (`generate_payment_authorize_response`) already correctly handles this using `convert_connector_metadata_to_secret_string()`
- This fix follows the exact same pattern

## Implementation

### Change 1 of 1 — `crates/types-traits/domain_types/src/types.rs`

**Line 6126**: `connector_metadata: _,` → `connector_metadata,` (capture instead of discard)

**Line 6188**: `metadata: None,` → `metadata: convert_connector_metadata_to_secret_string(connector_metadata),` (convert and write through)

## Build Tail
```
Compiling domain_types v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 42.88s
```

## Clippy Tail
```
Checking domain_types v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.33s
```

## Collateral Impact

This fix benefits **all connectors** that populate `connector_metadata` in PSync responses, not just forte.

## Acceptance Criteria
- [x] Build passes
- [x] Clippy passes
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)