### PR TITLE
fix(finix): capture RouterData diffs vs hyperswitch (shadow validation)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -596,7 +596,9 @@ pub struct FinixPaymentsResponse {
     pub links: Option<FinixLinks>,
     pub failure_code: Option<String>,
     pub failure_message: Option<String>,
+    pub messages: Option<Vec<String>>,
     pub transfer: Option<String>,
+    pub is_void: Option<bool>,
     // Stored Payment Instrument backing this transaction (PI...). Hyperswitch maps this
     // into `mandate_reference.connector_mandate_id` so the sync response stays in parity.
     pub source: Option<Secret<String>>,
@@ -750,22 +752,86 @@ impl TryFrom<ResponseRouterData<FinixCaptureResponse, Self>>
 
     fn try_from(item: ResponseRouterData<FinixCaptureResponse, Self>) -> Result<Self, Self::Error> {
         let response = item.response;
-        let status = AttemptStatus::from(&response.state);
 
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(response.id.clone()),
+        // A SUCCEEDED capture only confirms the authorization update; the funds
+        // movement (transfer) settles asynchronously, so the attempt stays Pending
+        // until a PSync on the transfer id confirms the charge.
+        let status = if response.is_void == Some(true) {
+            match response.state {
+                FinixPaymentStatus::Pending | FinixPaymentStatus::Succeeded => {
+                    AttemptStatus::Voided
+                }
+                FinixPaymentStatus::Failed
+                | FinixPaymentStatus::Canceled
+                | FinixPaymentStatus::Unknown => AttemptStatus::VoidFailed,
+            }
+        } else {
+            match response.state {
+                FinixPaymentStatus::Pending | FinixPaymentStatus::Succeeded => {
+                    AttemptStatus::Pending
+                }
+                FinixPaymentStatus::Failed
+                | FinixPaymentStatus::Canceled
+                | FinixPaymentStatus::Unknown => AttemptStatus::Failure,
+            }
+        };
+
+        let connector_response = build_finix_connector_response(&response);
+
+        let is_failure = matches!(
+            response.state,
+            FinixPaymentStatus::Failed | FinixPaymentStatus::Canceled | FinixPaymentStatus::Unknown
+        );
+
+        let flow_response = if is_failure {
+            Err(ErrorResponse {
+                code: response
+                    .failure_code
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+                message: response
+                    .failure_message
+                    .clone()
+                    .or_else(|| response.messages.clone().map(|msg| msg.join(",")))
+                    .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+                reason: None,
+                status_code: item.http_code,
+                attempt_status: Some(FlowStatus::Payment(status)),
+                connector_transaction_id: Some(response.id.clone()),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            })
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
+                // The transfer id (TR*) tracks the actual funds movement; fall back
+                // to the authorization id when Finix has not created a transfer yet.
+                resource_id: ResponseId::ConnectorTransactionId(
+                    response
+                        .transfer
+                        .clone()
+                        .unwrap_or_else(|| response.id.clone()),
+                ),
                 redirection_data: None,
-                mandate_reference: None,
+                mandate_reference: Some(Box::new(MandateReference {
+                    connector_mandate_id: response.source.clone().map(|id| id.expose()),
+                    payment_method_id: None,
+                    connector_mandate_request_reference_id: None,
+                })),
                 connector_metadata: None,
                 network_txn_id: None,
                 network_txn_link_id: None,
                 connector_response_reference_id: Some(response.id.clone()),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response: flow_response,
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response,
                 ..item.router_data.resource_common_data.clone()
             },
             ..item.router_data

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8826,6 +8826,23 @@ pub fn generate_payment_capture_response(
         .resource_common_data
         .get_raw_connector_request();
 
+    let connector_response = router_data_v2
+        .resource_common_data
+        .connector_response
+        .as_ref()
+        .and_then(|connector_response_data| {
+            grpc_api_types::payments::ConnectorResponseData::foreign_try_from(
+                connector_response_data.clone(),
+            )
+            .map_err(|error| {
+                tracing::warn!(
+                    ?error,
+                    "Failed to convert connector_response for capture response; omitting it"
+                );
+            })
+            .ok()
+        });
+
     match transaction_response {
         Ok(response) => match response {
             PaymentsResponseData::TransactionResponse {
@@ -8873,6 +8890,7 @@ pub fn generate_payment_capture_response(
                     connector_feature_data: convert_connector_metadata_to_secret_string(
                         connector_metadata,
                     ),
+                    connector_response,
                 })
             }
             _ => Err(report!(ConnectorError::UnexpectedResponseError {
@@ -8921,6 +8939,7 @@ pub fn generate_payment_capture_response(
                 mandate_reference: None,
                 captured_amount: None,
                 connector_feature_data: None,
+                connector_response,
             })
         }
     }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2546,6 +2546,9 @@ message PaymentServiceCaptureResponse {
 
   optional SecretString connector_feature_data =
       12; // Connector-specific metadata for the transaction
+
+  // Additional connector response details (e.g. AVS / CVV checks, auth code)
+  optional ConnectorResponseData connector_response = 13;
 }
 
 // Request message for creating an order

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -388,7 +388,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   PaymentClientAuthenticationContext: { "amount": "Money", "customer": "Customer" },
   MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse: { "sessionData": "ClientAuthenticationTokenData", "error": "ErrorInfo" },
   PaymentServiceCaptureRequest: { "amountToCapture": "Money", "multipleCaptureData": "MultipleCaptureRequestData", "browserInfo": "BrowserInformation", "state": "ConnectorState", "orderTaxAmount": "Money" },
-  PaymentServiceCaptureResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference" },
+  PaymentServiceCaptureResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference", "connectorResponse": "ConnectorResponseData" },
   PaymentServiceCreateOrderRequest: { "amount": "Money", "state": "ConnectorState" },
   PaymentServiceCreateOrderResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "sessionData": "ClientAuthenticationTokenData" },
   PaymentServiceRefundRequest: { "refundAmount": "Money", "browserInfo": "BrowserInformation", "state": "ConnectorState", "paymentMethod": "PaymentMethod" },


### PR DESCRIPTION
## Description

Shadow validation reported RouterData diffs on every Finix manual-capture request (8/8). Five fields diverged from hyperswitch:

| Field | hyperswitch | UCS (before) |
|---|---|---|
| `status` | `pending` | `charged` |
| `resource_id` | transfer id (`TR*`) | authorization id (`AU*`) |
| `mandate_reference.connector_mandate_id` | `source` (`PI*`) | `null` |
| `connector_response_reference_id` | `null` | `AU*` id |
| `connector_response` (AVS / auth code / card network) | populated | `null` |

**Why it was there:** hyperswitch routes all Finix flows through one shared `get_finix_response(.., FinixFlow::Capture)`, which intentionally keeps a SUCCEEDED capture as `Pending` (Finix captures settle asynchronously; PSync on the transfer id confirms the charge), returns the transfer id, and populates mandate/AVS data. The UCS capture handler used a flow-agnostic status mapping (`SUCCEEDED -> Charged`), always returned the authorization id, and its `FinixPaymentsResponse` struct did not even deserialize `source` / `address_verification` / `network_details`. Additionally, `PaymentServiceCaptureResponse` had no `connector_response` proto field at all (authorize/get/setup_recurring/repeat charge all have one), so AVS data could never reach hyperswitch for capture.

**How it was resolved:**
- Rewrote the Finix capture response handler to mirror `get_finix_response` exactly: flow-aware status mapping (incl. `is_void -> Voided/VoidFailed` and failure states -> `Err(ErrorResponse)`), `transfer ?? id` as resource_id, mandate_reference from `source`, `connector_response_reference_id: None`, and `PaymentFlowData.connector_response` populated via a shared helper.
- Extended `FinixPaymentsResponse` with the missing optional fields (safe for the other flows sharing the struct).
- Added `optional ConnectorResponseData connector_response = 13` to `PaymentServiceCaptureResponse` and mapped it in `generate_payment_capture_response` (same idiom as authorize).

## Motivation and Context

Fixes the RouterData diff reported by the cypress shadow-validation suite for finix/card/capture . The hyperswitch connector is the source of truth; UCS must produce identical RouterData.

### Additional Changes
- [x] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

`PaymentServiceCaptureResponse` gains a new optional field (backward compatible, follows the existing pattern on the authorize/get/setup_recurring responses). Consuming it in hyperswitch requires a client release tag bump plus the readback wiring (raised separately in juspay/hyperswitch).

## How did you test it?

- `cargo check` / `cargo clippy` clean across the workspace.
- Re-ran the finix manual-capture cypress suite with hyperswitch<->UCS shadow validation against this branch: all 8 RouterData diffs from the issue resolve (the `connector_response` diff additionally needs the hyperswitch-side readback PR).