### PR TITLE
fix(connector): make shipping_cost optional in paypal authorize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -143,16 +143,20 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .change_context(IntegrationError::AmountConversionFailed {
                 context: Default::default(),
             })?;
-        let shipping_cost = item.router_data.request.shipping_cost.ok_or(
-            IntegrationError::MissingRequiredField {
-                field_name: "shipping_cost",
-                context: Default::default(),
-            },
-        )?;
+        // Hyperswitch treats `shipping_cost` as optional for the Authorize flow,
+        // defaulting to zero when absent (req.request.shipping_cost.unwrap_or(MinorUnit::zero())).
+        // Mirror that here instead of hard-failing with MissingRequiredField, otherwise UCS
+        // returns gRPC InvalidArgument for card payments that carry no shipping_cost.
         let shipping_value = item
             .connector
             .amount_converter
-            .convert(shipping_cost, item.router_data.request.currency)
+            .convert(
+                item.router_data
+                    .request
+                    .shipping_cost
+                    .unwrap_or(common_utils::types::MinorUnit::zero()),
+                item.router_data.request.currency,
+            )
             .change_context(IntegrationError::AmountConversionFailed {
                 context: Default::default(),
             })?;

--- a/data/field_probe/paypal.json
+++ b/data/field_probe/paypal.json
@@ -48,7 +48,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "apple_pay_sdk": {
               "payment_data": {
@@ -158,7 +157,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "card": {
               "card_number": "4111111111111111",
@@ -252,7 +250,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "eps": {}
           },
@@ -303,7 +300,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "giropay": {}
           },
@@ -358,7 +354,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "google_pay_sdk": {
               "type": "CARD",
@@ -418,7 +413,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "ideal": {}
           },
@@ -597,7 +591,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "paypal_redirect": {
               "email": "test@example.com"
@@ -752,7 +745,6 @@
             "minor_amount": 1000,
             "currency": "USD"
           },
-          "shipping_cost": 0,
           "payment_method": {
             "sofort": {}
           },
@@ -1094,8 +1086,7 @@
               "expires_in_seconds": 3600,
               "token_type": "Bearer"
             }
