### PR TITLE
feat(braintree): implement SetupMandate (ZeroDollarAuth) via vaultPaymentMethod

### DIFF
--- a/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
@@ -8,24 +8,33 @@ use ucs_env::configs;
 mod common;
 mod utils;
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
+use cards::CardNumber;
 use grpc_api_types::payments::{
-    payment_service_client::PaymentServiceClient, AcceptanceType, Currency, CustomerAcceptance,
-    FutureUsage, MandateAmountData, MandateType, PaymentAddress, PaymentServiceTokenSetupRecurringRequest,
-    PaymentStatus, SetupMandateDetails,
+    payment_method, payment_service_client::PaymentServiceClient, AcceptanceType,
+    AuthenticationType, CardDetails, Currency, CustomerAcceptance, FutureUsage, MandateAmountData,
+    PaymentAddress, PaymentMethod, PaymentServiceSetupRecurringRequest, PaymentStatus,
+    SetupMandateDetails,
 };
 use grpc_api_types::payments::mandate_type::MandateType as MandateTypeInner;
+use grpc_api_types::payments::MandateType;
 use tonic::{transport::Channel, Request};
 use uuid::Uuid;
 
 const CONNECTOR_NAME: &str = "braintree";
+const AUTH_TYPE: &str = "signature-key";
 const MERCHANT_ID: &str = "merchant_braintree_test";
 
-// Braintree sandbox fake nonces for testing
-// https://developer.paypal.com/braintree/docs/reference/general/testing
-const FAKE_VALID_NONCE: &str = "fake-valid-nonce";
-const FAKE_PROCESSOR_DECLINED_NONCE: &str = "fake-processor-declined-visa-nonce";
+const TEST_CARD_NUMBER: &str = "4242424242424242";
+const TEST_CARD_EXP_MONTH: &str = "10";
+const TEST_CARD_EXP_YEAR: &str = "25";
+const TEST_CARD_CVC: &str = "123";
+const TEST_CARD_HOLDER: &str = "Test User";
 
 fn get_timestamp() -> u64 {
     SystemTime::now()
@@ -62,7 +71,8 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
         .cloned()
         .unwrap_or_else(|| "USD".to_string());
 
-    // x-connector-config with full Braintree config; repeated fields must be empty arrays.
+    // Use x-connector-config with full Braintree config so merchant_account_id is available.
+    // Repeated proto fields (apple_pay_supported_networks etc.) must be present as empty arrays.
     let connector_config_json = format!(
         r#"{{"config":{{"Braintree":{{"public_key":"{public_key}","private_key":"{private_key}","merchant_account_id":"{merchant_account_id}","merchant_config_currency":"{merchant_config_currency}","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}}}}"#,
         public_key = api_key,
@@ -76,6 +86,7 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
             .parse()
             .expect("Failed to parse x-connector-config"),
     );
+
     request.metadata_mut().append(
         "x-merchant-id",
         MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
@@ -98,50 +109,41 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
     );
 }
 
-/// Add bad credentials metadata for negative auth tests.
-fn add_bad_braintree_metadata<T>(request: &mut Request<T>) {
-    let connector_config_json = r#"{"config":{"Braintree":{"public_key":"bad_key","private_key":"bad_secret","merchant_account_id":"bad_account","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}"#;
-    request.metadata_mut().insert(
-        "x-connector-config",
-        connector_config_json
-            .parse()
-            .expect("Failed to parse x-connector-config"),
-    );
-    request.metadata_mut().append(
-        "x-merchant-id",
-        MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
-    );
-    request.metadata_mut().append(
-        "x-request-id",
-        format!("test_request_{}", get_timestamp())
-            .parse()
-            .expect("Failed to parse x-request-id"),
-    );
-    request.metadata_mut().append(
-        "x-tenant-id",
-        "default".parse().expect("Failed to parse x-tenant-id"),
-    );
-    request.metadata_mut().append(
-        "x-connector-request-reference-id",
-        format!("conn_ref_{}", get_timestamp())
-            .parse()
-            .expect("Failed to parse x-connector-request-reference-id"),
-    );
-}
+fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    let card_details = CardDetails {
+        card_number: Some(CardNumber::from_str(TEST_CARD_NUMBER).unwrap()),
+        card_exp_month: Some(Secret::new(TEST_CARD_EXP_MONTH.to_string())),
+        card_exp_year: Some(Secret::new(TEST_CARD_EXP_YEAR.to_string())),
+        card_cvc: Some(Secret::new(TEST_CARD_CVC.to_string())),
+        card_holder_name: Some(Secret::new(TEST_CARD_HOLDER.to_string())),
+        card_issuer: None,
+        card_network: Some(1),
+        card_type: None,
+        card_issuing_country_alpha2: None,
+        bank_code: None,
+        nick_name: None,
+    };
 
-fn create_token_setup_recurring_request(
-    nonce: &str,
-) -> PaymentServiceTokenSetupRecurringRequest {
-    PaymentServiceTokenSetupRecurringRequest {
+    let mut merchant_account_metadata_map = HashMap::new();
+    merchant_account_metadata_map.insert("merchant_account_id".to_string(), "juspay".to_string());
+    merchant_account_metadata_map
+        .insert("merchant_config_currency".to_string(), "USD".to_string());
+    merchant_account_metadata_map.insert("currency".to_string(), "USD".to_string());
+    let merchant_account_metadata_json =
+        serde_json::to_string(&merchant_account_metadata_map).unwrap();
+
+    PaymentServiceSetupRecurringRequest {
         merchant_recurring_payment_id: generate_unique_id("braintree_mandate"),
         amount: Some(grpc_api_types::payments::Money {
             minor_amount: 0,
             currency: i32::from(Currency::Usd),
         }),
-        connector_token: Some(Secret::new(nonce.to_string())),
+        payment_method: Some(PaymentMethod {
+            payment_method: Some(payment_method::PaymentMethod::Card(card_details)),
+        }),
         customer: Some(grpc_api_types::payments::Customer {
             email: Some(format!("test_{}@example.com", get_timestamp()).into()),
-            name: Some("Test User".to_string()),
+            name: Some(TEST_CARD_HOLDER.to_string()),
             id: None,
             connector_customer_id: None,
             phone_number: None,
@@ -153,7 +155,10 @@ fn create_token_setup_recurring_request(
             online_mandate_details: None,
         }),
         address: Some(PaymentAddress::default()),
+        auth_type: i32::from(AuthenticationType::NoThreeDs),
         setup_future_usage: Some(i32::from(FutureUsage::OffSession)),
+        enrolled_for_3ds: false,
+        metadata: Some(Secret::new(merchant_account_metadata_json)),
         setup_mandate_details: Some(SetupMandateDetails {
             update_mandate_id: None,
             customer_acceptance: None,
@@ -172,153 +177,33 @@ fn create_token_setup_recurring_request(
     }
 }
 
-/// TC-1: Happy path — card nonce vaults successfully, status = Charged,
-/// connector_transaction_id (verification.id) and connector_mandate_id (paymentMethod.id) present.
 #[tokio::test]
-async fn test_setup_mandate_happy_path() {
+async fn test_setup_mandate() {
     grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_token_setup_recurring_request(FAKE_VALID_NONCE);
+        let request = create_setup_recurring_request();
         let mut grpc_request = Request::new(request);
         add_braintree_metadata(&mut grpc_request);
 
         let response = client
-            .token_setup_recurring(grpc_request)
+            .setup_recurring(grpc_request)
             .await
-            .expect("gRPC token_setup_recurring call failed")
+            .expect("gRPC setup_recurring call failed")
             .into_inner();
 
-        assert_eq!(
-            response.status,
-            i32::from(PaymentStatus::Charged),
-            "Happy path: expected Charged, got status {}",
+        assert!(
+            response.status == i32::from(PaymentStatus::Charged)
+                || response.status == i32::from(PaymentStatus::AuthenticationPending)
+                || response.status == i32::from(PaymentStatus::Pending),
+            "Setup mandate should be in Charged, AuthenticationPending, or Pending state, got: {}",
             response.status
         );
-
-        // connector_recurring_payment_id maps to verification.id
-        assert!(
-            response.connector_recurring_payment_id.as_deref().map(|s| !s.is_empty()).unwrap_or(false),
-            "Happy path: connector_transaction_id (verification.id) must be present"
-        );
-
-        // mandate_reference.connector_mandate_id maps to paymentMethod.id
-        let mandate_ref = response
-            .mandate_reference
-            .as_ref()
-            .expect("Happy path: mandate_reference must be present");
-        let has_connector_mandate_id = match &mandate_ref.mandate_id_type {
-            Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
-                ref_id,
-            )) => ref_id.connector_mandate_id.as_deref().map(|s| !s.is_empty()).unwrap_or(false),
-            _ => false,
-        };
-        assert!(
-            has_connector_mandate_id,
-            "Happy path: connector_mandate_id (paymentMethod.id) must be present"
-        );
     });
 }
 
-/// TC-2: Declined card — processor-declined nonce → status = Failure.
-#[tokio::test]
-async fn test_setup_mandate_declined_card() {
-    grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_token_setup_recurring_request(FAKE_PROCESSOR_DECLINED_NONCE);
-        let mut grpc_request = Request::new(request);
-        add_braintree_metadata(&mut grpc_request);
-
-        let response = client
-            .token_setup_recurring(grpc_request)
-            .await
-            .expect("gRPC token_setup_recurring call failed")
-            .into_inner();
-
-        assert_eq!(
-            response.status,
-            i32::from(PaymentStatus::Failure),
-            "Declined card: expected Failure, got status {}",
-            response.status
-        );
-        assert!(
-            response.error.is_some(),
-            "Declined card: error info should be present"
-        );
-    });
-}
-
-/// TC-3: Invalid credentials — bad API keys → gRPC error or Failure status.
-#[tokio::test]
-async fn test_setup_mandate_invalid_credentials() {
-    grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_token_setup_recurring_request(FAKE_VALID_NONCE);
-        let mut grpc_request = Request::new(request);
-        add_bad_braintree_metadata(&mut grpc_request);
-
-        let result = client.token_setup_recurring(grpc_request).await;
-
-        match result {
-            Err(status) => {
-                // gRPC-level error — acceptable for auth failure
-                let code = status.code();
-                assert!(
-                    code == tonic::Code::Unauthenticated
-                        || code == tonic::Code::PermissionDenied
-                        || code == tonic::Code::Internal,
-                    "Invalid credentials: unexpected gRPC error code {:?}",
-                    code
-                );
-            }
-            Ok(response) => {
-                let inner = response.into_inner();
-                assert_eq!(
-                    inner.status,
-                    i32::from(PaymentStatus::Failure),
-                    "Invalid credentials: expected Failure status, got {}",
-                    inner.status
-                );
-            }
-        }
-    });
-}
-
-/// TC-4: Missing required fields — empty connector_token → error response.
-#[tokio::test]
-async fn test_setup_mandate_missing_token() {
-    grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_token_setup_recurring_request("");
-        let mut grpc_request = Request::new(request);
-        add_braintree_metadata(&mut grpc_request);
-
-        let result = client.token_setup_recurring(grpc_request).await;
-
-        match result {
-            Err(status) => {
-                // gRPC-level validation error — acceptable
-                assert!(
-                    status.code() == tonic::Code::InvalidArgument
-                        || status.code() == tonic::Code::FailedPrecondition
-                        || status.code() == tonic::Code::Internal,
-                    "Missing token: unexpected gRPC error code {:?}",
-                    status.code()
-                );
-            }
-            Ok(response) => {
-                let inner = response.into_inner();
-                assert_eq!(
-                    inner.status,
-                    i32::from(PaymentStatus::Failure),
-                    "Missing token: expected Failure, got {}",
-                    inner.status
-                );
-            }
-        }
-    });
-}
-
-/// Offline unit test: verify x-connector-config JSON deserializes correctly.
 #[test]
 fn test_braintree_config_deser() {
     let json = r#"{"config":{"Braintree":{"public_key":"testkey","private_key":"testsecret","merchant_account_id":"juspay","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}"#;
-    let result: Result<grpc_api_types::payments::ConnectorSpecificConfig, _> =
-        serde_json::from_str(json);
-    assert!(result.is_ok(), "Config deser failed: {:?}", result.err());
+    let result: Result<grpc_api_types::payments::ConnectorSpecificConfig, _> = serde_json::from_str(json);
+    println!("Deser result: {:?}", result);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
 }

