### PR TITLE
parity(braintree/infra): add serde(default) for repeated proto fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,6 +3232,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "serde",
+ "serde_json",
  "tonic 0.14.5",
  "tonic-build",
  "tonic-prost",

--- a/crates/types-traits/grpc-api-types/Cargo.toml
+++ b/crates/types-traits/grpc-api-types/Cargo.toml
@@ -19,9 +19,13 @@ error-stack = "0.5.0"
 cards = { path = "../cards", package = "ucs_cards" }
 hyperswitch_masking = { version = "0.0.1", default-features = false, features = [ "proto_tonic","alloc", "serde", "time"] }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [build-dependencies]
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 heck = "0.5.0"
 g2h = { git = "https://github.com/juspay/g2h", rev = "399d5257744cabffe88d9871a1192eacbbe9f484" }

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -83,10 +83,7 @@ fn add_serde_default_recursive(config: &mut prost_build::Config, message: &Descr
     for field in &message.field {
         if field.label() == Label::Repeated && field.r#type() != Type::Enum {
             let field_name = field.name.as_deref().unwrap_or_default();
-            config.field_attribute(
-                format!("{message_name}.{field_name}"),
-                "#[serde(default)]",
-            );
+            config.field_attribute(format!("{message_name}.{field_name}"), "#[serde(default)]");
         }
     }
     for nested in &message.nested_type {

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -1,5 +1,10 @@
 use std::{env, path::PathBuf};
 
+use prost_types::{
+    field_descriptor_proto::{Label, Type},
+    DescriptorProto, FileDescriptorSet,
+};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
@@ -32,40 +37,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "#[serde(rename_all = \"snake_case\")]",
     );
 
+    let protos: &[&str] = &[
+        "proto/services.proto",
+        "proto/health_check.proto",
+        "proto/payment.proto",
+        "proto/composite_services.proto",
+        "proto/composite_payment.proto",
+        "proto/payment_methods.proto",
+        "proto/sdk_config.proto",
+        "proto/payouts.proto",
+        "proto/surcharge.proto",
+    ];
+
+    // g2h's add_skip_null_attribute_static does not add #[serde(default)] for repeated
+    // (Vec<T>) proto fields. Protobuf semantics say repeated fields default to empty,
+    // so serde(default) is always correct. Load the file descriptors and patch the config
+    // before handing it to g2h.
+    let fds = prost_build::Config::new().load_fds(protos, &["proto"])?;
+    add_serde_default_for_repeated_fields(&mut config, &fds);
+
     // Use compile_protos_with_config which handles everything internally
     // including string enum support, serde derives, and descriptor set writing
-    bridge_generator.compile_protos_with_config(
-        config,
-        &[
-            "proto/services.proto",
-            "proto/health_check.proto",
-            "proto/payment.proto",
-            "proto/composite_services.proto",
-            "proto/composite_payment.proto",
-            "proto/payment_methods.proto",
-            "proto/sdk_config.proto",
-            "proto/payouts.proto",
-            "proto/surcharge.proto",
-        ],
-        &["proto"],
-    )?;
-
-    // prost_build::Config::new()
-    //     .service_generator(Box::new(web_generator))
-    //     .file_descriptor_set_path(out_dir.join("connector_service_descriptor.bin"))
-    //     .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
-    //     .type_attribute(".", "#[allow(clippy::large_enum_variant)]")
-    //     .compile_protos(
-    //         &[
-    //             "proto/services.proto",
-    //             "proto/health_check.proto",
-    //             "proto/payment.proto",
-    //             "proto/composite_services.proto",
-    //             "proto/composite_payment.proto",
-    //             "proto/payment_methods.proto",
-    //         ],
-    //         &["proto"],
-    //     )?;
+    bridge_generator.compile_protos_with_config(config, protos, &["proto"])?;
 
     Ok(())
+}
+
+/// Add `#[serde(default)]` for all repeated non-enum proto fields.
+///
+/// g2h already adds `default` for repeated enum fields via its enum serializer attributes,
+/// so we skip those to avoid duplicate serde(default) which would cause a compile error.
+fn add_serde_default_for_repeated_fields(
+    config: &mut prost_build::Config,
+    fds: &FileDescriptorSet,
+) {
+    for file in &fds.file {
+        for message in &file.message_type {
+            add_serde_default_recursive(config, message);
+        }
+    }
+}
+
+fn add_serde_default_recursive(config: &mut prost_build::Config, message: &DescriptorProto) {
+    let message_name = message.name.as_deref().unwrap_or_default();
+    for field in &message.field {
+        if field.label() == Label::Repeated && field.r#type() != Type::Enum {
+            let field_name = field.name.as_deref().unwrap_or_default();
+            config.field_attribute(
+                format!("{message_name}.{field_name}"),
+                "#[serde(default)]",
+            );
+        }
+    }
+    for nested in &message.nested_type {
+        add_serde_default_recursive(config, nested);
+    }
 }

