### PR TITLE
feat(twoc_twop_paco): implement VerifyRedirectResponse stub

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco.rs
@@ -12,8 +12,8 @@ use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void, VoidPC},
     connector_types::{
         PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCancelPostCaptureData,
-        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
-        RefundSyncData, RefundsData, RefundsResponseData,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RedirectDetailsResponse,
+        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RequestDetails,
     },
     errors,
     payment_method_data::PaymentMethodDataTypes,
@@ -25,8 +25,11 @@ use domain_types::{
 use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, Maskable, PeekInterface};
 use interfaces::{
-    api::ConnectorCommon, connector_integration_v2::ConnectorIntegrationV2, connector_types,
-    decode::BodyDecoding, verification::SourceVerification,
+    api::ConnectorCommon,
+    connector_integration_v2::ConnectorIntegrationV2,
+    connector_types,
+    decode::BodyDecoding,
+    verification::{ConnectorSourceVerificationSecrets, SourceVerification},
 };
 use serde::Serialize;
 use transformers::{
@@ -90,6 +93,36 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::VerifyRedirectResponse for TwocTwopPaco<T>
 {
+    fn verify_redirect_response_source(
+        &self,
+        _request: &RequestDetails,
+        _secrets: Option<ConnectorSourceVerificationSecrets>,
+    ) -> CustomResult<bool, errors::IntegrationError> {
+        // PACO does not sign the post-3DS return; merchant is expected to
+        // follow up with Inquiry/PSync to fetch the authoritative status.
+        Ok(false)
+    }
+
+    fn process_redirect_response(
+        &self,
+        _request: &RequestDetails,
+    ) -> CustomResult<RedirectDetailsResponse, errors::IntegrationError> {
+        // PACO has no synchronous "complete authorize" endpoint — the ACS
+        // posts back the challenge result to the merchant's return_url and the
+        // merchant must call PSync (`/api/2.0/Inquiry/transactionStatus`) for
+        // the final payment status. Return an empty response so the caller
+        // proceeds to PSync.
+        Ok(RedirectDetailsResponse {
+            resource_id: None,
+            status: None,
+            connector_response_reference_id: None,
+            error_code: None,
+            error_message: None,
+            error_reason: None,
+            response_amount: None,
+            raw_connector_response: None,
+        })
+    }
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> SourceVerification
     for TwocTwopPaco<T>

--- a/data/field_probe/twoctwoppaco.json
+++ b/data/field_probe/twoctwoppaco.json
@@ -615,7 +615,7 @@
     },
     "verify_redirect": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported"
       }
     },
     "void": {

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -200,7 +200,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Trustpayments](connectors/trustpayments.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ✓ | ⚠ | ✓ | ⚠ | x | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Tsys](connectors/tsys.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | x | ✓ | x | x | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Twoc Twop Paco](connectors/twoc_twop_paco.md) | ✓ | ✓ | ✓ | ✓ | x | ✓ | x | x | x | x | x | x | x | x | x | ✓ | x | x | x | x | x | x | ⚠ | ✓ | ✓ | x | x | x | x | x | x |
-| [Twoctwoppaco](connectors/twoctwoppaco.md) | ? | ? | ? | ? | x | ? | ⚠ | ⚠ | ⚠ | ? | ⚠ | ? | ⚠ | ⚠ | ⚠ | ? | x | x | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
+| [Twoctwoppaco](connectors/twoctwoppaco.md) | ? | ? | ? | ? | x | ? | ⚠ | ✓ | ⚠ | ? | ⚠ | ? | ⚠ | ⚠ | ⚠ | ? | x | x | ⚠ | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Volt](connectors/volt.md) | ✓ | ⚠ | x | x | x | ✓ | x | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ⚠ | x | x | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Wellsfargo](connectors/wellsfargo.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | x | ✓ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ |
 | [Worldpay](connectors/worldpay.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | ✓ | ⚠ | ⚠ | ? | ⚠ | x | ⚠ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ? | ⚠ | ? | x | ⚠ | x | x | ⚠ | ⚠ |

--- a/docs-generated/connectors/twoctwoppaco.md
+++ b/docs-generated/connectors/twoctwoppaco.md
@@ -1,0 +1,106 @@
+# Twoctwoppaco
+
+<!--
+This file is auto-generated. Do not edit by hand.
+Source: data/field_probe/twoctwoppaco.json
+Regenerate: python3 scripts/generators/docs/generate.py twoctwoppaco
+-->
+
+## SDK Configuration
+
+Use this config for all flows in this connector. Replace `YOUR_API_KEY` with your actual credentials.
+
+<table>
+<tr><td><b>Python</b></td><td><b>JavaScript</b></td><td><b>Kotlin</b></td><td><b>Rust</b></td></tr>
+<tr>
+<td valign="top">
+
+<details><summary>Python</summary>
+
+```python
+from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
+
+config = sdk_config_pb2.ConnectorConfig(
+    options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
+    # connector_config=payment_pb2.ConnectorSpecificConfig(
+    #     twoctwoppaco=payment_pb2.TwoctwoppacoConfig(api_key=...),
+    # ),
+)
+
+```
+
+</details>
+
+</td>
+<td valign="top">
+
+<details><summary>JavaScript</summary>
+
+```javascript
+const { PaymentClient } = require('hyperswitch-prism');
+const { ConnectorConfig, Environment, Connector } = require('hyperswitch-prism').types;
+
+const config = ConnectorConfig.create({
+    connector: Connector.TWOCTWOPPACO,
+    environment: Environment.SANDBOX,
+    // auth: { twoctwoppaco: { apiKey: { value: 'YOUR_API_KEY' } } },
+});
+```
+
+</details>
+
+</td>
+<td valign="top">
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+val config = ConnectorConfig.newBuilder()
+    .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
+    // .setConnectorConfig(...) — set your Twoctwoppaco credentials here
+    .build()
+```
+
+</details>
+
+</td>
+<td valign="top">
+
+<details><summary>Rust</summary>
+
+```rust
+use grpc_api_types::payments::*;
+use grpc_api_types::payments::connector_specific_config;
+
+let config = ConnectorConfig {
+    connector_config: None,  // TODO: Add your connector config here,
+    options: Some(SdkOptions {
+        environment: Environment::Sandbox.into(),
+    }),
+};
+```
+
+</details>
+
+</td>
+</tr>
+</table>
+
+## API Reference
+
+| Flow (Service.RPC) | Category | gRPC Request Message |
+|--------------------|----------|----------------------|
+| [PaymentService.VerifyRedirectResponse](#paymentserviceverifyredirectresponse) | Payments | `PaymentServiceVerifyRedirectResponseRequest` |
+
+### Payments
+
+#### PaymentService.VerifyRedirectResponse
+
+Verify and process redirect responses from 3D Secure or other external flows. Validates authentication results and updates payment state accordingly.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceVerifyRedirectResponseRequest` |
+| **Response** | `PaymentServiceVerifyRedirectResponseResponse` |
+
+**Examples:** [Python](../../examples/twoctwoppaco/twoctwoppaco.py) · [TypeScript](../../examples/twoctwoppaco/twoctwoppaco.ts#L28) · [Kotlin](../../examples/twoctwoppaco/twoctwoppaco.kt#L27) · [Rust](../../examples/twoctwoppaco/twoctwoppaco.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -667,7 +667,7 @@ connector_id: twoctwoppaco
 doc: docs/connectors/twoctwoppaco.md
 scenarios: none
 payment_methods: none
-flows: 
+flows: verify_redirect
 examples_python: none
 
 ## Volt

--- a/examples/twoctwoppaco/twoctwoppaco.kt
+++ b/examples/twoctwoppaco/twoctwoppaco.kt
@@ -1,0 +1,44 @@
+// This file is auto-generated. Do not edit manually.
+// Replace YOUR_API_KEY and placeholder values with real data.
+// Regenerate: python3 scripts/generate-connector-docs.py twoctwoppaco
+//
+// Twoctwoppaco — all scenarios and flows in one file.
+// Run a scenario:  ./gradlew run --args="twoctwoppaco processCheckoutCard"
+
+package examples.twoctwoppaco
+
+import types.Payment.*
+import types.PaymentMethods.*
+import payments.PaymentClient
+import payments.ConnectorConfig
+import payments.SdkOptions
+import payments.Environment
+
+
+val SUPPORTED_FLOWS = listOf<String>()
+
+val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
+    .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
+    // .setConnectorConfig(...) — set your Twoctwoppaco credentials here
+    .build()
+
+
+// Flow: PaymentService.VerifyRedirectResponse
+fun verifyRedirect(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = PaymentServiceVerifyRedirectResponseRequest.newBuilder().apply {
+
+    }.build()
+    val response = client.verify_redirect_response(request)
+    println("Source verified: ${response.sourceVerified}")
+}
+
+
+fun main(args: Array<String>) {
+    val txnId = "order_001"
+    val flow = args.firstOrNull() ?: "verifyRedirect"
+    when (flow) {
+        "verifyRedirect" -> verifyRedirect(txnId)
+        else -> System.err.println("Unknown flow: $flow. Available: verifyRedirect")
+    }
+}

--- a/examples/twoctwoppaco/twoctwoppaco.py
+++ b/examples/twoctwoppaco/twoctwoppaco.py
@@ -1,0 +1,31 @@
+# This file is auto-generated. Do not edit manually.
+# Replace YOUR_API_KEY and placeholder values with real data.
+# Regenerate: python3 scripts/generate-connector-docs.py twoctwoppaco
+#
+# Twoctwoppaco — all integration scenarios and flows in one file.
+# Run a scenario:  python3 twoctwoppaco.py checkout_card
+
+import asyncio
+import sys
+from payments import PaymentClient
+from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
+
+SUPPORTED_FLOWS: list[str] = []
+
+_default_config = sdk_config_pb2.ConnectorConfig(
+    options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
+    # connector_config=payment_pb2.ConnectorSpecificConfig(
+    #     twoctwoppaco=payment_pb2.TwoctwoppacoConfig(api_key=...),
+    # ),
+)
+
+
+
+if __name__ == "__main__":
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "checkout_autocapture"
+    fn = globals().get(f"process_{scenario}")
+    if not fn:
+        available = [k[8:] for k in globals() if k.startswith("process_")]
+        print(f"Unknown scenario: {scenario}. Available: {available}", file=sys.stderr)
+        sys.exit(1)
+    asyncio.run(fn("order_001"))

--- a/examples/twoctwoppaco/twoctwoppaco.rs
+++ b/examples/twoctwoppaco/twoctwoppaco.rs
@@ -1,0 +1,50 @@
+// This file is auto-generated. Do not edit manually.
+// Replace YOUR_API_KEY and placeholder values with real data.
+// Regenerate: python3 scripts/generate-connector-docs.py twoctwoppaco
+//
+// Twoctwoppaco — all scenarios and flows in one file.
+// Run a scenario:  cargo run --example twoctwoppaco -- process_checkout_card
+use grpc_api_types::payments::connector_specific_config;
+use grpc_api_types::payments::*;
+use hyperswitch_payments_client::ConnectorClient;
+use std::collections::HashMap;
+
+#[allow(dead_code)]
+pub const SUPPORTED_FLOWS: &[&str] = &[];
+
+#[allow(dead_code)]
+fn build_client() -> ConnectorClient {
+    // Configure the connector with authentication
+    let config = ConnectorConfig {
+        connector_config: None, // TODO: Add your connector config here,
+        options: Some(SdkOptions {
+            environment: Environment::Sandbox.into(),
+        }),
+    };
+    ConnectorClient::new(config, None).unwrap()
+}
+
+pub fn build_verify_redirect_request() -> PaymentServiceVerifyRedirectResponseRequest {
+    PaymentServiceVerifyRedirectResponseRequest {
+        ..Default::default()
+    }
+}
+
+#[allow(dead_code)]
+#[tokio::main]
+async fn main() {
+    let client = build_client();
+    let flow = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "authorize".to_string());
+    let result: Result<String, Box<dyn std::error::Error>> = match flow.as_str() {
+        _ => {
+            eprintln!("Unknown flow: {}. Available: ", flow);
+            return;
+        }
+    };
+    match result {
+        Ok(msg) => println!("✓ {msg}"),
+        Err(e) => eprintln!("✗ {e}"),
+    }
+}

--- a/examples/twoctwoppaco/twoctwoppaco.ts
+++ b/examples/twoctwoppaco/twoctwoppaco.ts
@@ -1,0 +1,55 @@
+// This file is auto-generated. Do not edit manually.
+// Replace YOUR_API_KEY and placeholder values with real data.
+// Regenerate: python3 scripts/generate-connector-docs.py twoctwoppaco
+//
+// Twoctwoppaco — all integration scenarios and flows in one file.
+// Run a scenario:  npx tsx twoctwoppaco.ts checkout_autocapture
+
+import { PaymentClient, types } from 'hyperswitch-prism';
+const { Environment } = types;
+export const SUPPORTED_FLOWS = [];
+
+const _defaultConfig: types.IConnectorConfig = {
+    options: {
+        environment: Environment.SANDBOX,
+    },
+    // connectorConfig: { twoctwoppaco: { apiKey: { value: 'YOUR_API_KEY' } } },
+};
+
+
+function _buildVerifyRedirectRequest(): types.IPaymentServiceVerifyRedirectResponseRequest {
+    return {
+    };
+}
+
+
+// ANCHOR: scenario_functions
+// Flow: PaymentService.VerifyRedirectResponse
+async function verifyRedirect(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const verifyResponse = await paymentClient.verifyRedirectResponse(_buildVerifyRedirectRequest());
+
+    return verifyResponse;
+}
+
+
+// Export all process* functions for the smoke test
+export {
+    verifyRedirect, _buildVerifyRedirectRequest
+};
+
+// CLI runner
+if (require.main === module) {
+    const scenario = process.argv[2] || 'checkout_autocapture';
+    const key = 'process' + scenario.replace(/_([a-z])/g, (_, l) => l.toUpperCase()).replace(/^(.)/, c => c.toUpperCase());
+    const fn = (globalThis as any)[key] || (exports as any)[key];
+    if (!fn) {
+        const available = Object.keys(exports).map(k =>
+            k.replace(/^process/, '').replace(/([A-Z])/g, '_$1').toLowerCase().replace(/^_/, '')
+        );
+        console.error(`Unknown scenario: ${scenario}. Available: ${available.join(', ')}`);
+        process.exit(1);
+    }
+    fn('order_001').catch(console.error);
+}


### PR DESCRIPTION
## Summary

- Fills the empty `impl VerifyRedirectResponse for TwocTwopPaco<T>` block with two trait method overrides so the 3DS return path no longer errors out with `This feature is not implemented: process_redirect_response` (HTTP 412 / gRPC `FailedPrecondition`).
- `verify_redirect_response_source` returns `Ok(false)` — PACO does not sign the post-3DS return.
- `process_redirect_response` returns an empty `RedirectDetailsResponse` — PACO has no synchronous "complete authorize" endpoint; the merchant follows up with `PSync` (`/api/2.0/Inquiry/transactionStatus`) for the final status. Mirrors the pattern in Revolut / Flywire.

## Context

The commit `ee031f48b` was made on `feat/twoctwop-paco` a few hours after PR #1273 (the initial squash-merge of the PACO connector) landed on main, so it never reached main with that PR. None of the later targeted paco PRs (#1355, #1377, #1411) carried it forward. This PR cherry-picks it onto main directly.

## Test plan

- [ ] `cargo check -p connector-integration` passes (verified locally)
- [ ] Run a 3DS Card Authorize through PACO UAT, follow the ACS redirect, POST the merchant return URL to `/payments/verify_redirect_response` — expect HTTP 200 with an empty body (was 412 before)
- [ ] Confirm a subsequent `PaymentService.Get` (PSync) returns the authoritative final status from PACO