--- a/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 const CONNECTOR_NAME: &str = "braintree";
 const AUTH_TYPE: &str = "signature-key";
-const MERCHANT_ID: &str = "merchant_17555143863";
+const MERCHANT_ID: &str = "merchant_braintree_test";
 
 const TEST_CARD_NUMBER: &str = "4242424242424242";
 const TEST_CARD_EXP_MONTH: &str = "10";
@@ -51,7 +51,7 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
     let auth = utils::credential_utils::load_connector_auth(CONNECTOR_NAME)
         .expect("Failed to load braintree credentials");
 
-    let (api_key, key1, api_secret) = match auth {
+    let (api_key, _key1, api_secret) = match auth {
         domain_types::router_data::ConnectorAuthType::SignatureKey {
             api_key,
             key1,
@@ -60,24 +60,33 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
         _ => panic!("Expected SignatureKey auth type for braintree"),
     };
 
-    request.metadata_mut().append(
-        "x-connector",
-        CONNECTOR_NAME.parse().expect("Failed to parse x-connector"),
+    let metadata = utils::credential_utils::load_connector_metadata(CONNECTOR_NAME)
+        .expect("Failed to load braintree metadata");
+    let merchant_account_id = metadata
+        .get("merchant_account_id")
+        .expect("merchant_account_id missing from braintree metadata")
+        .clone();
+    let merchant_config_currency = metadata
+        .get("merchant_config_currency")
+        .cloned()
+        .unwrap_or_else(|| "USD".to_string());
+
+    // Use x-connector-config with full Braintree config so merchant_account_id is available.
+    // Repeated proto fields (apple_pay_supported_networks etc.) must be present as empty arrays.
+    let connector_config_json = format!(
+        r#"{{"config":{{"Braintree":{{"public_key":"{public_key}","private_key":"{private_key}","merchant_account_id":"{merchant_account_id}","merchant_config_currency":"{merchant_config_currency}","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}}}}"#,
+        public_key = api_key,
+        private_key = api_secret,
+        merchant_account_id = merchant_account_id,
+        merchant_config_currency = merchant_config_currency,
     );
-    request
-        .metadata_mut()
-        .append("x-auth", AUTH_TYPE.parse().expect("Failed to parse x-auth"));
-    request.metadata_mut().append(
-        "x-api-key",
-        api_key.parse().expect("Failed to parse x-api-key"),
+    request.metadata_mut().insert(
+        "x-connector-config",
+        connector_config_json
+            .parse()
+            .expect("Failed to parse x-connector-config"),
     );
-    request
-        .metadata_mut()
-        .append("x-key1", key1.parse().expect("Failed to parse x-key1"));
-    request.metadata_mut().append(
-        "x-api-secret",
-        api_secret.parse().expect("Failed to parse x-api-secret"),
-    );
+
     request.metadata_mut().append(
         "x-merchant-id",
         MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
@@ -116,7 +125,7 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
     };
 
     let mut merchant_account_metadata_map = HashMap::new();
-    merchant_account_metadata_map.insert("merchant_account_id".to_string(), "Anand".to_string());
+    merchant_account_metadata_map.insert("merchant_account_id".to_string(), "juspay".to_string());
     merchant_account_metadata_map
         .insert("merchant_config_currency".to_string(), "USD".to_string());
     merchant_account_metadata_map.insert("currency".to_string(), "USD".to_string());
@@ -189,4 +198,12 @@ async fn test_setup_mandate() {
             response.status
         );
     });
+}
+
+#[test]
+fn test_braintree_config_deser() {
+    let json = r#"{"config":{"Braintree":{"public_key":"testkey","private_key":"testsecret","merchant_account_id":"juspay","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}"#;
+    let result: Result<grpc_api_types::payments::ConnectorSpecificConfig, _> = serde_json::from_str(json);
+    println!("Deser result: {:?}", result);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
 }

--- a/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
@@ -16,10 +16,11 @@ use std::{
 
 use cards::CardNumber;
 use grpc_api_types::payments::{
-    payment_method, payment_service_client::PaymentServiceClient, AcceptanceType,
-    AuthenticationType, CardDetails, Currency, CustomerAcceptance, FutureUsage, MandateAmountData,
-    PaymentAddress, PaymentMethod, PaymentServiceSetupRecurringRequest, PaymentStatus,
-    SetupMandateDetails,
+    payment_method, payment_method_service_client::PaymentMethodServiceClient,
+    payment_service_client::PaymentServiceClient, AcceptanceType, CardDetails,
+    Currency, Customer, CustomerAcceptance, FutureUsage, MandateAmountData, Money, PaymentAddress,
+    PaymentMethod, PaymentMethodServiceTokenizeRequest, PaymentServiceTokenSetupRecurringRequest,
+    PaymentStatus, SetupMandateDetails,
 };
 use grpc_api_types::payments::mandate_type::MandateType as MandateTypeInner;
 use grpc_api_types::payments::MandateType;
@@ -27,7 +28,6 @@ use tonic::{transport::Channel, Request};
 use uuid::Uuid;
 
 const CONNECTOR_NAME: &str = "braintree";
-const AUTH_TYPE: &str = "signature-key";
 const MERCHANT_ID: &str = "merchant_braintree_test";
 
 const TEST_CARD_NUMBER: &str = "4242424242424242";
@@ -109,7 +109,7 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
     );
 }
 
-fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+fn create_card_payment_method() -> PaymentMethod {
     let card_details = CardDetails {
         card_number: Some(CardNumber::from_str(TEST_CARD_NUMBER).unwrap()),
         card_exp_month: Some(Secret::new(TEST_CARD_EXP_MONTH.to_string())),
@@ -123,7 +123,34 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
         bank_code: None,
         nick_name: None,
     };
+    PaymentMethod {
+        payment_method: Some(payment_method::PaymentMethod::Card(card_details)),
+    }
+}
 
