### PR TITLE
fix(config): accept legacy mitm_ca_cert and bypass_proxy_urls as serde aliases

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -755,13 +755,17 @@ pub struct ProxyConfig {
 #[derive(Deserialize)]
 struct ProxyConfigLegacy {
     idle_pool_connection_timeout: Option<u64>,
-    #[serde(default)]
+    // `bypass_proxy_urls` is the pre-named-proxy-map field name; accepted as an alias so old configs keep working.
+    #[serde(default, alias = "bypass_proxy_urls")]
     bypass_urls: Vec<String>,
     #[serde(default)]
     proxies: HashMap<String, Proxy>,
-    // Legacy flat keys — promoted to proxies["primary"] and proxies["shadow"] if proxies is empty
+    // Legacy flat keys — promoted to proxies["primary"] and proxies["shadow"] if proxies is empty.
+    // `mitm_ca_cert` is the pre-named-proxy-map field name; accepted as an alias so the CA cert
+    // is not silently dropped when an old config runs on a new binary.
     https_url: Option<String>,
     http_url: Option<String>,
+    #[serde(alias = "mitm_ca_cert")]
     ca_cert: Option<String>,
 }
 


### PR DESCRIPTION
## Problem
The named-proxy-map migration (#1238) added a backward-compat shim (`ProxyConfigLegacy`) intended to keep old `[proxy]` configs working after a binary-only deploy. But it renamed two fields:
- `mitm_ca_cert` → `ca_cert`
- `bypass_proxy_urls` → `bypass_urls`

The shim has no `deny_unknown_fields`, so an old-format config on a new binary **silently drops the CA cert and bypass list**. The flat `http_url`/`https_url` are still promoted to `primary`/`shadow`, so traffic keeps routing through the (TLS-intercepting) mitm proxy — but without the CA, the HTTPS handshake to connectors fails certificate verification.

## Fix
Accept the original field names as serde aliases on `ProxyConfigLegacy`:
- `#[serde(alias = "mitm_ca_cert")]` on `ca_cert`
- `#[serde(default, alias = "bypass_proxy_urls")]` on `bypass_urls`

A genuine old config now deserializes correctly on a new binary (cert + bypass preserved), behaving exactly as on the old binary. New `[proxy.proxies.<name>]` configs are unaffected (the shim only promotes flat keys when `proxies` is empty).

## Notes
- `mitm_proxy_enabled` is intentionally not re-added: in the new model the proxy URL is always applied when present, which matches all existing configs.
- Follow-up: add a unit test in `tests/test_config_override.rs` asserting old-name deserialization promotes the cert into `primary`/`shadow`.