### PR TITLE
chore(grace): dual-path tech spec generation + self-healing recovery

### DIFF
--- a/grace/rulesbook/codegen/.gracerules
+++ b/grace/rulesbook/codegen/.gracerules
@@ -70,6 +70,19 @@ This workflow is designed for NEW CONNECTOR INTEGRATIONS ONLY where:
 
 ## MANDATORY EXECUTION SEQUENCE
 
+### PHASE 1.0: TECH SPEC DISCOVERY & RECOVERY (MANDATORY)
+
+The tech spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md` is a hard dependency for every downstream subagent (Foundation Setup, Flow Implementation, Quality Guardian). If the file is missing at this point, recover via the Links → Tech Spec dependency chain — do NOT stop straight to GATE FAILURE.
+
+Procedure:
+
+1. **Check** for the spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md`. If present, proceed to PHASE 1 below.
+2. **If missing — recover**:
+   - **(Re-)spawn the Links Agent** via the Task tool with workflow file `grace/workflow/2.1_links.md`. Skip this step if `data/integration-source-links.json` already has a non-empty array under `"{Connector_Name}"` or `"{connector_name}"`.
+   - **(Re-)spawn the Tech Spec Agent** via the Task tool with workflow file `grace/workflow/2.2_techspec.md`. The Tech Spec Agent picks Path A (`grace techspec` CLI when `grace/.env` is configured) or Path B (Claude-native, following `.skills/generate-tech-spec/references/techspec-generation-native.md`) based on its internal environment check.
+   - **Re-check** the canonical path.
+3. **Hard stop** (fail GATE 1) only if the spec is still missing after recovery. Capture the failure reason from whichever recovery subagent returned FAILED so the GATE failure report names the root cause.
+
 ### PHASE 1: TECH SPEC VALIDATION
 1. **MANDATORY**: Read tech spec from grace/rulesbook/codegen/references/{connector_name}/technical_specification.md
 2. **MANDATORY**: Validate tech spec completeness and UCS compatibility
@@ -1224,11 +1237,11 @@ Before finalizing any request/response struct, verify:
 ## VALIDATION GATES (MANDATORY CHECKPOINTS)
 
 ### GATE 1: TECH SPEC VALIDATION
-- ✅ Tech spec file exists in grace/rulesbook/codegen/references/{connector_name}/technical_specification.md
+- ✅ Tech spec file exists in grace/rulesbook/codegen/references/{connector_name}/technical_specification.md *(after PHASE 1.0 Discovery & Recovery has run)*
 - ✅ Tech spec contains connector name and base URL
 - ✅ Tech spec lists supported payment methods
 - ✅ Tech spec defines required flows
-- **GATE FAILURE**: Cannot proceed without valid tech spec
+- **GATE FAILURE**: Cannot proceed without valid tech spec. GATE fails only if PHASE 1.0 recovery (Links Agent → Tech Spec Agent) also failed to produce the spec. Include the failing subagent's reason in the gate-failure report.
 
 ### GATE 2: FOUNDATION COMPLETION
 - ✅ add_connector.sh executed successfully

--- a/grace/rulesbook/codegen/.gracerules_add_flow
+++ b/grace/rulesbook/codegen/.gracerules_add_flow
@@ -88,6 +88,19 @@ This workflow adds specific flows to an existing connector implementation.
 **IF CONNECTOR EXISTS:**
 - Skip Phase 0 and proceed directly to Phase 1
 
+### PHASE 1.0: TECH SPEC DISCOVERY & RECOVERY (MANDATORY)
+
+The tech spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md` is a hard dependency for every downstream subagent (Prerequisite Validation, Flow Implementation). If the file is missing at this point, recover via the Links → Tech Spec dependency chain — do NOT hard-stop on the PHASE 2 availability check.
+
+Procedure:
+
+1. **Check** for the spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md`. If present, proceed to PHASE 1 below.
+2. **If missing — recover**:
+   - **(Re-)spawn the Links Agent** via the Task tool with workflow file `grace/workflow/2.1_links.md`. Skip this step if `data/integration-source-links.json` already has a non-empty array under `"{Connector_Name}"` or `"{connector_name}"`.
+   - **(Re-)spawn the Tech Spec Agent** via the Task tool with workflow file `grace/workflow/2.2_techspec.md`. The Tech Spec Agent picks Path A (`grace techspec` CLI when `grace/.env` is configured) or Path B (Claude-native, following `.skills/generate-tech-spec/references/techspec-generation-native.md`) based on its internal environment check.
+   - **Re-check** the canonical path.
+3. **Hard stop** only if the spec is still missing after recovery. Capture the failure reason from whichever recovery subagent returned FAILED so the report names the root cause.
+
 ### PHASE 1: TECH SPEC READING & CONNECTOR STATE ANALYSIS
 1. **MANDATORY**: Read tech spec from grace/rulesbook/codegen/references/{connector_name}/technical_specification.md
 2. **MANDATORY**: Extract flow-specific requirements from tech spec
