### PR TITLE
fix(grpc-server): treat connector 4xx/5xx as business outcomes in PSync

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -29,7 +29,7 @@ use domain_types::{
         ServerAuthenticationTokenResponseData, ServerSessionAuthenticationTokenRequestData,
         ServerSessionAuthenticationTokenResponseData, SetupMandateRequestData,
     },
-    errors::{ConnectorError, IntegrationError},
+    errors::{ConnectorError, ConnectorFlowError, IntegrationError},
     payment_method_data::{DefaultPCIHolder, PaymentMethodDataTypes, VaultTokenHolder},
     router_data::{ConnectorSpecificConfig, ErrorResponse},
     router_data_v2::RouterDataV2,
@@ -1059,7 +1059,12 @@ impl PaymentService for Payments {
                     // handle_response field removed from proto (field 5 reserved)
                     let consume_or_trigger_flow = common_enums::CallConnectorAction::Trigger;
 
-                    let response_result = Box::pin(
+                    // Clone router_data before moving it into execute_connector_processing_step
+                    // so we can reconstruct an error RouterData if the connector returns a
+                    // 4xx/5xx HTTP response (which surfaces as ConnectorFlowError::Response rather
+                    // than RouterData.response = Err).
+                    let router_data_for_error = router_data.clone();
+                    let connector_result = Box::pin(
                         external_services::service::execute_connector_processing_step(
                             &config.proxy,
                             connector_integration,
@@ -1072,8 +1077,27 @@ impl PaymentService for Payments {
                             api_tag,
                         ),
                     )
-                    .await
-                    .into_grpc_status()?;
+                    .await;
+
+                    // For PSync, connector 4xx/5xx error responses (e.g. a 404 "payment not
+                    // found") are valid business outcomes — not UCS infrastructure failures.
+                    // Reconstruct RouterData with response = Err(ErrorResponse) so that
+                    // generate_payment_sync_response returns Ok(PaymentServiceGetResponse {
+                    // error: Some(...) }) with gRPC OK status, instead of propagating a gRPC
+                    // NotFound/error status to HS.
+                    let response_result = match connector_result {
+                        Ok(rd) => rd,
+                        Err(err) => match err.current_context() {
+                            ConnectorFlowError::Response(
+                                ConnectorError::ConnectorErrorResponse(error_response),
+                            ) => {
+                                let mut error_router_data = router_data_for_error;
+                                error_router_data.response = Err(error_response.clone());
+                                error_router_data
+                            }
+                            _ => return Err(err.into_grpc_status()),
+                        },
+                    };
 
                     // Generate response
                     let final_response =


### PR DESCRIPTION
## Problem

When a connector returns a non-2xx HTTP response during PSync (e.g. Cybersource returns HTTP 404 for an unknown `connector_transaction_id`), `execute_connector_processing_step` wraps the parsed `ErrorResponse` in `Err(ConnectorFlowError::Response(ConnectorError::ConnectorErrorResponse(error_response)))`.

The previous PSync handler called `.into_grpc_status()?` directly on this result. The `IntoGrpcStatus` impl for `ConnectorError::ConnectorErrorResponse` maps:
- HTTP 404 → `tonic::Code::NotFound` (gRPC 5)

HS received a gRPC-level error instead of a `PaymentServiceGetResponse` with error details, breaking the sync flow.

## Root cause (location)

`crates/grpc-server/grpc-server/src/server/payments.rs` — PSync handler, former line 1076:
```rust
.await
.into_grpc_status()?;   // ← converts ConnectorErrorResponse(404) → gRPC NotFound
```

## Fix

Match on `connector_result` before calling `into_grpc_status`. For `ConnectorFlowError::Response(ConnectorError::ConnectorErrorResponse(error_response))`:
1. Clone `router_data` before the call (since it's moved into `execute_connector_processing_step`)
2. Reconstruct `RouterData` with `response = Err(error_response)`
3. Pass it to `generate_payment_sync_response`, which already handles `Err(ErrorResponse)` correctly — returns `Ok(PaymentServiceGetResponse { error: Some(...) })` with gRPC OK status

All other error variants (request-phase `IntegrationError`, network `ApiClientError`, etc.) still propagate as gRPC errors via `into_grpc_status()` unchanged.

## Verified

- `cargo clippy -p grpc-server` — clean (no new warnings)
- `cargo fmt --check -p grpc-server` — clean

## Related

- Issue #16579 (Cybersource PSync 404 → gRPC NotFound)