### PR TITLE
feat(payconex): map MOTO payment_type from payment_channel

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
@@ -222,8 +222,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             _ => TransactionType::Sale,
         };
 
-        let payment_type =
-            map_payment_type(request.payment_channel.as_ref(), request.off_session);
+        let payment_type = map_payment_type(request.payment_channel.as_ref(), request.off_session);
 
         let transaction_amount = item
             .connector

--- a/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
@@ -95,6 +95,25 @@ pub enum PaymentType {
     Moto,
 }
 
+// Maps the UCS request to PayConex `payment_type`. MOTO has a real signal
+// (`payment_channel` = mail / telephone order); a merchant-initiated payment
+// (`off_session`) maps to RECURRING, which PayConex accepts without a stored
+// credential. INSTALLMENT needs `installment_count` / `installment_number`, which
+// UCS does not surface, so it is not inferred here.
+fn map_payment_type(
+    payment_channel: Option<&common_enums::PaymentChannel>,
+    off_session: Option<bool>,
+) -> PaymentType {
+    match payment_channel {
+        Some(common_enums::PaymentChannel::MailOrder)
+        | Some(common_enums::PaymentChannel::TelephoneOrder) => PaymentType::Moto,
+        _ => match off_session {
+            Some(true) => PaymentType::Recurring,
+            _ => PaymentType::Ecommerce,
+        },
+    }
+}
+
 // =============================================================================
 // FLEXIBLE BOOLEAN — PayConex returns "1"/"0"/true/false/null for booleans
 // =============================================================================
@@ -203,13 +222,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             _ => TransactionType::Sale,
         };
 
-        // Off-session (merchant-initiated) card payments are recurring; everything
-        // else is a customer-present e-commerce transaction. MOTO / INSTALLMENT
-        // have no corresponding UCS signal, so they are not inferred here.
-        let payment_type = match request.off_session {
-            Some(true) => PaymentType::Recurring,
-            _ => PaymentType::Ecommerce,
-        };
+        let payment_type =
+            map_payment_type(request.payment_channel.as_ref(), request.off_session);
 
         let transaction_amount = item
             .connector


### PR DESCRIPTION
## Summary

PayConex QSAPI `payment_type` (`ECOMMERCE | INSTALLMENT | RECURRING | MOTO`) was only ever emitting `ECOMMERCE`/`RECURRING`. **MOTO** has a real UCS signal — `payment_channel` (`MailOrder`/`TelephoneOrder`) — already mapped by sibling connectors (`ppro`, `fiservcommercehub`), so this maps it too.

- Extracted a `map_payment_type` helper (mirrors the existing `map_payment_status` / `map_refund_status` helpers):
  - `payment_channel = MailOrder | TelephoneOrder` → `MOTO` (takes precedence)
  - `off_session = Some(true)` → `RECURRING` (PayConex accepts it without a stored credential)
  - otherwise → `ECOMMERCE`
- **INSTALLMENT is intentionally not inferred** — PayConex requires `installment_count` / `installment_number`, which UCS does not surface on the authorize request.

## Testing (grpcurl, live vs `cert.payconex.net`)

Verified with `return_raw_connector_data=true` to inspect the actual outgoing form body:

| Input | Sent `payment_type` | Status |
|---|---|---|
| (none) | `ECOMMERCE` | `CHARGED` |
| `payment_channel=MAIL_ORDER` | `MOTO` | `CHARGED` |
| `payment_channel=TELEPHONE_ORDER` | `MOTO` | `CHARGED` |
| `off_session=true` | `RECURRING` | `CHARGED` |
| `MAIL_ORDER` + `off_session=true` | `MOTO` (precedence) | `CHARGED` |

The 7 standard flows still pass unchanged: SALE→`CHARGED`, manual→`AUTHORIZED`, Capture→`CHARGED`, PSync→`CHARGED`, Refund/RSync→`REFUND_SUCCESS`, zero-amount→`FAILURE` (20001).


<details>
<summary><b>🧪 Reproduce — grpcurl (credentials redacted)</b></summary>

#### Setup

```bash
# Start the gRPC server with raw connector data enabled so the outgoing
# form body (incl. payment_type) is echoed back in the response.
CS__COMMON__RETURN_RAW_CONNECTOR_DATA=true ./target/debug/grpc-server &
until grpcurl -plaintext localhost:8000 list >/dev/null 2>&1; do sleep 1; done

# id -> account_id, access-key -> api_key. base_url comes from config (cert.payconex.net).
export CONFIG='{"config":{"Payconex":{"api_key":"<API_ACCESS_KEY>","account_id":"<ACCOUNT_ID>"}}}'

# Shared card body
CARD='"payment_method":{"card":{"card_number":{"value":"4111111111111111"},"card_exp_month":{"value":"03"},"card_exp_year":{"value":"2030"},"card_cvc":{"value":"737"},"card_holder_name":{"value":"John Doe"}}}'

# Helper: prints the status + the payment_type actually sent to PayConex
ptype() { # $1 = request-id, $2 = extra JSON fields (e.g. ,"payment_channel":"MAIL_ORDER")
  grpcurl -plaintext \
    -H "x-connector-config: $CONFIG" -H "x-merchant-id: m1" -H "x-tenant-id: default" \
    -H "x-request-id: $1" -H "x-connector-request-reference-id: ref-$1" \
    -d "{\"merchant_transaction_id\":\"$1\",\"amount\":{\"minor_amount\":1000,\"currency\":\"USD\"},$CARD,\"capture_method\":\"AUTOMATIC\",\"address\":{\"billing_address\":{}},\"auth_type\":\"NO_THREE_DS\",\"return_url\":\"https://example.com/return\"$2}" \
    localhost:8000 types.PaymentService/Authorize \
  | jq -r '"status=\(.status)  sent_payment_type=\(.rawConnectorRequest.value | capture("payment_type=(?<v>[A-Z]+)").v)"'
}
```

#### payment_type mapping

```bash
ptype ecom        ''                                              # -> status=CHARGED  sent_payment_type=ECOMMERCE
ptype moto-mail   ',"payment_channel":"MAIL_ORDER"'              # -> status=CHARGED  sent_payment_type=MOTO
ptype moto-tel    ',"payment_channel":"TELEPHONE_ORDER"'         # -> status=CHARGED  sent_payment_type=MOTO
ptype recurring   ',"off_session":true'                          # -> status=CHARGED  sent_payment_type=RECURRING
ptype precedence  ',"payment_channel":"MAIL_ORDER","off_session":true'  # -> status=CHARGED  sent_payment_type=MOTO
```

| Request fields | `sent_payment_type` | `status` |
|---|---|---|
| (none) | `ECOMMERCE` | `CHARGED` |
| `payment_channel=MAIL_ORDER` | `MOTO` | `CHARGED` |
| `payment_channel=TELEPHONE_ORDER` | `MOTO` | `CHARGED` |
| `off_session=true` | `RECURRING` | `CHARGED` |
| `MAIL_ORDER` + `off_session=true` | `MOTO` (precedence) | `CHARGED` |

> Credentials are redacted (`<API_ACCESS_KEY>` / `<ACCOUNT_ID>`). `api_key` is the 32-char PayConex `api_accesskey`; `account_id` is the numeric PayConex account id.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