@@ -99,7 +112,7 @@ This workflow adds specific flows to an existing connector implementation.
 ### PHASE 2: PREREQUISITE VALIDATION
 1. **MANDATORY**: Verify connector foundation exists (confirm Phase 0 result)
 2. **MANDATORY**: Confirm prerequisite flows are implemented
-3. **MANDATORY**: Validate tech spec availability
+3. **MANDATORY**: Confirm tech spec is present after PHASE 1.0 Discovery & Recovery; treat missing-after-recovery as a hard error
 4. **MANDATORY**: Extract flow-specific requirements from tech spec
 
 ### PHASE 3: FLOW IMPLEMENTATION (Sequential Subagent Delegation)

--- a/grace/rulesbook/codegen/.gracerules_add_payment_method
+++ b/grace/rulesbook/codegen/.gracerules_add_payment_method
@@ -102,6 +102,19 @@ You, as the controller, must provide all necessary context including the pattern
 **IF CONNECTOR EXISTS:**
 - Skip Phase 0 and proceed directly to Phase 1
 
+### PHASE 1.0: TECH SPEC DISCOVERY & RECOVERY (MANDATORY)
+
+The tech spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md` is a hard dependency for every downstream subagent (Target Flow Identification, Payment Method Implementation). If the file is missing at this point, recover via the Links → Tech Spec dependency chain — do NOT hard-stop before attempting recovery.
+
+Procedure:
+
+1. **Check** for the spec at `grace/rulesbook/codegen/references/{connector_name}/technical_specification.md`. If present, proceed to PHASE 1 below.
+2. **If missing — recover**:
+   - **(Re-)spawn the Links Agent** via the Task tool with workflow file `grace/workflow/2.1_links.md`. Skip this step if `data/integration-source-links.json` already has a non-empty array under `"{Connector_Name}"` or `"{connector_name}"`.
+   - **(Re-)spawn the Tech Spec Agent** via the Task tool with workflow file `grace/workflow/2.2_techspec.md`. The Tech Spec Agent picks Path A (`grace techspec` CLI when `grace/.env` is configured) or Path B (Claude-native, following `.skills/generate-tech-spec/references/techspec-generation-native.md`) based on its internal environment check.
+   - **Re-check** the canonical path.
+3. **Hard stop** only if the spec is still missing after recovery. Capture the failure reason from whichever recovery subagent returned FAILED so the report names the root cause.
+
 ### PHASE 1: TECH SPEC READING & CONNECTOR STATE ANALYSIS
 1. **MANDATORY**: Read tech spec from grace/rulesbook/codegen/references/{connector_name}/technical_specification.md
 2. **MANDATORY**: Extract payment method specific requirements from tech spec

--- a/grace/workflow/2.2_techspec.md
+++ b/grace/workflow/2.2_techspec.md
@@ -1,6 +1,11 @@
 # Tech Spec Agent
 
-You generate the tech spec for **{CONNECTOR}** using `grace techspec`. This must complete before any code work begins.
+You generate the tech spec for **{CONNECTOR}**. Two execution paths are supported:
+
+- **Path A — Grace CLI** (`grace techspec`) when `grace/.env` is configured with real API keys.
+- **Path B — Claude-Native** when `grace/.env` is missing or contains placeholder values. Path B follows the workflow at `.skills/generate-tech-spec/references/techspec-generation-native.md` and uses Claude tools (WebFetch + in-place edits) to produce the same canonical spec.
+
+The environment check in Phase 1c selects the path automatically. This must complete before any code work begins.
 
 ---
 
@@ -47,7 +52,31 @@ If the file is empty (0 lines), return FAILED with reason "No URLs extracted for
 
 ---
 
-## Phase 1c: Run grace techspec
+## Phase 1c: Environment Check (select Path A or Path B)
+
+Before generating the spec, detect whether the grace CLI is configured. The check verifies that `grace/.env` exists **and** contains real (non-placeholder) values for `AI_API_KEY` and `FIRECRAWL_API_KEY`:
+
+```bash
+# From connector-service root:
+if [ -f grace/.env ] \
+   && grep -q '^AI_API_KEY=' grace/.env \
+   && ! grep -q '^AI_API_KEY=your_' grace/.env \
+   && grep -q '^FIRECRAWL_API_KEY=' grace/.env \
+   && ! grep -q '^FIRECRAWL_API_KEY=your_' grace/.env; then
+  echo "GRACE_ENV_READY"
+else
+  echo "GRACE_ENV_MISSING"
+fi
+```
+
+- `GRACE_ENV_READY` → continue to **Phase 2a: Path A — Grace CLI**.
+- `GRACE_ENV_MISSING` → continue to **Phase 2b: Path B — Claude-Native**.
+
+This single check catches a missing `.env`, an empty `.env`, or an `.env` whose values are still the `your_…` placeholders copied from `.env.example`.
+
+---
+
+## Phase 2a: Path A — Grace CLI (when GRACE_ENV_READY)
 
 ```bash
 # IMPORTANT: Switch to grace/ directory and activate virtualenv