+fn create_tokenize_request() -> PaymentMethodServiceTokenizeRequest {
+    PaymentMethodServiceTokenizeRequest {
+        amount: Some(Money {
+            minor_amount: 0,
+            currency: i32::from(Currency::Usd),
+        }),
+        payment_method: Some(create_card_payment_method()),
+        customer: Some(Customer {
+            email: Some(format!("test_{}@example.com", get_timestamp()).into()),
+            name: Some(TEST_CARD_HOLDER.to_string()),
+            id: None,
+            connector_customer_id: None,
+            phone_number: None,
+            phone_country_code: None,
+        }),
+        address: Some(PaymentAddress::default()),
+        ..Default::default()
+    }
+}
+
+fn create_token_setup_recurring_request(
+    connector_token: String,
+) -> PaymentServiceTokenSetupRecurringRequest {
     let mut merchant_account_metadata_map = HashMap::new();
     merchant_account_metadata_map.insert("merchant_account_id".to_string(), "juspay".to_string());
     merchant_account_metadata_map
@@ -132,16 +159,14 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
     let merchant_account_metadata_json =
         serde_json::to_string(&merchant_account_metadata_map).unwrap();
 
-    PaymentServiceSetupRecurringRequest {
+    PaymentServiceTokenSetupRecurringRequest {
         merchant_recurring_payment_id: generate_unique_id("braintree_mandate"),
-        amount: Some(grpc_api_types::payments::Money {
+        amount: Some(Money {
             minor_amount: 0,
             currency: i32::from(Currency::Usd),
         }),
-        payment_method: Some(PaymentMethod {
-            payment_method: Some(payment_method::PaymentMethod::Card(card_details)),
-        }),
-        customer: Some(grpc_api_types::payments::Customer {
+        connector_token: Some(Secret::new(connector_token)),
+        customer: Some(Customer {
             email: Some(format!("test_{}@example.com", get_timestamp()).into()),
             name: Some(TEST_CARD_HOLDER.to_string()),
             id: None,
@@ -155,9 +180,7 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
             online_mandate_details: None,
         }),
         address: Some(PaymentAddress::default()),
-        auth_type: i32::from(AuthenticationType::NoThreeDs),
         setup_future_usage: Some(i32::from(FutureUsage::OffSession)),
-        enrolled_for_3ds: false,
         metadata: Some(Secret::new(merchant_account_metadata_json)),
         setup_mandate_details: Some(SetupMandateDetails {
             update_mandate_id: None,
@@ -179,25 +202,53 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
 
 #[tokio::test]
 async fn test_setup_mandate() {
-    grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_setup_recurring_request();
-        let mut grpc_request = Request::new(request);
-        add_braintree_metadata(&mut grpc_request);
+    grpc_test!(
+        [
+            pm_client: PaymentMethodServiceClient<Channel>,
+            payment_client: PaymentServiceClient<Channel>
+        ],
+        {
+            // Step 1: Tokenize card to get a payment method token (Braintree nonce/vaultToken).
+            // SetupMandate transformer only accepts PaymentMethodToken, not raw card data.
+            let tokenize_request = create_tokenize_request();
+            let mut tok_grpc_request = Request::new(tokenize_request);
+            add_braintree_metadata(&mut tok_grpc_request);
 
-        let response = client
-            .setup_recurring(grpc_request)
-            .await
-            .expect("gRPC setup_recurring call failed")
-            .into_inner();
+            let tokenize_response = pm_client
+                .tokenize(tok_grpc_request)
+                .await
+                .expect("gRPC Tokenize call failed")
+                .into_inner();
 
-        assert!(
-            response.status == i32::from(PaymentStatus::Charged)
-                || response.status == i32::from(PaymentStatus::AuthenticationPending)
-                || response.status == i32::from(PaymentStatus::Pending),
-            "Setup mandate should be in Charged, AuthenticationPending, or Pending state, got: {}",
-            response.status
-        );
-    });
+            assert!(
+                tokenize_response.error.is_none(),
+                "Tokenize should succeed, got error: {:?}",
+                tokenize_response.error
+            );
+
+            let token = tokenize_response.payment_method_token;
+            assert!(!token.is_empty(), "Tokenize should return a non-empty token");
+
+            // Step 2: Use the token in TokenSetupRecurring (vaultPaymentMethod flow).
+            let setup_request = create_token_setup_recurring_request(token);
+            let mut setup_grpc_request = Request::new(setup_request);
+            add_braintree_metadata(&mut setup_grpc_request);
+
+            let response = payment_client
+                .token_setup_recurring(setup_grpc_request)
+                .await
+                .expect("gRPC TokenSetupRecurring call failed")
+                .into_inner();
+
+            assert!(
+                response.status == i32::from(PaymentStatus::Charged)
+                    || response.status == i32::from(PaymentStatus::AuthenticationPending)
+                    || response.status == i32::from(PaymentStatus::Pending),
+                "Setup mandate should be in Charged, AuthenticationPending, or Pending state, got: {}",
+                response.status
+            );
+        }
+    );
 }
 
 #[test]

--- a/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
@@ -8,33 +8,24 @@ use ucs_env::configs;
 mod common;
 mod utils;
 
-use std::{
-    collections::HashMap,
-    str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use cards::CardNumber;
 use grpc_api_types::payments::{
-    payment_method, payment_service_client::PaymentServiceClient, AcceptanceType,
-    AuthenticationType, CardDetails, Currency, CustomerAcceptance, FutureUsage, MandateAmountData,
-    PaymentAddress, PaymentMethod, PaymentServiceSetupRecurringRequest, PaymentStatus,
-    SetupMandateDetails,
+    payment_service_client::PaymentServiceClient, AcceptanceType, Currency, CustomerAcceptance,
+    FutureUsage, MandateAmountData, MandateType, PaymentAddress, PaymentServiceTokenSetupRecurringRequest,
+    PaymentStatus, SetupMandateDetails,
 };
 use grpc_api_types::payments::mandate_type::MandateType as MandateTypeInner;
-use grpc_api_types::payments::MandateType;
 use tonic::{transport::Channel, Request};
 use uuid::Uuid;
 
 const CONNECTOR_NAME: &str = "braintree";
-const AUTH_TYPE: &str = "signature-key";
 const MERCHANT_ID: &str = "merchant_braintree_test";
 
-const TEST_CARD_NUMBER: &str = "4242424242424242";
-const TEST_CARD_EXP_MONTH: &str = "10";
-const TEST_CARD_EXP_YEAR: &str = "25";
-const TEST_CARD_CVC: &str = "123";
-const TEST_CARD_HOLDER: &str = "Test User";
+// Braintree sandbox fake nonces for testing
+// https://developer.paypal.com/braintree/docs/reference/general/testing
+const FAKE_VALID_NONCE: &str = "fake-valid-nonce";
+const FAKE_PROCESSOR_DECLINED_NONCE: &str = "fake-processor-declined-visa-nonce";
 
 fn get_timestamp() -> u64 {
     SystemTime::now()
@@ -71,8 +62,7 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
         .cloned()
         .unwrap_or_else(|| "USD".to_string());
 
-    // Use x-connector-config with full Braintree config so merchant_account_id is available.
-    // Repeated proto fields (apple_pay_supported_networks etc.) must be present as empty arrays.
+    // x-connector-config with full Braintree config; repeated fields must be empty arrays.
     let connector_config_json = format!(
         r#"{{"config":{{"Braintree":{{"public_key":"{public_key}","private_key":"{private_key}","merchant_account_id":"{merchant_account_id}","merchant_config_currency":"{merchant_config_currency}","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}}}}"#,
         public_key = api_key,
@@ -86,7 +76,6 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
             .parse()
             .expect("Failed to parse x-connector-config"),
     );
-
     request.metadata_mut().append(
         "x-merchant-id",
         MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
@@ -109,41 +98,50 @@ fn add_braintree_metadata<T>(request: &mut Request<T>) {
     );
 }
 
-fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
-    let card_details = CardDetails {
-        card_number: Some(CardNumber::from_str(TEST_CARD_NUMBER).unwrap()),
-        card_exp_month: Some(Secret::new(TEST_CARD_EXP_MONTH.to_string())),
-        card_exp_year: Some(Secret::new(TEST_CARD_EXP_YEAR.to_string())),
-        card_cvc: Some(Secret::new(TEST_CARD_CVC.to_string())),
-        card_holder_name: Some(Secret::new(TEST_CARD_HOLDER.to_string())),
-        card_issuer: None,
-        card_network: Some(1),
-        card_type: None,
-        card_issuing_country_alpha2: None,
-        bank_code: None,
-        nick_name: None,
-    };
+/// Add bad credentials metadata for negative auth tests.
+fn add_bad_braintree_metadata<T>(request: &mut Request<T>) {
+    let connector_config_json = r#"{"config":{"Braintree":{"public_key":"bad_key","private_key":"bad_secret","merchant_account_id":"bad_account","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}"#;
+    request.metadata_mut().insert(
+        "x-connector-config",
+        connector_config_json
+            .parse()
+            .expect("Failed to parse x-connector-config"),
+    );
+    request.metadata_mut().append(
+        "x-merchant-id",
+        MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
+    );
+    request.metadata_mut().append(
+        "x-request-id",
+        format!("test_request_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-request-id"),
+    );
+    request.metadata_mut().append(
+        "x-tenant-id",
+        "default".parse().expect("Failed to parse x-tenant-id"),
+    );
+    request.metadata_mut().append(
+        "x-connector-request-reference-id",
+        format!("conn_ref_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-connector-request-reference-id"),
+    );
+}
 
-    let mut merchant_account_metadata_map = HashMap::new();
-    merchant_account_metadata_map.insert("merchant_account_id".to_string(), "juspay".to_string());
-    merchant_account_metadata_map
-        .insert("merchant_config_currency".to_string(), "USD".to_string());
-    merchant_account_metadata_map.insert("currency".to_string(), "USD".to_string());
-    let merchant_account_metadata_json =
-        serde_json::to_string(&merchant_account_metadata_map).unwrap();
-
-    PaymentServiceSetupRecurringRequest {
+fn create_token_setup_recurring_request(
+    nonce: &str,
+) -> PaymentServiceTokenSetupRecurringRequest {
+    PaymentServiceTokenSetupRecurringRequest {
         merchant_recurring_payment_id: generate_unique_id("braintree_mandate"),
         amount: Some(grpc_api_types::payments::Money {
             minor_amount: 0,
             currency: i32::from(Currency::Usd),
         }),
-        payment_method: Some(PaymentMethod {
-            payment_method: Some(payment_method::PaymentMethod::Card(card_details)),
-        }),
+        connector_token: Some(Secret::new(nonce.to_string())),
         customer: Some(grpc_api_types::payments::Customer {
             email: Some(format!("test_{}@example.com", get_timestamp()).into()),
-            name: Some(TEST_CARD_HOLDER.to_string()),
+            name: Some("Test User".to_string()),
             id: None,
             connector_customer_id: None,
             phone_number: None,
@@ -155,10 +153,7 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
             online_mandate_details: None,
         }),
         address: Some(PaymentAddress::default()),
-        auth_type: i32::from(AuthenticationType::NoThreeDs),
         setup_future_usage: Some(i32::from(FutureUsage::OffSession)),
-        enrolled_for_3ds: false,
-        metadata: Some(Secret::new(merchant_account_metadata_json)),
         setup_mandate_details: Some(SetupMandateDetails {
             update_mandate_id: None,
             customer_acceptance: None,
@@ -177,33 +172,153 @@ fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
     }
 }
 
+/// TC-1: Happy path — card nonce vaults successfully, status = Charged,
+/// connector_transaction_id (verification.id) and connector_mandate_id (paymentMethod.id) present.
 #[tokio::test]
-async fn test_setup_mandate() {
+async fn test_setup_mandate_happy_path() {
     grpc_test!(client, PaymentServiceClient<Channel>, {
-        let request = create_setup_recurring_request();
+        let request = create_token_setup_recurring_request(FAKE_VALID_NONCE);
         let mut grpc_request = Request::new(request);
         add_braintree_metadata(&mut grpc_request);
 
         let response = client
-            .setup_recurring(grpc_request)
+            .token_setup_recurring(grpc_request)
             .await
-            .expect("gRPC setup_recurring call failed")
+            .expect("gRPC token_setup_recurring call failed")
             .into_inner();
 
-        assert!(
-            response.status == i32::from(PaymentStatus::Charged)
-                || response.status == i32::from(PaymentStatus::AuthenticationPending)
-                || response.status == i32::from(PaymentStatus::Pending),
-            "Setup mandate should be in Charged, AuthenticationPending, or Pending state, got: {}",
+        assert_eq!(
+            response.status,
+            i32::from(PaymentStatus::Charged),
+            "Happy path: expected Charged, got status {}",
             response.status
+        );
+
+        // connector_recurring_payment_id maps to verification.id
+        assert!(
+            response.connector_recurring_payment_id.as_deref().map(|s| !s.is_empty()).unwrap_or(false),
+            "Happy path: connector_transaction_id (verification.id) must be present"
+        );
+
+        // mandate_reference.connector_mandate_id maps to paymentMethod.id
+        let mandate_ref = response
+            .mandate_reference
+            .as_ref()
+            .expect("Happy path: mandate_reference must be present");
+        let has_connector_mandate_id = match &mandate_ref.mandate_id_type {
+            Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
+                ref_id,
+            )) => ref_id.connector_mandate_id.as_deref().map(|s| !s.is_empty()).unwrap_or(false),
+            _ => false,
+        };
+        assert!(
+            has_connector_mandate_id,
+            "Happy path: connector_mandate_id (paymentMethod.id) must be present"
         );
     });
 }
 
+/// TC-2: Declined card — processor-declined nonce → status = Failure.
+#[tokio::test]
+async fn test_setup_mandate_declined_card() {
+    grpc_test!(client, PaymentServiceClient<Channel>, {
+        let request = create_token_setup_recurring_request(FAKE_PROCESSOR_DECLINED_NONCE);
+        let mut grpc_request = Request::new(request);
+        add_braintree_metadata(&mut grpc_request);
+
+        let response = client
+            .token_setup_recurring(grpc_request)
+            .await
+            .expect("gRPC token_setup_recurring call failed")
+            .into_inner();
+
+        assert_eq!(
+            response.status,
+            i32::from(PaymentStatus::Failure),
+            "Declined card: expected Failure, got status {}",
+            response.status
+        );
+        assert!(
+            response.error.is_some(),
+            "Declined card: error info should be present"
+        );
+    });
+}
+
+/// TC-3: Invalid credentials — bad API keys → gRPC error or Failure status.
+#[tokio::test]
+async fn test_setup_mandate_invalid_credentials() {
+    grpc_test!(client, PaymentServiceClient<Channel>, {
+        let request = create_token_setup_recurring_request(FAKE_VALID_NONCE);
+        let mut grpc_request = Request::new(request);
+        add_bad_braintree_metadata(&mut grpc_request);
+
+        let result = client.token_setup_recurring(grpc_request).await;
+
+        match result {
+            Err(status) => {
+                // gRPC-level error — acceptable for auth failure
+                let code = status.code();
+                assert!(
+                    code == tonic::Code::Unauthenticated
+                        || code == tonic::Code::PermissionDenied
+                        || code == tonic::Code::Internal,
+                    "Invalid credentials: unexpected gRPC error code {:?}",
+                    code
+                );
+            }
+            Ok(response) => {
+                let inner = response.into_inner();
+                assert_eq!(
+                    inner.status,
+                    i32::from(PaymentStatus::Failure),
+                    "Invalid credentials: expected Failure status, got {}",
+                    inner.status
+                );
+            }
+        }
+    });
+}
+
+/// TC-4: Missing required fields — empty connector_token → error response.
+#[tokio::test]
+async fn test_setup_mandate_missing_token() {
+    grpc_test!(client, PaymentServiceClient<Channel>, {
+        let request = create_token_setup_recurring_request("");
+        let mut grpc_request = Request::new(request);
+        add_braintree_metadata(&mut grpc_request);
+
+        let result = client.token_setup_recurring(grpc_request).await;
+
+        match result {
+            Err(status) => {
+                // gRPC-level validation error — acceptable
+                assert!(
+                    status.code() == tonic::Code::InvalidArgument
+                        || status.code() == tonic::Code::FailedPrecondition
+                        || status.code() == tonic::Code::Internal,
+                    "Missing token: unexpected gRPC error code {:?}",
+                    status.code()
+                );
+            }
+            Ok(response) => {
+                let inner = response.into_inner();
+                assert_eq!(
+                    inner.status,
+                    i32::from(PaymentStatus::Failure),
+                    "Missing token: expected Failure, got {}",
+                    inner.status
+                );
+            }
+        }
+    });
+}
+
+/// Offline unit test: verify x-connector-config JSON deserializes correctly.
 #[test]
 fn test_braintree_config_deser() {
     let json = r#"{"config":{"Braintree":{"public_key":"testkey","private_key":"testsecret","merchant_account_id":"juspay","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}"#;
-    let result: Result<grpc_api_types::payments::ConnectorSpecificConfig, _> = serde_json::from_str(json);
-    println!("Deser result: {:?}", result);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
+    let result: Result<grpc_api_types::payments::ConnectorSpecificConfig, _> =
+        serde_json::from_str(json);
+    assert!(result.is_ok(), "Config deser failed: {:?}", result.err());
 }

--- a/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs
@@ -1,0 +1,192 @@
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use grpc_server::app;
+use hyperswitch_masking::{ExposeInterface, Secret};
+use ucs_env::configs;
+mod common;
+mod utils;
+
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use cards::CardNumber;
+use grpc_api_types::payments::{
+    payment_method, payment_service_client::PaymentServiceClient, AcceptanceType,
+    AuthenticationType, CardDetails, Currency, CustomerAcceptance, FutureUsage, MandateAmountData,
+    PaymentAddress, PaymentMethod, PaymentServiceSetupRecurringRequest, PaymentStatus,
+    SetupMandateDetails,
+};
+use grpc_api_types::payments::mandate_type::MandateType as MandateTypeInner;
+use grpc_api_types::payments::MandateType;
+use tonic::{transport::Channel, Request};
+use uuid::Uuid;
+
+const CONNECTOR_NAME: &str = "braintree";
+const AUTH_TYPE: &str = "signature-key";
+const MERCHANT_ID: &str = "merchant_17555143863";
+
+const TEST_CARD_NUMBER: &str = "4242424242424242";
+const TEST_CARD_EXP_MONTH: &str = "10";
+const TEST_CARD_EXP_YEAR: &str = "25";
+const TEST_CARD_CVC: &str = "123";
+const TEST_CARD_HOLDER: &str = "Test User";
+
+fn get_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn generate_unique_id(prefix: &str) -> String {
+    format!("{}_{}", prefix, Uuid::new_v4())
+}
+
+fn add_braintree_metadata<T>(request: &mut Request<T>) {
+    let auth = utils::credential_utils::load_connector_auth(CONNECTOR_NAME)
+        .expect("Failed to load braintree credentials");
+
+    let (api_key, key1, api_secret) = match auth {
+        domain_types::router_data::ConnectorAuthType::SignatureKey {
+            api_key,
+            key1,
+            api_secret,
+        } => (api_key.expose(), key1.expose(), api_secret.expose()),
+        _ => panic!("Expected SignatureKey auth type for braintree"),
+    };
+
+    request.metadata_mut().append(
+        "x-connector",
+        CONNECTOR_NAME.parse().expect("Failed to parse x-connector"),
+    );
+    request
+        .metadata_mut()
+        .append("x-auth", AUTH_TYPE.parse().expect("Failed to parse x-auth"));
+    request.metadata_mut().append(
+        "x-api-key",
+        api_key.parse().expect("Failed to parse x-api-key"),
+    );
+    request
+        .metadata_mut()
+        .append("x-key1", key1.parse().expect("Failed to parse x-key1"));
+    request.metadata_mut().append(
+        "x-api-secret",
+        api_secret.parse().expect("Failed to parse x-api-secret"),
+    );
+    request.metadata_mut().append(
+        "x-merchant-id",
+        MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
+    );
+    request.metadata_mut().append(
+        "x-request-id",
+        format!("test_request_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-request-id"),
+    );
+    request.metadata_mut().append(
+        "x-tenant-id",
+        "default".parse().expect("Failed to parse x-tenant-id"),
+    );
+    request.metadata_mut().append(
+        "x-connector-request-reference-id",
+        format!("conn_ref_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-connector-request-reference-id"),
+    );
+}
+
+fn create_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    let card_details = CardDetails {
+        card_number: Some(CardNumber::from_str(TEST_CARD_NUMBER).unwrap()),
+        card_exp_month: Some(Secret::new(TEST_CARD_EXP_MONTH.to_string())),
+        card_exp_year: Some(Secret::new(TEST_CARD_EXP_YEAR.to_string())),
+        card_cvc: Some(Secret::new(TEST_CARD_CVC.to_string())),
+        card_holder_name: Some(Secret::new(TEST_CARD_HOLDER.to_string())),
+        card_issuer: None,
+        card_network: Some(1),
+        card_type: None,
+        card_issuing_country_alpha2: None,
+        bank_code: None,
+        nick_name: None,
+    };
+
+    let mut merchant_account_metadata_map = HashMap::new();
+    merchant_account_metadata_map.insert("merchant_account_id".to_string(), "Anand".to_string());
+    merchant_account_metadata_map
+        .insert("merchant_config_currency".to_string(), "USD".to_string());
+    merchant_account_metadata_map.insert("currency".to_string(), "USD".to_string());
+    let merchant_account_metadata_json =
+        serde_json::to_string(&merchant_account_metadata_map).unwrap();
+
+    PaymentServiceSetupRecurringRequest {
+        merchant_recurring_payment_id: generate_unique_id("braintree_mandate"),
+        amount: Some(grpc_api_types::payments::Money {
+            minor_amount: 0,
+            currency: i32::from(Currency::Usd),
+        }),
+        payment_method: Some(PaymentMethod {
+            payment_method: Some(payment_method::PaymentMethod::Card(card_details)),
+        }),
+        customer: Some(grpc_api_types::payments::Customer {
+            email: Some(format!("test_{}@example.com", get_timestamp()).into()),
+            name: Some(TEST_CARD_HOLDER.to_string()),
+            id: None,
+            connector_customer_id: None,
+            phone_number: None,
+            phone_country_code: None,
+        }),
+        customer_acceptance: Some(CustomerAcceptance {
+            acceptance_type: i32::from(AcceptanceType::Offline),
+            accepted_at: 0,
+            online_mandate_details: None,
+        }),
+        address: Some(PaymentAddress::default()),
+        auth_type: i32::from(AuthenticationType::NoThreeDs),
+        setup_future_usage: Some(i32::from(FutureUsage::OffSession)),
+        enrolled_for_3ds: false,
+        metadata: Some(Secret::new(merchant_account_metadata_json)),
+        setup_mandate_details: Some(SetupMandateDetails {
+            update_mandate_id: None,
+            customer_acceptance: None,
+            mandate_type: Some(MandateType {
+                mandate_type: Some(MandateTypeInner::MultiUse(MandateAmountData {
+                    amount: 0,
+                    currency: i32::from(Currency::Usd),
+                    start_date: None,
+                    end_date: None,
+                    amount_type: Some("max".to_string()),
+                    frequency: Some("monthly".to_string()),
+                })),
+            }),
+        }),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_setup_mandate() {
+    grpc_test!(client, PaymentServiceClient<Channel>, {
+        let request = create_setup_recurring_request();
+        let mut grpc_request = Request::new(request);
+        add_braintree_metadata(&mut grpc_request);
+
+        let response = client
+            .setup_recurring(grpc_request)
+            .await
+            .expect("gRPC setup_recurring call failed")
+            .into_inner();
+
+        assert!(
+            response.status == i32::from(PaymentStatus::Charged)
+                || response.status == i32::from(PaymentStatus::AuthenticationPending)
+                || response.status == i32::from(PaymentStatus::Pending),
+            "Setup mandate should be in Charged, AuthenticationPending, or Pending state, got: {}",
+            response.status
+        );
+    });
+}

--- a/crates/integrations/connector-integration/src/connectors/braintree.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree.rs
@@ -704,6 +704,11 @@ macros::macro_connector_implementation!(
     }
 );
 
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::SetupMandateV2<T> for Braintree<T>
+{
+}
+
 // ConnectorIntegrationV2 implementations for authentication flows
 
 macros::macro_connector_flow_status_impls!(

--- a/crates/integrations/connector-integration/src/connectors/braintree.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree.rs
@@ -14,13 +14,13 @@ use common_utils::{
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, PSync, PaymentMethodToken, RSync, Refund,
-        RepeatPayment, Void,
+        RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         ClientAuthenticationTokenRequestData, PaymentFlowData, PaymentMethodTokenResponse,
         PaymentMethodTokenizationData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
         PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData, RepeatPaymentData,
+        RefundsResponseData, RepeatPaymentData, SetupMandateRequestData,
     },
     payment_method_data::PaymentMethodDataTypes,
     router_data::{ConnectorSpecificConfig, ErrorResponse},
@@ -41,8 +41,8 @@ use transformers::{
     BraintreePSyncRequest, BraintreePSyncResponse, BraintreePaymentsRequest,
     BraintreePaymentsResponse, BraintreeRSyncRequest, BraintreeRSyncResponse,
     BraintreeRefundRequest, BraintreeRefundResponse, BraintreeRepeatPaymentRequest,
-    BraintreeRepeatPaymentResponse, BraintreeSessionResponse, BraintreeTokenRequest,
-    BraintreeTokenResponse,
+    BraintreeRepeatPaymentResponse, BraintreeSessionResponse, BraintreeSetupMandateRequest,
+    BraintreeSetupMandateResponse, BraintreeTokenRequest, BraintreeTokenResponse,
 };
 
 use super::macros;
@@ -280,6 +280,12 @@ macros::create_all_prerequisites!(
             request_body: BraintreeRepeatPaymentRequest,
             response_body: BraintreeRepeatPaymentResponse,
             router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: BraintreeSetupMandateRequest,
+            response_body: BraintreeSetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [
@@ -670,6 +676,34 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Braintree,
+    curl_request: Json(BraintreeSetupMandateRequest),
+    curl_response: BraintreeSetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            Ok(self.connector_base_url_payments(req).to_string())
+        }
+    }
+);
+
 // ConnectorIntegrationV2 implementations for authentication flows
 
 macros::macro_connector_flow_status_impls!(
@@ -685,7 +719,6 @@ macros::macro_connector_flow_status_impls!(
         SubmitEvidence,
         DefendDispute,
         Accept,
-        SetupMandate,
         MandateRevoke,
         PreAuthenticate,
         Authenticate,

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -80,7 +80,7 @@ pub type BraintreeRefundResponse = GenericBraintreeResponse<RefundResponse>;
 pub type BraintreeCaptureResponse = GenericBraintreeResponse<CaptureResponse>;
 pub type BraintreePSyncResponse = GenericBraintreeResponse<PSyncResponse>;
 pub type BraintreeSetupMandateRequest =
-    GenericBraintreeRequest<GenericVariableInput<VerifyPaymentMethodInput>>;
+    GenericBraintreeRequest<GenericVariableInput<VaultPaymentMethodInput>>;
 
 pub type VariablePaymentInput = GenericVariableInput<PaymentInput>;
 pub type VariableClientTokenInput = GenericVariableInput<InputClientTokenData>;
@@ -2942,29 +2942,31 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-// SetupMandate (ZeroDollarAuth via verifyPaymentMethod) types
+// SetupMandate (ZeroDollarAuth / vaultPaymentMethod + verification) types
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VerifyPaymentMethodInput {
+pub struct VaultPaymentMethodInput {
     payment_method_id: Secret<String>,
-    merchant_account_id: Secret<String>,
+    verification_merchant_account_id: Secret<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct VerifyPaymentMethodResponse {
-    data: VerifyPaymentMethodDataResponse,
+pub struct VaultPaymentMethodResponse {
+    data: VaultPaymentMethodDataResponse,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VerifyPaymentMethodDataResponse {
-    verify_payment_method: VerifyPaymentMethodWrapper,
+pub struct VaultPaymentMethodDataResponse {
+    vault_payment_method: VaultPaymentMethodWrapper,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct VerifyPaymentMethodWrapper {
-    verification: VerificationBody,
+#[serde(rename_all = "camelCase")]
+pub struct VaultPaymentMethodWrapper {
+    payment_method: Option<PaymentMethodInfo>,
+    verification: Option<VerificationBody>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2998,7 +3000,7 @@ impl From<BraintreeVerificationStatus> for enums::AttemptStatus {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BraintreeSetupMandateResponse {
-    VerifyResponse(Box<VerifyPaymentMethodResponse>),
+    VaultResponse(Box<VaultPaymentMethodResponse>),
     ErrorResponse(Box<ErrorResponse>),
 }
 
@@ -3049,11 +3051,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         };
 
         Ok(Self {
-            query: constants::VERIFY_PAYMENT_METHOD_MUTATION.to_string(),
+            query: constants::VAULT_PAYMENT_METHOD_MUTATION.to_string(),
             variables: GenericVariableInput {
-                input: VerifyPaymentMethodInput {
+                input: VaultPaymentMethodInput {
                     payment_method_id,
-                    merchant_account_id,
+                    verification_merchant_account_id: merchant_account_id,
                 },
             },
         })
@@ -3083,45 +3085,84 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .map_err(|err| *err),
                 ..item.router_data
             }),
-            BraintreeSetupMandateResponse::VerifyResponse(verify_response) => {
-                let verification = verify_response.data.verify_payment_method.verification;
-                let status = enums::AttemptStatus::from(verification.status.clone());
-                let response = if domain_types::utils::is_payment_failure(status) {
-                    Err(create_failure_error_response(
-                        verification.status,
-                        Some(verification.id),
-                        item.http_code,
-                    ))
-                } else {
-                    let mandate_pm_id = verification
-                        .payment_method
-                        .as_ref()
-                        .map(|pm| pm.id.clone().expose());
-                    Ok(PaymentsResponseData::TransactionResponse {
-                        resource_id: ResponseId::ConnectorTransactionId(verification.id),
-                        redirection_data: None,
-                        mandate_reference: mandate_pm_id.map(|id| {
-                            Box::new(MandateReference {
-                                connector_mandate_id: Some(id),
-                                payment_method_id: None,
-                                connector_mandate_request_reference_id: None,
+            BraintreeSetupMandateResponse::VaultResponse(vault_response) => {
+                let vault_data = vault_response.data.vault_payment_method;
+                let vaulted_pm = vault_data.payment_method;
+
+                match vault_data.verification {
+                    Some(verification) => {
+                        let status =
+                            enums::AttemptStatus::from(verification.status.clone());
+                        let response = if domain_types::utils::is_payment_failure(status)
+                        {
+                            Err(create_failure_error_response(
+                                verification.status,
+                                Some(verification.id),
+                                item.http_code,
+                            ))
+                        } else {
+                            let mandate_pm_id = vaulted_pm
+                                .as_ref()
+                                .or(verification.payment_method.as_ref())
+                                .map(|pm| pm.id.clone().expose());
+                            Ok(PaymentsResponseData::TransactionResponse {
+                                resource_id: ResponseId::ConnectorTransactionId(
+                                    verification.id,
+                                ),
+                                redirection_data: None,
+                                mandate_reference: mandate_pm_id.map(|id| {
+                                    Box::new(MandateReference {
+                                        connector_mandate_id: Some(id),
+                                        payment_method_id: None,
+                                        connector_mandate_request_reference_id: None,
+                                    })
+                                }),
+                                connector_metadata: None,
+                                network_txn_id: None,
+                                connector_response_reference_id: None,
+                                incremental_authorization_allowed: None,
+                                status_code: item.http_code,
                             })
-                        }),
-                        connector_metadata: None,
-                        network_txn_id: None,
-                        connector_response_reference_id: None,
-                        incremental_authorization_allowed: None,
-                        status_code: item.http_code,
-                    })
-                };
-                Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        ..item.router_data.resource_common_data
-                    },
-                    response,
-                    ..item.router_data
-                })
+                        };
+                        Ok(Self {
+                            resource_common_data: PaymentFlowData {
+                                status,
+                                ..item.router_data.resource_common_data
+                            },
+                            response,
+                            ..item.router_data
+                        })
+                    }
+                    None => {
+                        let mandate_pm_id =
+                            vaulted_pm.as_ref().map(|pm| pm.id.clone().expose());
+                        Ok(Self {
+                            resource_common_data: PaymentFlowData {
+                                status: enums::AttemptStatus::Charged,
+                                ..item.router_data.resource_common_data
+                            },
+                            response: Ok(
+                                PaymentsResponseData::TransactionResponse {
+                                    resource_id: ResponseId::NoResponseId,
+                                    redirection_data: None,
+                                    mandate_reference: mandate_pm_id.map(|id| {
+                                        Box::new(MandateReference {
+                                            connector_mandate_id: Some(id),
+                                            payment_method_id: None,
+                                            connector_mandate_request_reference_id: None,
+                                        })
+                                    }),
+                                    connector_metadata: None,
+                                    network_txn_id: None,
+                                    connector_response_reference_id: None,
+                                    incremental_authorization_allowed: None,
+                                    status_code: item.http_code,
+                                },
+                            ),
+                            ..item.router_data
+                        })
+                    }
+                }
             }
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -52,6 +52,7 @@ pub mod constants {
     pub const AUTHORIZE_AND_VAULT_CREDIT_CARD_MUTATION: &str="mutation authorizeCreditCard($input: AuthorizeCreditCardInput!) { authorizeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
     pub const CHARGE_AND_VAULT_TRANSACTION_MUTATION: &str ="mutation ChargeCreditCard($input: ChargeCreditCardInput!) { chargeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
     pub const DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION: &str = "mutation deletePaymentMethodFromVault($input: DeletePaymentMethodFromVaultInput!) { deletePaymentMethodFromVault(input: $input) { clientMutationId } }";
+    pub const VAULT_PAYMENT_METHOD_MUTATION: &str = "mutation vaultPaymentMethod($input: VaultPaymentMethodInput!) { vaultPaymentMethod(input: $input) { paymentMethod { id } verification { id status paymentMethod { id } } } }";
     pub const VERIFY_PAYMENT_METHOD_MUTATION: &str = "mutation verifyPaymentMethod($input: VerifyPaymentMethodInput!) { verifyPaymentMethod(input: $input) { verification { id status paymentMethod { id } } } }";
     pub const TRANSACTION_QUERY: &str = "query($input: TransactionSearchInput!) { search { transactions(input: $input) { edges { node { id status } } } } }";
     pub const REFUND_QUERY: &str = "query($input: RefundSearchInput!) { search { refunds(input: $input, first: 1) { edges { node { id status createdAt amount { value currencyCode } orderId } } } } }";
@@ -79,7 +80,7 @@ pub type BraintreeRefundResponse = GenericBraintreeResponse<RefundResponse>;
 pub type BraintreeCaptureResponse = GenericBraintreeResponse<CaptureResponse>;
 pub type BraintreePSyncResponse = GenericBraintreeResponse<PSyncResponse>;
 pub type BraintreeSetupMandateRequest =
-    GenericBraintreeRequest<GenericVariableInput<VerifyPaymentMethodInput>>;
+    GenericBraintreeRequest<GenericVariableInput<VaultPaymentMethodInput>>;
 
 pub type VariablePaymentInput = GenericVariableInput<PaymentInput>;
 pub type VariableClientTokenInput = GenericVariableInput<InputClientTokenData>;
@@ -2941,29 +2942,31 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-// SetupMandate (ZeroDollarAuth / verifyPaymentMethod) types
+// SetupMandate (ZeroDollarAuth / vaultPaymentMethod + verification) types
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VerifyPaymentMethodInput {
+pub struct VaultPaymentMethodInput {
     payment_method_id: Secret<String>,
-    merchant_account_id: Secret<String>,
+    verification_merchant_account_id: Secret<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct VerifyPaymentMethodResponse {
-    data: VerifyPaymentMethodDataResponse,
+pub struct VaultPaymentMethodResponse {
+    data: VaultPaymentMethodDataResponse,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VerifyPaymentMethodDataResponse {
-    verify_payment_method: VerifyPaymentMethodWrapper,
+pub struct VaultPaymentMethodDataResponse {
+    vault_payment_method: VaultPaymentMethodWrapper,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct VerifyPaymentMethodWrapper {
-    verification: VerificationBody,
+#[serde(rename_all = "camelCase")]
+pub struct VaultPaymentMethodWrapper {
+    payment_method: Option<PaymentMethodInfo>,
+    verification: Option<VerificationBody>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2997,7 +3000,7 @@ impl From<BraintreeVerificationStatus> for enums::AttemptStatus {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BraintreeSetupMandateResponse {
-    VerifyResponse(Box<VerifyPaymentMethodResponse>),
+    VaultResponse(Box<VaultPaymentMethodResponse>),
     ErrorResponse(Box<ErrorResponse>),
 }
 
@@ -3048,11 +3051,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         };
 
         Ok(Self {
-            query: constants::VERIFY_PAYMENT_METHOD_MUTATION.to_string(),
+            query: constants::VAULT_PAYMENT_METHOD_MUTATION.to_string(),
             variables: GenericVariableInput {
-                input: VerifyPaymentMethodInput {
+                input: VaultPaymentMethodInput {
                     payment_method_id,
-                    merchant_account_id,
+                    verification_merchant_account_id: merchant_account_id,
                 },
             },
         })
@@ -3074,45 +3077,92 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ) -> Result<Self, Self::Error> {
         match item.response {
             BraintreeSetupMandateResponse::ErrorResponse(error_response) => Ok(Self {
+                resource_common_data: PaymentFlowData {
+                    status: enums::AttemptStatus::Failure,
+                    ..item.router_data.resource_common_data
+                },
                 response: build_error_response(&error_response.errors, item.http_code)
                     .map_err(|err| *err),
                 ..item.router_data
             }),
-            BraintreeSetupMandateResponse::VerifyResponse(verify_response) => {
-                let verification = verify_response.data.verify_payment_method.verification;
-                let status = enums::AttemptStatus::from(verification.status.clone());
-                let response = if domain_types::utils::is_payment_failure(status) {
-                    Err(create_failure_error_response(
-                        verification.status,
-                        Some(verification.id),
-                        item.http_code,
-                    ))
-                } else {
-                    Ok(PaymentsResponseData::TransactionResponse {
-                        resource_id: ResponseId::ConnectorTransactionId(verification.id),
-                        redirection_data: None,
-                        mandate_reference: verification.payment_method.as_ref().map(|pm| {
-                            Box::new(MandateReference {
-                                connector_mandate_id: Some(pm.id.clone().expose()),
-                                payment_method_id: None,
-                                connector_mandate_request_reference_id: None,
+            BraintreeSetupMandateResponse::VaultResponse(vault_response) => {
+                let vault_data = vault_response.data.vault_payment_method;
+                let vaulted_pm = vault_data.payment_method;
+
+                match vault_data.verification {
+                    Some(verification) => {
+                        let status =
+                            enums::AttemptStatus::from(verification.status.clone());
+                        let response = if domain_types::utils::is_payment_failure(status)
+                        {
+                            Err(create_failure_error_response(
+                                verification.status,
+                                Some(verification.id),
+                                item.http_code,
+                            ))
+                        } else {
+                            let mandate_pm_id = vaulted_pm
+                                .as_ref()
+                                .or(verification.payment_method.as_ref())
+                                .map(|pm| pm.id.clone().expose());
+                            Ok(PaymentsResponseData::TransactionResponse {
+                                resource_id: ResponseId::ConnectorTransactionId(
+                                    verification.id,
+                                ),
+                                redirection_data: None,
+                                mandate_reference: mandate_pm_id.map(|id| {
+                                    Box::new(MandateReference {
+                                        connector_mandate_id: Some(id),
+                                        payment_method_id: None,
+                                        connector_mandate_request_reference_id: None,
+                                    })
+                                }),
+                                connector_metadata: None,
+                                network_txn_id: None,
+                                connector_response_reference_id: None,
+                                incremental_authorization_allowed: None,
+                                status_code: item.http_code,
                             })
-                        }),
-                        connector_metadata: None,
-                        network_txn_id: None,
-                        connector_response_reference_id: None,
-                        incremental_authorization_allowed: None,
-                        status_code: item.http_code,
-                    })
-                };
-                Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        ..item.router_data.resource_common_data
-                    },
-                    response,
-                    ..item.router_data
-                })
+                        };
+                        Ok(Self {
+                            resource_common_data: PaymentFlowData {
+                                status,
+                                ..item.router_data.resource_common_data
+                            },
+                            response,
+                            ..item.router_data
+                        })
+                    }
+                    None => {
+                        let mandate_pm_id =
+                            vaulted_pm.as_ref().map(|pm| pm.id.clone().expose());
+                        Ok(Self {
+                            resource_common_data: PaymentFlowData {
+                                status: enums::AttemptStatus::Charged,
+                                ..item.router_data.resource_common_data
+                            },
+                            response: Ok(
+                                PaymentsResponseData::TransactionResponse {
+                                    resource_id: ResponseId::NoResponseId,
+                                    redirection_data: None,
+                                    mandate_reference: mandate_pm_id.map(|id| {
+                                        Box::new(MandateReference {
+                                            connector_mandate_id: Some(id),
+                                            payment_method_id: None,
+                                            connector_mandate_request_reference_id: None,
+                                        })
+                                    }),
+                                    connector_metadata: None,
+                                    network_txn_id: None,
+                                    connector_response_reference_id: None,
+                                    incremental_authorization_allowed: None,
+                                    status_code: item.http_code,
+                                },
+                            ),
+                            ..item.router_data
+                        })
+                    }
+                }
             }
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -80,7 +80,7 @@ pub type BraintreeRefundResponse = GenericBraintreeResponse<RefundResponse>;
 pub type BraintreeCaptureResponse = GenericBraintreeResponse<CaptureResponse>;
 pub type BraintreePSyncResponse = GenericBraintreeResponse<PSyncResponse>;
 pub type BraintreeSetupMandateRequest =
-    GenericBraintreeRequest<GenericVariableInput<VaultPaymentMethodInput>>;
+    GenericBraintreeRequest<GenericVariableInput<VerifyPaymentMethodInput>>;
 
 pub type VariablePaymentInput = GenericVariableInput<PaymentInput>;
 pub type VariableClientTokenInput = GenericVariableInput<InputClientTokenData>;
@@ -2942,31 +2942,29 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-// SetupMandate (ZeroDollarAuth / vaultPaymentMethod + verification) types
+// SetupMandate (ZeroDollarAuth via verifyPaymentMethod) types
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VaultPaymentMethodInput {
+pub struct VerifyPaymentMethodInput {
     payment_method_id: Secret<String>,
-    verification_merchant_account_id: Secret<String>,
+    merchant_account_id: Secret<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct VaultPaymentMethodResponse {
-    data: VaultPaymentMethodDataResponse,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VaultPaymentMethodDataResponse {
-    vault_payment_method: VaultPaymentMethodWrapper,
+pub struct VerifyPaymentMethodResponse {
+    data: VerifyPaymentMethodDataResponse,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct VaultPaymentMethodWrapper {
-    payment_method: Option<PaymentMethodInfo>,
-    verification: Option<VerificationBody>,
+pub struct VerifyPaymentMethodDataResponse {
+    verify_payment_method: VerifyPaymentMethodWrapper,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VerifyPaymentMethodWrapper {
+    verification: VerificationBody,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -3000,7 +2998,7 @@ impl From<BraintreeVerificationStatus> for enums::AttemptStatus {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BraintreeSetupMandateResponse {
-    VaultResponse(Box<VaultPaymentMethodResponse>),
+    VerifyResponse(Box<VerifyPaymentMethodResponse>),
     ErrorResponse(Box<ErrorResponse>),
 }
 
@@ -3051,11 +3049,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         };
 
         Ok(Self {
-            query: constants::VAULT_PAYMENT_METHOD_MUTATION.to_string(),
+            query: constants::VERIFY_PAYMENT_METHOD_MUTATION.to_string(),
             variables: GenericVariableInput {
-                input: VaultPaymentMethodInput {
+                input: VerifyPaymentMethodInput {
                     payment_method_id,
-                    verification_merchant_account_id: merchant_account_id,
+                    merchant_account_id,
                 },
             },
         })
@@ -3085,84 +3083,45 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .map_err(|err| *err),
                 ..item.router_data
             }),
-            BraintreeSetupMandateResponse::VaultResponse(vault_response) => {
-                let vault_data = vault_response.data.vault_payment_method;
-                let vaulted_pm = vault_data.payment_method;
-
-                match vault_data.verification {
-                    Some(verification) => {
-                        let status =
-                            enums::AttemptStatus::from(verification.status.clone());
-                        let response = if domain_types::utils::is_payment_failure(status)
-                        {
-                            Err(create_failure_error_response(
-                                verification.status,
-                                Some(verification.id),
-                                item.http_code,
-                            ))
-                        } else {
-                            let mandate_pm_id = vaulted_pm
-                                .as_ref()
-                                .or(verification.payment_method.as_ref())
-                                .map(|pm| pm.id.clone().expose());
-                            Ok(PaymentsResponseData::TransactionResponse {
-                                resource_id: ResponseId::ConnectorTransactionId(
-                                    verification.id,
-                                ),
-                                redirection_data: None,
-                                mandate_reference: mandate_pm_id.map(|id| {
-                                    Box::new(MandateReference {
-                                        connector_mandate_id: Some(id),
-                                        payment_method_id: None,
-                                        connector_mandate_request_reference_id: None,
-                                    })
-                                }),
-                                connector_metadata: None,
-                                network_txn_id: None,
-                                connector_response_reference_id: None,
-                                incremental_authorization_allowed: None,
-                                status_code: item.http_code,
+            BraintreeSetupMandateResponse::VerifyResponse(verify_response) => {
+                let verification = verify_response.data.verify_payment_method.verification;
+                let status = enums::AttemptStatus::from(verification.status.clone());
+                let response = if domain_types::utils::is_payment_failure(status) {
+                    Err(create_failure_error_response(
+                        verification.status,
+                        Some(verification.id),
+                        item.http_code,
+                    ))
+                } else {
+                    let mandate_pm_id = verification
+                        .payment_method
+                        .as_ref()
+                        .map(|pm| pm.id.clone().expose());
+                    Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: ResponseId::ConnectorTransactionId(verification.id),
+                        redirection_data: None,
+                        mandate_reference: mandate_pm_id.map(|id| {
+                            Box::new(MandateReference {
+                                connector_mandate_id: Some(id),
+                                payment_method_id: None,
+                                connector_mandate_request_reference_id: None,
                             })
-                        };
-                        Ok(Self {
-                            resource_common_data: PaymentFlowData {
-                                status,
-                                ..item.router_data.resource_common_data
-                            },
-                            response,
-                            ..item.router_data
-                        })
-                    }
-                    None => {
-                        let mandate_pm_id =
-                            vaulted_pm.as_ref().map(|pm| pm.id.clone().expose());
-                        Ok(Self {
-                            resource_common_data: PaymentFlowData {
-                                status: enums::AttemptStatus::Charged,
-                                ..item.router_data.resource_common_data
-                            },
-                            response: Ok(
-                                PaymentsResponseData::TransactionResponse {
-                                    resource_id: ResponseId::NoResponseId,
-                                    redirection_data: None,
-                                    mandate_reference: mandate_pm_id.map(|id| {
-                                        Box::new(MandateReference {
-                                            connector_mandate_id: Some(id),
-                                            payment_method_id: None,
-                                            connector_mandate_request_reference_id: None,
-                                        })
-                                    }),
-                                    connector_metadata: None,
-                                    network_txn_id: None,
-                                    connector_response_reference_id: None,
-                                    incremental_authorization_allowed: None,
-                                    status_code: item.http_code,
-                                },
-                            ),
-                            ..item.router_data
-                        })
-                    }
-                }
+                        }),
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id: None,
+                        incremental_authorization_allowed: None,
+                        status_code: item.http_code,
+                    })
+                };
+                Ok(Self {
+                    resource_common_data: PaymentFlowData {
+                        status,
+                        ..item.router_data.resource_common_data
+                    },
+                    response,
+                    ..item.router_data
+                })
             }
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -8,7 +8,7 @@ use common_utils::{
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, PSync, PaymentMethodToken, RSync,
-        RepeatPayment, Void,
+        RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         self, AmountInfo, ApplePayPaymentRequest, ApplePaySessionResponse,
@@ -22,7 +22,7 @@ use domain_types::{
         PaymentsResponseData, PaymentsSyncData, PaypalClientAuthenticationResponse,
         PaypalTransactionInfo, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
         RepeatPaymentData, ResponseId, SdkNextAction, SecretInfoToInitiateSdk,
-        ThirdPartySdkSessionResponse,
+        SetupMandateRequestData, ThirdPartySdkSessionResponse,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber, WalletData},
@@ -52,6 +52,7 @@ pub mod constants {
     pub const AUTHORIZE_AND_VAULT_CREDIT_CARD_MUTATION: &str="mutation authorizeCreditCard($input: AuthorizeCreditCardInput!) { authorizeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
     pub const CHARGE_AND_VAULT_TRANSACTION_MUTATION: &str ="mutation ChargeCreditCard($input: ChargeCreditCardInput!) { chargeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
     pub const DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION: &str = "mutation deletePaymentMethodFromVault($input: DeletePaymentMethodFromVaultInput!) { deletePaymentMethodFromVault(input: $input) { clientMutationId } }";
+    pub const VERIFY_PAYMENT_METHOD_MUTATION: &str = "mutation verifyPaymentMethod($input: VerifyPaymentMethodInput!) { verifyPaymentMethod(input: $input) { verification { id status paymentMethod { id } } } }";
     pub const TRANSACTION_QUERY: &str = "query($input: TransactionSearchInput!) { search { transactions(input: $input) { edges { node { id status } } } } }";
     pub const REFUND_QUERY: &str = "query($input: RefundSearchInput!) { search { refunds(input: $input, first: 1) { edges { node { id status createdAt amount { value currencyCode } orderId } } } } }";
     pub const CHARGE_GOOGLE_PAY_MUTATION: &str = "mutation ChargeGPay($input: ChargePaymentMethodInput!) { chargePaymentMethod(input: $input) { transaction { id status amount { value currencyCode } } } }";
@@ -77,6 +78,8 @@ pub type BraintreeWalletRequest = GenericBraintreeRequest<GenericVariableInput<W
 pub type BraintreeRefundResponse = GenericBraintreeResponse<RefundResponse>;
 pub type BraintreeCaptureResponse = GenericBraintreeResponse<CaptureResponse>;
 pub type BraintreePSyncResponse = GenericBraintreeResponse<PSyncResponse>;
+pub type BraintreeSetupMandateRequest =
+    GenericBraintreeRequest<GenericVariableInput<VerifyPaymentMethodInput>>;
 
 pub type VariablePaymentInput = GenericVariableInput<PaymentInput>;
 pub type VariableClientTokenInput = GenericVariableInput<InputClientTokenData>;
@@ -2912,6 +2915,183 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         resource_id: ResponseId::ConnectorTransactionId(transaction_data.id),
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
+                            Box::new(MandateReference {
+                                connector_mandate_id: Some(pm.id.clone().expose()),
+                                payment_method_id: None,
+                                connector_mandate_request_reference_id: None,
+                            })
+                        }),
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id: None,
+                        incremental_authorization_allowed: None,
+                        status_code: item.http_code,
+                    })
+                };
+                Ok(Self {
+                    resource_common_data: PaymentFlowData {
+                        status,
+                        ..item.router_data.resource_common_data
+                    },
+                    response,
+                    ..item.router_data
+                })
+            }
+        }
+    }
+}
+
+// SetupMandate (ZeroDollarAuth / verifyPaymentMethod) types
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyPaymentMethodInput {
+    payment_method_id: Secret<String>,
+    merchant_account_id: Secret<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VerifyPaymentMethodResponse {
+    data: VerifyPaymentMethodDataResponse,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyPaymentMethodDataResponse {
+    verify_payment_method: VerifyPaymentMethodWrapper,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VerifyPaymentMethodWrapper {
+    verification: VerificationBody,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationBody {
+    id: String,
+    status: BraintreeVerificationStatus,
+    payment_method: Option<PaymentMethodInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, strum::Display)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BraintreeVerificationStatus {
+    Verified,
+    Failed,
+    GatewayRejected,
+    ProcessorDeclined,
+}
+
+impl From<BraintreeVerificationStatus> for enums::AttemptStatus {
+    fn from(item: BraintreeVerificationStatus) -> Self {
+        match item {
+            BraintreeVerificationStatus::Verified => Self::Charged,
+            BraintreeVerificationStatus::Failed
+            | BraintreeVerificationStatus::GatewayRejected
+            | BraintreeVerificationStatus::ProcessorDeclined => Self::Failure,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BraintreeSetupMandateResponse {
+    VerifyResponse(Box<VerifyPaymentMethodResponse>),
+    ErrorResponse(Box<ErrorResponse>),
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        BraintreeRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for BraintreeSetupMandateRequest
+{
+    type Error = Report<IntegrationError>;
+    fn try_from(
+        item: BraintreeRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let auth = BraintreeAuthType::try_from(&item.router_data.connector_config)?;
+        let merchant_account_id =
+            auth.merchant_account_id
+                .ok_or(IntegrationError::InvalidConnectorConfig {
+                    config: "merchant_account_id",
+                    context: Default::default(),
+                })?;
+
+        let payment_method_id = match &item.router_data.request.payment_method_data {
+            PaymentMethodData::PaymentMethodToken(token_data) => {
+                token_data.token.clone()
+            }
+            _ => {
+                return Err(error_stack::report!(IntegrationError::NotSupported {
+                    message: utils::get_unimplemented_payment_method_error_message("braintree"),
+                    connector: "Braintree",
+                    context: Default::default(),
+                }));
+            }
+        };
+
+        Ok(Self {
+            query: constants::VERIFY_PAYMENT_METHOD_MUTATION.to_string(),
+            variables: GenericVariableInput {
+                input: VerifyPaymentMethodInput {
+                    payment_method_id,
+                    merchant_account_id,
+                },
+            },
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<BraintreeSetupMandateResponse, Self>>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<BraintreeSetupMandateResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            BraintreeSetupMandateResponse::ErrorResponse(error_response) => Ok(Self {
+                response: build_error_response(&error_response.errors, item.http_code)
+                    .map_err(|err| *err),
+                ..item.router_data
+            }),
+            BraintreeSetupMandateResponse::VerifyResponse(verify_response) => {
+                let verification = verify_response.data.verify_payment_method.verification;
+                let status = enums::AttemptStatus::from(verification.status.clone());
+                let response = if domain_types::utils::is_payment_failure(status) {
+                    Err(create_failure_error_response(
+                        verification.status,
+                        Some(verification.id),
+                        item.http_code,
+                    ))
+                } else {
+                    Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: ResponseId::ConnectorTransactionId(verification.id),
+                        redirection_data: None,
+                        mandate_reference: verification.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,


### PR DESCRIPTION
## Summary

- Implements the `SetupMandate` flow for Braintree using the `vaultPaymentMethod` GraphQL mutation
- The card is tokenized via the existing `PaymentMethodToken` prerequisite flow (`tokenizeCreditCard`), then vaulted to a multi-use payment method via `vaultPaymentMethod` with verification
- Verification status mapping: `VERIFIED` → `Charged`, `FAILED`/`GATEWAY_REJECTED`/`PROCESSOR_DECLINED` → `Failure`
- The `verification.id` maps to `connector_transaction_id` and `paymentMethod.id` maps to `connector_mandate_id` for future `RepeatPayment` use

**CTO routing decision:** GRAA-3156 — Option A (Supersede), `vaultPaymentMethod`
**CEO resolution:** GRAA-3169 — reverted commit `5193c631b` which had switched to `verifyPaymentMethod`
**Tracking:** GRAA-3154, GRAA-3171, GRAA-3172

## API Documentation

Braintree GraphQL API — `vaultPaymentMethod` mutation:
- https://graphql.braintreepayments.com/reference/#mutation--vaultPaymentMethod

## Files Changed

| File | Change |
|------|--------|
| `connectors/braintree.rs` | `SetupMandate` flow implementation via `macro_connector_implementation!`, `SetupMandateV2<T>` trait impl |
| `connectors/braintree/transformers.rs` | `BraintreeSetupMandateRequest` (GraphQL `vaultPaymentMethod`), `BraintreeSetupMandateResponse` (verification result), `TryFrom` impls for request/response mapping |
| `tests/braintree_payment_flows_test.rs` | gRPC integration test for `token_setup_recurring` endpoint |

## Revert History

- `38263ced5` — original `vaultPaymentMethod` implementation (CTO-approved)
- `5193c631b` — switched to `verifyPaymentMethod` (reverted per CEO resolution GRAA-3169)
- `a311396c6` — revert of `5193c631b`, restoring `vaultPaymentMethod`

## gRPC Test Results

**QA Run:** 2026-05-13 | **Branch:** `feat/braintree-setup-mandate-v2` | **Build:** `a311396c6` (revert commit) | **Verdict: PASS ✅**

### Notes
- The SetupMandate flow requires a **two-step** sequence: Tokenize → TokenSetupRecurring. Sending a raw `Card` directly to `SetupRecurring` returns `NOT_SUPPORTED` — this is correct behavior since the transformer expects a `PaymentMethodToken`.
- The included test file (`braintree_payment_flows_test.rs`) sends a raw Card to `setup_recurring` and panics — see test-file bug note below.

---

### STEP 1/2 — `PaymentMethodService/Tokenize` (prerequisite)

**grpcurl command:**
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto payment.proto -proto services.proto \
  -H "x-connector: braintree" \
  -H "x-merchant-id: merchant_braintree_test" \
  -H "x-request-id: req_tok_1778692371" \
  -H "x-tenant-id: default" \
  -H "x-connector-request-reference-id: conn_ref_tok_1778692371" \
  -H 'x-connector-config: {"config":{"Braintree":{"public_key":"<REDACTED_API_KEY>","private_key":"<REDACTED>","merchant_account_id":"<REDACTED>","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}' \
  -d '{
    "amount": {"minor_amount": 0, "currency": "USD"},
    "payment_method": {
      "card": {
        "card_number": {"value": "<REDACTED_PAN>"},
        "card_exp_month": {"value": "10"},
        "card_exp_year": {"value": "25"},
        "card_cvc": {"value": "<REDACTED_CVV>"},
        "card_holder_name": {"value": "John Doe"}
      }
    }
  }' \
  localhost:8000 types.PaymentMethodService/Tokenize
```

**Raw Braintree request (`tokenizeCreditCard` mutation):**
```json
{
  "url": "https://payments.sandbox.braintree-api.com/graphql",
  "method": "POST",
  "headers": {
    "Authorization": "Basic <REDACTED>",
    "Content-Type": "application/json",
    "Braintree-Version": "2019-01-01",
    "via": "HyperSwitch"
  },
  "body": {
    "query": "mutation tokenizeCreditCard($input: TokenizeCreditCardInput!) { tokenizeCreditCard(input: $input) { clientMutationId paymentMethod { id } } }",
    "variables": {
      "input": {
        "creditCard": {
          "number": "<REDACTED_PAN>",
          "expirationYear": "<REDACTED>",
          "expirationMonth": "<REDACTED>",
          "cvv": "<REDACTED_CVV>",
          "cardholderName": "John Doe"
        }
      }
    }
  }
}
```

**Raw Braintree response:**
```json
{
  "data": {
    "tokenizeCreditCard": {
      "paymentMethod": {
        "id": "<REDACTED_TOKEN>"
      }
    }
  }
}
```

**Prism response:**
```json
{
  "paymentMethodToken": "<REDACTED_TOKEN>",
  "statusCode": 200,
  "merchantPaymentMethodId": "<REDACTED_TOKEN>"
}
```

**Result:** ✅ PASS — token extracted, latency ~431 ms

---

### STEP 2/2 — `PaymentService/TokenSetupRecurring` (vaultPaymentMethod)

**grpcurl command:**
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto payment.proto -proto services.proto \
  -H "x-connector: braintree" \
  -H "x-merchant-id: merchant_braintree_test" \
  -H "x-request-id: req_tsr_1778692396" \
  -H "x-tenant-id: default" \
  -H "x-connector-request-reference-id: conn_ref_tsr_1778692396" \
  -H 'x-connector-config: {"config":{"Braintree":{"public_key":"<REDACTED_API_KEY>","private_key":"<REDACTED>","merchant_account_id":"<REDACTED>","merchant_config_currency":"USD","apple_pay_supported_networks":[],"apple_pay_merchant_capabilities":[],"gpay_allowed_auth_methods":[],"gpay_allowed_card_networks":[]}}}' \
  -d '{
    "merchant_recurring_payment_id": "braintree_mandate_1778692396",
    "amount": {"minor_amount": 0, "currency": "USD"},
    "connector_token": {"value": "<REDACTED_TOKEN>"},
    "customer": {
      "email": {"value": "test_1778692396@example.com"},
      "name": "John Doe"
    },
    "customer_acceptance": {"acceptance_type": 1, "accepted_at": 0},
    "address": {},
    "setup_mandate_details": {
      "mandate_type": {
        "multi_use": {
          "amount": 0, "currency": "USD",
          "amount_type": "max", "frequency": "monthly"
        }
      }
    },
    "setup_future_usage": 2
  }' \
  localhost:8000 types.PaymentService/TokenSetupRecurring
```

**Raw Braintree request (`vaultPaymentMethod` mutation):**
```json
{
  "url": "https://payments.sandbox.braintree-api.com/graphql",
  "method": "POST",
  "headers": {
    "Authorization": "Basic <REDACTED>",
    "Content-Type": "application/json",
    "Braintree-Version": "2019-01-01",
    "via": "HyperSwitch"
  },
  "body": {
    "query": "mutation vaultPaymentMethod($input: VaultPaymentMethodInput!) { vaultPaymentMethod(input: $input) { paymentMethod { id } verification { id status paymentMethod { id } } } }",
    "variables": {
      "input": {
        "paymentMethodId": "<REDACTED_TOKEN>",
        "verificationMerchantAccountId": "<REDACTED>"
      }
    }
  }
}
```

**Raw Braintree response:**
```json
{
  "data": {
    "vaultPaymentMethod": {
      "paymentMethod": { "id": "<REDACTED_TOKEN>" },
      "verification": {
        "id": "dmVyaWZpY2F0aW9uX2U2ZzZrYnN4",
        "status": "VERIFIED",
        "paymentMethod": { "id": "<REDACTED_TOKEN>" }
      }
    }
  }
}
```

**Prism response:**
```json
{
  "connectorRecurringPaymentId": "dmVyaWZpY2F0aW9uX2U2ZzZrYnN4",
  "status": "CHARGED",
  "statusCode": 200,
  "mandateReference": {
    "connectorMandateId": {
      "connectorMandateId": "cGF5bWVudG1ldGhvZF9jY19xNHo1Ym1qeQ"
    }
  },
  "capturedAmount": "0"
}
```

**Result:** ✅ PASS — `vaultPaymentMethod` executed, Braintree verification status `VERIFIED` → Prism `CHARGED`, `verification.id` returned as `connectorRecurringPaymentId`, `paymentMethod.id` as `connectorMandateId` for future RepeatPayment use. Latency ~1152 ms.

---

### Error Cases

**Error Case 1 — Invalid token:**
```json
{
  "status": "FAILURE",
  "error": {
    "connectorDetails": {
      "code": "93108",
      "message": "Unknown or expired single-use payment method.",
      "reason": "Unknown or expired single-use payment method."
    }
  },
  "statusCode": 200
}
```
Braintree raw response: `{"errors": [{"message": "Unknown or expired single-use payment method.", "extensions": {"legacyCode": "93108"}}]}`
Result: ✅ PASS — error correctly mapped to `FAILURE` status.

**Error Case 2 — Processor-declined card (4000111111111115) tokenize → vault:**
- Tokenize: succeeds (Braintree tokenizes any card number)
- Vault: `ProcessorDeclined` from Braintree
```json
{
  "status": "FAILURE",
  "error": {
    "connectorDetails": {
      "code": "ProcessorDeclined",
      "message": "ProcessorDeclined",
      "reason": "ProcessorDeclined",
      "connectorTransactionId": "dmVyaWZpY2F0aW9uX2Y0OWp0eGNk"
    }
  },
  "statusCode": 200
}
```
Result: ✅ PASS — `ProcessorDeclined` mapped to `FAILURE` status.

---

### 🚨 Test-File Bug (Blocking)

`crates/grpc-server/grpc-server/tests/braintree_payment_flows_test.rs` panics at runtime:

```
Status { code: FailedPrecondition, message: "Selected payment method through braintree is not supported by Braintree" ... }
```

**Root cause:** `test_setup_mandate` sends a raw `CardDetails` to `PaymentService/SetupRecurring`. The Braintree `SetupMandate` transformer (`transformers.rs:3040`) only accepts `PaymentMethodData::PaymentMethodToken` — it does not accept a raw card.

**Fix required:** The test must use a two-step flow:
1. `PaymentMethodService/Tokenize` → get `payment_method_token`
2. `PaymentService/TokenSetupRecurring` with `connector_token`

This is a **blocking** finding — the included integration test does not validate the implemented flow and will fail CI if run with `CONNECTOR_AUTH_FILE_PATH` set. ConnectorEngineer should fix the test before marking this PR ready-for-review.

---

**Overall verdict: PASS (implementation) / BLOCKED (test file)**
- `vaultPaymentMethod` mutation fires correctly ✅
- Status mapping `VERIFIED → CHARGED` correct ✅
- Error path `93108 → FAILURE` correct ✅
- Error path `ProcessorDeclined → FAILURE` correct ✅
- Integration test file is broken and must be fixed before merge ❌