-          },
-          "shipping_cost": 0
+          }
         },
         "sample": {
           "url": "https://api-m.sandbox.paypal.com/v2/checkout/orders",

--- a/data/field_probe/payu.json
+++ b/data/field_probe/payu.json
@@ -461,7 +461,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -510,7 +510,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in/pl/standard/user/oauth/authorize",
+          "url": "https://secure.snd.payu.com/pl/standard/user/oauth/authorize",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -561,7 +561,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -638,7 +638,7 @@
           "reason": "customer_request"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -658,7 +658,7 @@
           "refund_id": "probe_refund_id_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -712,7 +712,7 @@
           "connector_transaction_id": "probe_connector_txn_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",

--- a/docs-generated/connectors/paypal.md
+++ b/docs-generated/connectors/paypal.md
@@ -131,7 +131,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/paypal/paypal.py#L316) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L156) · [Rust](../../examples/paypal/paypal.rs#L395)
+**Examples:** [Python](../../examples/paypal/paypal.py#L314) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L155) · [Rust](../../examples/paypal/paypal.rs#L393)
 
 ### Card Payment (Authorize + Capture)
 
@@ -145,25 +145,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/paypal/paypal.py#L335) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L172) · [Rust](../../examples/paypal/paypal.rs#L411)
+**Examples:** [Python](../../examples/paypal/paypal.py#L333) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L171) · [Rust](../../examples/paypal/paypal.rs#L409)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/paypal/paypal.py#L360) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L194) · [Rust](../../examples/paypal/paypal.rs#L434)
+**Examples:** [Python](../../examples/paypal/paypal.py#L358) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L193) · [Rust](../../examples/paypal/paypal.rs#L432)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/paypal/paypal.py#L385) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L216) · [Rust](../../examples/paypal/paypal.rs#L457)
+**Examples:** [Python](../../examples/paypal/paypal.py#L383) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L215) · [Rust](../../examples/paypal/paypal.rs#L455)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/paypal/paypal.py#L407) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L235) · [Rust](../../examples/paypal/paypal.rs#L476)
+**Examples:** [Python](../../examples/paypal/paypal.py#L405) · [JavaScript](../../examples/paypal/paypal.js) · [Kotlin](../../examples/paypal/paypal.kt#L234) · [Rust](../../examples/paypal/paypal.rs#L474)
 
 ## API Reference
 
@@ -335,7 +335,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L457) · [Kotlin](../../examples/paypal/paypal.kt#L253) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L455) · [Kotlin](../../examples/paypal/paypal.kt#L252) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.Capture
 
@@ -346,7 +346,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L466) · [Kotlin](../../examples/paypal/paypal.kt#L265) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L464) · [Kotlin](../../examples/paypal/paypal.kt#L264) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.CreateOrder
 
@@ -357,7 +357,7 @@ Create a payment order for later processing. Establishes a transaction context t
 | **Request** | `PaymentServiceCreateOrderRequest` |
 | **Response** | `PaymentServiceCreateOrderResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L484) · [Kotlin](../../examples/paypal/paypal.kt#L291) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L482) · [Kotlin](../../examples/paypal/paypal.kt#L290) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.Get
 
@@ -368,7 +368,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L502) · [Kotlin](../../examples/paypal/paypal.kt#L322) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L500) · [Kotlin](../../examples/paypal/paypal.kt#L321) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -379,7 +379,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L529) · [Kotlin](../../examples/paypal/paypal.kt#L361) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L527) · [Kotlin](../../examples/paypal/paypal.kt#L360) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.ProxySetupRecurring
 
@@ -390,7 +390,7 @@ Setup recurring mandate using vault-aliased card data.
 | **Request** | `PaymentServiceProxySetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L538) · [Kotlin](../../examples/paypal/paypal.kt#L398) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L536) · [Kotlin](../../examples/paypal/paypal.kt#L396) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.Refund
 
@@ -401,7 +401,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L556) · [Kotlin](../../examples/paypal/paypal.kt#L475) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L554) · [Kotlin](../../examples/paypal/paypal.kt#L473) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.SetupRecurring
 
@@ -412,7 +412,7 @@ Configure a payment method for recurring billing. Sets up the mandate and paymen
 | **Request** | `PaymentServiceSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L574) · [Kotlin](../../examples/paypal/paypal.kt#L504) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L572) · [Kotlin](../../examples/paypal/paypal.kt#L502) · [Rust](../../examples/paypal/paypal.rs)
 
 #### PaymentService.Void
 
@@ -423,7 +423,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts) · [Kotlin](../../examples/paypal/paypal.kt#L550) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts) · [Kotlin](../../examples/paypal/paypal.kt#L548) · [Rust](../../examples/paypal/paypal.rs)
 
 ### Refunds
 
@@ -436,7 +436,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L565) · [Kotlin](../../examples/paypal/paypal.kt#L485) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L563) · [Kotlin](../../examples/paypal/paypal.kt#L483) · [Rust](../../examples/paypal/paypal.rs)
 
 ### Mandates
 
@@ -449,7 +449,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L547) · [Kotlin](../../examples/paypal/paypal.kt#L437) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L545) · [Kotlin](../../examples/paypal/paypal.kt#L435) · [Rust](../../examples/paypal/paypal.rs)
 
 ### Authentication
 
@@ -462,7 +462,7 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L475) · [Kotlin](../../examples/paypal/paypal.kt#L275) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L473) · [Kotlin](../../examples/paypal/paypal.kt#L274) · [Rust](../../examples/paypal/paypal.rs)
 
 #### MerchantAuthenticationService.CreateServerAuthenticationToken
 
@@ -473,4 +473,4 @@ Generate short-lived connector authentication token. Provides secure credentials
 | **Request** | `MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L493) · [Kotlin](../../examples/paypal/paypal.kt#L312) · [Rust](../../examples/paypal/paypal.rs)
+**Examples:** [Python](../../examples/paypal/paypal.py) · [TypeScript](../../examples/paypal/paypal.ts#L491) · [Kotlin](../../examples/paypal/paypal.kt#L311) · [Rust](../../examples/paypal/paypal.rs)

--- a/examples/paypal/paypal.kt
+++ b/examples/paypal/paypal.kt
@@ -54,7 +54,6 @@ private fun buildAuthorizeRequest(captureMethodStr: String): PaymentServiceAutho
             minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
             currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
         }
-        shippingCost = 0L  // Cost of shipping for the order.
         paymentMethodBuilder.apply {  // Payment method to be used.
             cardBuilder.apply {  // Generic card payment.
                 cardNumberBuilder.value = "4111111111111111"  // Card Identification.
@@ -388,7 +387,6 @@ fun proxyAuthorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
                 tokenType = "Bearer"  // Token type (e.g., "Bearer", "Basic").
             }
         }
-        shippingCost = 0L  // Cost of shipping for the order.
     }.build()
     val response = client.proxy_authorize(request)
     println("Status: ${response.status.name}")

--- a/examples/paypal/paypal.py
+++ b/examples/paypal/paypal.py
@@ -38,7 +38,6 @@ def _build_authorize_request(capture_method: str):
             minor_amount=1000,  # Amount in minor units (e.g., 1000 = $10.00).
             currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
         ),
-        shipping_cost=0,  # Cost of shipping for the order.
         payment_method=payment_methods_pb2.PaymentMethod(  # Payment method to be used.
             card=payment_methods_pb2.CardDetails(
                 card_number=payment_methods_pb2.CardNumberType(value="4111111111111111"),  # Card Identification.
@@ -166,7 +165,6 @@ def _build_proxy_authorize_request():
                 token_type="Bearer",  # Token type (e.g., "Bearer", "Basic").
             ),
         ),
-        shipping_cost=0,  # Cost of shipping for the order.
     )
 
 def _build_proxy_setup_recurring_request():

--- a/examples/paypal/paypal.rs
+++ b/examples/paypal/paypal.rs
@@ -65,7 +65,6 @@ pub fn build_authorize_request(capture_method: &str) -> PaymentServiceAuthorizeR
             minor_amount: 1000, // Amount in minor units (e.g., 1000 = $10.00).
             currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
         }),
-        shipping_cost: Some(0), // Cost of shipping for the order.
         payment_method: Some(PaymentMethod {
             // Payment method to be used.
             payment_method: Some(payment_method::PaymentMethod::Card(CardDetails {
@@ -251,7 +250,6 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
             }),
             ..Default::default()
         }),
-        shipping_cost: Some(0), // Cost of shipping for the order.
         ..Default::default()
     }
 }