@@ -58,17 +87,53 @@ cat ../{connector_name}.txt | grace techspec {Connector_Name} -e
 
 **Wait for the `grace techspec` command to complete before proceeding.** This can take approximately 20 minutes. Do NOT interrupt or proceed until the techspec is fully generated.
 
-**Critical**:
+**Critical:**
 
 - The working directory MUST be `grace/` when running this command.
 - The virtual environment MUST be activated first.
-- The `-e` flag is required.
+- The `-e` flag is required (enables Claude Agent SDK enhancement + field-dependency analysis).
+
+Path A writes the spec under `grace/rulesbook/codegen/references/` (legacy path: `specs/{ConnectorName}.md`).
+
+Skip Phase 2b — proceed to Phase 3 (Verify).
 
 ---
 
-## Phase 1d: Verify tech spec output
+## Phase 2b: Path B — Claude-Native (when GRACE_ENV_MISSING)
 
-After `grace techspec` finishes, verify the spec was created:
+The grace CLI is not available in this environment. Generate the spec using Claude tools instead by following the canonical Claude-native workflow at:
+
+```
+.skills/generate-tech-spec/references/techspec-generation-native.md
+```
+
+That workflow file is self-contained. Read it and execute its steps with these inputs:
+
+- `CONNECTOR` / `CONNECTOR_NAME` = `{Connector_Name}` (exact casing)
+- `FLOW` = `{FLOW}`
+- URL list: from `data/integration-source-links.json` (already extracted in Phase 1a) or from `{connector_name}.txt` (already created in Phase 1b)
+
+**Expected outputs from Path B:**
+
+- Scraped sources at `grace/rulesbook/codegen/references/{connector}/source_{N}.md` (one per URL)
+- The generated tech spec at `grace/rulesbook/codegen/references/specs/{ConnectorName}.md` (same path Path A writes to)
+- Sections 10/11/12 (`## API Call Sequences`, `## Field Dependency Analysis`, `## UNDECIDED Fields`) appended to the spec by the field-analysis step inside that workflow
+
+**Limitations vs Path A:**
+
+- Web scraping uses WebFetch, which may not render JavaScript-heavy documentation pages as well as Firecrawl.
+- Sources are processed sequentially (one URL at a time) rather than in parallel.
+- No mock-server generation (the grace CLI `-m` flag has no equivalent here).
+
+Path B is functionally equivalent for downstream consumers: the spec it produces conforms to the canonical 12-section schema in `.skills/generate-tech-spec/references/techspec-generation-native.md` and lands where consumer skills (`new-connector`, `add-connector-flow`, `add-payment-method`) look for it.
+
+Proceed to Phase 3 (Verify) once Path B completes.
+
+---
+
+## Phase 3: Verify tech spec output
+
+After either path finishes, verify the spec was created:
 
 ```bash
 # From connector-service root:
@@ -84,6 +149,7 @@ If no spec was generated, return FAILED.
 ```
 CONNECTOR: {CONNECTOR}
 FLOW: {FLOW}
