### PR TITLE
fix(domain_types): use proto payment_method field instead of hardcoded Card

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4350,7 +4350,11 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card,
+            payment_method: value
+                .payment_method
+                .map(PaymentMethod::foreign_try_from)
+                .transpose()?
+                .unwrap_or(PaymentMethod::Card),
             address,
             auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
             connector_request_reference_id: extract_connector_request_reference_id(
@@ -4436,7 +4440,11 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card,
+            payment_method: value
+                .payment_method
+                .map(PaymentMethod::foreign_try_from)
+                .transpose()?
+                .unwrap_or(PaymentMethod::Card),
             address,
             auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: extract_connector_request_reference_id(&Some(
@@ -4548,7 +4556,11 @@ impl
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card, //TODO
+            payment_method: value
+                .payment_method
+                .map(PaymentMethod::foreign_try_from)
+                .transpose()?
+                .unwrap_or(PaymentMethod::Card),
             address,
             auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: extract_connector_request_reference_id(
@@ -8728,7 +8740,11 @@ impl
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card, //TODO
+            payment_method: value
+                .payment_method
+                .map(PaymentMethod::foreign_try_from)
+                .transpose()?
+                .unwrap_or(PaymentMethod::Card),
             address,
             auth_type: common_enums::AuthenticationType::foreign_try_from(
                 grpc_api_types::payments::AuthenticationType::try_from(value.auth_type)
@@ -8827,7 +8843,11 @@ impl
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
             status: common_enums::AttemptStatus::Pending,
-            payment_method: PaymentMethod::Card,
+            payment_method: value
+                .payment_method
+                .map(PaymentMethod::foreign_try_from)
+                .transpose()?
+                .unwrap_or(PaymentMethod::Card),
             address,
             auth_type: common_enums::AuthenticationType::default(),
             connector_request_reference_id: value.merchant_recurring_payment_id,


### PR DESCRIPTION
## Verdict in one line
All flows: Prism hardcodes `PaymentMethod::Card` in 5 `PaymentFlowData::foreign_try_from` impls that have the actual payment method available in their proto field. Non-card payments (bank redirect, bank transfer, wallet, etc.) are misrouted. Fix in Prism.

## Decision trail
- 14 instances of `payment_method: PaymentMethod::Card` across `foreign_try_from` impls in `types.rs`
- 5 of 14 source proto types carry a `payment_method` field — these are fixed
- 9 of 14 proto types lack the field — these require proto schema additions (follow-up)
- Existing `ForeignTryFrom<grpc_api_types::payments::PaymentMethod> for PaymentMethod` conversion handles all payment method variants

### Code pattern (same across all 5 changes)
```rust
// Before:
payment_method: PaymentMethod::Card,

// After:
payment_method: value
    .payment_method
    .map(PaymentMethod::foreign_try_from)
    .transpose()?
    .unwrap_or(PaymentMethod::Card),
```

## Raw evidence
- PRD issue: PRI-333 (Paperclip)
- GH issues: #16385, #16384, #16383, #16396, #16397
- Parent RCA: PRI-330

### Fixed instances (proto field available)
| Flow | Source Type | Line |
|------|-----------|------|
| Authorize | `AuthorizationRequest` | L4353 |
| SetupRecurring | `SetupRecurringRequest` | L4439 |
| RecurringCharge | `RecurringPaymentServiceChargeRequest` | L4551 |
| SetupRecurring (grpc+Env) | `PaymentServiceSetupRecurringRequest` | L8731 |
| SetupRecurring (grpc) | `PaymentServiceSetupRecurringRequest` | L8830 |

### Unfixed instances (proto gap — follow-up)
| Flow | Source Type | Line |
|------|-----------|------|
| AccessToken | `MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest` | L4138 |
| PSync | `PaymentServiceGetRequest` | L4632 |
| Void | `PaymentServiceVoidRequest` | L4715 |
| Reverse | `PaymentServiceReverseRequest` | L7568 |
| IncrementalAuth | `PaymentServiceIncrementalAuthorizationRequest` | L7678 |
| Capture | `PaymentServiceCaptureRequest` | L8297 |
| CreateOrder | `PaymentServiceCreateOrderRequest` | L9973 |
| SessionToken | `MerchantAuthenticationServiceCreateServerSessionAuthenticationTokenRequest` | L10488 |
| ConnectorCustomer | `CustomerServiceCreateRequest` | L10818 |

## Verification
<details><summary>cargo build -p domain_types (clean)</summary>

```
Compiling domain_types v0.1.0
Finished dev profile target(s) in 57.97s
```
</details>
<details><summary>cargo clippy -p domain_types (clean)</summary>

```
Checking domain_types v0.1.0
Finished dev profile target(s) in 53.55s
```
</details>
<details><summary>cargo build -p connector-integration (clean)</summary>

```
Compiling connector-integration v0.1.0
Finished dev profile target(s) in 1m 19s
```
</details>
<details><summary>cargo clippy -p connector-integration (clean)</summary>

```
Checking connector-integration v0.1.0
Finished dev profile target(s) in 1m 27s
```
</details>
<details><summary>cargo test -p connector-integration --lib (78 passed)</summary>

```
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
</details>

## What this PR is NOT
- Does NOT touch the 9 proto types that lack a `payment_method` field (requires proto schema additions)
- Does NOT modify proto definitions (scope constraint: value-source fixes only)
- Does NOT change connector-specific transformers
- Only file touched: `crates/types-traits/domain_types/src/types.rs`

## Acceptance Criteria
- [x] Build clean (`domain_types` + `connector-integration`)
- [x] Clippy clean (`domain_types` + `connector-integration`)
- [x] All existing tests pass (78/78)
- [x] `unwrap_or(PaymentMethod::Card)` preserves backward-compatible default
- [ ] Shadow-replay produces zero diff for fixed flows (next `run_all.sh` cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)