### PR TITLE
parity(hipay/PaymentMethodToken): propagate connector_http_status_code + connector_response

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -14,7 +14,9 @@ use common_utils::{
     request::{Method, Request, RequestContent},
 };
 use domain_types::{
-    connector_types::{ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse},
+    connector_types::{
+        ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse,
+    },
     errors::ApiErrorResponse,
     router_data_v2::RouterDataV2,
     router_response_types::Response,
@@ -231,7 +233,8 @@ where
     F: Clone + 'static,
     Req: Clone + 'static + std::fmt::Debug,
     Resp: Clone + 'static + std::fmt::Debug,
-    ResourceCommonData: Clone + RawConnectorRequestResponse + ConnectorResponseHeaders + ConnectorHttpStatusCode,
+    ResourceCommonData:
+        Clone + RawConnectorRequestResponse + ConnectorResponseHeaders + ConnectorHttpStatusCode,
 {
     let return_raw = event_params.is_none_or(|p| p.return_raw_connector_data);
     match response {
@@ -275,7 +278,9 @@ where
                     }
 
                     let mut result = handle_response_result?;
-                    result.resource_common_data.set_connector_http_status_code(status_code);
+                    result
+                        .resource_common_data
+                        .set_connector_http_status_code(status_code);
                     result
                 }
                 Err(body) => {

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -14,7 +14,7 @@ use common_utils::{
     request::{Method, Request, RequestContent},
 };
 use domain_types::{
-    connector_types::{ConnectorResponseHeaders, RawConnectorRequestResponse},
+    connector_types::{ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse},
     errors::ApiErrorResponse,
     router_data_v2::RouterDataV2,
     router_response_types::Response,
@@ -231,7 +231,7 @@ where
     F: Clone + 'static,
     Req: Clone + 'static + std::fmt::Debug,
     Resp: Clone + 'static + std::fmt::Debug,
-    ResourceCommonData: Clone + RawConnectorRequestResponse + ConnectorResponseHeaders,
+    ResourceCommonData: Clone + RawConnectorRequestResponse + ConnectorResponseHeaders + ConnectorHttpStatusCode,
 {
     let return_raw = event_params.is_none_or(|p| p.return_raw_connector_data);
     match response {
@@ -274,7 +274,9 @@ where
                             .record("response.headers", tracing::field::debug(&evt.headers));
                     }
 
-                    handle_response_result?
+                    let mut result = handle_response_result?;
+                    result.resource_common_data.set_connector_http_status_code(status_code);
+                    result
                 }
                 Err(body) => {
                     // Record metrics only if event_params is provided
@@ -409,6 +411,7 @@ where
         + 'static
         + RawConnectorRequestResponse
         + ConnectorResponseHeaders
+        + ConnectorHttpStatusCode
         + ConnectorRequestReference
         + AdditionalHeaders,
 {

--- a/crates/integrations/connector-integration/src/connectors/hipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay.rs
@@ -1,4 +1,5 @@
 pub mod transformers;
+mod test;
 
 use std::fmt::Debug;
 

--- a/crates/integrations/connector-integration/src/connectors/hipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay.rs
@@ -1,5 +1,5 @@
-pub mod transformers;
 mod test;
+pub mod transformers;
 
 use std::fmt::Debug;
 

--- a/crates/integrations/connector-integration/src/connectors/hipay/parity_fixtures/15803.json
+++ b/crates/integrations/connector-integration/src/connectors/hipay/parity_fixtures/15803.json
@@ -1,0 +1,11 @@
+{
+    "token": "8d97bfb7cf0141e09f56fd7337dca4131c3b550d3e367d5752e7fba54ef69cc4",
+    "request_id": "019dda64-085b-70f1-89c9-26dfcdc86741",
+    "brand": "VISA",
+    "pan": "411111XXXXXX1111",
+    "card_holder": "Joseph Doe",
+    "card_expiry_month": "06",
+    "card_expiry_year": "2050",
+    "issuer": "CONOTOXIA SP Z O.O.",
+    "country": "PL"
+}

--- a/crates/integrations/connector-integration/src/connectors/hipay/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/test.rs
@@ -17,10 +17,7 @@ mod tests {
         types::Connectors,
     };
 
-    use crate::{
-        connectors::hipay::transformers::HipayTokenResponse,
-        types::ResponseRouterData,
-    };
+    use crate::{connectors::hipay::transformers::HipayTokenResponse, types::ResponseRouterData};
 
     fn default_payment_flow_data() -> PaymentFlowData {
         PaymentFlowData {

--- a/crates/integrations/connector-integration/src/connectors/hipay/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/test.rs
@@ -1,0 +1,145 @@
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use common_enums::Currency;
+    use common_utils::types::MinorUnit;
+    use domain_types::{
+        connector_flow::PaymentMethodToken,
+        connector_types::{
+            PaymentFlowData, PaymentMethodTokenResponse, PaymentMethodTokenizationData,
+        },
+        payment_method_data::{DefaultPCIHolder, PaymentMethodData},
+        router_data::{ConnectorSpecificConfig, ErrorResponse},
+        router_data_v2::RouterDataV2,
+        types::Connectors,
+    };
+
+    use crate::{
+        connectors::hipay::transformers::HipayTokenResponse,
+        types::ResponseRouterData,
+    };
+
+    fn default_payment_flow_data() -> PaymentFlowData {
+        PaymentFlowData {
+            merchant_id: common_utils::id_type::MerchantId::default(),
+            customer_id: None,
+            connector_customer: None,
+            payment_id: "pay_test".to_string(),
+            attempt_id: "attempt_test".to_string(),
+            status: common_enums::AttemptStatus::Pending,
+            payment_method: common_enums::PaymentMethod::Card,
+            description: None,
+            return_url: None,
+            address: Default::default(),
+            auth_type: common_enums::AuthenticationType::NoThreeDs,
+            connector_feature_data: None,
+            amount_captured: None,
+            minor_amount_captured: None,
+            minor_amount_capturable: None,
+            amount: None,
+            access_token: None,
+            session_token: None,
+            reference_id: None,
+            connector_order_id: None,
+            preprocessing_id: None,
+            connector_api_version: None,
+            connector_request_reference_id: "ref_test".to_string(),
+            test_mode: None,
+            connector_http_status_code: None,
+            connector_response_headers: None,
+            external_latency: None,
+            connectors: Connectors::default(),
+            raw_connector_response: None,
+            raw_connector_request: None,
+            vault_headers: None,
+            connector_response: None,
+            recurring_mandate_payment_data: None,
+            order_details: None,
+            minor_amount_authorized: None,
+            l2_l3_data: None,
+            merchant_request_id: None,
+            sender_payment_instrument_id: None,
+        }
+    }
+
+    #[test]
+    fn test_parity_15803_connector_response() {
+        let raw = include_str!("parity_fixtures/15803.json");
+        let response: HipayTokenResponse = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(response.brand, "VISA");
+
+        let router_data: RouterDataV2<
+            PaymentMethodToken,
+            PaymentFlowData,
+            PaymentMethodTokenizationData<DefaultPCIHolder>,
+            PaymentMethodTokenResponse,
+        > = RouterDataV2 {
+            flow: PhantomData,
+            resource_common_data: default_payment_flow_data(),
+            connector_config: ConnectorSpecificConfig::NoKey,
+            request: PaymentMethodTokenizationData {
+                payment_method_data: PaymentMethodData::MandatePayment,
+                browser_info: None,
+                currency: Currency::EUR,
+                amount: MinorUnit::new(6000),
+                capture_method: None,
+                customer_acceptance: None,
+                setup_future_usage: None,
+                setup_mandate_details: None,
+                mandate_id: None,
+                integrity_object: None,
+                split_payments: None,
+                connector_feature_data: None,
+            },
+            response: Err(ErrorResponse::default()),
+        };
+
+        let response_router_data = ResponseRouterData {
+            response,
+            router_data,
+            http_code: 201,
+        };
+
+        let result: RouterDataV2<
+            PaymentMethodToken,
+            PaymentFlowData,
+            PaymentMethodTokenizationData<DefaultPCIHolder>,
+            PaymentMethodTokenResponse,
+        > = response_router_data.try_into().unwrap();
+
+        let token_response = result.response.unwrap();
+        assert_eq!(
+            token_response.token,
+            "8d97bfb7cf0141e09f56fd7337dca4131c3b550d3e367d5752e7fba54ef69cc4"
+        );
+
+        let connector_response = result
+            .resource_common_data
+            .connector_response
+            .expect("connector_response should be Some");
+        let additional_data = connector_response
+            .additional_payment_method_data
+            .expect("additional_payment_method_data should be Some");
+
+        match additional_data {
+            domain_types::router_data::AdditionalPaymentMethodConnectorResponse::Card {
+                card_network,
+                domestic_network,
+                authentication_data,
+                payment_checks,
+                auth_code,
+            } => {
+                assert_eq!(card_network, Some("VISA".to_string()));
+                assert_eq!(domestic_network, None);
+                assert_eq!(authentication_data, None);
+                assert_eq!(payment_checks, None);
+                assert_eq!(auth_code, None);
+            }
+            _ => panic!("Expected Card variant"),
+        }
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
@@ -630,12 +630,22 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<HipayTokenResponse, S
 
     fn try_from(item: ResponseRouterData<HipayTokenResponse, Self>) -> Result<Self, Self::Error> {
         use hyperswitch_masking::ExposeInterface;
-        Ok(Self {
-            response: Ok(PaymentMethodTokenResponse {
-                token: item.response.token.expose(),
-            }),
-            ..item.router_data
-        })
+        let mut router_data = item.router_data;
+        router_data.resource_common_data.connector_response = Some(
+            domain_types::router_data::ConnectorResponseData::with_additional_payment_method_data(
+                domain_types::router_data::AdditionalPaymentMethodConnectorResponse::Card {
+                    authentication_data: None,
+                    payment_checks: None,
+                    card_network: Some(item.response.brand.clone()),
+                    domestic_network: None,
+                    auth_code: None,
+                },
+            ),
+        );
+        router_data.response = Ok(PaymentMethodTokenResponse {
+            token: item.response.token.expose(),
+        });
+        Ok(router_data)
     }
 }
 

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -478,6 +478,10 @@ pub trait ConnectorResponseHeaders {
     }
 }
 
+pub trait ConnectorHttpStatusCode {
+    fn set_connector_http_status_code(&mut self, _status_code: u16) {}
+}
+
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Eq, PartialEq)]
 pub struct NetworkTokenWithNTIRef {
     pub network_transaction_id: String,
@@ -1158,6 +1162,12 @@ impl ConnectorResponseHeaders for PaymentFlowData {
 
     fn get_connector_response_headers(&self) -> Option<&http::HeaderMap> {
         self.connector_response_headers.as_ref()
+    }
+}
+
+impl ConnectorHttpStatusCode for PaymentFlowData {
+    fn set_connector_http_status_code(&mut self, status_code: u16) {
+        self.connector_http_status_code = Some(status_code);
     }
 }
 
@@ -2004,6 +2014,8 @@ impl ConnectorResponseHeaders for RefundFlowData {
         self.connector_response_headers.as_ref()
     }
 }
+
+impl ConnectorHttpStatusCode for RefundFlowData {}
 
 impl RefundFlowData {
     pub fn get_merchant_request_id(&self) -> Result<String, Error> {
@@ -2988,6 +3000,8 @@ impl ConnectorResponseHeaders for DisputeFlowData {
     }
 }
 
+impl ConnectorHttpStatusCode for DisputeFlowData {}
+
 #[derive(Debug, Clone)]
 pub struct VerifyWebhookSourceFlowData {
     pub connectors: Connectors,
@@ -3024,6 +3038,8 @@ impl ConnectorResponseHeaders for VerifyWebhookSourceFlowData {
         self.connector_response_headers.as_ref()
     }
 }
+
+impl ConnectorHttpStatusCode for VerifyWebhookSourceFlowData {}
 
 #[derive(Debug, Clone)]
 pub struct DisputeResponseData {

--- a/crates/types-traits/domain_types/src/payouts/payouts_types.rs
+++ b/crates/types-traits/domain_types/src/payouts/payouts_types.rs
@@ -1,7 +1,7 @@
 use super::payout_method_data::{Bank, PayoutMethodData};
 use crate::{
     connector_types::{
-        ConnectorResponseHeaders, RawConnectorRequestResponse,
+        ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse,
         ServerAuthenticationTokenResponseData,
     },
     errors::IntegrationError,
@@ -53,6 +53,8 @@ impl ConnectorResponseHeaders for PayoutFlowData {
         self.connector_response_headers.as_ref()
     }
 }
+
+impl ConnectorHttpStatusCode for PayoutFlowData {}
 
 impl PayoutFlowData {
     pub fn get_access_token(&self) -> Result<String, Error> {

--- a/crates/types-traits/domain_types/src/surcharge/surcharge_types.rs
+++ b/crates/types-traits/domain_types/src/surcharge/surcharge_types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connector_types::{ConnectorResponseHeaders, RawConnectorRequestResponse},
+    connector_types::{ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse},
     types::Connectors,
 };
 use common_enums::Currency;
@@ -44,6 +44,8 @@ impl ConnectorResponseHeaders for SurchargeFlowData {
         self.connector_response_headers.as_ref()
     }
 }
+
+impl ConnectorHttpStatusCode for SurchargeFlowData {}
 
 /// Strategy for handling calculated surcharge
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/types-traits/domain_types/src/surcharge/surcharge_types.rs
+++ b/crates/types-traits/domain_types/src/surcharge/surcharge_types.rs
@@ -1,5 +1,7 @@
 use crate::{
-    connector_types::{ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse},
+    connector_types::{
+        ConnectorHttpStatusCode, ConnectorResponseHeaders, RawConnectorRequestResponse,
+    },
     types::Connectors,
 };
 use common_enums::Currency;

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -10718,6 +10718,17 @@ pub fn generate_create_payment_method_token_response<T: PaymentMethodDataTypes>(
 > {
     let token_response = router_data_v2.response;
 
+    let connector_response = router_data_v2
+        .resource_common_data
+        .connector_response
+        .as_ref()
+        .map(|connector_response_data| {
+            grpc_api_types::payments::ConnectorResponseData::foreign_try_from(
+                connector_response_data.clone(),
+            )
+        })
+        .transpose()?;
+
     match token_response {
         Ok(response) => {
             let token_clone = response.token.clone();
@@ -10725,12 +10736,16 @@ pub fn generate_create_payment_method_token_response<T: PaymentMethodDataTypes>(
                 grpc_api_types::payments::PaymentMethodServiceTokenizeResponse {
                     payment_method_token: response.token,
                     error: None,
-                    status_code: 200,
+                    status_code: router_data_v2
+                        .resource_common_data
+                        .connector_http_status_code
+                        .unwrap_or(200) as u32,
                     response_headers: router_data_v2
                         .resource_common_data
                         .get_connector_response_headers_as_map(),
                     merchant_payment_method_id: Some(token_clone),
                     state: None,
+                    connector_response: connector_response.clone(),
                 },
             )
         }
@@ -10753,6 +10768,7 @@ pub fn generate_create_payment_method_token_response<T: PaymentMethodDataTypes>(
                     .get_connector_response_headers_as_map(),
                 merchant_payment_method_id: e.connector_transaction_id,
                 state: None,
+                connector_response,
             },
         ),
     }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3551,6 +3551,9 @@ message PaymentMethodServiceTokenizeResponse {
 
   // State Information
   optional ConnectorState state = 6;
+
+  // Connector response data (card network, etc.)
+  optional ConnectorResponseData connector_response = 7;
 }
 
 // Request message for getting a payment method

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -406,7 +406,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   DisputeServiceDefendResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry" },
   DisputeServiceAcceptResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry" },
   PaymentMethodServiceTokenizeRequest: { "amount": "Money", "paymentMethod": "PaymentMethod", "customer": "Customer", "address": "PaymentAddress" },
-  PaymentMethodServiceTokenizeResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState" },
+  PaymentMethodServiceTokenizeResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "connectorResponse": "ConnectorResponseData" },
   PaymentMethodServiceGetRequest: { "state": "ConnectorState" },
   PaymentMethodServiceGetResponse: { "paymentMethod": "PaymentMethod", "customer": "Customer", "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry" },
   CustomerServiceCreateRequest: { "address": "PaymentAddress" },


### PR DESCRIPTION
## Verdict in one line
hipay/PaymentMethodToken: Prism was hardcoding `connector_http_status_code: 200` and returning `connector_response: null`. Per HiPay tokenization API (returns 201 + brand info), fix in Prism.

## Decision trail
- HS reads (`crates/hyperswitch_interfaces/src/api_client.rs:L339-340`):
  ```rust
  data.connector_http_status_code = connector_http_status_code;
  ```
- HS reads (`crates/hyperswitch_connectors/src/connectors/hipay/transformers.rs:L297-313`):
  ```rust
  connector_response: Some(ConnectorResponseData::with_additional_payment_method_data(
      AdditionalPaymentMethodConnectorResponse::from(&item.response),
  )),
  ```
- Prism reads (`crates/common/external-services/src/service.rs:L277`):
  ```rust
  handle_response_result? // never sets connector_http_status_code
  ```
- Prism reads (`crates/types-traits/domain_types/src/types.rs:L10728`):
  ```rust
  status_code: 200, // hardcoded
  ```
- Connector doc: https://developer.hipay.com/ (Secure Vault / Tokenization API)
  > `POST /rest/v2/token/create` returns HTTP 201 with `brand` field containing card network
- Conclusion: Prism infrastructure + proto generation diverge from oracle behavior
- Fix direction: Prism

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/15803
- Fixture: `crates/integrations/connector-integration/src/connectors/hipay/parity_fixtures/15803.json`
- Expected RouterData fields after fix: `connector_http_status_code: 201`, `connector_response.additional_payment_method_data.Card.card_network: "VISA"`
- Regression test: `test_parity_15803_connector_response` in `hipay/test.rs`

## Changes

### Fix 1 (infrastructure): connector_http_status_code
- **New trait `ConnectorHttpStatusCode`** in `connector_types.rs` — enables generic `handle_connector_response` to set the HTTP status code on `resource_common_data`
- **Trait impls**: `PaymentFlowData` (real setter), `RefundFlowData`, `DisputeFlowData`, `VerifyWebhookSourceFlowData`, `PayoutFlowData`, `SurchargeFlowData` (default no-op)
- **service.rs**: `handle_connector_response` + `execute_connector_processing_step` — propagate `status_code` after successful `handle_response_v2`
- **types.rs**: `generate_create_payment_method_token_response` — read `connector_http_status_code` instead of hardcoding `200`

### Fix 2 (per-connector + proto): connector_response
- **payment.proto**: Add `optional ConnectorResponseData connector_response = 7` to `PaymentMethodServiceTokenizeResponse`
- **hipay/transformers.rs**: Populate `connector_response` with `Card { card_network: brand }` from `HipayTokenResponse`
- **types.rs**: Extract and emit `connector_response` in proto generation (both Ok/Err branches)

### Note: Router-side extraction (separate HS PR needed)
The hyperswitch router needs to extract `connector_response` from the new proto field in:
- `crates/router/src/core/unified_connector_service/transformers.rs`
- `crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs`

This is a separate PR against `juspay/hyperswitch` — tracked as follow-up.

## Verification
<details><summary>cargo build (clean)</summary>

```
Compiling domain_types v0.1.0
Compiling interfaces v0.1.0
Compiling external-services v0.1.0
Compiling connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
```
</details>
<details><summary>cargo clippy (clean)</summary>

```
Checking domain_types v0.1.0
Checking interfaces v0.1.0
Checking external-services v0.1.0
Checking connector-integration v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 37s
```
</details>
<details><summary>parity regression test (PASS)</summary>

```
$ cargo test -p connector-integration --lib -- hipay::test
running 1 test
test connectors::hipay::test::tests::test_parity_15803_connector_response ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out
```
</details>
<details><summary>all existing tests (PASS)</summary>

```
$ cargo test -p connector-integration --lib
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
</details>
<details><summary>downstream build (grpc-server + ffi — clean)</summary>

```
Compiling grpc-server v0.1.0
Compiling ffi v0.1.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 07s
```
</details>

## What this PR is NOT
- Field paths NOT touched: `connector_customer`, `status`, `reference_id`
- Files NOT touched (despite being in same module): `hipay.rs` flow routing, other connector transformers
- PRD `Out of scope` items: Adding `domestic_network` to prism's `HipayTokenResponse` struct, other connectors' tokenization flows

## Acceptance Criteria
- [x] Build clean
- [x] Clippy clean
- [x] All existing tests pass
- [x] New parity regression test added and passing
- [x] Fixture committed under `parity_fixtures/`
- [ ] Shadow-replay produces zero diff (verified by next regular `run_all.sh` cycle; not blocking merge — requires companion HS PR for router-side extraction)
- [ ] Companion HS PR for router-side extraction (follow-up)