### PR TITLE
fix(nmi/authorize): add customer_vault field and fix merchant_defined_field ordering

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/tests/parity_fixtures/16028.json
+++ b/crates/integrations/connector-integration/src/connectors/nmi/tests/parity_fixtures/16028.json
@@ -1,0 +1,5 @@
+{
+  "udf1": "value1",
+  "login_date": "2019-09-10T10:11:12Z",
+  "new_customer": "true"
+}

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -584,7 +584,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         .resource_common_data
                         .get_optional_shipping_email(),
                 }),
-                customer_vault: router_data.request.is_mandate_payment().then_some(CustomerAction::AddCustomer),
+                customer_vault: router_data
+                    .request
+                    .is_mandate_payment()
+                    .then_some(CustomerAction::AddCustomer),
                 customer_vault_id: None,
                 email: None,
                 cardholder_auth: None,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -211,10 +211,12 @@ impl NmiMerchantDefinedField {
         let inner = metadata
             .as_object()
             .map(|obj| {
-                obj.iter()
+                let sorted: std::collections::BTreeMap<&String, &serde_json::Value> =
+                    obj.iter().collect();
+                sorted
+                    .into_iter()
                     .enumerate()
                     .map(|(index, (hs_key, hs_value))| {
-                        // Extract string value properly to avoid JSON encoding
                         let value_str = hs_value
                             .as_str()
                             .map(str::to_owned)
@@ -295,6 +297,8 @@ pub struct NmiPaymentsRequest<T: PaymentMethodDataTypes> {
     #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
     shipping_details: Option<NmiShippingDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    customer_vault: Option<CustomerAction>,
     // Fields for 3DS completion (when redirect_response is present)
     #[serde(skip_serializing_if = "Option::is_none")]
     customer_vault_id: Option<Secret<String>>,
@@ -434,6 +438,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 merchant_defined_field: None,
                 billing_details: None,
                 shipping_details: None,
+                customer_vault: None,
                 customer_vault_id: Some(three_ds_data.customer_vault_id),
                 email: router_data.request.email.clone(),
                 cardholder_auth: three_ds_data.card_holder_auth,
@@ -579,6 +584,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         .resource_common_data
                         .get_optional_shipping_email(),
                 }),
+                customer_vault: router_data.request.is_mandate_payment().then_some(CustomerAction::AddCustomer),
                 customer_vault_id: None,
                 email: None,
                 cardholder_auth: None,
@@ -1927,5 +1933,37 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             },
             ..item.router_data
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperswitch_masking::PeekInterface;
+
+    #[test]
+    fn test_parity_16028_merchant_defined_field_ordering() {
+        let metadata: serde_json::Value =
+            serde_json::from_str(include_str!("tests/parity_fixtures/16028.json")).unwrap();
+        let mdf = NmiMerchantDefinedField::new(&metadata);
+
+        assert_eq!(
+            mdf.inner
+                .get("merchant_defined_field_1")
+                .map(|s| s.peek().to_string()),
+            Some("login_date=2019-09-10T10:11:12Z".to_string()),
+        );
+        assert_eq!(
+            mdf.inner
+                .get("merchant_defined_field_2")
+                .map(|s| s.peek().to_string()),
+            Some("new_customer=true".to_string()),
+        );
+        assert_eq!(
+            mdf.inner
+                .get("merchant_defined_field_3")
+                .map(|s| s.peek().to_string()),
+            Some("udf1=value1".to_string()),
+        );
     }
 }


### PR DESCRIPTION
## Verdict in one line
nmi/authorize: Prism was missing `customer_vault` field on mandate payments and assigning `merchant_defined_field_N` slots in insertion order instead of alphabetical. Per NMI docs and HS oracle, fix in Prism.

## Decision trail
- HS reads (`crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs:L542,L760-L764`):
  ```rust
  customer_vault: item
      .router_data
      .request
      .is_mandate_payment()
      .then_some(CustomerAction::AddCustomer),
  ```
- HS reads (`crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs:L587-L588`):
  ```rust
  let hash_map: std::collections::BTreeMap<String, serde_json::Value> =
      serde_json::from_str(&metadata_as_string).unwrap_or(std::collections::BTreeMap::new());
  ```
- Prism reads (`crates/integrations/connector-integration/src/connectors/nmi/transformers.rs:L298-L300`):
  No `customer_vault` field in `NmiPaymentsRequest` struct.
- Prism reads (`crates/integrations/connector-integration/src/connectors/nmi/transformers.rs:L214`):
  ```rust
  obj.iter() // insertion order due to serde_json preserve_order feature
  ```
- Connector doc: https://docs.nmi.com/reference/transactions-processing
  > **customer_vault** — Associate payment information with a Customer Vault record if the transaction is successful.
  > **merchant_defined_field_#** — Merchant defined field. You can pass custom information in up to 20 fields.
- Conclusion: Prism is the divergent side on both fields. Fix in Prism.
- Fix direction: Prism

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16028
- Fixture: `crates/integrations/connector-integration/src/connectors/nmi/tests/parity_fixtures/16028.json`
- Expected merchant_defined_field after fix: `field_1=login_date=..., field_2=new_customer=..., field_3=udf1=...` (alphabetical)
- Expected customer_vault after fix: `add_customer` when `is_mandate_payment()` is true
- Regression test: `test_parity_16028_merchant_defined_field_ordering` in `transformers.rs`

## Changes

### PRD-A: customer_vault field
1. Added `customer_vault: Option<CustomerAction>` to `NmiPaymentsRequest` struct with `skip_serializing_if`
2. Set to `is_mandate_payment().then_some(CustomerAction::AddCustomer)` in regular authorize path
3. Set to `None` in 3DS redirect completion path

### PRD-B: merchant_defined_field ordering
4. In `NmiMerchantDefinedField::new()`, collect metadata entries into `BTreeMap` before enumerating — produces alphabetical key order matching HS

## Verification
<details><summary>cargo build (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 22s
```
</details>
<details><summary>cargo clippy (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.93s
```
</details>
<details><summary>parity regression test (PASS)</summary>

```
$ cargo test -p connector-integration --lib parity_16028
running 1 test
test connectors::nmi::transformers::tests::test_parity_16028_merchant_defined_field_ordering ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out
```
</details>
<details><summary>all lib tests (PASS)</summary>

```
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
</details>

## What this PR is NOT
- Field paths NOT touched: `first_name`, `last_name` (duplicate of #15678, PR #1326 open)
- Files NOT touched: `nmi.rs` (connector module), `types-traits/` (no proto/domain changes)
- PRD `Out of scope` items:
  - ConnectorMandateId branch (recurring mandate with existing vault_id)
  - `first_name`/`last_name` fields (covered by #15678)
  - Changing `preserve_order` feature flag (workspace-wide)

## Acceptance Criteria
- [x] Build clean
- [x] Clippy clean
- [x] All existing tests pass (79 total)
- [x] New parity regression test added and passing
- [x] Fixture committed under `parity_fixtures/`
- [ ] Shadow-replay produces zero diff (verified by next regular `run_all.sh` cycle; not blocking merge)

Refs #16028