--- a/examples/paypal/paypal.ts
+++ b/examples/paypal/paypal.ts
@@ -31,7 +31,6 @@ function _buildAuthorizeRequest(captureMethod: types.CaptureMethod): types.IPaym
             "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
             "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
         },
-        "shippingCost": 0,  // Cost of shipping for the order.
         "paymentMethod": {  // Payment method to be used.
             "card": {  // Generic card payment.
                 "cardNumber": {"value": "4111111111111111"},  // Card Identification.
@@ -181,8 +180,7 @@ function _buildProxyAuthorizeRequest(): types.IPaymentServiceProxyAuthorizeReque
                 "expiresInSeconds": 3600,  // Expiration timestamp (seconds since epoch).
                 "tokenType": "Bearer"  // Token type (e.g., "Bearer", "Basic").
             }
-        },
-        "shippingCost": 0  // Cost of shipping for the order.
+        }
     };
 }
 


### PR DESCRIPTION
## What
Make `shipping_cost` optional in the PayPal **Authorize** request transformer, mirroring hyperswitch.

Fixes shadow-validation diff: juspay/hyperswitch-cloud#16564 (`paypal / card / card / authorize`)

## RCA
- Shadow issue reported **16/16 RouterData diffs**; auto-summary labelled it `not_reached` ("handler unimplemented"). That label is wrong.
- Real cause is in the UCS RouterData `error`: `gRPC InvalidArgument — "Missing required field: shipping_cost"`. UCS returned an error → empty RouterData → every field shows `hs:true / ucs:false` (one empty record, not 16 real diffs).
- Proto defines `shipping_cost` as `optional` — so this is UCS transformer logic, **not** a proto/cutoff issue.
- UCS `OrderRequestAmount::try_from` (Authorize) hard-required it: `request.shipping_cost.ok_or(MissingRequiredField)?`.
- Hyperswitch treats it as optional: `request.shipping_cost.unwrap_or(MinorUnit::zero())`.
- Card payments carry no `shipping_cost`, so all 16 requests tripped the `ok_or`.
- Inconsistency confirms the bug: the **RepeatPayment** variant in the same file already used `.unwrap_or(zero())`.

## Fix
- `paypal/transformers.rs` Authorize `OrderRequestAmount`: replace `.ok_or(MissingRequiredField{"shipping_cost"})?` with `.unwrap_or(MinorUnit::zero())`.
- No hyperswitch connector code changed (it is the parity source of truth).
- Verified rest of card/authorize path has no other field hard-required that hyperswitch treats as optional.

<details>
<summary>Diff</summary>

```rust
-        let shipping_cost = item.router_data.request.shipping_cost.ok_or(
-            IntegrationError::MissingRequiredField {
-                field_name: "shipping_cost",
-                context: Default::default(),
-            },
-        )?;
         let shipping_value = item
             .connector
             .amount_converter
-            .convert(shipping_cost, item.router_data.request.currency)
+            .convert(
+                item.router_data
+                    .request
+                    .shipping_cost
+                    .unwrap_or(common_utils::types::MinorUnit::zero()),
+                item.router_data.request.currency,
+            )
             .change_context(IntegrationError::AmountConversionFailed {
                 context: Default::default(),
             })?;
```
</details>

## Testing
- `cargo check -p connector-integration` — passes.
- Re-run PayPal card-authorize Cypress, then shadow validation (expect 16/16 no_diff):
```bash
cd cypress-tests   # hyperswitch repo
CYPRESS_CONNECTOR="paypal" npx cypress run \
  --spec 'cypress/e2e/spec/Payment/04-NoThreeDSAutoCapture.cy.js,cypress/e2e/spec/Payment/06-NoThreeDSManualCapture.cy.js'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
