### PR TITLE
fix(setup_mandate): use direct amount_captured in generate_setup_mandate_response

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -9575,14 +9575,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
         })
         .transpose()?;
 
-    // Set amount_captured based on status - only if Charged/PartialCharged
-    let captured_amount = match status {
-        common_enums::AttemptStatus::Charged
-        | common_enums::AttemptStatus::PartialCharged
-        | common_enums::AttemptStatus::PartialChargedAndChargeable => router_data_v2.request.amount,
-        _ => None,
-    };
-
+    let captured_amount = router_data_v2.resource_common_data.amount_captured;
     let minor_captured_amount = captured_amount;
 
     let response = match transaction_response {


### PR DESCRIPTION
## Verdict in one line
setup_mandate (all connectors): Prism was computing `amount_captured = Some(0)` from `request.amount` for setup mandates. Per Stripe docs, SetupIntents have no capture concept — `amount_captured` should be `None`. Fix in Prism.

## Decision trail
- HS reads (`crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs:L3768-L3772`):
  ```rust
  Ok(Self {
      status,
      response,
      connector_response: connector_response_data,
      ..item.data  // amount_captured inherited from input = None
  })
  ```
- Prism reads (`crates/types-traits/domain_types/src/types.rs:L9578-L9585`):
  ```rust
  let captured_amount = match status {
      common_enums::AttemptStatus::Charged
      | common_enums::AttemptStatus::PartialCharged
      | common_enums::AttemptStatus::PartialChargedAndChargeable => router_data_v2.request.amount,
      _ => None,
  };
  ```
- Connector doc: https://docs.stripe.com/api/setup_intents/object
  > The SetupIntent object does NOT have `amount_captured`, `amount_received`, or `amount` fields. SetupIntent is designed for setting up payment methods for future use, not for processing payments.
- Conclusion: Prism is wrong — uses payment amount (0) as captured amount instead of the actual captured amount field (None)
- Fix direction: Prism

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16337
- Expected RouterData field after fix: `amount_captured: None`, `minor_amount_captured: None`

## Diff
Single line change: replace status-based match block with direct read from `resource_common_data.amount_captured` (matches `generate_payment_response()` at L5202).

## Verification
<details><summary>cargo check -p domain_types (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.23s
```
</details>
<details><summary>cargo clippy -p domain_types -- -D warnings (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 56.80s
```
</details>

## What this PR is NOT
- Field paths NOT touched: `connector_response_reference_id` (separate PR on hyperswitch repo)
- Files NOT touched: connector-specific transformers, grpc-server, ffi
- PRD `Out of scope` items: `generate_payment_response()` (already correct), HS UCS handler (passthrough is correct)

## Acceptance Criteria
- [x] Build clean
- [x] Clippy clean
- [ ] Shadow-replay produces zero diff for `amount_captured` and `minor_amount_captured`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes juspay/hyperswitch-cloud#16337
