### PR TITLE
chore(grace): workflow docs + pr-resolver prompts

### DIFF
--- a/grace/pr-resolver/prompts/README.md
+++ b/grace/pr-resolver/prompts/README.md
@@ -1,0 +1,31 @@
+# PR Resolver Prompts
+
+Markdown prompts consumed by `grace/grace-workspace/packages/core/src/pr-resolver/prompts.ts`. The loader anchors lookup at `cfg.projectRoot + 'grace/pr-resolver/prompts/'`. Each file has YAML frontmatter declaring `name`, `description`, and `variables`. The body is rendered with Mustache; HTML escaping is disabled in the loader so variable values pass through verbatim (cargo output, diff hunks, etc., are not mangled).
+
+## Files
+
+| File | Used when | Required variables |
+| --- | --- | --- |
+| `resolve-comment.md` | First Claude call per sub-task (all triggered comments on one connector). | `connector`, `thread_count`, `threads` |
+| `fix-loop.md` | After `cargo build` / `cargo clippy` fails. Resumes the same Claude session via `claudeSessionId` + `incremental: true`. | `connector`, `loop_iteration`, `threads`, `error_output` |
+
+## `threads` shape
+
+Each element of the `threads` array:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `number` | string | 1-based position in this sub-task. |
+| `path` | string | File path relative to repo root. |
+| `line` | string | `'?'` when the GitHub thread has no line anchor. |
+| `author` | string | GitHub login of the reviewer who left the trigger comment. |
+| `instruction` | string | Comment body with the trigger tag (`@HS-prism-bot`) stripped. |
+| `diff_hunk` | string \| undefined | Optional; the `Code context` block in the template is wrapped in a Mustache section so it's omitted when this is falsy. |
+
+## Editing prompts
+
+Prompt edits do not require a TypeScript rebuild — the loader reads from disk on every call. Keep variable names in the body in sync with the `variables:` list in the frontmatter; the loader logs a warning if a referenced variable is missing or if a declared variable is unused.
+
+## Not in this directory
+
+- Connector-codegen skills (L1–L4) live under `grace/grace-workspace/packages/core/skills/` and are loaded by the Byne pipeline, not the PR resolver. Don't mix the two.

