### PR TITLE
feat(proto): add attempt_status to PaymentServiceGetRequest

### DIFF
--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2096,6 +2096,9 @@ message PaymentServiceGetRequest {
 
   // Payment Experience
   optional PaymentExperience payment_experience = 14;
+
+  // Current attempt status, populated by the caller for context during sync
+  optional PaymentStatus attempt_status = 15;
 }
 
 // Response message for a payment status synchronization


### PR DESCRIPTION
## Summary

- Adds `optional PaymentStatus attempt_status = 15` to `PaymentServiceGetRequest`
- Allows hyperswitch callers to pass the current attempt status during payment sync for context-aware parity tracking
- Required by hyperswitch PR juspay/hyperswitch#12145 (`parity/ucs/psync-attempt-status`)

## Test plan

- [ ] Proto compiles cleanly via `buf build`
- [ ] Existing psync flows unaffected (field is optional with no behavior change server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)