### PR TITLE
fix(connector): source NMI SetupMandate email from billing address

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1708,7 +1708,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             payment_method,
             first_name: common_data.get_optional_billing_first_name(),
             last_name: common_data.get_optional_billing_last_name(),
-            email: router_data.request.email.clone(),
+            email: common_data.get_optional_billing_email(),
             address1: common_data.get_optional_billing_line1(),
             address2: common_data.get_optional_billing_line2(),
             city: common_data.get_optional_billing_city(),

--- a/crates/integrations/connector-integration/src/types.rs
+++ b/crates/integrations/connector-integration/src/types.rs
@@ -210,7 +210,11 @@ impl ConnectorDataProvider for PayoutConnectorData {
     ) -> Option<Self> {
         variant
             .as_payout()
-            .or_else(|| variant.as_payment().and_then(|c| PayoutConnectorEnum::try_from(c).ok()))
+            .or_else(|| {
+                variant
+                    .as_payment()
+                    .and_then(|c| PayoutConnectorEnum::try_from(c).ok())
+            })
             .map(|c| Self::get_connector_by_name(&c))
     }
 }


### PR DESCRIPTION
## Summary

- Fix NMI `NmiSetupMandateRequest` email source: change from `router_data.request.email` (payment-level) to `common_data.get_optional_billing_email()` (billing address)
- NMI documents `email` as "Billing email address" in CreditCardValidateRequest schema — Hyperswitch correctly sources from billing, Prism was divergent
- Aligns email with all other billing fields in the same struct which already use `common_data.get_optional_billing_*()`

## PRD Reference

- **PRD**: juspay/hyperswitch-cloud#16479 (PRD #2: email source mapping, targets Prism)
- **Connector**: NMI
- **Flow**: setup_mandate
- **Classification**: passthrough-mismatch
- **Root cause**: `NmiSetupMandateRequest` TryFrom impl at L1711 sourced `email` from `router_data.request.email.clone()` instead of `common_data.get_optional_billing_email()`, introduced in commit `48437cd7a`

## Change

**File**: `crates/integrations/connector-integration/src/connectors/nmi/transformers.rs`

```diff
-            email: router_data.request.email.clone(),
+            email: common_data.get_optional_billing_email(),
```

## Verification

- [x] `cargo build -p connector-integration` — passes
- [x] `cargo clippy -p connector-integration -- -D warnings` — passes
- [x] `cargo test -p connector-integration --lib` — 78 passed, 0 failed
- [x] No collateral impact: `NmiSetupMandateRequest` is only used by SetupMandate flow
- [x] Same `Option<Email>` return type — no type changes needed
- [ ] Unit test for billing email sourcing — skipped: constructing macro-generated `NmiRouterData` wrapper requires disproportionate boilerplate for a 1-line type-safe fix; parity is verified by shadow-diff replay

## Risk

**Low** — single field source change within a single flow. Billing email and payment-level email are typically the same value; divergence only occurs when billing address lacks email but `request.email` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)