### PR TITLE
feat(shadow): add x-merchant-id header to outgoing shadow mode requests

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -270,6 +270,7 @@ pub struct EventProcessingParams<'a> {
     pub reference_id: &'a Option<String>,
     pub resource_id: &'a Option<String>,
     pub shadow_mode: bool,
+    pub merchant_id: &'a str,
 }
 
 #[cfg(feature = "injector-client")]
@@ -391,6 +392,10 @@ where
                     req.add_header(
                         consts::X_CONNECTOR_NAME,
                         Maskable::Masked(Secret::new(event_params.connector_name.to_string())),
+                    );
+                    req.add_header(
+                        consts::X_MERCHANT_ID,
+                        Maskable::Masked(Secret::new(event_params.merchant_id.to_string())),
                     );
                 }
                 req

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -109,6 +109,7 @@ impl DisputeService for Disputes {
                         reference_id,
                         resource_id,
                         shadow_mode,
+                        merchant_id,
                         ..
                     } = request_data.extracted_metadata;
                     let connector_data: ConnectorData<DefaultPCIHolder> =
@@ -158,6 +159,7 @@ impl DisputeService for Disputes {
                         reference_id: &reference_id,
                         resource_id: &resource_id,
                         shadow_mode,
+                        merchant_id: merchant_id.as_str(),
                     };
 
                     let response = Box::pin(
@@ -325,6 +327,7 @@ impl DisputeService for Disputes {
                         reference_id,
                         resource_id,
                         shadow_mode,
+                        merchant_id,
                         ..
                     } = request_data.extracted_metadata;
 
@@ -376,6 +379,7 @@ impl DisputeService for Disputes {
                         reference_id: &reference_id,
                         resource_id: &resource_id,
                         shadow_mode,
+                        merchant_id: merchant_id.as_str(),
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -221,6 +221,7 @@ async fn verify_webhook_source_external(
         reference_id: &metadata_payload.reference_id,
         resource_id: &metadata_payload.resource_id,
         shadow_mode: metadata_payload.shadow_mode,
+        merchant_id: metadata_payload.merchant_id.as_str(),
     };
 
     match Box::pin(

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -102,6 +102,7 @@ struct EventParams<'a> {
     reference_id: &'a Option<String>,
     resource_id: &'a Option<String>,
     shadow_mode: bool,
+    merchant_id: &'a str,
 }
 
 /// Helper function for converting CardDetails to TokenData with structured types
@@ -379,6 +380,7 @@ impl CustomerService for Customer {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let response = Box::pin(
@@ -504,6 +506,7 @@ impl Payments {
             reference_id: &metadata_payload.reference_id,
             resource_id: &metadata_payload.resource_id,
             shadow_mode: metadata_payload.shadow_mode,
+            merchant_id: metadata_payload.merchant_id.as_str(),
         };
 
         // Execute connector processing - ONLY the authorize call
@@ -864,6 +867,7 @@ impl PaymentService for Payments {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let consume_or_trigger_flow = match payload.handle_response {
@@ -1427,6 +1431,7 @@ impl PaymentService for Payments {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let response = Box::pin(
@@ -1870,6 +1875,7 @@ impl PaymentMethodService for PaymentMethod {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let response = Box::pin(
@@ -1991,6 +1997,7 @@ impl MerchantAuthentication {
             reference_id: event_params.reference_id,
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
+            merchant_id: event_params.merchant_id,
         };
 
         // Execute connector processing
@@ -2104,6 +2111,7 @@ impl MerchantAuthentication {
             reference_id: event_params.reference_id,
             resource_id: event_params.resource_id,
             shadow_mode: event_params.shadow_mode,
+            merchant_id: event_params.merchant_id,
         };
 
         let response = Box::pin(
@@ -2276,6 +2284,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let session_response = Box::pin(self.handle_session_token(
@@ -2391,6 +2400,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     // Reuse the existing handle_access_token function which now uses
@@ -2547,6 +2557,7 @@ impl RecurringPaymentService for RecurringPayments {
                         reference_id: &metadata_payload.reference_id,
                         resource_id: &metadata_payload.resource_id,
                         shadow_mode: metadata_payload.shadow_mode,
+                        merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
                     let response = Box::pin(

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -520,6 +520,7 @@ macro_rules! implement_connector_operation {
                 reference_id: &metadata_payload.reference_id,
                 resource_id: &metadata_payload.resource_id,
                 shadow_mode: metadata_payload.shadow_mode,
+                merchant_id: metadata_payload.merchant_id.as_str(),
             };
             let response_result = external_services::service::execute_connector_processing_step(
                 &config.proxy,


### PR DESCRIPTION
## Summary

- Adds `x-merchant-id` header to outgoing shadow mode requests
- Hotfix for #1310

## Changes

- `service.rs` — added `merchant_id` field to `EventProcessingParams` and sends `x-merchant-id` header in shadow mode
- `disputes.rs` — passes `merchant_id` to `EventProcessingParams`
- `events.rs` — passes `merchant_id` to `EventProcessingParams`
- `payments.rs` — passes `merchant_id` to `EventProcessingParams` across all payment flows
- `utils.rs` — passes `merchant_id` to `EventProcessingParams` in macro

## Test plan

- [ ] Verify `x-merchant-id` header is sent in shadow mode requests

<img width="1720" height="471" alt="Screenshot 2026-05-19 at 1 20 01 PM" src="https://github.com/user-attachments/assets/d00e0142-7fc5-4cac-9c98-aff58d4b7e6f" />
