### PR TITLE
fix(connector): update types.rs for payouts

### DIFF
--- a/crates/integrations/connector-integration/src/types.rs
+++ b/crates/integrations/connector-integration/src/types.rs
@@ -208,7 +208,10 @@ impl ConnectorDataProvider for PayoutConnectorData {
     fn from_connector_variant(
         variant: &domain_types::connector_types::ConnectorVariant,
     ) -> Option<Self> {
-        variant.as_payout().map(|c| Self::get_connector_by_name(&c))
+        variant
+            .as_payout()
+            .or_else(|| variant.as_payment().and_then(|c| PayoutConnectorEnum::try_from(c).ok()))
+            .map(|c| Self::get_connector_by_name(&c))
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Minor fix in order for paypal payouts to correctly work with recent payouts changes.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
When routing payouts to UCS via gRPC, dual-purpose connector names (like "paypal") deserialize as Payment variants by default, causing strict .as_payout() checks to fail. This PR adds a fallback to safely cast supported Payment variants into PayoutConnectorEnum, preventing valid payouts from being rejected.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ref PR: #1203 