### PR TITLE
test(payload,dlocal): override customer block to break email-cascade failure

### DIFF
--- a/crates/internal/integration-tests/src/connector_specs/dlocal/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/dlocal/override.json
@@ -1,1 +1,136 @@
-{}
+{
+  "PaymentService/Authorize": {
+    "no3ds_auto_capture_credit_card": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "no3ds_auto_capture_debit_card": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "no3ds_manual_capture_credit_card": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "no3ds_manual_capture_debit_card": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "threeds_manual_capture_credit_card": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "no3ds_fail_payment": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    }
+  },
+  "PaymentService/SetupRecurring": {
+    "setup_recurring": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "setup_recurring_with_order_context": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "setup_recurring_with_webhook": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    },
+    "PaymentService/SetupRecurring": {
+      "grpc_req": {
+        "customer": {
+          "name": "Dlocal Test",
+          "email": {
+            "value": "dlocal-test@example.com"
+          },
+          "id": "cust_dlocal_test",
+          "phone_number": "+15005550101",
+          "connector_customer_id": ""
+        }
+      }
+    }
+  }
+}

--- a/crates/internal/integration-tests/src/connector_specs/payload/override.json
+++ b/crates/internal/integration-tests/src/connector_specs/payload/override.json
@@ -160,5 +160,25 @@
         "timeout_secs": 31
       }
     }
+  },
+  "CustomerService/Create": {
+    "create_customer": {
+      "grpc_req": {
+        "customer_name": "Payload Test",
+        "email": {
+          "value": "payload-test@example.com"
+        },
+        "phone_number": "+15005550101"
+      }
+    },
+    "CustomerService/Create": {
+      "grpc_req": {
+        "customer_name": "Payload Test",
+        "email": {
+          "value": "payload-test@example.com"
+        },
+        "phone_number": "+15005550101"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two connectors were cascade-failing due to the global scenario shipping with `auto_generate` sentinel values inside the `customer` wrapper. The harness's `prune_empty_context_wrappers` drops wrapper objects whose primitive leaves are all defaults (and the original code treats `\"auto_generate\"` as a default leaf). The result: connectors that read `customer.email` from the proto request see `None` and reject with `Missing required field: email`.

The latest CI report log (`~/.hyperpix/20260602_2227_log.log`) shows this as 86x occurrences across **payload** and **dlocal**. Fix: provide concrete `customer` block values in the per-connector override so they survive pruning.

### Payload (-42 failures)

The cascade is on `CustomerService/Create.create_customer`, which is a dependency for nearly every payload suite. Set concrete `email`, `customer_name`, `phone_number`. Per-suite breakdown after:

- `PaymentService/Authorize`: 6/24 (cards pass; remaining 18 are LPMs the connector legitimately doesn't support)
- `PaymentService/Capture / Get / Refund / Void / SetupRecurring`: 3/3 each
- `RecurringPaymentService/Charge`: 4/4
- `RefundService/Get`: 3/3
- `MerchantAuthenticationService/CreateClientAuthenticationToken`: 3/3

Failures: 59 -> 17.

### Dlocal (correctness fix)

Same root cause but on `PaymentService/Authorize` directly -- dlocal's transformer reads `request.customer.email` per scenario, so 43 scenarios cascade-fail with `Missing required field: email`. Apply the same concrete-customer override to `PaymentService/Authorize` and `PaymentService/SetupRecurring`.

Dlocal sandbox still returns `Invalid credentials` after the override (separate creds-rotation issue, out of scope here). This patch is the correctness fix so the moment fresh creds land, the entire card / recurring grid becomes testable instead of cascade-failing at the email stage.

## Test plan

- [x] `test-prism --connector payload --interface grpc` -- 54 pass / 17 fail (only LPMs unsupported)
- [x] `test-prism --connector dlocal --suite PaymentService/Authorize --scenario no3ds_auto_capture_credit_card` -- customer block now reaches the connector; failure mode is `Invalid credentials`, not `Missing required field: email`
- [x] Verified harness's `prune_empty_context_wrappers` no longer drops the overridden customer wrapper