### PR TITLE
fix(grpc-api-types): apply #[serde(default)] to BraintreeConfig to accept partial X-Connector-Config JSON

### DIFF
--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -32,6 +32,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "#[serde(rename_all = \"snake_case\")]",
     );
 
+    // BraintreeConfig has four `repeated string` fields (apple_pay_supported_networks,
+    // apple_pay_merchant_capabilities, gpay_allowed_auth_methods, gpay_allowed_card_networks)
+    // which compile to bare `Vec<String>`. Without `#[serde(default)]`, serde rejects JSON
+    // that omits them — and HS does not serialize these wallet-config fields for standard
+    // card flows. Applying `#[serde(default)]` at the type level makes every missing field
+    // use its `Default::default()` value (Vec → empty, Option → None, String → ""), which
+    // is the correct proto3 semantics for `repeated` and also future-proofs new fields.
+    config.type_attribute(".types.BraintreeConfig", "#[serde(default)]");
+
     // Use compile_protos_with_config which handles everything internally
     // including string enum support, serde derives, and descriptor set writing
     bridge_generator.compile_protos_with_config(

--- a/data/field_probe/payu.json
+++ b/data/field_probe/payu.json
@@ -461,7 +461,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -510,7 +510,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in/pl/standard/user/oauth/authorize",
+          "url": "https://secure.snd.payu.com/pl/standard/user/oauth/authorize",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -561,7 +561,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -638,7 +638,7 @@
           "reason": "customer_request"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -658,7 +658,7 @@
           "refund_id": "probe_refund_id_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -712,7 +712,7 @@
           "connector_transaction_id": "probe_connector_txn_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",

--- a/data/field_probe/payu.json
+++ b/data/field_probe/payu.json
@@ -461,7 +461,7 @@
           }
         },
         "sample": {
-          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
+          "url": "https://test.payu.in//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -510,7 +510,7 @@
           }
         },
         "sample": {
-          "url": "https://secure.snd.payu.com/pl/standard/user/oauth/authorize",
+          "url": "https://test.payu.in/pl/standard/user/oauth/authorize",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -561,7 +561,7 @@
           }
         },
         "sample": {
-          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
+          "url": "https://test.payu.in//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -638,7 +638,7 @@
           "reason": "customer_request"
         },
         "sample": {
-          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
+          "url": "https://test.payu.in//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -658,7 +658,7 @@
           "refund_id": "probe_refund_id_001"
         },
         "sample": {
-          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
+          "url": "https://test.payu.in//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -712,7 +712,7 @@
           "connector_transaction_id": "probe_connector_txn_001"
         },
         "sample": {
-          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
+          "url": "https://test.payu.in//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",


### PR DESCRIPTION
## Description

`BraintreeConfig` has four `repeated string` fields (`apple_pay_supported_networks`, `apple_pay_merchant_capabilities`, `gpay_allowed_auth_methods`, `gpay_allowed_card_networks`). `prost_build` generates them as bare `Vec<String>`, and the `g2h`-derived `serde::Deserialize` impl treats `Vec<T>` as required by default.

Hyperswitch does not serialize those four wallet-config fields for standard card flows. Result: every braintree `X-Connector-Config` JSON payload was being rejected at the gRPC entry layer with:

```
Failed to parse X-Connector-Config JSON into ConnectorSpecificConfig
```

Net effect: every braintree call (any flow, any payment method) failed before reaching the connector transformer.

## Motivation and Context

The fix applies `#[serde(default)]` to `BraintreeConfig` at the type level via `prost_build::Config::type_attribute`. Any missing field then uses its `Default::default()` value (`Vec` → empty, `Option` → `None`, `String` → `""`), which is the correct proto3 semantics for `repeated` and also future-proofs new BraintreeConfig fields.

Other `ConnectorSpecificConfig` variants (Adyen, Cybersource, Stripe, Paypal, etc.) use `Option<...>` for every field, so serde's missing-field handling already produces `None` for them — they were unaffected. Broader hardening to apply `#[serde(default)]` to all `*Config` types is left for a separate change.

## How did you test it?

- `cargo check -p grpc-api-types` clean
- Inspected generated `BraintreeConfig` struct after build — `#[serde(default)]` is correctly emitted at the type level

## Development

Closes: juspay/hyperswitch-cloud#16580
