### PR TITLE
fix(connector): map NMI refund connector_refund_id to orderid for Execute and RSync

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -807,7 +807,6 @@ pub struct SyncResponse {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SyncTransactionData {
     pub transaction_id: String,
-    #[serde(default)]
     pub order_id: String,
     pub condition: String, // Maps to status
 }

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -807,6 +807,8 @@ pub struct SyncResponse {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SyncTransactionData {
     pub transaction_id: String,
+    #[serde(default)]
+    pub order_id: String,
     pub condition: String, // Maps to status
 }
 
@@ -1079,7 +1081,7 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
 
         Ok(Self {
             response: Ok(RefundsResponseData {
-                connector_refund_id: response.transactionid.clone(),
+                connector_refund_id: response.orderid.clone(),
                 refund_status: status,
                 status_code: item.http_code,
             }),
@@ -1141,17 +1143,18 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
     fn try_from(item: ResponseRouterData<SyncResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Try to find exact match first, fallback to last transaction
+        // The query is keyed by order_id (= connector_refund_id), so match on the
+        // echoed order_id, falling back to the last transaction
         let transaction = response
             .transaction
             .iter()
-            .find(|txn| txn.transaction_id == item.router_data.request.connector_refund_id)
+            .find(|txn| txn.order_id == item.router_data.request.connector_refund_id)
             .or_else(|| response.transaction.last());
 
         // Map condition field from XML to RefundStatus using NmiStatus enum
         let (status, connector_refund_id) = if let Some(transaction) = transaction {
             let status = RefundStatus::from(NmiStatus::from(transaction.condition.clone()));
-            (status, transaction.transaction_id.clone())
+            (status, transaction.order_id.clone())
         } else {
             // Empty response - treat as pending with proper error for connector_refund_id
             return Err(error_stack::report!(


### PR DESCRIPTION
## Issue
Shadow validation diff — `nmi / card / refund`: every refund (3/3) produced a RouterData mismatch:

| Field | Hyperswitch | UCS |
|---|---|---|
| `response.Ok.connector_refund_id` | `ref_Y81E4w1fftiVvf0E5YZ5` | `12133747992` |

## Why it occurred
- NMI's refund response carries two ids: `transactionid` (the newly created refund transaction) and `orderid` (echo of the merchant refund_id sent in the request).
- Hyperswitch refund Execute maps `connector_refund_id = response.orderid` (`hyperswitch_connectors/src/connectors/nmi/transformers.rs:1542`); UCS mapped `response.transactionid`.
- Coupled RSync bug: hyperswitch RSync queries NMI by `order_id = connector_refund_id` and returns `transaction.order_id` (`nmi/transformers.rs:1600`). UCS sent the same query but then matched the response by `transaction_id == connector_refund_id` — which can never match once the stored id is `ref_…` — and returned `transaction_id`. With the numeric id stored (pre-fix), a live RSync query (`order_id=<numeric>`) would find no transaction at all.

## Resolution
All in `crates/integrations/connector-integration/src/connectors/nmi/transformers.rs` (UCS only):
1. Refund Execute response: `connector_refund_id: response.orderid` (was `transactionid`).
2. RSync response: match the transaction by `order_id` and return `transaction.order_id` (mirrors hyperswitch).
3. `SyncTransactionData`: added `#[serde(default)] order_id` to the shared XML struct. PSync handler is untouched — it still keys on `transaction_id`, same as hyperswitch PSync.

No hyperswitch-side change needed: the old (wrong) value round-tripped the gRPC proto and readback intact, so the cutoff layer was already correct.

## Proof
- Before (issue #16551): `connector_refund_id` → HS `ref_Y81E4w1fftiVvf0E5YZ5` vs UCS `12133747992` on all 3 refunds.
- After (shadow re-run with this fix): HS and UCS RouterData both return `"connector_refund_id": "ref_l0j0CbvAMGC57UPXUqbP"`, `"refund_status": "success"` — refund RouterData is `no_diff`.
- `cargo check -p connector-integration` passes.


