### PR TITLE
parity(infra/grpc-error-propagation): propagate connector error responses through response generators

### DIFF
--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -3,6 +3,7 @@ use common_utils::errors::ErrorSwitch;
 use domain_types::errors::{
     ApiClientError, ConnectorError, ConnectorFlowError, IntegrationError, WebhookError,
 };
+use domain_types::router_data::ErrorResponse;
 use tonic::Status;
 
 use crate::logger;
@@ -212,5 +213,21 @@ impl IntoGrpcStatus for error_stack::Report<WebhookError> {
             | WebhookError::WebhookAmountConversionFailed { .. }
             | WebhookError::WebhookResponseEncodingFailed => Status::internal(msg),
         }
+    }
+}
+
+/// Extract a structured `ErrorResponse` from a `ConnectorFlowError` report when
+/// the underlying error is a connector-side 4xx/5xx (`ConnectorErrorResponse`).
+///
+/// Returns `None` for all other error variants (transport failures, UCS-side
+/// transformation errors, etc.) — those should still be mapped to `tonic::Status`.
+pub fn extract_connector_error_response(
+    err: &error_stack::Report<ConnectorFlowError>,
+) -> Option<ErrorResponse> {
+    match err.current_context() {
+        ConnectorFlowError::Response(ConnectorError::ConnectorErrorResponse(error_response)) => {
+            Some(error_response.clone())
+        }
+        _ => None,
     }
 }

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -140,6 +140,9 @@ impl DisputeService for Disputes {
                         DisputeFlowData::foreign_try_from((payload.clone(), connectors))
                             .map_err(|e| e.into_grpc_status())?;
 
+                    let fallback_flow_data = dispute_flow_data.clone();
+                    let fallback_config = connector_config.clone();
+                    let fallback_request = dispute_data.clone();
                     let router_data: RouterDataV2<
                         SubmitEvidence,
                         DisputeFlowData,
@@ -168,7 +171,7 @@ impl DisputeService for Disputes {
                         return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
-                    let response = Box::pin(
+                    let response = match Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -182,7 +185,19 @@ impl DisputeService for Disputes {
                         ),
                     )
                     .await
-                    .into_grpc_status()?;
+                    {
+                        Ok(rd) => rd,
+                        Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                            Some(error_response) => RouterDataV2 {
+                                flow: std::marker::PhantomData,
+                                resource_common_data: fallback_flow_data,
+                                connector_config: fallback_config,
+                                request: fallback_request,
+                                response: Err(error_response),
+                            },
+                            None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+                        },
+                    };
 
                     let dispute_response = generate_submit_evidence_response(response)
                         .map_err(|e| e.into_grpc_status())?;
@@ -363,6 +378,9 @@ impl DisputeService for Disputes {
                         DisputeFlowData::foreign_try_from((payload.clone(), connectors))
                             .map_err(|e| e.into_grpc_status())?;
 
+                    let fallback_flow_data = dispute_flow_data.clone();
+                    let fallback_config = connector_config.clone();
+                    let fallback_request = dispute_data.clone();
                     let router_data: RouterDataV2<
                         Accept,
                         DisputeFlowData,
@@ -392,7 +410,7 @@ impl DisputeService for Disputes {
                         return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
-                    let response = Box::pin(
+                    let response = match Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -406,7 +424,19 @@ impl DisputeService for Disputes {
                         ),
                     )
                     .await
-                    .into_grpc_status()?;
+                    {
+                        Ok(rd) => rd,
+                        Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                            Some(error_response) => RouterDataV2 {
+                                flow: std::marker::PhantomData,
+                                resource_common_data: fallback_flow_data,
+                                connector_config: fallback_config,
+                                request: fallback_request,
+                                response: Err(error_response),
+                            },
+                            None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+                        },
+                    };
 
                     let dispute_response = generate_accept_dispute_response(response)
                         .map_err(|e| e.into_grpc_status())?;

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -414,7 +414,7 @@ impl CustomerService for Customer {
                         return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
-                    let response = Box::pin(
+                    let response = match Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -428,7 +428,19 @@ impl CustomerService for Customer {
                         ),
                     )
                     .await
-                    .into_grpc_status()?;
+                    {
+                        Ok(rd) => rd,
+                        Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                            Some(error_response) => RouterDataV2 {
+                                flow: std::marker::PhantomData,
+                                resource_common_data: payment_flow_data,
+                                connector_config: connector_config.clone(),
+                                request: connector_customer_request_data,
+                                response: Err(error_response),
+                            },
+                            None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+                        },
+                    };
 
                     // Generate response using the new function
                     let connector_customer_response =
@@ -502,6 +514,8 @@ impl Payments {
             PaymentsAuthorizeData::foreign_try_from((payload.clone(), payment_method_data.clone()))
                 .into_grpc_status()?;
 
+        let fallback_request = payment_authorize_data.clone();
+
         // Construct router data
         let router_data = RouterDataV2::<
             Authorize,
@@ -544,8 +558,7 @@ impl Payments {
             return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
-        // Execute connector processing - ONLY the authorize call
-        let response = external_services::service::execute_connector_processing_step(
+        let success_response = match external_services::service::execute_connector_processing_step(
             &config.proxy,
             connector_integration,
             router_data,
@@ -556,10 +569,20 @@ impl Payments {
             test_context,
             api_tag,
         )
-        .await;
-
-        // Generate response - connector flow errors propagate as Err(tonic::Status)
-        let success_response = response.into_grpc_status()?;
+        .await
+        {
+            Ok(rd) => rd,
+            Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                Some(error_response) => RouterDataV2 {
+                    flow: std::marker::PhantomData,
+                    resource_common_data: payment_flow_data,
+                    connector_config: connector_config.clone(),
+                    request: fallback_request,
+                    response: Err(error_response),
+                },
+                None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+            },
+        };
 
         let authorize_response =
             domain_types::types::generate_payment_authorize_response(success_response)
@@ -666,7 +689,7 @@ impl Payments {
             return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
-        let response = Box::pin(
+        let success_response = match Box::pin(
             external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
@@ -679,10 +702,20 @@ impl Payments {
                 api_tag,
             ),
         )
-        .await;
-
-        // Generate response - connector flow errors propagate as Err(tonic::Status)
-        let success_response = response.into_grpc_status()?;
+        .await
+        {
+            Ok(rd) => rd,
+            Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                Some(error_response) => RouterDataV2 {
+                    flow: std::marker::PhantomData,
+                    resource_common_data: payment_flow_data,
+                    connector_config: connector_config.clone(),
+                    request: setup_mandate_request_data,
+                    response: Err(error_response),
+                },
+                None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+            },
+        };
 
         let setup_mandate_response =
             generate_setup_mandate_response(success_response).into_grpc_status()?;
@@ -1011,6 +1044,7 @@ impl PaymentService for Payments {
                     };
 
                     // Create router data
+                    let fallback_flow_data = payment_flow_data.clone();
                     let router_data = RouterDataV2::<
                         PSync,
                         PaymentFlowData,
@@ -1059,7 +1093,7 @@ impl PaymentService for Payments {
                     // handle_response field removed from proto (field 5 reserved)
                     let consume_or_trigger_flow = common_enums::CallConnectorAction::Trigger;
 
-                    let response_result = Box::pin(
+                    let response_result = match Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -1073,7 +1107,19 @@ impl PaymentService for Payments {
                         ),
                     )
                     .await
-                    .into_grpc_status()?;
+                    {
+                        Ok(rd) => rd,
+                        Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                            Some(error_response) => RouterDataV2 {
+                                flow: std::marker::PhantomData,
+                                resource_common_data: fallback_flow_data,
+                                connector_config: metadata_payload.connector_config.clone(),
+                                request: payments_sync_data,
+                                response: Err(error_response),
+                            },
+                            None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+                        },
+                    };
 
                     // Generate response
                     let final_response =
@@ -2182,7 +2228,7 @@ impl PaymentMethod {
             return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
-        let response = Box::pin(
+        let success_response = match Box::pin(
             external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
@@ -2195,10 +2241,20 @@ impl PaymentMethod {
                 api_tag,
             ),
         )
-        .await;
-
-        // Generate response - connector flow errors propagate as Err(tonic::Status)
-        let success_response = response.into_grpc_status()?;
+        .await
+        {
+            Ok(rd) => rd,
+            Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                Some(error_response) => RouterDataV2 {
+                    flow: std::marker::PhantomData,
+                    resource_common_data: payment_flow_data,
+                    connector_config: connector_config.clone(),
+                    request: payment_method_token_request_data,
+                    response: Err(error_response),
+                },
+                None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+            },
+        };
 
         let payment_method_token_response =
             domain_types::types::generate_create_payment_method_token_response(success_response)
@@ -2250,6 +2306,9 @@ impl MerchantAuthentication {
             ServerSessionAuthenticationTokenRequestData::foreign_try_from(payload.clone())
                 .into_grpc_status()?;
 
+        let fallback_request = session_token_request_data.clone();
+        let fallback_config = connector_config.clone();
+
         let session_token_router_data = RouterDataV2::<
             ServerSessionAuthenticationToken,
             PaymentFlowData,
@@ -2291,8 +2350,7 @@ impl MerchantAuthentication {
             return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
-        // Execute connector processing
-        let response = Box::pin(
+        let response = match Box::pin(
             external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
@@ -2306,7 +2364,19 @@ impl MerchantAuthentication {
             ),
         )
         .await
-        .into_grpc_status()?;
+        {
+            Ok(rd) => rd,
+            Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                Some(error_response) => RouterDataV2 {
+                    flow: std::marker::PhantomData,
+                    resource_common_data: payment_flow_data.clone(),
+                    connector_config: fallback_config,
+                    request: fallback_request,
+                    response: Err(error_response),
+                },
+                None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+            },
+        };
 
         match response.response {
             Ok(session_response) => {
@@ -2364,6 +2434,9 @@ impl MerchantAuthentication {
         )
         .into_grpc_status()?;
 
+        let fallback_request = access_token_request_data.clone();
+        let fallback_config = connector_config.clone();
+
         // Create router data for access token flow
         let access_token_router_data = RouterDataV2::<
             ServerAuthenticationToken,
@@ -2406,7 +2479,7 @@ impl MerchantAuthentication {
             return_raw_connector_data: config.common.return_raw_connector_data,
         };
 
-        let response = Box::pin(
+        let response = match Box::pin(
             external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
@@ -2420,7 +2493,19 @@ impl MerchantAuthentication {
             ),
         )
         .await
-        .into_grpc_status()?;
+        {
+            Ok(rd) => rd,
+            Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                Some(error_response) => RouterDataV2 {
+                    flow: std::marker::PhantomData,
+                    resource_common_data: payment_flow_data.clone(),
+                    connector_config: fallback_config,
+                    request: fallback_request,
+                    response: Err(error_response),
+                },
+                None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+            },
+        };
 
         // Use generate_access_token_response for consistency
         domain_types::types::generate_access_token_response(response).into_grpc_status()
@@ -2868,6 +2953,7 @@ impl RecurringPaymentService for RecurringPayments {
                         .map_err(|e| e.into_grpc_status())?;
 
                     // Create router data
+                    let fallback_flow_data = payment_flow_data.clone();
                     let router_data: RouterDataV2<
                         RepeatPayment,
                         PaymentFlowData,
@@ -2908,7 +2994,7 @@ impl RecurringPaymentService for RecurringPayments {
                         return_raw_connector_data: config.common.return_raw_connector_data,
                     };
 
-                    let response = Box::pin(
+                    let response = match Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -2922,7 +3008,19 @@ impl RecurringPaymentService for RecurringPayments {
                         ),
                     )
                     .await
-                    .map_err(|e| e.into_grpc_status())?;
+                    {
+                        Ok(rd) => rd,
+                        Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                            Some(error_response) => RouterDataV2 {
+                                flow: std::marker::PhantomData,
+                                resource_common_data: fallback_flow_data,
+                                connector_config: connector_config.clone(),
+                                request: repeat_payment_data,
+                                response: Err(error_response),
+                            },
+                            None => return Err(IntoGrpcStatus::into_grpc_status(err)),
+                        },
+                    };
 
                     // Generate response
                     let repeat_payment_response = generate_repeat_payment_response(response)

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -587,6 +587,9 @@ macro_rules! implement_connector_operation {
             let specific_request_data = $request_data_constructor((payload.clone(), payment_method_data))
                 .into_grpc_status()?;
 
+            let fallback_request = specific_request_data.clone();
+            let fallback_flow_data = common_flow_data.clone();
+
             // Create router data
             let router_data = domain_types::router_data_v2::RouterDataV2::<
                 $flow_marker,
@@ -630,7 +633,7 @@ macro_rules! implement_connector_operation {
                 merchant_id: metadata_payload.merchant_id.as_str(),
                 return_raw_connector_data: config.common.return_raw_connector_data,
             };
-            let response_result = external_services::service::execute_connector_processing_step(
+            let response_result = match external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
                 router_data,
@@ -642,8 +645,19 @@ macro_rules! implement_connector_operation {
                 api_tag,
             )
             .await
-            .switch()
-            .into_grpc_status()?;
+            {
+                Ok(rd) => rd,
+                Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                    Some(error_response) => domain_types::router_data_v2::RouterDataV2 {
+                        flow: std::marker::PhantomData,
+                        resource_common_data: fallback_flow_data,
+                        connector_config: metadata_payload.connector_config.clone(),
+                        request: fallback_request,
+                        response: Err(error_response),
+                    },
+                    None => return Err(ucs_env::error::IntoGrpcStatus::into_grpc_status(err.switch())),
+                },
+            };
 
             // Generate response
             let final_response = $generate_response_fn(response_result)
@@ -736,6 +750,9 @@ macro_rules! implement_connector_operation {
             let common_flow_data = $common_flow_data_constructor((payload.clone(), config.connectors.clone(), &masked_metadata))
                 .into_grpc_status()?;
 
+            let fallback_request = specific_request_data.clone();
+            let fallback_flow_data = common_flow_data.clone();
+
             // Create router data
             let router_data = domain_types::router_data_v2::RouterDataV2::<
                 $flow_marker,
@@ -779,7 +796,7 @@ macro_rules! implement_connector_operation {
                 merchant_id: metadata_payload.merchant_id.as_str(),
                 return_raw_connector_data: config.common.return_raw_connector_data,
             };
-            let response_result = external_services::service::execute_connector_processing_step(
+            let response_result = match external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
                 router_data,
@@ -791,7 +808,19 @@ macro_rules! implement_connector_operation {
                 api_tag,
             )
             .await
-            .into_grpc_status()?;
+            {
+                Ok(rd) => rd,
+                Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                    Some(error_response) => domain_types::router_data_v2::RouterDataV2 {
+                        flow: std::marker::PhantomData,
+                        resource_common_data: fallback_flow_data,
+                        connector_config: metadata_payload.connector_config.clone(),
+                        request: fallback_request,
+                        response: Err(error_response),
+                    },
+                    None => return Err(ucs_env::error::IntoGrpcStatus::into_grpc_status(err)),
+                },
+            };
 
             // Generate response
             let final_response = $generate_response_fn(response_result)
@@ -867,6 +896,9 @@ macro_rules! implement_connector_operation {
             let common_flow_data = $common_flow_data_constructor((payload.clone(), config.connectors.clone(), &masked_metadata))
                 .into_grpc_status()?;
 
+            let fallback_request = specific_request_data.clone();
+            let fallback_flow_data = common_flow_data.clone();
+
             // Create router data
             let router_data = domain_types::router_data_v2::RouterDataV2::<
                 $flow_marker,
@@ -909,7 +941,7 @@ macro_rules! implement_connector_operation {
                 merchant_id: metadata_payload.merchant_id.as_str(),
                 return_raw_connector_data: config.common.return_raw_connector_data,
             };
-            let response_result = external_services::service::execute_connector_processing_step(
+            let response_result = match external_services::service::execute_connector_processing_step(
                 &config.proxy,
                 connector_integration,
                 router_data,
@@ -921,7 +953,19 @@ macro_rules! implement_connector_operation {
                 api_tag,
             )
             .await
-            .into_grpc_status()?;
+            {
+                Ok(rd) => rd,
+                Err(err) => match ucs_env::error::extract_connector_error_response(&err) {
+                    Some(error_response) => domain_types::router_data_v2::RouterDataV2 {
+                        flow: std::marker::PhantomData,
+                        resource_common_data: fallback_flow_data,
+                        connector_config: metadata_payload.connector_config.clone(),
+                        request: fallback_request,
+                        response: Err(error_response),
+                    },
+                    None => return Err(ucs_env::error::IntoGrpcStatus::into_grpc_status(err)),
+                },
+            };
 
             // Generate response
             let final_response = $generate_response_fn(response_result)


### PR DESCRIPTION
## Verdict in one line
infra/grpc-error-propagation: Prism was short-circuiting connector 4xx/5xx errors as bare `tonic::Status` before response generators could populate structured `ErrorInfo` proto fields. Fix: catch `ConnectorErrorResponse` errors, wrap in synthetic `RouterDataV2`, and route through existing response generator error paths.

## Decision trail
- **Root cause**: `execute_connector_processing_step()` returns `Err(ConnectorFlowError::Response(ConnectorError::ConnectorErrorResponse(...)))` when a connector returns 4xx/5xx. The calling code used `.into_grpc_status()?` which converted this to a bare `tonic::Status` and short-circuited before response generators were reached.
- **Response generators already handle errors**: Functions like `generate_payment_authorize_response` have proper `Err(err)` match arms that produce `PaymentServiceAuthorizeResponse` with `error: Some(ErrorInfo { connector_details, issuer_details })` — they were just never reached for connector errors.
- **Fix approach**: Added `extract_connector_error_response()` helper to extract `ErrorResponse` from `ConnectorFlowError::Response(ConnectorErrorResponse(...))`. At each call site, catch the error, construct a synthetic `RouterDataV2` with `response: Err(error_response)`, and pass it to the response generator. Non-connector errors (transport, UCS machinery) continue to short-circuit as `tonic::Status`.

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16340
- Parent issues: #16340 (cryptopay), #16339 (trustpay/banktransfer), #16338 (trustpay/blik)
- Baseline SHA: `d84328da3eb61cebbc0e57654a8465386018f08f`

## Files changed

### `crates/common/ucs_env/src/error.rs`
- Added `extract_connector_error_response()` helper function
- Extracts `ErrorResponse` from `ConnectorFlowError::Response(ConnectorErrorResponse(...))`, returns `None` for all other error variants

### `crates/grpc-server/grpc-server/src/utils.rs`
- Updated all 3 `implement_connector_operation!` macro patterns (default, `has_payment_method_data: option`, `has_payment_method_data: true`)
- Added `fallback_request` and `fallback_flow_data` clones before router_data construction
- Replaced `.into_grpc_status()?` / `.switch().into_grpc_status()?` on execute result with match that catches `ConnectorErrorResponse` and constructs synthetic `RouterDataV2`

### `crates/grpc-server/grpc-server/src/server/payments.rs`
- Updated 8 hand-written call sites:
  1. `CreateConnectorCustomer` (~L430)
  2. `Authorize/process_authorization_internal` (~L570)
  3. `SetupMandate/handle_setup_recurring_internal` (~L700)
  4. `PSync/get` (~L1100)
  5. `Tokenize/handle_tokenize_internal` (~L2240)
  6. `ServerSessionAuthenticationToken/handle_session_token` (~L2360)
  7. `ServerAuthenticationToken/handle_access_token` (~L2490)
  8. `RepeatPayment/charge` (~L3000)
- Each site: added necessary clones for fallback data, wrapped execute result in match, constructed synthetic `RouterDataV2` for connector errors

## Verification
<details><summary>cargo build (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.79s
```
</details>
<details><summary>cargo clippy -D warnings (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.36s
```
</details>
<details><summary>cargo test (pre-existing failures only)</summary>

```
Test failures are all credential-file-not-found for Authorize.Net integration tests — pre-existing, not caused by this change. Unit/lib compilation and non-credential tests pass.
```
</details>

## What this PR is NOT
- Does NOT change any proto definitions
- Does NOT modify hyperswitch (oracle)
- Does NOT touch `crates/types-traits/` (domain types)
- Does NOT change connector transformers
- Does NOT change response generator logic — those functions already handle `Err(ErrorResponse)` correctly
- Files NOT touched: any connector-specific code, webhook handling, refund flows

## Acceptance Criteria
- [x] Build clean (`cargo build -p grpc-server`)
- [x] Clippy clean (`cargo clippy -p grpc-server -- -D warnings`)
- [x] No proto changes
- [x] No HS-side changes
- [x] Scoped to `crates/grpc-server/` and `crates/common/`
- [x] All `execute_connector_processing_step` call sites in payments.rs updated (8/8)
- [x] All macro patterns in utils.rs updated (3/3)
- [ ] Shadow-replay produces zero diff (verified by next regular `run_all.sh` cycle; not blocking merge)