+PATH_USED: A | B
 STATUS: SUCCESS | FAILED
 TECHSPEC_PATH: <path to generated tech spec, if successful>
 REASON: <details, if failed>
@@ -95,6 +161,7 @@ REASON: <details, if failed>
 
 1. **No code generation** — this agent only produces the tech spec, nothing else.
 2. **Verify before reporting success** — always confirm the file exists on disk.
-3. **Clean up on failure** — if the grace command fails, capture the error output and include it in the `REASON` field.
+3. **Clean up on failure** — if the chosen path fails, capture the error output and include it in the `REASON` field. Do NOT silently fall over from Path A to Path B mid-run; the Phase 1c check selects the path, and the chosen path either succeeds or fails.
 4. **Idempotent** — if a tech spec already exists for this connector, report SUCCESS with the existing path (do not regenerate).
 5. **URL source** — URLs come from `data/integration-source-links.json`, written by the Links Agent. Do NOT expect or require an integration details file.
+6. **Canonical schema** — regardless of path, the produced spec must match `.skills/generate-tech-spec/references/techspec-generation-native.md` (12 sections + appended Sections 10/11/12).

--- a/grace/workflow/2_connector.md
+++ b/grace/workflow/2_connector.md
@@ -9,7 +9,7 @@ You coordinate by **spawning subagents via the Task tool** for heavy work (links
 **HARD GUARDRAIL — MANDATORY SUBAGENT DELEGATION**: You MUST use the Task tool to spawn separate subagents for Phases 1, 2, 4, and 5. Do NOT read the subagent workflow files (`2.1_links.md`, `2.2_techspec.md`, `2.3_codegen.md`, `2.4_pr.md`) yourself — each subagent reads its own file. You are FORBIDDEN from doing the following yourself:
 
 - **Phase 1 (Links)**: Do NOT use WebFetch to search for documentation URLs. Do NOT browse connector websites. Do NOT write to `integration-source-links.json`. ONLY spawn the Links Agent (`2.1_links.md`) via Task tool.
-- **Phase 2 (Tech Spec)**: Do NOT read `integration-source-links.json` to extract URLs. Do NOT create URL files. Do NOT run `grace techspec`. Do NOT activate the virtualenv. ONLY spawn the Tech Spec Agent (`2.2_techspec.md`) via Task tool.
+- **Phase 2 (Tech Spec)**: Do NOT read `integration-source-links.json` to extract URLs. Do NOT create URL files. Do NOT run `grace techspec`. Do NOT activate the virtualenv. Do NOT use WebFetch to scrape connector docs. Do NOT synthesize the spec yourself or write to `grace/rulesbook/codegen/references/`. ONLY spawn the Tech Spec Agent (`2.2_techspec.md`) via Task tool — it picks Path A or Path B internally.
 - **Phase 4 (Codegen)**: Do NOT read pattern guides or tech specs for implementation. Do NOT write connector code. Do NOT run `cargo build`. Do NOT run `grpcurl`. ONLY spawn the Code Generation Agent (`2.3_codegen.md`) via Task tool.
 - **Phase 5 (Commit & PR)**: Do NOT run `git add`, `git commit`, `git cherry-pick`, `git push`, or `gh pr create`. Do NOT stage files or create branches. ONLY spawn the PR Agent (`2.4_pr.md`) via Task tool. The PR Agent handles ALL git commit, cherry-pick, push, and PR creation work.
 
@@ -19,7 +19,7 @@ Follow the phases below in order. Do not skip or reorder. Do not run phases in p
 
 **Credentials**: Available in `creds.json` at the repo root. If credentials fail during testing (HTTP 401/403), report FAILED — do NOT ask the user.
 
-**Note**: Connector names in `{CONNECTORS_FILE}` use the exact casing provided (e.g., `Adyen`, `Paypal`). Use this casing (`{Connector_Name}`) when running `grace techspec`. Use lowercase (`{connector}`) for file names, branch names, and directory paths.
+**Note**: Connector names in `{CONNECTORS_FILE}` use the exact casing provided (e.g., `Adyen`, `Paypal`). Use this casing (`{Connector_Name}`) when invoking the Tech Spec Agent (it flows into both `grace techspec` for Path A and the Claude-native workflow for Path B). Use lowercase (`{connector}`) for file names, branch names, and directory paths.
 
 ---
 
@@ -60,9 +60,11 @@ Variables:
 
 ## Phase 2: Tech Spec Generation (SPAWN SUBAGENT)
 
-**GUARDRAIL: You MUST spawn a subagent. Do NOT extract URLs, create URL files, run `grace techspec`, or activate any virtualenv yourself. Violation = broken architecture.**
+**GUARDRAIL: You MUST spawn a subagent. Do NOT extract URLs, create URL files, run `grace techspec`, activate any virtualenv, scrape docs via WebFetch, or synthesize a spec yourself. Violation = broken architecture.**
 
-You MUST use the **Task tool** to spawn a **Tech Spec Agent**. Do NOT extract URLs, run grace techspec, or do any tech spec work yourself. Do NOT read the workflow file yourself — the subagent reads it on its own.
+You MUST use the **Task tool** to spawn a **Tech Spec Agent**. Do NOT extract URLs, run `grace techspec`, scrape docs, or do any tech spec work yourself. Do NOT read the workflow file yourself — the subagent reads it on its own.
+
+**Note**: `2.2_techspec.md` detects the grace CLI environment internally and picks one of two paths: Path A (`grace techspec`) when `grace/.env` is configured with real API keys, or Path B (Claude-native, following `.skills/generate-tech-spec/references/techspec-generation-native.md`) when it is not. Both paths produce a spec under `grace/rulesbook/codegen/references/` that this Connector Agent can read in Phase 3 — no behaviour change is required on the orchestrator side.
 
 **Spawn a Task with these parameters:**
 
@@ -93,7 +95,9 @@ git status                                  # verify on {BRANCH} branch
 
 If not on `{BRANCH}`, something is wrong — do NOT create a new branch, report FAILED.
 
-### 3b: Find the tech spec
+### 3b: Find (or create) the tech spec
+
+The tech spec is a **hard dependency** for Phase 4 (codegen) — without it, there is nothing for the Code Generation Agent to read. The normal flow already creates it in Phase 2, and the Tech Spec Agent is idempotent (re-running it is a no-op if a spec already exists). If for any reason no spec is present at this point, recover by re-running the dependency chain — do NOT skip straight to SKIPPED.
 
 **Important**: All searches must run from the repo root (where `Cargo.toml` is). Verify with `pwd` if unsure. Do NOT skip this search — actually run it.
 
@@ -103,9 +107,19 @@ Glob search the entire references directory (case-insensitive, specs may be in s
 find grace/rulesbook/codegen/references -iname "*{connector}*{flow}*" -o -iname "*{connector}*" | head -20
 ```
 
-If no results, also try with underscores/hyphens (e.g., `wells_fargo` vs `wellsfargo`). If still nothing -> report SKIPPED, go to Phase 6.
+If no results, also try with underscores/hyphens (e.g., `wells_fargo` vs `wellsfargo`).
 
 Note: Specs may be in a flat `specs/` folder (e.g., `specs/adyen_bank_debit.md`) OR in a per-connector subfolder (e.g., `Braintree/Technical_specification/bank_debit_spec.md`). The connector name may be capitalized. Search recursively.
+
+**Recovery — if the spec is still missing after the search above:**
+
+The tech spec depends on documentation URLs (produced by the Links Agent), which feed the Tech Spec Agent. Re-run that chain via the same subagent spawns used in Phases 1 and 2:
+
+1. **(Re-)spawn the Links Agent** (`2.1_links.md`) — unless `data/integration-source-links.json` already has a non-empty entry for `{Connector_Name}` (in which case skip this step and reuse the existing entry).
+2. **(Re-)spawn the Tech Spec Agent** (`2.2_techspec.md`) — it picks Path A (`grace techspec`) or Path B (Claude-native, per `.skills/generate-tech-spec/references/techspec-generation-native.md`) based on its internal environment check.
+3. **Re-run the `find` command above.**
+
+Only if the spec is still missing after this recovery → report SKIPPED, go to Phase 6 with reason `"Tech spec could not be created — Links Agent or Tech Spec Agent failed during recovery."` Capture the failure reason from whichever recovery subagent returned FAILED so it surfaces in the final report.
 
 ### 3c: Find connector source files
 
@@ -212,7 +226,7 @@ REASON: <if not SUCCESS, explain why>
 
 - **SUCCESS**: Build passed AND grpcurl Authorize passed AND code was committed AND PR was created. All must be true. No exceptions.
 - **FAILED**: Any phase failed after attempting it (build errors, test errors, service won't start, credentials rejected, PR creation failed, etc.)
-- **SKIPPED**: Connector was skipped before implementation (no tech spec found, no source files, already implemented, no credentials)
+- **SKIPPED**: Connector was skipped before implementation (no tech spec and creation recovery in Phase 3b also failed, no source files, already implemented, no credentials)
 
 ---
 
@@ -221,6 +235,6 @@ REASON: <if not SUCCESS, explain why>
 | Agent                 | File              | Purpose                                                                                               |
 | --------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
 | Links Agent           | `2.1_links.md`    | Find and verify backend API documentation links                                                       |
-| Tech Spec Agent       | `2.2_techspec.md` | Generate tech spec via grace CLI                                                                      |
+| Tech Spec Agent       | `2.2_techspec.md` | Generate tech spec via grace CLI (Path A) or Claude-native fallback (Path B); selected by env check   |
 | Code Generation Agent | `2.3_codegen.md`  | Read, analyze, implement, build, and grpcurl test                                                     |
 | PR Agent              | `2.4_pr.md`       | Commit on dev branch, cherry-pick to clean branch, scrub creds, create PR in juspay/hyperswitch-prism |


### PR DESCRIPTION
## Summary

- `grace/workflow/2.2_techspec.md` now picks between **Path A** (`grace techspec` CLI when `grace/.env` is configured) and **Path B** (Claude-native, following `.skills/generate-tech-spec/references/techspec-generation-native.md`) via the same env-check used in `.skills/generate-tech-spec/SKILL.md`. Either path produces a canonical spec; downstream verification is path-agnostic.
- `grace/workflow/2_connector.md` Phase 3b becomes **self-healing**: if the tech spec isn't found, re-spawn the Links Agent (skipping when `data/integration-source-links.json` already has the entry) and the Tech Spec Agent before reporting SKIPPED. Phase 2 guardrails extended to forbid Path B-style operations (WebFetch scraping, manual synthesis) at the Connector Agent layer.
- `.gracerules`, `.gracerules_add_flow`, `.gracerules_add_payment_method` gain a **PHASE 1.0: Tech Spec Discovery & Recovery** block that runs the same Links → Tech Spec dependency chain when the spec is missing. `.gracerules` GATE 1 softened to acknowledge recovery; `.gracerules_add_flow` PHASE 2 wording aligned.

The dependency chain *Links → Tech Spec → Codegen* is now consistent across `2_connector.md`, all three `.gracerules*` controllers, and `.skills/generate-tech-spec/`.

## Test plan

- [ ] Tech Spec Agent — `grace/.env` configured: workflow takes Path A, runs `grace techspec`, produces spec under `grace/rulesbook/codegen/references/`.
- [ ] Tech Spec Agent — `grace/.env` missing or placeholder values: workflow takes Path B, follows `.skills/generate-tech-spec/references/techspec-generation-native.md`, produces equivalent spec.
- [ ] Connector Agent — invoke against a connector with **no** pre-existing tech spec: Phase 3b detects missing spec, re-spawns Links + Tech Spec Agents, completes Phase 4 codegen normally.
- [ ] Connector Agent — invoke against a connector **with** an existing tech spec: Phase 3b finds the spec immediately, no redundant recovery.
- [ ] `.gracerules` (new connector) — invoke against a connector without a tech spec on disk: PHASE 1.0 recovers, GATE 1 passes after recovery, subagents proceed.
- [ ] `.gracerules_add_flow` / `.gracerules_add_payment_method` — same dry-run; PHASE 1.0 fires when spec missing, short-circuits when present.
- [ ] Idempotency: re-running any of the above against an already-spec'd connector skips the Links re-scrape (driven by `2.1_links.md` reuse rule + `2.2_techspec.md` Rule 4).