--- a/crates/types-traits/grpc-api-types/src/lib.rs
+++ b/crates/types-traits/grpc-api-types/src/lib.rs
@@ -47,7 +47,10 @@ mod tests {
             "gpay_allowed_auth_methods": ["PAN_ONLY"]
         }"#;
         let config: BraintreeConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.apple_pay_supported_networks, vec!["visa", "mastercard"]);
+        assert_eq!(
+            config.apple_pay_supported_networks,
+            vec!["visa", "mastercard"]
+        );
         assert_eq!(config.gpay_allowed_auth_methods, vec!["PAN_ONLY"]);
         assert!(config.apple_pay_merchant_capabilities.is_empty());
         assert!(config.gpay_allowed_card_networks.is_empty());

--- a/crates/types-traits/grpc-api-types/src/lib.rs
+++ b/crates/types-traits/grpc-api-types/src/lib.rs
@@ -20,3 +20,36 @@ pub mod payouts {
 pub mod surcharge {
     tonic::include_proto!("types");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::payments::BraintreeConfig;
+
+    #[test]
+    fn parity_16464_braintree_config_missing_repeated_fields() {
+        let json = r#"{
+            "public_key": "test_pub_key",
+            "private_key": "test_priv_key"
+        }"#;
+        let config: BraintreeConfig = serde_json::from_str(json).unwrap();
+        assert!(config.apple_pay_supported_networks.is_empty());
+        assert!(config.apple_pay_merchant_capabilities.is_empty());
+        assert!(config.gpay_allowed_auth_methods.is_empty());
+        assert!(config.gpay_allowed_card_networks.is_empty());
+    }
+
+    #[test]
+    fn parity_16464_braintree_config_with_repeated_fields() {
+        let json = r#"{
+            "public_key": "test_pub_key",
+            "private_key": "test_priv_key",
+            "apple_pay_supported_networks": ["visa", "mastercard"],
+            "gpay_allowed_auth_methods": ["PAN_ONLY"]
+        }"#;
+        let config: BraintreeConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.apple_pay_supported_networks, vec!["visa", "mastercard"]);
+        assert_eq!(config.gpay_allowed_auth_methods, vec!["PAN_ONLY"]);
+        assert!(config.apple_pay_merchant_capabilities.is_empty());
+        assert!(config.gpay_allowed_card_networks.is_empty());
+    }
+}


### PR DESCRIPTION
## Verdict in one line
Braintree (and any future connector with `repeated` proto fields): Prism's `build.rs` did not add `#[serde(default)]` for `Vec<T>` fields generated from proto `repeated`. Per protobuf semantics, repeated fields default to empty. Fix in Prism `build.rs`.

## Decision trail
- g2h `add_skip_null_attribute_static` (`lib.rs:L1073-L1096`):
  ```rust
  // Handles optional/message → skip_serializing_if = "Option::is_none"
  // Handles string (non-repeated) → skip_serializing_if = "String::is_empty"
  // Does NOT handle repeated → Vec<T> fields get no serde(default)
  ```
- BraintreeConfig proto (`payment.proto:L3805-L3820`):
  ```protobuf
  repeated string apple_pay_supported_networks = 53;
  repeated string apple_pay_merchant_capabilities = 54;
  repeated string gpay_allowed_auth_methods = 58;
  repeated string gpay_allowed_card_networks = 59;
  ```
- HS sends JSON without these fields → Prism fails with "missing field" → gRPC INVALID_ARGUMENT
- Protobuf semantics: repeated fields always default to empty — `#[serde(default)]` is always correct
- Fix direction: Prism build.rs (g2h is external, fix applied before compile_protos_with_config)

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16464
- Sibling issues: #16434 (braintree authorize), #16435 (braintree capture)
- g2h library: `juspay/g2h` rev `399d5257` — `add_skip_null_attribute_static` has no `Label::Repeated` branch

## Diff
The fix loads proto file descriptors in `build.rs` and adds `#[serde(default)]` for all repeated non-enum fields before passing the config to g2h. This is general: any future connector config that adds `repeated` fields will automatically get the attribute.

Repeated enum fields are excluded because g2h's enum serializer already adds `default` for those — adding it twice would cause a serde compile error.

## Verification
<details><summary>cargo build -p grpc-api-types (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.96s
```
</details>
<details><summary>cargo clippy -p grpc-api-types (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.79s
```
</details>
<details><summary>cargo test -p grpc-api-types (PASS)</summary>

```
running 2 tests
test tests::parity_16464_braintree_config_missing_repeated_fields ... ok
test tests::parity_16464_braintree_config_with_repeated_fields ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
</details>

## What this PR is NOT
- Does NOT modify g2h (external dependency) — a general g2h fix should follow separately
- Does NOT touch connector transformers
- Does NOT touch `ucs_interface_common/src/auth.rs`
- PRD `Out of scope`: connector API field mapping (this is internal config transport)

## Acceptance Criteria
- [x] Build clean
- [x] Clippy clean
- [x] Regression tests added and passing (2 tests)
- [x] Fix is general (handles all repeated non-enum fields, not just BraintreeConfig)
- [ ] Shadow-replay produces zero diff (verified by next regular `run_all.sh` cycle; not blocking merge)