### PR TITLE
feat(coverage-report): add test-pass coverage mode from grpc CI reports

### DIFF
--- a/.skills/coverage-report/SKILL.md
+++ b/.skills/coverage-report/SKILL.md
@@ -30,6 +30,27 @@ when the probe's status taxonomy shifts between two snapshots (a status bucket a
 combos reclassified to `not_supported` which is excluded), the share moves for non-work reasons. Always
 run the taxonomy-shift check and state its caveats before presenting any percentage.
 
+## Two coverage data sources — capability vs test-pass
+
+This skill reports **two complementary kinds** of coverage. Be explicit about which one a number is:
+
+| | **Capability coverage** (default) | **Test-pass coverage** |
+|---|---|---|
+| Question | "Can the connector *build* a valid request?" | "Does it actually *pass* end-to-end against the sandbox?" |
+| Source | `data/field_probe/*.json` (static, git-tracked) | grpc CI reports (`report_latest.json` / dated `report_YYYYMMDD_HHMM.json`); base from `REPORT_BASE_URL` env |
+| Status | `supported` / `not_implemented` / `not_supported` | `PASS` / `FAIL` / `SKIP` (assertion_result) |
+| Modes | Diff / PR activity / Snapshot / Drilldown (§1–§4) | Test coverage (§5) |
+
+Capability is the broader number (code exists) and is the default for "what did we ship". Test-pass is the
+stricter, live number (it works against the real sandbox, creds permitting) — use it when the question is about
+*real working coverage* or pass-rate growth. They will not match; capability ≥ test-pass by construction.
+
+**Unit consistency (HARD):** in BOTH sources, **API coverage = `connector × flow` cells** and **PMT coverage =
+`connector × payment-method` cells** — the full cross-product, so denominators are in the 100s. Do NOT report
+test-pass API/PMT as "N of 25 flows" or "N of 18 methods" (distinct-dimension counting) — that silently changes
+the unit and is not comparable to the capability numbers or to the production rows. `§5` already uses the
+cross-product unit; keep it that way.
+
 ## When to use
 
 - A manager/stakeholder asks for coverage data, "what changed", or a month-over-month / since-release delta.