--- a/grace/pr-resolver/prompts/fix-loop.md
+++ b/grace/pr-resolver/prompts/fix-loop.md
@@ -1,0 +1,53 @@
+---
+name: fix-loop
+description: Build-fix retry prompt. Sent after cargo build or clippy fails on the resolver's edits. Keeps the original review-comment intent visible while showing the new errors. Used with `claudeSessionId` + `incremental: true` so Claude resumes the same conversation as the first attempt.
+variables:
+  - connector
+  - loop_iteration
+  - threads
+  - error_output
+---
+
+You were resolving review comments on connector `{{connector}}`, but the build/clippy check failed.
+
+This is fix attempt {{loop_iteration}}. Please fix the errors below while STILL addressing the original review comments.
+
+## Original Review Comments
+
+{{#threads}}
+### Comment {{number}} — `{{path}}:{{line}}`
+
+{{#is_outdated}}
+> ⚠️ Thread is marked outdated — line anchor may have shifted; locate by context inside `{{path}}`.
+
+{{/is_outdated}}
+{{#has_original}}
+**Original review comment** by @{{original_author}}:
+> {{original_comment}}
+
+{{/has_original}}
+**Trigger** by @{{author}}: {{instruction}}
+
+{{#diff_hunk}}
+**Code context:**
+```diff
+{{diff_hunk}}
+```
+{{/diff_hunk}}
+
+{{/threads}}
+
+## Build/Clippy Errors
+
+```
+{{error_output}}
+```
+
+## Instructions
+
+1. Read the error messages carefully — they tell you exactly what's wrong.
+2. Fix the errors while preserving the intent of the **original review comments** (not the trigger replies).
+3. If a fix is incompatible with building, revert that specific fix and leave the code as it was.
+4. ONLY modify files under `connectors/{{connector}}/` or `connectors/{{connector}}.rs`.
+5. Do NOT run cargo build yourself — the service will verify externally.
+6. Use RELATIVE paths for all Read/Edit operations — never use absolute paths starting with /Users/.

--- a/grace/pr-resolver/prompts/grpc-test-plan.md
+++ b/grace/pr-resolver/prompts/grpc-test-plan.md
@@ -1,0 +1,114 @@
+---
+name: grpc-test-plan
+description: Generate a structured grpcurl test plan that exercises a PR's connector changes against the local gRPC server. Reads PR description / diff / connector creds and emits a single JSON object with named, dependency-ordered test steps. Replaces the older bash-block-of-grpcurls flow — the runner now substitutes values from prior step responses, so chained sequences (Authorize → Capture → Reverse) actually work.
+variables:
+  - connector
+  - pr_title
+  - pr_body
+  - pr_comments
+  - diff
+  - grpc_port
+  - creds_block
+  - service_hint
+---
+
+You are building a **gRPC test plan** that exercises the changes in this PR against a local server at `localhost:{{grpc_port}}`. The harness will run each step via `grpcurl`, capture responses, and chain values between steps. Output is a single JSON object — no prose, no bash, no markdown around the JSON.
+
+## Connector
+
+`{{connector}}`
+
+## PR
+
+**Title:** {{pr_title}}
+
+**Body:**
+
+{{pr_body}}
+
+**Conversation comments** (chronological, includes ad-hoc test snippets reviewers may have dropped here):
+
+{{pr_comments}}
+
+## Cumulative diff (truncated)
+
+```diff
+{{diff}}
+```
+
+## Credentials for this connector
+
+These come from `creds.json`. Use the **actual values** verbatim in headers / payloads — never `<api_key>` or `REDACTED`.
+
+```json
+{{creds_block}}
+```
+
+## Service surface hint
+
+{{service_hint}}
+
+## Output schema
+
+Reply with exactly one JSON object, no surrounding text. The runner will `JSON.parse` it directly.
+
+```json
+{
+  "tests": [
+    {
+      "name": "string (unique within the plan, snake_case, e.g. 'authorize_card_manual_capture')",
+      "method": "string (full gRPC method, e.g. 'types.PaymentService/Authorize')",
+      "depends_on": "string (optional — name of an earlier step this one needs)",
+      "headers": {
+        "x-connector": "{{connector}}",
+        "x-auth": "header-key | body-key | signature-key (match the creds.auth_type)",
+        "x-api-key": "<real value from creds_block>"
+      },
+      "body": {
+        "...": "...",
+        "connector_transaction_id": "{{ prior_step_name.connector_transaction_id }}"
+      },
+      "captures": {
+        "connector_transaction_id": "$.connectorTransactionId",
+        "status": "$.status"
+      },
+      "expect": {
+        "exit_code": 0,
+        "status_in": ["AUTHORIZED", "PENDING"]
+      }
+    }
+  ]
+}
+```
+
+### Field semantics
+
+- **`name`** — unique snake_case label. Used by `depends_on` and `{{ … }}` templating.
+- **`method`** — the full proto method. The runner sends `grpcurl ... localhost:{{grpc_port}} <method>`.
+- **`depends_on`** — when set, this step is skipped if the parent failed or was skipped.
+- **`headers`** — sent as `-H "k: v"`. Fill in real credentials from the `creds_block` above.
+- **`body`** — JSON object; the runner stringifies and sends via `-d`. You can interpolate prior captures with Mustache: `{{ step_name.capture_key }}`. The runner resolves these before execution.
+- **`captures`** — JSONPath subset (`$.field.nested`) extracted from the grpcurl stdout (the gRPC response, JSON-decoded). Captures are scoped under the step's `name`.
+- **`expect`** — optional rules the runner enforces:
+  - `exit_code: 0` — grpcurl must exit 0 (default if omitted).
+  - `status_in: ["X", "Y"]` — match against the response's status. The runner reads `captures.status` first, then falls back to `$.status`, `$.response.status`, `$.payments_response.status` on the parsed response — so even if your capture path is wrong, the check still has a chance to pass. Hyperswitch-prism's responses use camelCase fields at the root (e.g. `status`, `connectorTransactionId`, `merchantTransactionId`); only use a `response.*` prefix if the connector you're targeting actually wraps its payload.
+  - `response_contains: "text"` — substring match in stdout.
+
+### Sequences
+
+Many connector flows require setup. Typical patterns:
+
+- **Authorize → Capture → Reverse** (manual capture flow): Authorize captures `connector_transaction_id`; Capture uses it via `{{ authorize.connector_transaction_id }}` and may itself capture a `capture_id`; Reverse uses whichever id the connector expects.
+- **Authorize → PSync**: PSync verifies the authorization status.
+- **Authorize → Refund → RSync**: same shape with refunds.
+
+Use `depends_on` and captures rather than guessing values — placeholder strings like `"<connector_transaction_id_from_authorize>"` will be sent literally and the call will fail.
+
+## Rules
+
+1. **Reply with one JSON object.** No prose, no triple-backtick wrapper, no "Here is the plan" header. The very first character must be `{`, the very last `}`.
+2. **Use real credential values** from the `creds_block`. Never invent or leave placeholders.
+3. **Cover the modified flow** specifically — read the diff above to decide which methods the PR touches, and design a plan that exercises that surface.
+4. **Sequence appropriately**: if the modified flow needs setup (e.g. you can't Reverse without Authorize + Capture first), include the setup steps and chain via `depends_on` + captures.
+5. **Keep it tight** — 1 to 6 steps. The runner caps at 10 and rejects more.
+6. **Don't include cleanup** unless it's part of the test surface (defer teardown to a future iteration).

--- a/grace/pr-resolver/prompts/resolve-comment.md
+++ b/grace/pr-resolver/prompts/resolve-comment.md
@@ -1,0 +1,104 @@
+---
+name: resolve-comment
+description: Orchestrator prompt for resolving PR review comments on one connector. Each thread carries both the **root review comment** (the actionable feedback) and the **trigger comment** (the human pinging the bot). The agent delegates each comment to a subagent via the Agent tool, processes them serially within the connector scope, then summarises. Optionally accepts reviewer revision feedback from a prior approval cycle that the agent should treat as the overriding instruction.
+variables:
+  - connector
+  - thread_count
+  - threads
+  - revision_feedback
+---
+
+You are an orchestrator resolving {{thread_count}} PR review comment(s) on connector `{{connector}}`.
+
+{{#revision_feedback}}
+## Reviewer revision feedback (HIGHEST PRIORITY)
+
+A previous attempt produced a diff that the reviewer asked you to change. Treat the feedback below as the **overriding instruction** — it supersedes any earlier interpretation of the original comments where they conflict.
+
+> {{revision_feedback}}
+
+Re-do the resolution with this feedback in mind. If the previous attempt only got part of the work right, keep what was correct and refine the rest accordingly.
+
+{{/revision_feedback}}
+
+## Important — read the WHOLE thread
+
+For each item below, the **`Original review comment`** is what the reviewer actually wants changed. The **`Trigger`** is just the human pinging the bot ("can we resolve this", "@10X-GRACE please fix", etc.) and rarely contains the actionable instruction itself. Treat the trigger as a *cue*, not as the request. If the trigger looks like a question but the original comment is actionable, **act on the original comment**.
+
+## Review Comments to Fix
+
+{{#threads}}
+### Comment {{number}} — `{{path}}:{{line}}`
+
+{{#is_outdated}}
+> ⚠️ **GitHub marks this thread outdated** — the original line anchor may have shifted since the comment was posted (someone pushed commits that moved the surrounding code). The `line` above is no longer reliable. Locate the relevant code by the diff hunk + surrounding context inside `{{path}}` rather than trusting the line number.
+
+{{/is_outdated}}
+{{#has_original}}
+**Original review comment** by @{{original_author}}:
+> {{original_comment}}
+
+{{/has_original}}
+**Trigger** by @{{author}}: {{instruction}}
+
+{{#diff_hunk}}
+**Code context:**
+```diff
+{{diff_hunk}}
+```
+{{/diff_hunk}}
+
+**Full thread transcript:**
+```
+{{thread_transcript}}
+```
+
+{{/threads}}
+
+## How to Resolve
+
+You MUST use the **Agent tool** to spawn a separate subagent for EACH comment above. Do NOT make edits yourself directly — delegate each comment to a subagent.
+
+For each comment, spawn an Agent like this:
+
+```
+Agent(
+  subagent_type="general-purpose",
+  description="Fix comment N on {{connector}}",
+  prompt="Fix this review comment on `<file>:<line>`:
+
+  Reviewer's original comment: <original_comment>
+
+  Code context:
+  ```
+  <diff_hunk>
+  ```
+
+  Rules:
+  - Read the file `<file>` to understand context
+  - Make the MINIMAL edit to address the ORIGINAL review comment (not the trigger reply)
+  - ONLY modify files under connectors/{{connector}}/
+  - Use RELATIVE paths (never /Users/...)
+  - Do NOT run cargo build
+  - After editing, output a 1-2 sentence summary of what you changed and why"
+)
+```
+
+Process comments ONE AT A TIME — wait for each subagent to finish before starting the next, because they may edit the same file.
+
+If a comment genuinely has no actionable change (e.g. the reviewer is just asking a question with no implied edit), the subagent should output a short note explaining why no code change was needed. **Do not make speculative edits.** The user will see your summary and decide whether to approve.
+
+After ALL subagents finish, output a final summary listing what was changed for each comment:
+
+```
+## Summary
+- Comment 1 (line X): Changed Y to Z because...
+- Comment 2 (line X): No code change — comment was a clarifying question; <one-sentence answer>
+```
+
+## Rules
+
+- ONLY modify files under `connectors/{{connector}}/` or `connectors/{{connector}}.rs`
+- Use RELATIVE paths for everything
+- Do NOT run cargo build — the service verifies externally
+- Do NOT post replies on GitHub yourself — the harness handles GitHub I/O after the human approves

--- a/grace/pr-resolver/prompts/review-summary.md
+++ b/grace/pr-resolver/prompts/review-summary.md
@@ -1,0 +1,58 @@
+---
+name: review-summary
+description: After cargo + grpc pass, ask Claude to write a reviewer-facing summary of what changed and why. Runs as a fresh session with the final diff + review comments, so the reviewer can approve or reject in ~30 seconds without re-reading the whole diff.
+variables:
+  - connector
+  - pr_number
+  - threads
+  - diff
+---
+
+A reviewer needs to approve or reject a set of code changes you (a separate Claude session) just produced on connector `{{connector}}` (PR #{{pr_number}}).
+
+Your job is to write a **short, plain-language summary** so the reviewer can decide quickly. The reviewer will read your summary first, then spot-check the diff below.
+
+## Review comments that drove these changes
+
+{{#threads}}
+**Comment {{number}} — `{{path}}:{{line}}`** by @{{author}}:
+> {{instruction}}
+{{#has_original}}
+> (original by @{{original_author}}: {{original_comment}})
+{{/has_original}}
+
+{{/threads}}
+
+## Final diff
+
+```diff
+{{diff}}
+```
+
+## What to write
+
+Output a markdown document with these exact sections. No preamble, no closing remarks. Keep the whole thing under 300 words.
+
+## TL;DR
+One or two sentences. What did the reviewer ask for, and what did you do? Be concrete.
+
+## What changed
+- Bullet per logical change, not per file. Name the enum variant, struct field, trait impl, or function — concrete Rust identifiers, not paraphrases.
+- If you changed an error path to a success path (or vice versa), say so explicitly.
+
+## Why
+- Plain English. What constraint or convention drove the choice?
+- If you consulted other files in the repo, similar connectors, or trait definitions, cite the path so the reviewer can spot-check.
+
+## Files touched
+- `path/to/file.rs` (Lx–Ly) — one-line role of the change
+
+## Risks
+- Anything the reviewer should look at twice. "None obvious" is fine if true.
+
+## Hard rules
+- Do NOT include `## Summary`, "The change is in place and correct," or any other preamble.
+- Do NOT restate the review comment verbatim — paraphrase what they wanted in one phrase.
+- Do NOT include code blocks for the changes themselves; the diff is already shown above.
+- Identifiers go in backticks; file paths go in backticks.
+- Under 300 words total.

--- a/grace/workflow/1_orchestrator.md
+++ b/grace/workflow/1_orchestrator.md
@@ -9,14 +9,23 @@ You do not invoke link agent or techspec agent or codegen agent you only invoke 
 
 ## Inputs
 
-| Parameter           | Description                                   | Example                                  |
-| ------------------- | --------------------------------------------- | ---------------------------------------- |
-| `{FLOW}`            | The payment flow to implement                 | `BankDebit`, `MIT`, `Wallet`, `PayLater` |
-| `{CONNECTORS_FILE}` | JSON file with connector names (simple array) | `connectors.json`                        |
-| `{BRANCH}`          | Git branch name for all work                  | `feat/mit`                               |
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `{FLOW}` | The payment flow to implement | `Authorize`, `Capture`, `Refund`, `Void`, `PSync`, `RSync`, `SetupMandate`, `MIT`, `3DS` |
+| `{PAYMENT_METHOD}` | (Optional) Payment method to add to existing flow | `BankDebit`, `Wallet`, `PayLater`, `Card` |
+| `{CONNECTORS_FILE}` | JSON file with connector names (simple array) | `connectors.json` |
+| `{BRANCH}` | Git branch name for all work | `feat/mit` |
+
+**Flow vs Payment Method:**
+- **Flows** are operations: `Authorize`, `Capture`, `Refund`, `Void`, `PSync`, `RSync`, `SetupMandate`
+- **Payment Methods** are instruments: `BankDebit`, `Wallet`, `PayLater`, `Card`
+
+If `{PAYMENT_METHOD}` is provided:
+- `{FLOW}` must be an existing flow (typically `Authorize`)
+- The implementation will extend the existing flow to support the new payment method
+- Do NOT create new `{Connector}{PaymentMethod}Request` structs; extend `PaymentInformation` enum instead
 
 `{CONNECTORS_FILE}` is a **simple JSON array of connector names**, e.g.:
-
 ```json
 ["Adyen", "Stripe", "Checkout", "Braintree"]
 ```
@@ -117,7 +126,6 @@ Variables:
 **WAIT** for the Task to return a result. Do NOT proceed to the next connector until you have received the result. The next connector's Task call goes in a SEPARATE, SUBSEQUENT message.
 
 Collect the result — the Connector Agent will return one of:
-
 - `SUCCESS` — connector implemented, built, tested, and committed
 - `FAILED` — connector could not be completed (with reason)
 - `SKIPPED` — connector was skipped (with reason)
@@ -145,139 +153,8 @@ Per-connector results:
 
 ---
 
-## MODE B: Hardening (Test Suite Validation)
-
-**Use this mode when**: "Harden all PMs and APIs in testing-lib by adding to GRACE flow and remove grpc once done"
-
-**Your job**: Run integration tests via test-prism to move connectors from "Integrated" (blue) → "Hardened/Tested" (green) status.
-
----
-
-### Inputs
-
-| Parameter     | Description               | Example                     |
-| ------------- | ------------------------- | --------------------------- |
-| `{TEST_MODE}` | Test runner mode          | `grpc` (default), `sdk`     |
-| `{BRANCH}`    | Git branch for test fixes | `hardening/connector-tests` |
-
----
-
-### RULES
-
-1. **Working directory**: `connector_service_ucs` repo root (where `crates/internal/integration-tests/` exists)
-2. **STRICTLY SEQUENTIAL**: Process ONE connector at a time. Never parallelize. Do not go by flows.
-3. **Run tests FIRST**: Always run tests to identify failures. Only create fix branches when tests fail.
-4. **Fix ONLY tests**: If test fails due to test bug → create fix branch, fix test. If fails due to real connector bug → report FAILED (don't fix connector code).
-5. **Fully autonomous**: Never ask questions. Make decisions and proceed.
-6. **Your subagent**: The **Test Suite Agent** (`3_test.md`). You can deploy multiple subagents within the "Test Suite Agent" subagent based on the requirement.
-7. **Do not assume suite chaining**: In hardening mode, suites such as `CreateOrder`, `Authorize`, and session-token flows may be standalone test entrypoints. Determine expected behavior from the actual suite request and latest report output, not from an assumed runtime chain.
-
----
-
-### STEP 0: DISCOVER CONNECTORS
-
-Find all connectors in the test suite:
-
-```bash
-ls crates/internal/integration-tests/src/connector_specs/
-```
-
-**Identify targets**: Connectors with "Integrated" (blue badge) but WITHOUT "Tested" (green badge) in `docs-generated/connectors/README.md`.
-
-Store as `CONNECTOR_LIST`.
-
----
-
-### STEP 1: PRE-FLIGHT (Setup Check + Verification)
-
-**Check if setup already done:**
-
-```bash
-test-prism --help && echo "SKIP_SETUP" || make setup-connector-tests
-```
-
-- If `SKIP_SETUP` echoed → Setup already done, skip
-- Otherwise → Run full setup (one-time)
-
-**THEN: Verify environment:**
-
-```bash
-pwd && ls crates/internal/integration-tests/README.md
-# Build test-prism if not available
-cargo build -p integration-tests
-# Check credentials exist
-cat creds.json | head -20
-# Clear stale listeners that can break grpc-server startup
-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
-lsof -ti:8080 | xargs kill -9 2>/dev/null || true
-```
-
-**Important startup note:** a stale listener on `8080` (metrics) can make `test-prism` look like it is failing readiness on `8000`. If startup fails, inspect and clear both ports before concluding the connector run is blocked.
-
-**Credentials Check (REQUIRED per connector):**
-
-- Before running tests for each connector, verify creds exist
-- If no creds → SKIP connector
-
-**Timeout:**
-
-- Set `UCS_TEST_TIMEOUT=600` (10 minutes per connector)
-- Tests typically take 5-10 minutes
-
-**View test results:**
-
-- Web: https://hyperswitch-prism-testing.netlify.app/
-- Latest JSON: https://integ.hyperswitch.io/connector-service/reports/grpc/report_latest.json
-
-**Debugging Test Failures:** See `grace/workflow/3_test.md` for detailed investigation procedures, common failure patterns, and debugging commands.
-
----
-
-### STEP 2: PROCESS EACH CONNECTOR
-
-For each connector in `CONNECTOR_LIST`, spawn ONE Test Suite Agent:
-
-```
-delegate_task(
-  subagent_type="general",
-  load_skills=[],
-  run_in_background=false,
-  description="Run test suite for {CONNECTOR}",
-  prompt="Read and follow the workflow defined in grace/workflow/3_test.md
-
-Variables:
-  CONNECTOR: <connector name>
-  TEST_MODE: grpc (or sdk)
-  BRANCH: <fix branch name>
-  TIMEOUT: 600 (10 minutes)"
-)
-```
-
----
-
-### STEP 3: AGGREGATE RESULTS
-
-Report summary:
-
-```
-=== HARDENING SUMMARY ===
-Total connectors: N
-Successfully hardened: N
-Failed: N
-Skipped: N
-
-Hardened connectors (can move to "Tested" status):
-- <list>
-
-Failed connectors (need manual review):
-- <list>
-```
-
----
-
 ## Subagent Reference
 
-| Agent            | File             | Purpose                                                              |
-| ---------------- | ---------------- | -------------------------------------------------------------------- |
-| Connector Agent  | `2_connector.md` | Implements payment flows for one connector                           |
-| Test Suite Agent | `3_test.md`      | Runs integration tests, fixes test bugs, validates for one connector |
+| Agent | File | Purpose |
+|-------|------|---------|
+| Connector Agent | `2_connector.md` | Handles everything for one connector: links, tech spec, code, build, test, commit, and PR |

--- a/grace/workflow/2.2_techspec.md
+++ b/grace/workflow/2.2_techspec.md
@@ -1,22 +1,30 @@
 # Tech Spec Agent
 
-You generate the tech spec for **{CONNECTOR}**. Two execution paths are supported:
-
-- **Path A — Grace CLI** (`grace techspec`) when `grace/.env` is configured with real API keys.
-- **Path B — Claude-Native** when `grace/.env` is missing or contains placeholder values. Path B follows the workflow at `.skills/generate-tech-spec/references/techspec-generation-native.md` and uses Claude tools (WebFetch + in-place edits) to produce the same canonical spec.
-
-The environment check in Phase 1c selects the path automatically. This must complete before any code work begins.
+You generate the tech spec for **{CONNECTOR}** using `grace techspec`. This must complete before any code work begins.
 
 ---
 
 ## Inputs
 
-| Parameter                          | Description                                       | Example                      |
-| ---------------------------------- | ------------------------------------------------- | ---------------------------- |
-| `{CONNECTOR}` / `{Connector_Name}` | Connector name (exact casing from connector list) | `Adyen`                      |
-| `{FLOW}`                           | Payment flow being implemented                    | `BankDebit`, `MIT`, `Wallet` |
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `{CONNECTOR}` / `{Connector_Name}` | Connector name (exact casing from connector list) | `Adyen` |
+| `{FLOW}` | Payment flow being implemented | `Authorize`, `Capture`, `Refund`, `MIT`, `3DS` |
+| `{PAYMENT_METHOD}` | (Optional) Payment method to add to existing flow | `BankDebit`, `Wallet`, `PayLater` |
 
 Use `{Connector_Name}` (exact casing) for `grace techspec` commands. Use `{connector}` (lowercase) for file names.
+
+### Examples
+
+**New Flow Implementation:**
+- FLOW=MIT
+- PAYMENT_METHOD=(not set)
+- Result: Creates new flow-specific request/response structs
+
+**Payment Method Addition:**
+- FLOW=Authorize
+- PAYMENT_METHOD=BankDebit
+- Result: Extends existing `PaymentInformation` enum to support BankDebit within Authorize flow
 
 ---
 
@@ -43,7 +51,6 @@ cat data/integration-source-links.json | jq -r '."{Connector_Name}" // ."{connec
 ```
 
 Verify the file is non-empty:
-
 ```bash
 wc -l {connector_name}.txt
 ```
@@ -52,31 +59,7 @@ If the file is empty (0 lines), return FAILED with reason "No URLs extracted for
 
 ---
 
-## Phase 1c: Environment Check (select Path A or Path B)
-
-Before generating the spec, detect whether the grace CLI is configured. The check verifies that `grace/.env` exists **and** contains real (non-placeholder) values for `AI_API_KEY` and `FIRECRAWL_API_KEY`:
-
-```bash
-# From connector-service root:
-if [ -f grace/.env ] \
-   && grep -q '^AI_API_KEY=' grace/.env \
-   && ! grep -q '^AI_API_KEY=your_' grace/.env \
-   && grep -q '^FIRECRAWL_API_KEY=' grace/.env \
-   && ! grep -q '^FIRECRAWL_API_KEY=your_' grace/.env; then
-  echo "GRACE_ENV_READY"
-else
-  echo "GRACE_ENV_MISSING"
-fi
-```
-
-- `GRACE_ENV_READY` → continue to **Phase 2a: Path A — Grace CLI**.
-- `GRACE_ENV_MISSING` → continue to **Phase 2b: Path B — Claude-Native**.
-
-This single check catches a missing `.env`, an empty `.env`, or an `.env` whose values are still the `your_…` placeholders copied from `.env.example`.
-
----
-
-## Phase 2a: Path A — Grace CLI (when GRACE_ENV_READY)
+## Phase 1c: Run grace techspec
 
 ```bash
 # IMPORTANT: Switch to grace/ directory and activate virtualenv
@@ -87,53 +70,16 @@ cat ../{connector_name}.txt | grace techspec {Connector_Name} -e
 
 **Wait for the `grace techspec` command to complete before proceeding.** This can take approximately 20 minutes. Do NOT interrupt or proceed until the techspec is fully generated.
 
-**Critical:**
-
+**Critical**:
 - The working directory MUST be `grace/` when running this command.
 - The virtual environment MUST be activated first.
-- The `-e` flag is required (enables Claude Agent SDK enhancement + field-dependency analysis).
-
-Path A writes the spec under `grace/rulesbook/codegen/references/` (legacy path: `specs/{ConnectorName}.md`).
-
-Skip Phase 2b — proceed to Phase 3 (Verify).
+- The `-e` flag is required.
 
 ---
 
-## Phase 2b: Path B — Claude-Native (when GRACE_ENV_MISSING)
+## Phase 1d: Verify tech spec output
 
-The grace CLI is not available in this environment. Generate the spec using Claude tools instead by following the canonical Claude-native workflow at:
-
-```
-.skills/generate-tech-spec/references/techspec-generation-native.md
-```
-
-That workflow file is self-contained. Read it and execute its steps with these inputs:
-
-- `CONNECTOR` / `CONNECTOR_NAME` = `{Connector_Name}` (exact casing)
-- `FLOW` = `{FLOW}`
-- URL list: from `data/integration-source-links.json` (already extracted in Phase 1a) or from `{connector_name}.txt` (already created in Phase 1b)
-
-**Expected outputs from Path B:**
-
-- Scraped sources at `grace/rulesbook/codegen/references/{connector}/source_{N}.md` (one per URL)
-- The generated tech spec at `grace/rulesbook/codegen/references/specs/{ConnectorName}.md` (same path Path A writes to)
-- Sections 10/11/12 (`## API Call Sequences`, `## Field Dependency Analysis`, `## UNDECIDED Fields`) appended to the spec by the field-analysis step inside that workflow
-
-**Limitations vs Path A:**
-
-- Web scraping uses WebFetch, which may not render JavaScript-heavy documentation pages as well as Firecrawl.
-- Sources are processed sequentially (one URL at a time) rather than in parallel.
-- No mock-server generation (the grace CLI `-m` flag has no equivalent here).
-
-Path B is functionally equivalent for downstream consumers: the spec it produces conforms to the canonical 12-section schema in `.skills/generate-tech-spec/references/techspec-generation-native.md` and lands where consumer skills (`new-connector`, `add-connector-flow`, `add-payment-method`) look for it.
-
-Proceed to Phase 3 (Verify) once Path B completes.
-
----
-
-## Phase 3: Verify tech spec output
-
-After either path finishes, verify the spec was created:
+After `grace techspec` finishes, verify the spec was created:
 
 ```bash
 # From connector-service root:
@@ -149,7 +95,6 @@ If no spec was generated, return FAILED.
 ```
 CONNECTOR: {CONNECTOR}
 FLOW: {FLOW}
-PATH_USED: A | B
 STATUS: SUCCESS | FAILED
 TECHSPEC_PATH: <path to generated tech spec, if successful>
 REASON: <details, if failed>
@@ -161,7 +106,6 @@ REASON: <details, if failed>
 
 1. **No code generation** — this agent only produces the tech spec, nothing else.
 2. **Verify before reporting success** — always confirm the file exists on disk.
-3. **Clean up on failure** — if the chosen path fails, capture the error output and include it in the `REASON` field. Do NOT silently fall over from Path A to Path B mid-run; the Phase 1c check selects the path, and the chosen path either succeeds or fails.
+3. **Clean up on failure** — if the grace command fails, capture the error output and include it in the `REASON` field.
 4. **Idempotent** — if a tech spec already exists for this connector, report SUCCESS with the existing path (do not regenerate).
 5. **URL source** — URLs come from `data/integration-source-links.json`, written by the Links Agent. Do NOT expect or require an integration details file.
-6. **Canonical schema** — regardless of path, the produced spec must match `.skills/generate-tech-spec/references/techspec-generation-native.md` (12 sections + appended Sections 10/11/12).

--- a/grace/workflow/2.3_codegen.md
+++ b/grace/workflow/2.3_codegen.md
@@ -28,6 +28,50 @@ Read ALL of these before writing any code:
 
 ---
 
+## Phase 4a: Determine Implementation Type
+
+Before implementing, determine if this is a **new flow** or a **payment method addition**:
+
+### Checklist
+
+1. **Does `{FLOW}` exist in `create_all_prerequisites!` macro?**
+   - Check `{connector}.rs` for `flow: {FLOW}`
+   - If YES → FLOW already exists
+   - If NO → New flow needed
+
+2. **Is `{PAYMENT_METHOD}` provided?**
+   - If YES and FLOW exists → **Payment Method Addition**
+   - If NO and FLOW doesn't exist → **New Flow**
+
+3. **Cross-connector validation:**
+   - Check if Adyen/Stripe have `{FLOW}` as a separate flow
+   - If they DON'T but have it in PaymentInformation → It's a payment method
+
+### Decision Table
+
+| FLOW Exists | PAYMENT_METHOD Set | Type | Action |
+|-------------|-------------------|------|--------|
+| No | No | `new_flow` | Create `{Connector}{Flow}Request/Response` |
+| No | Yes | `new_flow` | Create flow with payment method support |
+| Yes | No | `flow_completion` | Fill gaps in existing flow |
+| Yes | Yes | `payment_method_addition` | Extend PaymentInformation enum |
+
+### For Payment Method Additions
+
+Do NOT:
+- Create `{Connector}{PaymentMethod}Request` struct
+- Create `{Connector}{PaymentMethod}Response` struct
+- Add to `create_all_prerequisites!` as new flow
+
+DO:
+- Find `PaymentInformation` enum in transformers.rs
+- Add variant: `{PaymentMethod}(Box<{PaymentMethod}PaymentInformation>)`
+- Create `{PaymentMethod}PaymentInformation` struct
+- Add match arm to existing `{FLOW}` TryFrom implementation
+- Map `PaymentMethodData::{PaymentMethod}` to new PaymentInformation variant
+
+---
+
 ## Phase 5: Implement
 
 Verify prerequisites exist (connector struct, ConnectorCommon, auth type, error handling, transformers module). If anything is missing -> return FAILED.

--- a/grace/workflow/2.4_pr.md
+++ b/grace/workflow/2.4_pr.md
@@ -1,6 +1,6 @@
 # PR Agent
 
-You handle **all git operations** for the **{FLOW}** implementation of **{CONNECTOR}**: committing on the dev branch, cherry-picking to a clean PR branch, scrubbing credentials, pushing, and opening a **PR** on `juspay/hyperswitch-prism`.
+You handle **all git operations** for the **{FLOW}** implementation of **{CONNECTOR}**: committing on the preflight-created run branch, scrubbing credentials, pushing, and opening a **PR** on `juspay/hyperswitch-prism`.
 
 **First**: Read this file (`grace/workflow/2.4_pr.md`) fully to understand all phases and rules before proceeding.
 
@@ -12,43 +12,57 @@ You handle **all git operations** for the **{FLOW}** implementation of **{CONNEC
 
 **HARD GUARDRAIL — NO RETRYING SAME COMMAND**: If a `gh pr create` or `git push` command fails, do NOT retry the exact same command. Diagnose the error, fix the root cause, then retry with corrected parameters. Retrying identical commands wastes time and will produce identical errors.
 
+**HARD GUARDRAIL — NO BRANCH CREATION, NO CHERRY-PICK**: The run branch (`{BRANCH}`) was already created and checked out by the preflight checkpoint, and the implementation checkpoint wrote the connector files there. Do NOT run `git checkout -b ...` and do NOT run `git cherry-pick ...` in this agent. Commit and push directly on `{BRANCH}`.
+
 ---
 
 ## Inputs
 
-| Parameter                  | Description                                                                                             | Example                                                                                        |
-| -------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `{CONNECTOR}`              | Connector name (lowercase for branches/files, original casing for display)                              | `adyen`                                                                                        |
-| `{FLOW}`                   | Payment flow being implemented                                                                          | `BankDebit`                                                                                    |
-| `{DEV_BRANCH}`             | The shared dev branch where codegen work happened                                                       | `feat/grace_dev`                                                                               |
-| `{CONNECTOR_STATUS}`       | Whether the connector implementation passed or failed                                                   | `SUCCESS` or `FAILED`                                                                          |
-| `{FAILURE_REASON}`         | Why the connector failed (empty if SUCCESS)                                                             | `cargo build failed: missing field 'amount'`                                                   |
-| `{GRPCURL_OUTPUT}`         | The full grpcurl test output from the Codegen Agent (may be partial/error output for FAILED connectors) | _(raw text)_                                                                                   |
-| `{CONNECTOR_SOURCE_FILES}` | Paths to connector source files that were modified                                                      | `crates/integrations/connector-integration/src/connectors/adyen.rs, .../adyen/transformers.rs` |
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `{CONNECTOR}` | Connector name (lowercase for branches/files, original casing for display) | `cybersource` |
+| `{FLOW}` | Payment flow being implemented | `BankDebit` |
+| `{BRANCH}` | Run-scoped feature branch created by preflight (read from `userPayload.branch`) | `feat/grace-cybersource-bankdebit-3f69a1` |
+| `{CONNECTOR_STATUS}` | Whether the connector implementation passed or failed | `SUCCESS` or `FAILED` |
+| `{FAILURE_REASON}` | Why the connector failed (empty if SUCCESS) | `cargo build failed: missing field 'amount'` |
+| `{GRPCURL_OUTPUT}` | The full grpcurl test output from the Codegen Agent (may be partial/error output for FAILED connectors) | *(raw text)* |
+| `{CONNECTOR_SOURCE_FILES}` | Paths to connector source files that were modified | `crates/integrations/connector-integration/src/connectors/cybersource.rs, .../cybersource/transformers.rs` |
 
 ---
 
-## Phase 1: Commit on Dev Branch
+## Phase 1: Commit on the Run Branch
 
-You are on `{DEV_BRANCH}`. Commit the connector's changes here first — the cherry-pick in Phase 2 needs a commit hash.
+The implementation checkpoint left modified connector files in the working tree on `{BRANCH}`. Verify you are on that branch, then commit.
 
 ### 1a: Verify branch and check for changes
 
 ```bash
-git branch --show-current                   # must be {DEV_BRANCH}
+git branch --show-current                   # must equal {BRANCH}
+```
+
+If the current branch does NOT equal `{BRANCH}`, switch to it (preflight created it earlier in the run, so it exists locally):
+
+```bash
+git checkout {BRANCH}
+```
+
+Then check for changes:
+
+```bash
 git status -- crates/integrations/connector-integration/src/connectors/{connector}*
 ```
 
-If there are no modified/new connector files, there is nothing to commit. Skip to Phase 7 (return to dev branch) and return FAILED with reason "No connector files to commit."
+If there are no modified/new connector files, there is nothing to commit. Return FAILED with reason "No connector files to commit."
 
 ### 1b: Pre-commit validation (SUCCESS connectors only)
 
-**If `{CONNECTOR_STATUS}` is `SUCCESS`, you MUST verify ALL of the following based on the Codegen Agent's report. If ANY answer is NO, reclassify as FAILED.**
+**If `{CONNECTOR_STATUS}` is `SUCCESS`, you MUST verify ALL of the following based on the Codegen Agent's report and the gRPC test artifact in `userPayload.grpcTest`. If ANY answer is NO, reclassify as FAILED.**
 
 ```
 PRE-COMMIT CHECKLIST (mandatory for SUCCESS):
 [ ] Did `cargo build` complete with zero errors? (YES/NO)
-[ ] Did the codegen agent run at least one grpcurl Authorize call? (YES/NO)
+[ ] Did the gRPC test checkpoint run a grpcurl Authorize call?
+    Check userPayload.grpcTest.grpcurl_result === "PASS". (YES/NO)
 [ ] Was the `status_code` in the response 2xx (200-299)? (YES/NO)
 [ ] Did the grpcurl response contain a JSON object with a success status
     (authorized/PENDING/charged/REQUIRES_CUSTOMER_ACTION)? (YES/NO)
@@ -76,62 +90,29 @@ git status  # verify only expected files staged
 git commit -m "wip(connector): [FAILED] implement {FLOW} for {connector}"
 ```
 
-### 1d: Store the commit hash
+Capture the commit SHA for the JSON output:
 
 ```bash
 git log -1 --format='%H'
 ```
 
-Store as `{COMMIT_HASH}` for Phase 2.
+Store as `{COMMIT_HASH}`.
 
 ---
 
-## Phase 2: Prepare the PR Branch
-
-### 2a: Fetch latest main
-
-```bash
-# From connector-service root:
-git fetch origin main
-```
-
-### 2b: Create a clean branch from origin/main
-
-```bash
-git checkout -b feat/grace-{connector}-{flow} origin/main
-```
-
-Use lowercase for both connector and flow in the branch name (e.g., `feat/grace-adyen-bankdebit`, `feat/grace-stripe-mit`). Strip spaces, underscores become hyphens.
-
-### 2c: Cherry-pick the commit
-
-```bash
-git cherry-pick {COMMIT_HASH}
-```
-
-If the cherry-pick has conflicts:
-
-1. Run `git diff` to inspect conflicts.
-2. Resolve conflicts — prefer the incoming (cherry-picked) changes since the commit was already validated.
-3. `git add` the resolved files and `git cherry-pick --continue`.
-4. If conflicts are unresolvable, abort (`git cherry-pick --abort`), switch back to `{DEV_BRANCH}`, and return FAILED.
-
----
-
-## Phase 3: Credential Scrub (MANDATORY)
+## Phase 2: Credential Scrub (MANDATORY)
 
 **You MUST verify that no credentials, API keys, or secrets are present in the committed files before pushing.**
 
-### 3a: Inspect the diff
+### 2a: Inspect the diff
 
 ```bash
-git diff origin/main..HEAD -- crates/integrations/connector-integration/src/connectors/{connector}*
+git diff origin/main..{BRANCH} -- crates/integrations/connector-integration/src/connectors/{connector}*
 ```
 
-### 3b: Search for credential patterns
+### 2b: Search for credential patterns
 
 Scan the diff output for any of these patterns:
-
 - Hardcoded API keys (long alphanumeric strings that look like secrets)
 - Bearer tokens
 - `x-api-key: <actual_value>` (not a placeholder)
@@ -148,10 +129,10 @@ git add <fixed_files>
 git commit --amend --no-edit
 ```
 
-### 3c: Verify creds.json is NOT staged
+### 2c: Verify creds.json is NOT staged
 
 ```bash
-git diff --name-only origin/main..HEAD
+git diff --name-only origin/main..{BRANCH}
 ```
 
 If `creds.json` or any `.env` file appears in this list, something went wrong. Remove it:
@@ -163,25 +144,25 @@ git commit --amend --no-edit
 
 ---
 
-## Phase 4: Push the Branch
+## Phase 3: Push the Branch
 
 **Push to `origin` (`juspay/hyperswitch-prism`).**
 
 ```bash
-git push origin feat/grace-{connector}-{flow}
+git push origin {BRANCH}
 ```
 
 If push fails:
-
-- **Branch already exists**: Try `git push origin feat/grace-{connector}-{flow} --force-with-lease` only if this is a retry of a previous failed PR attempt for the same connector+flow.
-- **Genuinely conflicting branch**: Append a suffix: `feat/grace-{connector}-{flow}-v2`.
+- **Branch already exists on remote with diverged history**: Try `git push origin {BRANCH} --force-with-lease` only if this is a retry of a previous failed PR attempt for the same run (same `{BRANCH}` value).
 - **Permission denied**: Return FAILED — credentials may be misconfigured.
+
+The runId6 suffix in `{BRANCH}` makes collisions across runs effectively impossible, so the legacy "append `-v2` suffix" workaround no longer applies.
 
 ---
 
-## Phase 5: Prepare PR Description
+## Phase 4: Prepare PR Description
 
-### 5a: Sanitize grpcurl output
+### 4a: Sanitize grpcurl output
 
 Take the `{GRPCURL_OUTPUT}` and **redact ALL credentials** (this applies whether the connector passed or failed — even partial/error grpcurl output must be sanitized):
 
@@ -195,7 +176,6 @@ Take the `{GRPCURL_OUTPUT}` and **redact ALL credentials** (this applies whether
 8. Preserve the grpcurl command structure, endpoint, request body fields (keys only), and the full response JSON
 
 **Example of sanitized output:**
-
 ```
 grpcurl -plaintext \
   -H 'x-connector: adyen' \
@@ -225,7 +205,7 @@ Response:
 }
 ```
 
-### 5b: Build the PR description
+### 4b: Build the PR description
 
 **Use the appropriate template based on `{CONNECTOR_STATUS}`:**
 
@@ -253,10 +233,9 @@ This implementation was generated and validated by **GRACE** (automated connecto
 
 <details>
 <summary>grpcurl Authorize call (credentials redacted)</summary>
+
 ```
-
 {SANITIZED_GRPCURL_OUTPUT}
-
 ```
 
 </details>
@@ -297,10 +276,9 @@ This implementation was generated by **GRACE** (automated connector integration 
 
 <details>
 <summary>grpcurl output / error details (credentials redacted)</summary>
+
 ```
-
 {SANITIZED_GRPCURL_OUTPUT}
-
 ```
 
 </details>
@@ -317,66 +295,62 @@ This implementation was generated by **GRACE** (automated connector integration 
 
 ---
 
-## Phase 6: Create the Pull Request
+## Phase 5: Create the Pull Request
 
 **CRITICAL: All `gh` commands MUST use `--repo juspay/hyperswitch-prism`.**
 
-### 6a: Check for existing PR (idempotency)
+### 5a: Check for existing PR (idempotency)
 
 ```bash
-gh pr list --repo juspay/hyperswitch-prism --head feat/grace-{connector}-{flow} --state open --json url --jq '.[0].url' 2>/dev/null
+gh pr list --repo juspay/hyperswitch-prism --head {BRANCH} --state open --json url --jq '.[0].url' 2>/dev/null
 ```
 
-If a PR URL is returned, the PR already exists. Report SUCCESS with that URL and skip to Phase 7.
+Because `{BRANCH}` includes the runId6 suffix, this match only happens if the **same run** is re-entering this checkpoint (e.g. after a retry). If a PR URL is returned, the PR already exists for this run. Report SUCCESS with that URL and finish.
 
-### 6b: Ensure labels exist
+### 5b: Ensure labels exist
 
 ```bash
 gh label create "GRACE" --repo juspay/hyperswitch-prism --description "Auto-generated by GRACE pipeline" --color "7057ff" 2>/dev/null || true
 gh label create "do not merge" --repo juspay/hyperswitch-prism --description "PR requires manual intervention before merging" --color "e11d48" 2>/dev/null || true
 ```
 
-### 6c: Determine labels and title
+### 5c: Determine labels and title
 
 **For SUCCESS connectors:**
-
 - Labels: `GRACE`
 - Title: `feat(connector): implement {FLOW} for {connector}`
 
 **For FAILED connectors:**
-
 - Labels: `GRACE`, `do not merge`
 - Title: `[GRACE-FAILED] feat(connector): implement {FLOW} for {connector}`
 
-### 6d: Create the PR
+### 5d: Create the PR
 
 **For SUCCESS connectors:**
-
 ```bash
 gh pr create \
   --repo juspay/hyperswitch-prism \
   --base main \
-  --head feat/grace-{connector}-{flow} \
+  --head {BRANCH} \
   --title "feat(connector): implement {FLOW} for {connector}" \
   --label "GRACE" \
   --body "$(cat <<'EOF'
-<PR_DESCRIPTION_FROM_PHASE_5B_SUCCESS_TEMPLATE>
+<PR_DESCRIPTION_FROM_PHASE_4B_SUCCESS_TEMPLATE>
 EOF
 )"
 ```
 
 **For FAILED connectors:**
-
 ```bash
 gh pr create \
   --repo juspay/hyperswitch-prism \
   --base main \
-  --head feat/grace-{connector}-{flow} \
+  --head {BRANCH} \
   --title "[GRACE-FAILED] feat(connector): implement {FLOW} for {connector}" \
   --label "GRACE" \
   --label "do not merge" \
   --body "$(cat <<'EOF'
-<PR_DESCRIPTION_FROM_PHASE_5B_FAILED_TEMPLATE>
+<PR_DESCRIPTION_FROM_PHASE_4B_FAILED_TEMPLATE>
 EOF
 )"
 ```
@@ -385,42 +359,46 @@ Capture the PR URL from the output.
 
 ---
 
-## Phase 7: Return to Dev Branch
-
-After the PR is created, switch back to the dev branch so the Connector Agent can continue with the next connector:
-
-```bash
-git checkout {DEV_BRANCH}
-```
-
----
-
 ## Output
 
+Return your final answer as JSON. This is the only output format the engine accepts; the legacy `STATUS:`/`PR_URL:` free-text format is no longer parsed. Reply with ONLY the JSON object — no prose, no markdown fences.
+
+```json
+{
+  "approved": true,
+  "specComplianceScore": 0.85,
+  "comments": [
+    { "file": "crates/.../connector.rs", "line": 42, "comment": "...", "severity": "info" }
+  ],
+  "status": "SUCCESS",
+  "prUrl": "https://github.com/juspay/hyperswitch-prism/pull/1206",
+  "branchName": "{BRANCH}",
+  "commitHash": "<commit SHA from Phase 1c>",
+  "reason": ""
+}
 ```
-CONNECTOR: {CONNECTOR}
-FLOW: {FLOW}
-STATUS: SUCCESS | FAILED
-PR_URL: <URL of the created PR, or empty if failed>
-PR_BRANCH: feat/grace-{connector}-{flow}
-REASON: <details, if failed>
-```
+
+Field rules:
+
+- For SUCCESS connectors: `approved=true`, `status="SUCCESS"`, `prUrl` is the URL captured from `gh pr create` output (or from the existing-PR check in Phase 5a), `reason` is empty.
+- For FAILED connectors: `approved=false`, `status="FAILED"`, `prUrl` is still the URL of the do-not-merge PR (Rule 11: every connector gets a PR), `reason` explains the failure.
+- `branchName` is always `{BRANCH}` — the suffixed run branch from preflight (e.g. `feat/grace-cybersource-bankdebit-3f69a1`).
+- `commitHash` is the SHA stored in Phase 1c.
 
 ---
 
 ## Rules
 
 1. **Target repo is `juspay/hyperswitch-prism` — ALWAYS** — every `gh pr create`, `gh label create`, `gh pr list`, and any other `gh` command MUST include `--repo juspay/hyperswitch-prism`. Do NOT omit the `--repo` flag. Do NOT use any other org/repo. This is non-negotiable.
-2. **Same-repo PRs use bare branch names** — when creating or listing PRs, the `--head` flag uses bare branch names (e.g., `feat/grace-adyen-bankdebit`). No fork owner prefix needed.
+2. **Same-repo PRs use bare branch names** — when creating or listing PRs, the `--head` flag uses bare branch names (e.g., `feat/grace-cybersource-bankdebit-3f69a1`). No fork owner prefix needed.
 3. **Push to `origin` (`juspay/hyperswitch-prism`)** — all branches are pushed directly to `juspay/hyperswitch-prism`.
-4. **No connector logic changes** — this agent commits, cherry-picks, scrubs, pushes, and creates PRs. It does NOT modify connector logic (except removing hardcoded credentials, which is a scrub fix, not a logic change).
-5. **Never force push to main** — only push to the feature branch.
-6. **Credential scrub is mandatory** — applies to BOTH success and failed PRs. If credentials are found in source files, fix them before pushing. If credentials cannot be removed cleanly, return FAILED.
-7. **Sanitize ALL grpcurl output** — every header value, every account number, every secret must be redacted in the PR description. This applies to both successful and failed/partial grpcurl output.
-8. **Always return to dev branch** — the Connector Agent expects to be on `{DEV_BRANCH}` after this agent finishes.
-9. **Do not create the PR if cherry-pick failed** — return FAILED immediately.
-10. **Idempotent** — if a PR already exists for this connector+flow (check with `gh pr list --repo juspay/hyperswitch-prism --head branch`), report SUCCESS with the existing PR URL. Do NOT create a duplicate.
-11. **Failed connectors get "do not merge"** — if `{CONNECTOR_STATUS}` is `FAILED`, the PR MUST have both "GRACE" and "do not merge" labels, and the title MUST be prefixed with `[GRACE-FAILED]`.
-12. **Always create a PR** — both successful and failed connectors get PRs. The only reason to NOT create a PR is if the cherry-pick itself fails (no code to show).
-13. **Never retry identical commands** — if `gh pr create` or `git push` fails, diagnose the error first. Common causes: (a) branch not pushed yet, (b) permission denied, (c) branch name conflict. Fix the root cause, then retry with corrected parameters.
-14. **Scoped git staging** — when committing on the dev branch (Phase 1), only stage connector-specific files (`git add crates/integrations/connector-integration/src/connectors/{connector}*`). Never `git add -A`. Never stage `creds.json` or `.env`.
+4. **No connector logic changes** — this agent commits, scrubs, pushes, and creates PRs. It does NOT modify connector logic (except removing hardcoded credentials, which is a scrub fix, not a logic change).
+5. **No branch creation, no cherry-pick** — the run branch was created by the preflight checkpoint. This agent commits and pushes on that branch directly.
+6. **Never force push to main** — only `--force-with-lease` on the feature branch is permitted, and only as a retry within the same run.
+7. **Credential scrub is mandatory** — applies to BOTH success and failed PRs. If credentials are found in source files, fix them before pushing. If credentials cannot be removed cleanly, return FAILED.
+8. **Sanitize ALL grpcurl output** — every header value, every account number, every secret must be redacted in the PR description. This applies to both successful and failed/partial grpcurl output.
+9. **Idempotent within a run** — if a PR already exists for `{BRANCH}` (check with `gh pr list --repo juspay/hyperswitch-prism --head {BRANCH} --state open`), report SUCCESS with the existing PR URL. Do NOT create a duplicate.
+10. **Failed connectors get "do not merge"** — if `{CONNECTOR_STATUS}` is `FAILED`, the PR MUST have both "GRACE" and "do not merge" labels, and the title MUST be prefixed with `[GRACE-FAILED]`.
+11. **Always create a PR** — both successful and failed connectors get PRs. The only reason to NOT create a PR is if there are no connector files to commit (Phase 1a).
+12. **Never retry identical commands** — if `gh pr create` or `git push` fails, diagnose the error first. Common causes: (a) permission denied, (b) PR already exists (treat as idempotency hit, see Phase 5a). Fix the root cause, then retry with corrected parameters.
+13. **Scoped git staging** — only stage connector-specific files (`git add crates/integrations/connector-integration/src/connectors/{connector}*`). Never `git add -A`. Never stage `creds.json` or `.env`.


### PR DESCRIPTION
## Summary

Second of ~5 PRs splitting `feat/grace-session-management` into reviewable slices. Ships **only markdown** — the grace workflow docs and the pr-resolver prompt templates. Independent of PR-1 / PR-3 / PR-4 / PR-5 and can land in any order.

### What's in this PR
- `grace/workflow/{1_orchestrator, 2.2_techspec, 2.3_codegen, 2.4_pr}.md` — refreshed orchestrator/techspec/codegen/pr workflow docs.
- `grace/pr-resolver/prompts/{README, fix-loop, grpc-test-plan, resolve-comment, review-summary}.md` — Mustache templates consumed by the pr-resolver loader. The README documents the loader contract (YAML frontmatter, HTML escaping disabled, per-prompt variables).

### Why these belong together
The pr-resolver loader code shipped in #1381; the markdown prompts ship here. README references `grace/grace-workspace/packages/core/src/pr-resolver/prompts.ts`, which lands in a subsequent PR (PR-3) — the doc reference is forward-looking, same pattern as the pnpm lockfile in PR-1.

### What was originally planned for this PR but isn't here
The original split plan estimated ~33 files including placetopay teardown, crates spec overrides, docs-generated, and CHANGELOG.md. Investigation showed those entries were stat-only phantoms in `git diff --name-status` — zero actual content delta vs main. Either the branch never changed them or earlier merges absorbed the changes already.

## Test plan
- [ ] Verify pr-resolver loader (in #1381) finds prompts after merge.
- [ ] Verify workflow doc renders correctly on GitHub.

## Related
- PR-1 #1392 — grace-workspace monorepo foundation
- PR-3 — grace-workspace core (pending)