### PR TITLE
fix(connector): default Braintree repeated config fields

### DIFF
--- a/crates/types-traits/grpc-api-types/Cargo.toml
+++ b/crates/types-traits/grpc-api-types/Cargo.toml
@@ -23,5 +23,6 @@ hyperswitch_masking = { version = "0.0.1", default-features = false, features = 
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 heck = "0.5.0"
 g2h = { git = "https://github.com/juspay/g2h", rev = "399d5257744cabffe88d9871a1192eacbbe9f484" }

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -17,6 +17,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "::hyperswitch_masking::Secret<String>",
     );
 
+    // Add #[serde(default)] for all `repeated` (Vec) fields in connector config messages.
+    // Protobuf `repeated` fields map to Vec<T> in Rust. serde requires `#[serde(default)]`
+    // on Vec fields to treat a missing JSON key as an empty vec; without it, serde errors
+    // with "missing field" when the sender (HS) omits the field.  g2h already adds `default`
+    // for repeated *enum* fields, but not for repeated string/message fields, so we add it
+    // explicitly for each known repeated non-enum field in the connector config messages.
+    // BraintreeConfig is currently the only ConnectorConfig message with repeated fields.
+    for field in [
+        ".types.BraintreeConfig.apple_pay_supported_networks",
+        ".types.BraintreeConfig.apple_pay_merchant_capabilities",
+        ".types.BraintreeConfig.gpay_allowed_auth_methods",
+        ".types.BraintreeConfig.gpay_allowed_card_networks",
+    ] {
+        config.field_attribute(field, "#[serde(default)]");
+    }
+
     // Add serde rename_all = "snake_case" for oneof enum types to output proper proto JSON
     // This ensures variant names like "ApplePay" serialize as "apple_pay"
     config.type_attribute(

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -24,6 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // g2h handles repeated *enum* fields but not repeated string/message fields or map fields,
     // so we add it generically by reading ConnectorSpecificConfig's oneof from the descriptor —
     // no connector names hardcoded.
+    // Only payment.proto is needed here: ConnectorSpecificConfig (the x-connector-config
+    // header type) is defined there. Loading all protos would be slower and unnecessary.
     let fds = prost_build::Config::new().load_fds(&["proto/payment.proto"], &["proto"])?;
     add_serde_default_for_connector_configs(&mut config, &fds);
 
@@ -87,16 +89,32 @@ fn add_serde_default_for_connector_configs(
     config: &mut prost_build::Config,
     fds: &prost_types::FileDescriptorSet,
 ) {
-    let connector_config_names: std::collections::HashSet<&str> = fds
+    let maybe_config_msg = fds
         .file
         .iter()
         .flat_map(|f| &f.message_type)
-        .find(|m: &&prost_types::DescriptorProto| m.name() == "ConnectorSpecificConfig")
+        .find(|m: &&prost_types::DescriptorProto| m.name() == "ConnectorSpecificConfig");
+
+    if maybe_config_msg.is_none() {
+        eprintln!(
+            "cargo:warning=build.rs: ConnectorSpecificConfig not found in payment.proto; \
+             no #[serde(default)] will be added for connector config repeated fields"
+        );
+    }
+
+    let connector_config_names: std::collections::HashSet<&str> = maybe_config_msg
         .map(|m| {
             m.field
                 .iter()
                 .filter_map(|f: &prost_types::FieldDescriptorProto| {
-                    f.type_name().split('.').next_back()
+                    // type_name is empty for primitive fields (int32, string, etc.);
+                    // skip them — we only want message/enum type names.
+                    let tn = f.type_name();
+                    if tn.is_empty() {
+                        None
+                    } else {
+                        tn.split('.').next_back()
+                    }
                 })
                 .collect()
         })

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -17,15 +17,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "::hyperswitch_masking::Secret<String>",
     );
 
-    // Add #[serde(default)] for all `repeated` (Vec) and map (HashMap) fields in connector
-    // config messages referenced by ConnectorSpecificConfig (i.e. x-connector-config header).
-    // Proto3: absent repeated field = empty list. serde doesn't know this without the attribute
-    // and errors with "missing field" when HS omits an empty repeated field (spec-compliant).
-    // g2h handles repeated *enum* fields but not repeated string/message fields or map fields,
-    // so we add it generically by reading ConnectorSpecificConfig's oneof from the descriptor —
-    // no connector names hardcoded.
-    // Only payment.proto is needed here: ConnectorSpecificConfig (the x-connector-config
-    // header type) is defined there. Loading all protos would be slower and unnecessary.
+    // Add #[serde(default)] to repeated (Vec) fields in connector configs so missing
+    // keys deserialize as empty rather than erroring (proto3 semantics).
     let fds = prost_build::Config::new().load_fds(&["proto/payment.proto"], &["proto"])?;
     add_serde_default_for_connector_configs(&mut config, &fds);
 
@@ -82,9 +75,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Finds all message types listed in `ConnectorSpecificConfig`'s `oneof config` and adds
-/// `#[serde(default)]` to every repeated non-enum field in those messages.
-/// Scoped to x-connector-config only — no connector names are hardcoded.
+/// Adds `#[serde(default)]` to every repeated non-enum field in connector config messages.
 fn add_serde_default_for_connector_configs(
     config: &mut prost_build::Config,
     fds: &prost_types::FileDescriptorSet,
@@ -107,8 +98,6 @@ fn add_serde_default_for_connector_configs(
             m.field
                 .iter()
                 .filter_map(|f: &prost_types::FieldDescriptorProto| {
-                    // type_name is empty for primitive fields (int32, string, etc.);
-                    // skip them — we only want message/enum type names.
                     let tn = f.type_name();
                     if tn.is_empty() {
                         None
@@ -129,9 +118,7 @@ fn add_serde_default_for_connector_configs(
     }
 }
 
-/// Adds `#[serde(default)]` to every repeated non-enum field in a message (and its nested types).
-/// Repeated fields become `Vec<T>` or `HashMap<K,V>` in Rust; both need `#[serde(default)]`
-/// so serde treats a missing JSON key as empty rather than erroring.
+/// Adds `#[serde(default)]` to every repeated non-enum field in a message and its nested types.
 fn add_repeated_default(config: &mut prost_build::Config, message: &prost_types::DescriptorProto) {
     use prost_types::field_descriptor_proto::{Label, Type};
     for field in &message.field {

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -107,7 +107,11 @@ fn add_serde_default_for_connector_configs(
         .iter()
         .filter_map(|f: &prost_types::FieldDescriptorProto| {
             let name = f.type_name().split('.').next_back().unwrap_or("");
-            if name.is_empty() { None } else { Some(name) }
+            if name.is_empty() {
+                None
+            } else {
+                Some(name)
+            }
         })
         .collect();
 

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -80,56 +80,62 @@ fn add_serde_default_for_connector_configs(
     config: &mut prost_build::Config,
     fds: &prost_types::FileDescriptorSet,
 ) {
-    let maybe_config_msg = fds
-        .file
+    let file = match fds.file.iter().find(|f| {
+        f.message_type
+            .iter()
+            .any(|m| m.name() == "ConnectorSpecificConfig")
+    }) {
+        Some(f) => f,
+        None => {
+            eprintln!(
+                "cargo:warning=build.rs: ConnectorSpecificConfig not found in payment.proto; \
+                 no #[serde(default)] will be added for connector config repeated fields"
+            );
+            return;
+        }
+    };
+
+    let package = file.package();
+    let config_msg = file
+        .message_type
         .iter()
-        .flat_map(|f| &f.message_type)
-        .find(|m: &&prost_types::DescriptorProto| m.name() == "ConnectorSpecificConfig");
+        .find(|m| m.name() == "ConnectorSpecificConfig")
+        .expect("already verified above");
 
-    if maybe_config_msg.is_none() {
-        eprintln!(
-            "cargo:warning=build.rs: ConnectorSpecificConfig not found in payment.proto; \
-             no #[serde(default)] will be added for connector config repeated fields"
-        );
-    }
-
-    let connector_config_names: std::collections::HashSet<&str> = maybe_config_msg
-        .map(|m| {
-            m.field
-                .iter()
-                .filter_map(|f: &prost_types::FieldDescriptorProto| {
-                    let tn = f.type_name();
-                    if tn.is_empty() {
-                        None
-                    } else {
-                        tn.split('.').next_back()
-                    }
-                })
-                .collect()
+    let connector_config_names: std::collections::HashSet<&str> = config_msg
+        .field
+        .iter()
+        .filter_map(|f: &prost_types::FieldDescriptorProto| {
+            let name = f.type_name().split('.').next_back().unwrap_or("");
+            if name.is_empty() { None } else { Some(name) }
         })
-        .unwrap_or_default();
+        .collect();
 
-    for file in &fds.file {
-        for message in &file.message_type {
-            if connector_config_names.contains(message.name()) {
-                add_repeated_default(config, message);
-            }
+    for message in &file.message_type {
+        if connector_config_names.contains(message.name()) {
+            add_repeated_default(config, package, message.name(), message);
         }
     }
 }
 
 /// Adds `#[serde(default)]` to every repeated non-enum field in a message and its nested types.
-fn add_repeated_default(config: &mut prost_build::Config, message: &prost_types::DescriptorProto) {
+fn add_repeated_default(
+    config: &mut prost_build::Config,
+    package: &str,
+    parent_path: &str,
+    message: &prost_types::DescriptorProto,
+) {
     use prost_types::field_descriptor_proto::{Label, Type};
     for field in &message.field {
         if field.label() == Label::Repeated && field.r#type() != Type::Enum {
             config.field_attribute(
-                format!("{}.{}", message.name(), field.name()),
+                format!(".{package}.{parent_path}.{}", field.name()),
                 "#[serde(default)]",
             );
         }
     }
     for nested in &message.nested_type {
-        add_repeated_default(config, nested);
+        let nested_path = format!("{parent_path}.{}", nested.name());
+        add_repeated_default(config, package, &nested_path, nested);
     }
 }

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -96,7 +96,7 @@ fn add_serde_default_for_connector_configs(
             m.field
                 .iter()
                 .filter_map(|f: &prost_types::FieldDescriptorProto| {
-                    f.type_name().split('.').last()
+                    f.type_name().split('.').next_back()
                 })
                 .collect()
         })
@@ -114,15 +114,12 @@ fn add_serde_default_for_connector_configs(
 /// Adds `#[serde(default)]` to every repeated non-enum field in a message (and its nested types).
 /// Repeated fields become `Vec<T>` or `HashMap<K,V>` in Rust; both need `#[serde(default)]`
 /// so serde treats a missing JSON key as empty rather than erroring.
-fn add_repeated_default(
-    config: &mut prost_build::Config,
-    message: &prost_types::DescriptorProto,
-) {
+fn add_repeated_default(config: &mut prost_build::Config, message: &prost_types::DescriptorProto) {
     use prost_types::field_descriptor_proto::{Label, Type};
     for field in &message.field {
         if field.label() == Label::Repeated && field.r#type() != Type::Enum {
             config.field_attribute(
-                &format!("{}.{}", message.name(), field.name()),
+                format!("{}.{}", message.name(), field.name()),
                 "#[serde(default)]",
             );
         }

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -17,21 +17,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "::hyperswitch_masking::Secret<String>",
     );
 
-    // Add #[serde(default)] for all `repeated` (Vec) fields in connector config messages.
-    // Protobuf `repeated` fields map to Vec<T> in Rust. serde requires `#[serde(default)]`
-    // on Vec fields to treat a missing JSON key as an empty vec; without it, serde errors
-    // with "missing field" when the sender (HS) omits the field.  g2h already adds `default`
-    // for repeated *enum* fields, but not for repeated string/message fields, so we add it
-    // explicitly for each known repeated non-enum field in the connector config messages.
-    // BraintreeConfig is currently the only ConnectorConfig message with repeated fields.
-    for field in [
-        ".types.BraintreeConfig.apple_pay_supported_networks",
-        ".types.BraintreeConfig.apple_pay_merchant_capabilities",
-        ".types.BraintreeConfig.gpay_allowed_auth_methods",
-        ".types.BraintreeConfig.gpay_allowed_card_networks",
-    ] {
-        config.field_attribute(field, "#[serde(default)]");
-    }
+    // Add #[serde(default)] for all `repeated` (Vec) and map (HashMap) fields in connector
+    // config messages referenced by ConnectorSpecificConfig (i.e. x-connector-config header).
+    // Proto3: absent repeated field = empty list. serde doesn't know this without the attribute
+    // and errors with "missing field" when HS omits an empty repeated field (spec-compliant).
+    // g2h handles repeated *enum* fields but not repeated string/message fields or map fields,
+    // so we add it generically by reading ConnectorSpecificConfig's oneof from the descriptor —
+    // no connector names hardcoded.
+    let fds = prost_build::Config::new().load_fds(&["proto/payment.proto"], &["proto"])?;
+    add_serde_default_for_connector_configs(&mut config, &fds);
 
     // Add serde rename_all = "snake_case" for oneof enum types to output proper proto JSON
     // This ensures variant names like "ApplePay" serialize as "apple_pay"
@@ -84,4 +78,56 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     )?;
 
     Ok(())
+}
+
+/// Finds all message types listed in `ConnectorSpecificConfig`'s `oneof config` and adds
+/// `#[serde(default)]` to every repeated non-enum field in those messages.
+/// Scoped to x-connector-config only — no connector names are hardcoded.
+fn add_serde_default_for_connector_configs(
+    config: &mut prost_build::Config,
+    fds: &prost_types::FileDescriptorSet,
+) {
+    let connector_config_names: std::collections::HashSet<&str> = fds
+        .file
+        .iter()
+        .flat_map(|f| &f.message_type)
+        .find(|m: &&prost_types::DescriptorProto| m.name() == "ConnectorSpecificConfig")
+        .map(|m| {
+            m.field
+                .iter()
+                .filter_map(|f: &prost_types::FieldDescriptorProto| {
+                    f.type_name().split('.').last()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for file in &fds.file {
+        for message in &file.message_type {
+            if connector_config_names.contains(message.name()) {
+                add_repeated_default(config, message);
+            }
+        }
+    }
+}
+
+/// Adds `#[serde(default)]` to every repeated non-enum field in a message (and its nested types).
+/// Repeated fields become `Vec<T>` or `HashMap<K,V>` in Rust; both need `#[serde(default)]`
+/// so serde treats a missing JSON key as empty rather than erroring.
+fn add_repeated_default(
+    config: &mut prost_build::Config,
+    message: &prost_types::DescriptorProto,
+) {
+    use prost_types::field_descriptor_proto::{Label, Type};
+    for field in &message.field {
+        if field.label() == Label::Repeated && field.r#type() != Type::Enum {
+            config.field_attribute(
+                &format!("{}.{}", message.name(), field.name()),
+                "#[serde(default)]",
+            );
+        }
+    }
+    for nested in &message.nested_type {
+        add_repeated_default(config, nested);
+    }
 }


### PR DESCRIPTION
## Summary
- Add serde defaults for Braintree repeated connector config fields generated from protobuf.
- Prevent missing optional repeated fields from failing JSON deserialization when HS omits them.

## Verification
- cargo fmt --check
- cargo check -p grpc-api-types