### PR TITLE
fix(connector): populate finix repeat_payment mandate_reference and connector_response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -1592,15 +1592,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             (_, FinixPaymentStatus::Unknown) => AttemptStatus::Pending,
         };
 
+        // Mirror the Authorize flow for shadow parity: surface the charged Payment
+        // Instrument (`source`) as the connector mandate id and attach the AVS / network
+        // details as the connector_response.
+        let connector_response_data =
+            convert_to_additional_payment_method_connector_response(&item.response)
+                .map(ConnectorResponseData::with_additional_payment_method_data);
+
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response: connector_response_data,
                 ..item.router_data.resource_common_data.clone()
             },
             response: Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(response.id.clone()),
                 redirection_data: None,
-                mandate_reference: None,
+                mandate_reference: Some(Box::new(MandateReference {
+                    connector_mandate_id: response.source.clone().map(|id| id.expose()),
+                    payment_method_id: None,
+                    connector_mandate_request_reference_id: None,
+                })),
                 connector_metadata: None,
                 network_txn_id: None,
                 connector_response_reference_id: Some(response.id.clone()),


### PR DESCRIPTION
## Issue

Shadow-validation RouterData diff for **finix / card / repeat_payment** — juspay/hyperswitch-cloud#16540.

## RCA (root cause)

Shadow validation diffs the **hyperswitch-native** finix RouterData against the read-back **UCS** finix RouterData. For `repeat_payment`, two fields that hyperswitch-native populates were `null` on the UCS side:

| RouterData field | hyperswitch-native | UCS (before) |
|---|---|---|
| `response.Ok.TransactionResponse.mandate_reference` | object | `null` |
| `connector_response` (top-level) | object | `null` |

#1463 already fixed this exact diff for the finix **Authorize** flow — it added `source` / `address_verification` / `network_details` to `FinixAuthorizeResponse`, added the `convert_to_additional_payment_method_connector_response` helper, and wired both into the Authorize success handler. But the **RepeatPayment** handler was left untouched (`mandate_reference: None`, no `connector_response`), so `finix / card / repeat_payment` still diverged.

## How it was solved

Extends #1463's fix to the RepeatPayment success handler — **UCS connector only, reusing the helper #1463 added** (no struct, proto, or cutoff/readback change):

- `mandate_reference` ← `Some(MandateReference { connector_mandate_id: response.source.map(expose), .. })`
- `connector_response` ← `convert_to_additional_payment_method_connector_response(&item.response)` (AVS → `payment_checks`, card brand → `card_network`, auth code → `auth_code`)
- `connector_response_reference_id` is kept as the Finix transaction id (`response.id`), consistent with the Authorize flow.

Both fields already round-trip through the recurring-charge proto + hyperswitch readback (`mandate_reference` → `RecurringPaymentServiceChargeResponse.mandate_reference` field 9; `connector_response` → field 14 → top-level `RouterData.connector_response`), so populating them in the connector is sufficient.

## Verification — no diff

**Before** (from #16540):

```json
"typeDiff": {
  "response.Ok.TransactionResponse.mandate_reference": { "hyperswitch": "object", "ucs": "null" },
  "connector_response":                                { "hyperswitch": "object", "ucs": "null" }
}
```

**After:** re-ran shadow validation for **finix / card / repeat_payment** — the RouterData diff no longer reproduces; `mandate_reference` and the top-level `connector_response` now match hyperswitch-native finix (same values, sourced from the same Finix response fields).

- `cargo check -p connector-integration` passes.
- Rebased on latest `main` (which includes #1463); the diff is the RepeatPayment handler only.

Resolves juspay/hyperswitch-cloud#16540.
