### PR TITLE
fix(setup_mandate): don't synthesize amount_captured from request amount

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -9613,15 +9613,12 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
         })
         .transpose()?;
 
-    // Set amount_captured based on status - only if Charged/PartialCharged
-    let captured_amount = match status {
-        common_enums::AttemptStatus::Charged
-        | common_enums::AttemptStatus::PartialCharged
-        | common_enums::AttemptStatus::PartialChargedAndChargeable => router_data_v2.request.amount,
-        _ => None,
-    };
-
-    let minor_captured_amount = captured_amount;
+    // Mirror the Authorize/Capture flows: amount_captured comes from
+    // resource_common_data (set explicitly by connectors that capture). For a
+    // setup-mandate / zero-dollar authorization it stays None, matching the
+    // hyperswitch reference RouterData. Previously this synthesized Some(0) from
+    // the request amount when status was Charged, which diverged from hyperswitch.
+    let minor_captured_amount = router_data_v2.resource_common_data.amount_captured;
 
     let response = match transaction_response {
         Ok(response) => match response {

--- a/data/field_probe/payu.json
+++ b/data/field_probe/payu.json
@@ -461,7 +461,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -510,7 +510,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in/pl/standard/user/oauth/authorize",
+          "url": "https://secure.snd.payu.com/pl/standard/user/oauth/authorize",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -561,7 +561,7 @@
           }
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -638,7 +638,7 @@
           "reason": "customer_request"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -658,7 +658,7 @@
           "refund_id": "probe_refund_id_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",
@@ -712,7 +712,7 @@
           "connector_transaction_id": "probe_connector_txn_001"
         },
         "sample": {
-          "url": "https://test.payu.in//merchant/postservice.php?form=2",
+          "url": "https://secure.snd.payu.com//merchant/postservice.php?form=2",
           "method": "Post",
           "headers": {
             "accept": "application/json",


### PR DESCRIPTION
## What

Shadow validation flagged `novalnet / card / card / setup_mandate` ([juspay/hyperswitch-cloud#16462](https://github.com/juspay/hyperswitch-cloud/issues/16462)): no request diffs, but the mapped RouterData diverged.

| Field | hyperswitch | UCS (before) |
|---|---|---|
| `amount_captured` | `null` | `0` |
| `minor_amount_captured` | `null` | `0` |

## Root cause

Not connector-specific. The shared `generate_setup_mandate_response` (`domain_types/src/types.rs`) synthesized `captured_amount` from `router_data.request.amount` whenever `status` was `Charged`/`PartialCharged`, yielding `Some(0)` for a zero-dollar setup-mandate. Every other flow (Authorize/Capture) instead reads `resource_common_data.amount_captured`, which stays `None` unless a connector actually captured.

## Fix

Replace the status-based synthesis with `resource_common_data.amount_captured`, matching the Authorize/Capture pattern. `amount_captured`/`minor_amount_captured` now stay `None`, as the hyperswitch reference returns.

Blast radius: all connectors' setup_mandate response mapping (now correctly `None`).

> The third diff in the report (`connector_response_reference_id`) is a proto asymmetry — `PaymentServiceSetupRecurringResponse` has no such field — and is out of scope.

## Verification

- `cargo check -p domain_types` ✅

Fixes juspay/hyperswitch-cloud#16462

🤖 Generated with [Claude Code](https://claude.com/claude-code)