@@ -48,6 +69,7 @@ inline). For metric definitions and the caveat rules, read `references/methodolo
 | **PR activity** | "What did we ship in the window?" merged PRs bucketed by type/label | §2 PR activity | yes |
 | **Snapshot** | "Where do we stand now?" current PM/API supported + shares | §3 Snapshot | no |
 | **Drilldown** | "Which connectors/flows moved / are new?" top movers | §4 Drilldown | no |
+| **Test coverage** | "How much actually PASSES end-to-end?" pass-based growth table from two grpc CI reports | §5 Test coverage | no |
 
 For a full "meeting packet", run Diff + PR activity together (the diff gives the numbers, PR activity gives
 the "why").
@@ -97,6 +119,10 @@ bullets and the **Overall** line (§1 prints these too). **Always keep the one-l
 `%` is denominator-sensitive (its base shrinks as flows are reclassified to `not_supported`), so the
 trustworthy growth signal is the **counts / Change**, not the `%`. Only write a markdown file, Slack blurb, or
 CSV if the user explicitly asks.
+
+For **Test coverage** (§5), present the **Test Coverage Summary** table the script prints (`Metric | Base |
+Current | Change | Growth`). Label it clearly as *test-pass* (not capability) so it is not confused with the
+§1 numbers, and keep the unit footnote the script emits. Quote the **counts / Change** as growth.
 
 ## Common mistakes
 

--- a/.skills/coverage-report/references/command-cookbook.md
+++ b/.skills/coverage-report/references/command-cookbook.md
@@ -214,6 +214,44 @@ PY
 
 ---
 
+## §5 Test coverage — pass-based growth from two grpc CI reports
+
+Unlike §1–§4 (capability, from `data/field_probe`), this reports what actually **PASSES** end-to-end in the
+grpc integration reports. It takes a **baseline** and a **current** report (local path or http(s) URL) and
+prints a markdown growth table.
+
+The reports base is read from the `REPORT_BASE_URL` environment variable; the commands construct the report
+URLs from it. `report_latest.json` is the stable alias for the most recent run; dated snapshots are
+`report_YYYYMMDD_HHMM.json`.
+
+```bash
+# Set REPORT_BASE_URL to your grpc reports base directory.
+: "${REPORT_BASE_URL:?set REPORT_BASE_URL to your grpc reports base, e.g. export REPORT_BASE_URL=https://<host>/<path>/reports/grpc}"
+
+BASE_REPORT="$REPORT_BASE_URL/report_20260506_1458.json"   # dated baseline snapshot
+CURR_REPORT="$REPORT_BASE_URL/report_latest.json"          # stable alias for the most recent run
+
+python3 scripts/generators/docs/test_coverage.py "$BASE_REPORT" "$CURR_REPORT" \
+  --base-label "May 6" --current-label "latest"
+```
+
+Or pass **local file paths** instead — the script treats any non-`http(s)` argument as a file:
+```bash
+python3 scripts/generators/docs/test_coverage.py ./report_baseline.json ./report_latest.json
+```
+
+Prints rows: Passing tests · Connectors with ≥1 pass · API coverage (`connector × flow`) · PMT coverage
+(`connector × method`) · Production API coverage · Production PMT coverage · Overall run pass rate — each as
+`Base | Current | Change | Growth`. Override the production roster with `--prod adyen,stripe,...` if it changes
+(default is the 14 live connectors baked into the script).
+
+**Definitions (match the capability unit):** a coverage cell counts when it has ≥1 **PASS**; the denominator is
+every `connector × flow` (or `connector × method`) cell **attempted** in that report — the full cross-product,
+not a count of distinct flows/methods. `SKIP` and dependency setup runs are excluded. Quote the **counts /
+Change** as growth; the `%` base drifts as the test matrix grows.
+
+---
+
 ## Verification (run to confirm the cookbook works)
 - §0 → prints `prism/main` SHA/date (e49dc144… or newer) without changing your branch.
 - §1 with `SINCE=2026-05-01 BASE=prism/main`: prints supported deltas, **PM drift / API drift / TOTAL drift**,

--- a/scripts/generators/docs/test_coverage.py
+++ b/scripts/generators/docs/test_coverage.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Test Coverage Summary (grpc CI reports)
+
+Complements coverage_summary.py. Where coverage_summary.py measures *capability*
+(does the connector's request transformer build a valid request -- static, from
+data/field_probe/*.json), this script measures *test-pass coverage*: what actually
+PASSES end-to-end against the sandboxes in the grpc integration reports
+(report_YYYYMMDD_HHMM.json).
+
+It takes two reports -- a baseline and a current -- and prints a markdown growth
+table. Every coverage metric is expressed in the SAME unit the capability skill
+uses: `connector x flow` pairs (API) and `connector x payment-method` pairs (PMT),
+so the denominators are the full cross-product (100s of cells), not a count of
+distinct flows/methods. Production rows restrict that cross-product to the live
+production connector roster.
+
+A report is a JSON object with a top-level "runs" array; each run carries at least
+{connector, suite, pm, assertion_result, is_dependency}. Dependency runs and SKIP
+results are excluded from every metric.
+
+Usage:
+    python3 scripts/generators/docs/test_coverage.py BASE CURRENT
+    python3 scripts/generators/docs/test_coverage.py BASE CURRENT --prod adyen,stripe,...
+
+BASE / CURRENT may be a local file path or an http(s) URL.
+"""
+
+import sys
+import json
+import argparse
+import urllib.request
+from collections import defaultdict
+
+# Production connector roster -- the live connectors whose pass coverage matters
+# most for stakeholder reporting. Override with --prod if the roster changes.
+DEFAULT_PRODUCTION = [
+    "adyen", "authorizedotnet", "braintree", "cashtocode", "cryptopay",
+    "cybersource", "fiuu", "mifinity", "noon", "novalnet", "paypal",
+    "stripe", "volt", "worldpay",
+]
+
+
+def load_report(src):
+    """Load a report from a local path or an http(s) URL."""
+    if src.startswith("http://") or src.startswith("https://"):
+        with urllib.request.urlopen(src) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    else:
+        with open(src, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    return [r for r in (data.get("runs") or []) if not r.get("is_dependency")]
+
+
+def _g(run, key):
+    v = run.get(key)
+    return v if v is not None else ""
+
+
+def analyze(runs, production):
+    """Compute pass-based coverage metrics over a single report's runs."""
+    prod = {c.lower() for c in production}
+
+    total = passed = 0
+    conns_with_pass = set()
+
+    # connector x flow (API) and connector x payment-method (PMT) cells.
+    api_seen, api_pass = set(), set()
+    pm_seen, pm_pass = set(), set()
+    papi_seen, papi_pass = set(), set()
+    ppm_seen, ppm_pass = set(), set()
+
+    for r in runs:
+        if _g(r, "assertion_result") == "SKIP":
+            continue
+        conn = _g(r, "connector")
+        api = _g(r, "suite")
+        pm = _g(r, "pm")
+        ok = _g(r, "assertion_result") == "PASS"
+
+        total += 1
+        if ok:
+            passed += 1
+            conns_with_pass.add(conn)
+
+        api_seen.add((conn, api))
+        if ok:
+            api_pass.add((conn, api))
+        if pm:
+            pm_seen.add((conn, pm))
+            if ok:
+                pm_pass.add((conn, pm))
+
+        if conn.lower() in prod:
+            papi_seen.add((conn, api))
+            if ok:
+                papi_pass.add((conn, api))
+            if pm:
+                ppm_seen.add((conn, pm))
+                if ok:
+                    ppm_pass.add((conn, pm))
+
+    return {
+        "passed": passed,
+        "total": total,
+        "conns": len(conns_with_pass),
+        "api": (len(api_pass), len(api_seen)),
+        "pm": (len(pm_pass), len(pm_seen)),
+        "papi": (len(papi_pass), len(papi_seen)),
+        "ppm": (len(ppm_pass), len(ppm_seen)),
+    }
+
+
+def _rel(old, new):
+    if old == 0:
+        return "n/a"
+    return f"{100.0 * (new - old) / old:+.0f}%"
+
+
+def _frac(pair):
+    s, t = pair
+    pct = (100.0 * s / t) if t else 0.0
+    return f"{s}/{t} ({pct:.0f}%)"
+
+
+def _cov_pct(pair):
+    s, t = pair
+    return (100.0 * s / t) if t else 0.0
+
+
+def render(base, curr, base_label, curr_label):
+    out = []
+    out.append(f"### Test Coverage Summary  ({base_label} → {curr_label})\n")
+    out.append("| Metric | Base | Current | Change | Growth |")
+    out.append("| --- | ---: | ---: | ---: | ---: |")
+
+    # (label, base-cell, current-cell, change-cell, growth-cell)
+    rows = []
+    rows.append((
+        "Passing tests",
+        str(base["passed"]), str(curr["passed"]),
+        f"{curr['passed'] - base['passed']:+d}", _rel(base["passed"], curr["passed"]),
+    ))
+    rows.append((
+        "Connectors with ≥1 pass",
+        str(base["conns"]), str(curr["conns"]),
+        f"{curr['conns'] - base['conns']:+d}", _rel(base["conns"], curr["conns"]),
+    ))
+    rows.append((
+        "API coverage (connector × flow)",
+        _frac(base["api"]), _frac(curr["api"]),
+        f"{curr['api'][0] - base['api'][0]:+d}", _rel(base["api"][0], curr["api"][0]),
+    ))
+    rows.append((
+        "PMT coverage (connector × method)",
+        _frac(base["pm"]), _frac(curr["pm"]),
+        f"{curr['pm'][0] - base['pm'][0]:+d}", _rel(base["pm"][0], curr["pm"][0]),
+    ))
+    rows.append((
+        "Production API coverage",
+        _frac(base["papi"]), _frac(curr["papi"]),
+        f"{curr['papi'][0] - base['papi'][0]:+d}", _rel(base["papi"][0], curr["papi"][0]),
+    ))
+    rows.append((
+        "Production PMT coverage",
+        _frac(base["ppm"]), _frac(curr["ppm"]),
+        f"{curr['ppm'][0] - base['ppm'][0]:+d}", _rel(base["ppm"][0], curr["ppm"][0]),
+    ))
+    base_rate = (100.0 * base["passed"] / base["total"]) if base["total"] else 0.0
+    curr_rate = (100.0 * curr["passed"] / curr["total"]) if curr["total"] else 0.0
+    rows.append((
+        "Overall run pass rate",
+        f"{base_rate:.1f}% ({base['passed']}/{base['total']})",
+        f"{curr_rate:.1f}% ({curr['passed']}/{curr['total']})",
+        f"{curr_rate - base_rate:+.1f}pp", _rel(base_rate, curr_rate),
+    ))
+
+    for label, b, c, ch, gr in rows:
+        out.append(f"| {label} | {b} | {c} | {ch} | {gr} |")
+
+    out.append("")
+    out.append("> **Unit:** coverage rows count `connector × flow` (API) and `connector × payment-method` (PMT)")
+    out.append("> cells that have ≥1 passing scenario, over every such cell attempted — the same cross-product")
+    out.append("> unit the capability skill uses, so denominators are the full grid, not a count of distinct")
+    out.append("> flows/methods. SKIP runs and dependency setup runs are excluded. *Growth* is relative to base;")
+    out.append("> the trustworthy signal is the **counts / Change**, since the % base shifts as the test matrix grows.")
+    return "\n".join(out)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Pass-based test coverage summary from two grpc CI reports.")
+    ap.add_argument("base", help="Baseline report (file path or http(s) URL)")
+    ap.add_argument("current", help="Current report (file path or http(s) URL)")
+    ap.add_argument("--prod", default="", help="Comma-separated production connector roster (overrides default)")
+    ap.add_argument("--base-label", default=None, help="Label for the baseline column header")
+    ap.add_argument("--current-label", default=None, help="Label for the current column header")
+    args = ap.parse_args(argv)
+
+    production = [c.strip() for c in args.prod.split(",") if c.strip()] or DEFAULT_PRODUCTION
+
+    base_runs = load_report(args.base)
+    curr_runs = load_report(args.current)
+
+    base = analyze(base_runs, production)
+    curr = analyze(curr_runs, production)
+
+    base_label = args.base_label or f"baseline ({args.base.split('/')[-1]})"
+    curr_label = args.current_label or f"current ({args.current.split('/')[-1]})"
+
+    print(render(base, curr, base_label, curr_label))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a second coverage data source to the `coverage-report` skill: pass-based **test coverage** from the grpc integration reports, complementing the existing static field-probe **capability** coverage.

## Why

Capability coverage answers "can the connector build a valid request?" (static). It does not answer "does it actually pass end-to-end against the sandbox?" This adds that stricter, live view, and makes the two share one unit so they are comparable.

## Changes

- **`scripts/generators/docs/test_coverage.py`** (new) — takes a baseline + current report (file path or `http(s)` URL) and prints a markdown growth table: passing tests, connectors with ≥1 pass, API/PMT coverage, production API/PMT coverage, overall run pass rate. Production-aware; `SKIP` and dependency runs excluded.
- **`SKILL.md`** — documents the capability-vs-test-pass distinction, the unit-consistency rule, and the new **Test coverage** mode (§5).
- **`references/command-cookbook.md`** — adds **§5** with the copy-paste command.

## Unit consistency

Both sources express **API coverage = `connector × flow` cells** and **PMT coverage = `connector × payment-method` cells** (the full cross-product). Test-pass coverage no longer reports "N of 25 flows" / "N of 18 methods" (distinct-dimension counting), which silently changed the unit and was not comparable to the capability numbers or the production rows.

## Example output

| Metric | Base | Current | Change | Growth |
| --- | ---: | ---: | ---: | ---: |
| Passing tests | 325 | 657 | +332 | +102% |
| Connectors with ≥1 pass | 27 | 40 | +13 | +48% |
| API coverage (connector × flow) | 91/430 (21%) | 184/479 (38%) | +93 | +102% |
| PMT coverage (connector × method) | 34/856 (4%) | 78/968 (8%) | +44 | +129% |
| Production API coverage | 28/108 (26%) | 57/113 (50%) | +29 | +104% |
| Production PMT coverage | 20/180 (11%) | 27/196 (14%) | +7 | +35% |
| Overall run pass rate | 13.4% | 24.3% | +10.8pp | +81% |

## Testing

- `python3 scripts/generators/docs/test_coverage.py <base> <current>` verified against May 6 and Jun 4 reports, with both local-file and URL inputs.
- Docs/tooling only; no connector or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)