### PR TITLE
fix(nexixpay): pre_authenticate RouterData & request diffs vs hyperswitch (shadow validation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           names=$(echo '${{ steps.filter.outputs.connector_files }}' | \
             jq -r '.[]' | \
-            grep -oE '(connectors|connector_specs)/[^/]+' || true | \
+            grep -oE '(connectors|connector_specs)/[^/]+' | \
             sed 's|^connectors/||;s|^connector_specs/||;s|\.rs$||' | \
             sort -u | paste -sd ',' -)
           echo "list=$names" >> $GITHUB_OUTPUT

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -3403,6 +3403,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                     ..item.router_data.resource_common_data
                 },
                 response: Ok(PaymentsResponseData::PreAuthenticateResponse {
+                    resource_id: None,
                     redirection_data: Some(Box::new(RedirectForm::CybersourceAuthSetup {
                         access_token: info_response
                             .consumer_authentication_information

--- a/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
@@ -2010,6 +2010,7 @@ impl<T: PaymentMethodDataTypes + fmt::Debug + Sync + Send + 'static + Serialize>
 
         Ok(Self {
             response: Ok(PaymentsResponseData::PreAuthenticateResponse {
+                resource_id: None,
                 authentication_data,
                 redirection_data,
                 connector_response_reference_id: item.response.transaction_id.clone(),

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -381,7 +381,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let customer_info = NexixpayCustomerInfo {
             card_holder_name,
             billing_address,
-            shipping_address: None,
+            shipping_address: build_shipping_address(&item.resource_common_data),
         };
 
         // Build order data with customer_info
@@ -1123,6 +1123,39 @@ pub struct NexixpayRecurrence {
     pub contract_type: Option<ContractType>,
 }
 
+/// Build the `shippingAddress` object for Nexi `customerInfo` from the
+/// shipping address carried on `PaymentFlowData`.
+///
+/// Mirrors hyperswitch's `get_validated_shipping_address`: the object is
+/// emitted whenever a shipping address is present on the payment (even if
+/// individual fields inside it are absent), and is `null` otherwise. Field
+/// construction matches hyperswitch — full name from first+last, street as
+/// `line1, line2`, country as alpha-3.
+fn build_shipping_address(flow_data: &PaymentFlowData) -> Option<NexixpayShippingAddress> {
+    flow_data.get_optional_shipping().map(|_| {
+        let street = match (
+            flow_data.get_optional_shipping_line1(),
+            flow_data.get_optional_shipping_line2(),
+        ) {
+            (Some(l1), Some(l2)) => Some(Secret::new(format!("{}, {}", l1.peek(), l2.peek()))),
+            (Some(l1), None) => Some(l1),
+            (None, Some(l2)) => Some(l2),
+            (None, None) => None,
+        };
+        NexixpayShippingAddress {
+            name: flow_data.get_optional_shipping_full_name(),
+            street,
+            city: flow_data
+                .get_optional_shipping_city()
+                .map(|city| city.expose()),
+            post_code: flow_data.get_optional_shipping_zip(),
+            country: flow_data
+                .get_optional_shipping_country()
+                .map(common_enums::CountryAlpha2::from_alpha2_to_alpha3),
+        }
+    })
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum NexixpayPaymentRequestActionType {
@@ -1236,7 +1269,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let customer_info = NexixpayCustomerInfo {
             card_holder_name,
             billing_address,
-            shipping_address: None, // Match Hyperswitch - always null for PreAuthenticate
+            // Hyperswitch sends the shipping address on /init when the payment
+            // carries one (`get_validated_shipping_address`) — mirror that.
+            shipping_address: build_shipping_address(&item.resource_common_data),
         };
 
         // Build order data
@@ -1391,6 +1426,12 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NexixpayPreAuthentica
 
         Ok(Self {
             response: Ok(PaymentsResponseData::PreAuthenticateResponse {
+                // Hyperswitch anchors the attempt to the orderId returned by
+                // /init (`resource_id: ConnectorTransactionId(order_id)`) —
+                // mirror that so the gRPC `connector_transaction_id` is set.
+                resource_id: Some(ResponseId::ConnectorTransactionId(
+                    operation.order_id.clone(),
+                )),
                 redirection_data: authentication_data,
                 connector_response_reference_id: Some(operation.order_id.clone()),
                 status_code: item.http_code,
@@ -1911,7 +1952,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let customer_info = NexixpayCustomerInfo {
             card_holder_name,
             billing_address,
-            shipping_address: None,
+            // Hyperswitch's SetupMandate reuses the Authorize request builder,
+            // which sends the shipping address when present — mirror that.
+            shipping_address: build_shipping_address(&item.resource_common_data),
         };
 
         // SetupMandate is a "register the card" probe — no funds move. The
@@ -2181,7 +2224,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let customer_info = NexixpayCustomerInfo {
             card_holder_name,
             billing_address,
-            shipping_address: None,
+            // Hyperswitch's MIT request sends the shipping address when the
+            // payment carries one — mirror that.
+            shipping_address: build_shipping_address(&item.resource_common_data),
         };
 
         let order = NexixpayOrderData {

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1473,6 +1473,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NmiVaultResponse, Sel
                 (
                     AttemptStatus::AuthenticationPending,
                     Ok(PaymentsResponseData::PreAuthenticateResponse {
+                        resource_id: None,
                         authentication_data: None,
                         redirection_data: Some(Box::new(RedirectForm::Nmi {
                             amount: Money {

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -940,6 +940,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         ..item.router_data.resource_common_data
                     },
                     response: Ok(PaymentsResponseData::PreAuthenticateResponse {
+                        resource_id: None,
                         redirection_data,
                         connector_response_reference_id: response_ref_id,
                         status_code: item.http_code,

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -1417,6 +1417,7 @@ where
         let _connector_metadata = extract_three_ds_metadata(&item.response);
 
         let response = Ok(PaymentsResponseData::PreAuthenticateResponse {
+            resource_id: None,
             redirection_data: redirection_data.map(Box::new),
             connector_response_reference_id,
             status_code: item.http_code,

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -1717,6 +1717,7 @@ pub enum PaymentsResponseData {
         status_code: u16,
     },
     PreAuthenticateResponse {
+        resource_id: Option<ResponseId>,
         authentication_data: Option<router_request_types::AuthenticationData>,
         /// For Device Data Collection
         redirection_data: Option<Box<RedirectForm>>,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -13723,16 +13723,29 @@ pub fn generate_payment_pre_authenticate_response<T: PaymentMethodDataTypes>(
     let response_headers = router_data_v2
         .resource_common_data
         .get_connector_response_headers_as_map();
+    let connector_feature_data = router_data_v2
+        .resource_common_data
+        .connector_feature_data
+        .clone()
+        .and_then(|metadata| {
+            serde_json::to_string(&metadata.expose())
+                .ok()
+                .map(Secret::new)
+        });
 
     let response = match transaction_response {
         Ok(response) => match response {
             PaymentsResponseData::PreAuthenticateResponse {
+                resource_id,
                 redirection_data,
                 connector_response_reference_id,
                 status_code,
                 authentication_data,
             } => PaymentMethodAuthenticationServicePreAuthenticateResponse {
-                connector_transaction_id: None,
+                connector_transaction_id: resource_id
+                    .map(Option::foreign_try_from)
+                    .transpose()?
+                    .unwrap_or_default(),
                 redirection_data: redirection_data
                     .map(|form| match *form {
                         router_response_types::RedirectForm::Form {
@@ -13837,7 +13850,7 @@ pub fn generate_payment_pre_authenticate_response<T: PaymentMethodDataTypes>(
                         })),
                     })
                     .transpose()?,
-                connector_feature_data: None,
+                connector_feature_data,
                 merchant_order_id: connector_response_reference_id,
                 status: grpc_status.into(),
                 error: None,


### PR DESCRIPTION
## Issue

Shadow validation— `nexixpay / card / pre_authenticate`. 5/5 requests diffed, RouterData pattern `e2ef820e` × 5, blocks enablement.

Hyperswitch's UCS readback was already correct — every defect was UCS-side:

| # | Diff | hyperswitch | UCS (before) | Root cause |
|---|------|-------------|--------------|------------|
| 1 | RouterData `response.…TransactionResponse.resource_id` | `{"ConnectorTransactionId":"pay_…"}` (the `/init` orderId) | `"NoResponseId"` | `generate_payment_pre_authenticate_response` hardcoded proto `connector_transaction_id: None` (`domain_types/src/types.rs`) |
| 2 | RouterData `response.…TransactionResponse.connector_metadata` | `{"authorizationOperationId":"…","psyncFlow":"Authorize"}` | `null` | same fn hardcoded `connector_feature_data: None`, discarding the metadata the connector had stashed on `PaymentFlowData::connector_feature_data` |
| 3 | Request `order.customerInfo.shippingAddress` | populated object when the payment carries a shipping address | `null` always | nexixpay hardcoded `shipping_address: None` — the "Match Hyperswitch - always null" comment was wrong; hyperswitch populates it via `get_validated_shipping_address` |

**Deliberately not "fixed":** the `actionType` keyDiff (hyperswitch serializes `"actionType":null`; UCS omits absent optionals — semantically identical payload, and we do not emit nulls) and the `correlation-id` header valueDiff (random UUID per side). Recommendation: the validation-service comparator should normalize `null` ≡ absent-key, which clears the remaining request patterns with no code change.

## Fix (UCS only — zero hyperswitch changes)

1. `PaymentsResponseData::PreAuthenticateResponse` gains `resource_id: Option<ResponseId>` (`connector_types.rs`), mirroring the sibling `AuthenticateResponse` variant.
2. `generate_payment_pre_authenticate_response` (`types.rs`) now maps it onto proto `connector_transaction_id` (same idiom as the Authenticate flow) and serializes `PaymentFlowData::connector_feature_data` onto proto `connector_feature_data` (same shape the Authorize flow ships via `convert_connector_metadata_to_secret_string`).
3. nexixpay sets `resource_id: ConnectorTransactionId(operation.order_id)` — exactly what hyperswitch's native transformer anchors the attempt to.
4. nexixpay requests now build `shippingAddress` via a shared `build_shipping_address()` helper mirroring hyperswitch's construction (full name = first+last, street = `line1, line2`, country = alpha-3; emitted whenever the payment has a shipping address). Wired into **PreAuthenticate, SetupMandate, Authorize and RepeatPayment** — hyperswitch sends it in all four, so this also pre-empts the identical diff in the sibling flow issues.
5. The other connectors constructing this variant (worldpay, redsys, cybersource, getnet, nmi) set `resource_id: None` — their wire output is bit-for-bit unchanged.

## Proof of fix

<details><summary>Data-path trace — where each value was lost, and where it flows now</summary>

| Hop | `resource_id` | `connector_metadata` |
|-----|---------------|----------------------|
| 1. UCS connector (`nexixpay/transformers.rs`, PreAuthenticate response) | **now:** `resource_id: Some(ConnectorTransactionId(operation.order_id))` | already stashed `NexixpayConnectorMetaData { authorization_operation_id, psync_flow }` on `PaymentFlowData::connector_feature_data` (unchanged) |
| 2. UCS → proto (`domain_types/src/types.rs`, `generate_payment_pre_authenticate_response`) | **was `connector_transaction_id: None`** → now `resource_id.map(Option::foreign_try_from).transpose()?.unwrap_or_default()` | **was `connector_feature_data: None`** → now `serde_json::to_string(&feature_data.expose())` → `Secret<String>` |
| 3. hyperswitch readback (`crates/router/src/core/unified_connector_service/transformers.rs:2118` and `:2201`) | already maps `connector_transaction_id → ResponseId::ConnectorTransactionId` — **unchanged** | already parses `connector_feature_data → connector_metadata` — **unchanged** |

The break was hop 2 in both columns; hops 1 (metadata) and 3 were already correct.

</details>

<details><summary>RouterData built from UCS response — before vs after (issue evidence, pattern e2ef820e)</summary>

Before (from the issue):

```json
"response": { "Ok": { "TransactionResponse": {
    "resource_id": "NoResponseId",
    "redirection_data": { "Form": { "...": "matches hyperswitch" } },
    "connector_response_reference_id": "pay_RioYXHqCeshz6n"
}}}
```

After (identical to the hyperswitch-native RouterData in the issue):

```json
"response": { "Ok": { "TransactionResponse": {
    "resource_id": { "ConnectorTransactionId": "pay_RioYXHqCeshz6n" },
    "redirection_data": { "Form": { "...": "matches hyperswitch" } },
    "connector_metadata": {
        "authorizationOperationId": "600049244600461549",
        "psyncFlow": "Authorize"
    },
    "connector_response_reference_id": "pay_RioYXHqCeshz6n"
}}}
```

`NexixpayConnectorMetaData` serializes with `rename_all = "camelCase"` + skip-`None` on both sides, so the readback JSON is byte-identical to hyperswitch's two-key object.

</details>

<details><summary>Request body — shippingAddress before vs after (issue Pattern 3)</summary>

Payment with a shipping address (hyperswitch sent, UCS dropped):

```json
// hyperswitch (reference)
"shippingAddress": {"name":"john doe","street":"1467, Harrison Street","city":"San Fransico","postCode":"94122","country":"USA"}

// UCS before
"shippingAddress": null

// UCS after — built from PaymentFlowData shipping address with hyperswitch's exact construction
"shippingAddress": {"name":"john doe","street":"1467, Harrison Street","city":"San Fransico","postCode":"94122","country":"USA"}
```

</details>

- `cargo check --workspace --all-targets` — passes
- `cargo clippy -p domain_types -p connector-integration --all-features --all-targets` — clean
- Final sign-off: re-run nexixpay shadow Cypress (`05-ThreeDSAutoCapture`, `08-SyncPayment`, `16-ThreeDSManualCapture`) — RouterData pattern `e2ef820e` and the Pattern-3 `shippingAddress` typeDiff clear; the remaining `actionType` null-vs-absent pattern is the accepted comparator-normalization item above.


