### PR TITLE
fix(connector): [PayPal] populate connector_response_reference_id in 3DS authorize and sync responses

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2620,12 +2620,12 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalThreeDsSyncResponse, Self>>
                 ..item.router_data.resource_common_data
             },
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.id),
+                resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(item.response.id),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
             }),
@@ -2695,7 +2695,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 ..item.router_data.resource_common_data
             },
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.id),
+                resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
                 redirection_data: Some(Box::new(paypal_threeds_link(
                     (
                         link,
@@ -2706,7 +2706,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 mandate_reference: None,
                 connector_metadata: Some(connector_meta),
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(item.response.id),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
             }),


### PR DESCRIPTION
## Summary

- PayPal's 3DS authorize flow (`PaypalThreeDsResponse`) had `connector_response_reference_id: None` even though the PayPal order ID was already available at the same call-site
- Same issue in the mid-flow 3DS sync response (`PaypalThreeDsSyncResponse`)
- This caused every PayPal 3DS/redirect payment's UCS gRPC response to have a null `merchant_transaction_id`, which the external validation service flags as **VS_42** ("No Payment ID in UCS response")

## Changes

**`crates/integrations/connector-integration/src/connectors/paypal/transformers.rs`**

| Location | Before | After |
|---|---|---|
| `PaypalThreeDsResponse → RouterDataV2<Authorize>` (~line 2698–2709) | `resource_id: ConnectorTransactionId(item.response.id)` + `connector_response_reference_id: None` | `resource_id: ConnectorTransactionId(item.response.id.clone())` + `connector_response_reference_id: Some(item.response.id)` |
| `PaypalThreeDsSyncResponse → RouterDataV2<F>` (~line 2623–2628) | same pattern | same fix |

`PaypalRedirectResponse` already had the correct fallback (`purchase_units.invoice_id.or(order_id)`) — untouched.

## Testing

- `cargo check -p connector-integration` passes clean
- No functional regression: `resource_id` (the connector transaction ID used for payment tracking) is unchanged; `connector_response_reference_id` is the echo-back reference field used for idempotency/reconciliation

## Related

Closes #1367