### PR TITLE
feat(events): route connector and inbound events to separate topics

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -160,7 +160,12 @@ axisbank.base_url = "https://upiuatv3.axisbank.com/api/b2/"
 [events]
 enabled = false
 brokers = ["localhost:9092"]
-topic = "audit-trail-events"
+# Outbound payment-connector calls (ConnectorCall stage -> connector_events table).
+# (Legacy key `topic` is still accepted via serde alias for backward compatibility.)
+connector_events_topic = "audit-trail-events"
+# Inbound requests UCS serves over any transport, gRPC or HTTP (-> ucs_api_events table).
+# Optional: when unset, these events fall back to `topic` (pre-split behavior).
+ucs_api_events_topic = "audit-trail-service-events"
 partition_key_field = "request_id"
 
 [lineage]
@@ -177,7 +182,6 @@ field_prefix = "lineage_"
 "message.request_time" = "timestamp"
 "message.res_code" = "status_code"
 "message.url" = "url"
-"message.stage" = "stage"
 "message.req_body" = "connector_request_data"
 "message.res_body" = "connector_response_data"
 "udf_txn_uuid" = "reference_id"

--- a/config/development.toml
+++ b/config/development.toml
@@ -160,11 +160,9 @@ axisbank.base_url = "https://upiuatv3.axisbank.com/api/b2/"
 [events]
 enabled = false
 brokers = ["localhost:9092"]
-# Outbound payment-connector calls (ConnectorCall stage -> connector_events table).
-# (Legacy key `topic` is still accepted via serde alias for backward compatibility.)
+# Outbound connector calls (ConnectorCall stage) -> connector_events table.
 connector_events_topic = "audit-trail-events"
-# Inbound requests UCS serves over any transport, gRPC or HTTP (-> ucs_api_events table).
-# Optional: when unset, these events fall back to `topic` (pre-split behavior).
+# Inbound requests UCS serves (GrpcRequest stage) -> ucs_api_events table.
 ucs_api_events_topic = "audit-trail-service-events"
 partition_key_field = "request_id"
 
@@ -182,6 +180,7 @@ field_prefix = "lineage_"
 "message.request_time" = "timestamp"
 "message.res_code" = "status_code"
 "message.url" = "url"
+"message.stage" = "stage"
 "message.req_body" = "connector_request_data"
 "message.res_body" = "connector_response_data"
 "udf_txn_uuid" = "reference_id"

--- a/config/development.toml
+++ b/config/development.toml
@@ -163,12 +163,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "audit-trail-events"
+topic = "ucs-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "audit-trail-service-events"
+topic = "ucs-api-events"
 partition_key_field = "request_id"
 
 [lineage]

--- a/config/development.toml
+++ b/config/development.toml
@@ -163,12 +163,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "ucs-connector-events"
+topic = "unified-connector-service-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "ucs-api-events"
+topic = "unified-connector-service-api-events"
 partition_key_field = "request_id"
 
 [lineage]

--- a/config/development.toml
+++ b/config/development.toml
@@ -160,10 +160,15 @@ axisbank.base_url = "https://upiuatv3.axisbank.com/api/b2/"
 [events]
 enabled = false
 brokers = ["localhost:9092"]
-# Outbound connector calls (ConnectorCall stage) -> connector_events table.
-connector_events_topic = "audit-trail-events"
-# Inbound requests UCS serves (GrpcRequest stage) -> ucs_api_events table.
-ucs_api_events_topic = "audit-trail-service-events"
+
+# Outbound connector-call events.
+[events.connector_events]
+topic = "audit-trail-events"
+partition_key_field = "request_id"
+
+# Inbound request events.
+[events.api_events]
+topic = "audit-trail-service-events"
 partition_key_field = "request_id"
 
 [lineage]

--- a/config/production.toml
+++ b/config/production.toml
@@ -135,6 +135,7 @@ axisbank.base_url = "https://upisdk.axisbank.co.in/api/b2/"
 enabled = false
 brokers = ["localhost:9092"]
 topic = "audit-trail-events"
+ucs_api_events_topic = "audit-trail-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/production.toml
+++ b/config/production.toml
@@ -134,8 +134,15 @@ axisbank.base_url = "https://upisdk.axisbank.co.in/api/b2/"
 [events]
 enabled = false
 brokers = ["localhost:9092"]
+
+# Outbound connector-call events.
+[events.connector_events]
 topic = "audit-trail-events"
-ucs_api_events_topic = "audit-trail-events"
+partition_key_field = "request_id"
+
+# Inbound request events.
+[events.api_events]
+topic = "audit-trail-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/production.toml
+++ b/config/production.toml
@@ -137,12 +137,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "ucs-connector-events"
+topic = "unified-connector-service-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "ucs-api-events"
+topic = "unified-connector-service-api-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/production.toml
+++ b/config/production.toml
@@ -137,12 +137,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "audit-trail-events"
+topic = "ucs-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "audit-trail-events"
+topic = "ucs-api-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -135,6 +135,7 @@ axisbank.base_url = "https://upiuatv3.axisbank.com/api/b2/"
 enabled = false
 brokers = ["localhost:9092"]
 topic = "audit-trail-events"
+ucs_api_events_topic = "audit-trail-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -134,8 +134,15 @@ axisbank.base_url = "https://upiuatv3.axisbank.com/api/b2/"
 [events]
 enabled = false
 brokers = ["localhost:9092"]
+
+# Outbound connector-call events.
+[events.connector_events]
 topic = "audit-trail-events"
-ucs_api_events_topic = "audit-trail-events"
+partition_key_field = "request_id"
+
+# Inbound request events.
+[events.api_events]
+topic = "audit-trail-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -137,12 +137,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "ucs-connector-events"
+topic = "unified-connector-service-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "ucs-api-events"
+topic = "unified-connector-service-api-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -137,12 +137,12 @@ brokers = ["localhost:9092"]
 
 # Outbound connector-call events.
 [events.connector_events]
-topic = "audit-trail-events"
+topic = "ucs-connector-events"
 partition_key_field = "request_id"
 
 # Inbound request events.
 [events.api_events]
-topic = "audit-trail-events"
+topic = "ucs-api-events"
 partition_key_field = "request_id"
 
 [connector_request_kafka]

--- a/crates/common/common_utils/src/event_publisher.rs
+++ b/crates/common/common_utils/src/event_publisher.rs
@@ -6,7 +6,7 @@ use serde_json;
 use tracing_kafka::{builder::KafkaWriterBuilder, KafkaWriter};
 
 use crate::{
-    events::{Event, EventConfig},
+    events::{Event, EventConfig, EventStage},
     CustomResult, EventPublisherError,
 };
 
@@ -35,7 +35,7 @@ impl EventPublisher {
             ));
         }
 
-        if config.topic.is_empty() {
+        if config.connector_events_topic.is_empty() {
             return Err(error_stack::Report::new(
                 EventPublisherError::InvalidConfiguration {
                     message: "topic cannot be empty".to_string(),
@@ -45,20 +45,20 @@ impl EventPublisher {
 
         tracing::debug!(
           brokers = ?config.brokers,
-          topic = %config.topic,
+          topic = %config.connector_events_topic,
           "Creating EventPublisher with configuration"
         );
 
         let writer = KafkaWriterBuilder::new()
             .brokers(config.brokers.clone())
-            .topic(config.topic.clone())
+            .topic(config.connector_events_topic.clone())
             .build()
             .map_err(|e| {
                 error_stack::Report::new(EventPublisherError::KafkaWriterInitializationFailed)
                     .attach_printable(format!("KafkaWriter build failed: {e}"))
                     .attach_printable(format!(
                         "Brokers: {:?}, Topic: {}",
-                        config.brokers, config.topic
+                        config.brokers, config.connector_events_topic
                     ))
             })?;
 
@@ -180,7 +180,7 @@ pub fn init_event_publisher(config: &EventConfig) {
             tracing::warn!(
                 error = ?e,
                 brokers = ?config.brokers,
-                topic = %config.topic,
+                topic = %config.connector_events_topic,
                 "Failed to initialize EventPublisher (Kafka may be unavailable); \
                  events will be dropped until the service is restarted with Kafka reachable"
             );
@@ -206,10 +206,18 @@ pub fn publish_event_to_kafka(
     if config.enabled {
         if let Some(publisher) = get_event_publisher() {
             let metadata = publisher.build_kafka_metadata(event);
+            let topic = match event.stage {
+                EventStage::GrpcRequest if !config.ucs_api_events_topic.is_empty() => {
+                    &config.ucs_api_events_topic
+                }
+                // Unset -> fall back to `topic`: preserves the pre-split single-topic behavior
+                // for existing deployments that have not opted into the new stream.
+                _ => &config.connector_events_topic,
+            };
             let _ = publisher
                 .publish_event_with_metadata(
                     processed_event,
-                    &config.topic,
+                    topic,
                     &config.partition_key_field,
                     metadata,
                 )

--- a/crates/common/common_utils/src/event_publisher.rs
+++ b/crates/common/common_utils/src/event_publisher.rs
@@ -6,7 +6,7 @@ use serde_json;
 use tracing_kafka::{builder::KafkaWriterBuilder, KafkaWriter};
 
 use crate::{
-    events::{Event, EventConfig, EventStage},
+    events::{Event, EventConfig},
     CustomResult, EventPublisherError,
 };
 
@@ -35,38 +35,38 @@ impl EventPublisher {
             ));
         }
 
-        if config.connector_events_topic.is_empty() {
+        if config.connector_events.topic.is_empty() {
             return Err(error_stack::Report::new(
                 EventPublisherError::InvalidConfiguration {
-                    message: "connector_events_topic cannot be empty".to_string(),
+                    message: "connector_events.topic cannot be empty".to_string(),
                 },
             ));
         }
 
-        if config.ucs_api_events_topic.is_empty() {
+        if config.api_events.topic.is_empty() {
             return Err(error_stack::Report::new(
                 EventPublisherError::InvalidConfiguration {
-                    message: "ucs_api_events_topic cannot be empty".to_string(),
+                    message: "api_events.topic cannot be empty".to_string(),
                 },
             ));
         }
 
         tracing::debug!(
           brokers = ?config.brokers,
-          topic = %config.connector_events_topic,
+          topic = %config.connector_events.topic,
           "Creating EventPublisher with configuration"
         );
 
         let writer = KafkaWriterBuilder::new()
             .brokers(config.brokers.clone())
-            .topic(config.connector_events_topic.clone())
+            .topic(config.connector_events.topic.clone())
             .build()
             .map_err(|e| {
                 error_stack::Report::new(EventPublisherError::KafkaWriterInitializationFailed)
                     .attach_printable(format!("KafkaWriter build failed: {e}"))
                     .attach_printable(format!(
                         "Brokers: {:?}, Topic: {}",
-                        config.brokers, config.connector_events_topic
+                        config.brokers, config.connector_events.topic
                     ))
             })?;
 
@@ -188,7 +188,7 @@ pub fn init_event_publisher(config: &EventConfig) {
             tracing::warn!(
                 error = ?e,
                 brokers = ?config.brokers,
-                topic = %config.connector_events_topic,
+                topic = %config.connector_events.topic,
                 "Failed to initialize EventPublisher (Kafka may be unavailable); \
                  events will be dropped until the service is restarted with Kafka reachable"
             );
@@ -214,15 +214,12 @@ pub fn publish_event_to_kafka(
     if config.enabled {
         if let Some(publisher) = get_event_publisher() {
             let metadata = publisher.build_kafka_metadata(event);
-            let topic = match event.stage {
-                EventStage::ConnectorCall => &config.connector_events_topic,
-                EventStage::GrpcRequest => &config.ucs_api_events_topic,
-            };
+            let topic_config = config.topic_config(&event.stage);
             let _ = publisher
                 .publish_event_with_metadata(
                     processed_event,
-                    topic,
-                    &config.partition_key_field,
+                    &topic_config.topic,
+                    &topic_config.partition_key_field,
                     metadata,
                 )
                 .inspect_err(|e| {

--- a/crates/common/common_utils/src/event_publisher.rs
+++ b/crates/common/common_utils/src/event_publisher.rs
@@ -38,7 +38,15 @@ impl EventPublisher {
         if config.connector_events_topic.is_empty() {
             return Err(error_stack::Report::new(
                 EventPublisherError::InvalidConfiguration {
-                    message: "topic cannot be empty".to_string(),
+                    message: "connector_events_topic cannot be empty".to_string(),
+                },
+            ));
+        }
+
+        if config.ucs_api_events_topic.is_empty() {
+            return Err(error_stack::Report::new(
+                EventPublisherError::InvalidConfiguration {
+                    message: "ucs_api_events_topic cannot be empty".to_string(),
                 },
             ));
         }
@@ -208,13 +216,7 @@ pub fn publish_event_to_kafka(
             let metadata = publisher.build_kafka_metadata(event);
             let topic = match event.stage {
                 EventStage::ConnectorCall => &config.connector_events_topic,
-                EventStage::GrpcRequest => {
-                    if config.ucs_api_events_topic.is_empty() {
-                        &config.connector_events_topic
-                    } else {
-                        &config.ucs_api_events_topic
-                    }
-                }
+                EventStage::GrpcRequest => &config.ucs_api_events_topic,
             };
             let _ = publisher
                 .publish_event_with_metadata(

--- a/crates/common/common_utils/src/event_publisher.rs
+++ b/crates/common/common_utils/src/event_publisher.rs
@@ -207,12 +207,14 @@ pub fn publish_event_to_kafka(
         if let Some(publisher) = get_event_publisher() {
             let metadata = publisher.build_kafka_metadata(event);
             let topic = match event.stage {
-                EventStage::GrpcRequest if !config.ucs_api_events_topic.is_empty() => {
-                    &config.ucs_api_events_topic
+                EventStage::ConnectorCall => &config.connector_events_topic,
+                EventStage::GrpcRequest => {
+                    if config.ucs_api_events_topic.is_empty() {
+                        &config.connector_events_topic
+                    } else {
+                        &config.ucs_api_events_topic
+                    }
                 }
-                // Unset -> fall back to `topic`: preserves the pre-split single-topic behavior
-                // for existing deployments that have not opted into the new stream.
-                _ => &config.connector_events_topic,
             };
             let _ = publisher
                 .publish_event_with_metadata(

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -427,19 +427,10 @@ impl EventStage {
 }
 
 /// A Kafka topic plus the payload field whose value is used as its partition key.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct KafkaTopicConfig {
     pub topic: String,
     pub partition_key_field: String,
-}
-
-impl Default for KafkaTopicConfig {
-    fn default() -> Self {
-        Self {
-            topic: String::new(),
-            partition_key_field: "request_id".to_string(),
-        }
-    }
 }
 
 /// Configuration for events system
@@ -651,32 +642,4 @@ pub(crate) fn set_nested_value(
     );
 
     result.map(|_| ())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn stage_selects_topic_and_partition_key() {
-        let config = EventConfig {
-            connector_events: KafkaTopicConfig {
-                topic: "connector-events".to_string(),
-                partition_key_field: "request_id".to_string(),
-            },
-            api_events: KafkaTopicConfig {
-                topic: "ucs-api-events".to_string(),
-                partition_key_field: "merchant_id".to_string(),
-            },
-            ..Default::default()
-        };
-
-        let connector = config.topic_config(&EventStage::ConnectorCall);
-        assert_eq!(connector.topic, "connector-events");
-        assert_eq!(connector.partition_key_field, "request_id");
-
-        let ucs_api = config.topic_config(&EventStage::GrpcRequest);
-        assert_eq!(ucs_api.topic, "ucs-api-events");
-        assert_eq!(ucs_api.partition_key_field, "merchant_id");
-    }
 }

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -229,8 +229,6 @@ pub struct Event {
     /// HTTP verb for outbound connector calls; empty string for gRPC-only audit events.
     #[serde(serialize_with = "serialize_method")]
     pub method: Option<String>,
-    // Routing key only; not serialized.
-    #[serde(skip)]
     pub stage: EventStage,
     /// Primary execution or shadow mirror.
     pub execution_mode: ExecutionMode,
@@ -453,8 +451,8 @@ impl ExecutionMode {
 pub struct EventConfig {
     pub enabled: bool,
     /// Topic for outbound payment-connector calls (`ConnectorCall` stage -> the
-    /// `connector_events` table). Accepts the legacy key `topic` for backward compatibility
-    /// with existing deployments.
+    /// `connector_events` table). Accepts the legacy key `topic` for backward compatibility.
+    // TODO: remove the `topic` alias once configs use `connector_events_topic`.
     #[serde(alias = "topic")]
     pub connector_events_topic: String,
     /// Topic for inbound requests UCS serves over any transport — gRPC or HTTP
@@ -476,7 +474,7 @@ impl Default for EventConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            connector_events_topic: "events".to_string(),
+            connector_events_topic: String::new(),
             ucs_api_events_topic: String::new(),
             brokers: vec!["localhost:9092".to_string()],
             partition_key_field: "request_id".to_string(),

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -229,12 +229,11 @@ pub struct Event {
     /// HTTP verb for outbound connector calls; empty string for gRPC-only audit events.
     #[serde(serialize_with = "serialize_method")]
     pub method: Option<String>,
+    // Routing key only; deliberately not serialized (the stream is the discriminator).
+    #[serde(skip)]
     pub stage: EventStage,
     /// Service that produced this event (always `ucs`).
     pub source: &'static str,
-    /// Which leg this event records: the payment-connector call, or a UCS-service request.
-    /// Derived from `stage` (see `CallType: From<&EventStage>`).
-    pub call_type: CallType,
     /// Whether this leg was the primary execution or a shadow mirror.
     pub execution_mode: ExecutionMode,
     pub latency_ms: Option<u64>,
@@ -434,26 +433,6 @@ impl EventStage {
 /// `source` identifies the emitter (`ucs`), never the caller — UCS is caller-agnostic.
 pub const EVENT_SOURCE: &str = "ucs";
 
-/// Which leg of the call chain an event records.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CallType {
-    /// The outbound call to the payment connector (the external processor).
-    Connector,
-    /// A request at the UCS service interface (the inbound gRPC/HTTP request UCS serves).
-    /// Caller- and transport-agnostic.
-    Service,
-}
-
-impl From<&EventStage> for CallType {
-    fn from(stage: &EventStage) -> Self {
-        match stage {
-            EventStage::ConnectorCall => Self::Connector,
-            EventStage::GrpcRequest => Self::Service,
-        }
-    }
-}
-
 /// Whether a leg was the primary execution or a shadow mirror.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -479,7 +458,16 @@ impl ExecutionMode {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct EventConfig {
     pub enabled: bool,
-    pub topic: String,
+    /// Topic for outbound payment-connector calls (`ConnectorCall` stage -> the
+    /// `connector_events` table). Accepts the legacy key `topic` for backward compatibility
+    /// with existing deployments.
+    #[serde(alias = "topic")]
+    pub connector_events_topic: String,
+    /// Topic for inbound requests UCS serves over any transport — gRPC or HTTP
+    /// (`GrpcRequest` stage -> the `ucs_api_events` table). Falls back to
+    /// `connector_events_topic` when empty.
+    #[serde(default)]
+    pub ucs_api_events_topic: String,
     pub brokers: Vec<String>,
     pub partition_key_field: String,
     #[serde(default)]
@@ -494,7 +482,8 @@ impl Default for EventConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            topic: "events".to_string(),
+            connector_events_topic: "events".to_string(),
+            ucs_api_events_topic: String::new(),
             brokers: vec!["localhost:9092".to_string()],
             partition_key_field: "request_id".to_string(),
             transformations: HashMap::new(),

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -230,6 +230,13 @@ pub struct Event {
     #[serde(serialize_with = "serialize_method")]
     pub method: Option<String>,
     pub stage: EventStage,
+    /// Service that produced this event (always `ucs`).
+    pub source: &'static str,
+    /// Which leg this event records: the payment-connector call, or a UCS-service request.
+    /// Derived from `stage` (see `CallType: From<&EventStage>`).
+    pub call_type: CallType,
+    /// Whether this leg was the primary execution or a shadow mirror.
+    pub execution_mode: ExecutionMode,
     pub latency_ms: Option<u64>,
     pub status_code: Option<i32>,
     pub request_data: Option<MaskedSerdeValue>,
@@ -419,6 +426,51 @@ impl EventStage {
         match self {
             Self::ConnectorCall => "CONNECTOR_CALL",
             Self::GrpcRequest => "GRPC_REQUEST",
+        }
+    }
+}
+
+/// `source` value for events emitted by the connector-service (UCS).
+/// `source` identifies the emitter (`ucs`), never the caller — UCS is caller-agnostic.
+pub const EVENT_SOURCE: &str = "ucs";
+
+/// Which leg of the call chain an event records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallType {
+    /// The outbound call to the payment connector (the external processor).
+    Connector,
+    /// A request at the UCS service interface (the inbound gRPC/HTTP request UCS serves).
+    /// Caller- and transport-agnostic.
+    Service,
+}
+
+impl From<&EventStage> for CallType {
+    fn from(stage: &EventStage) -> Self {
+        match stage {
+            EventStage::ConnectorCall => Self::Connector,
+            EventStage::GrpcRequest => Self::Service,
+        }
+    }
+}
+
+/// Whether a leg was the primary execution or a shadow mirror.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    /// Real execution whose result is used.
+    Primary,
+    /// Shadow mirror whose result is discarded (validation only).
+    Shadow,
+}
+
+impl ExecutionMode {
+    /// Map the boolean shadow flag (from the `x-shadow-mode` metadata) to an execution mode.
+    pub fn from_shadow_flag(shadow_mode: bool) -> Self {
+        if shadow_mode {
+            Self::Shadow
+        } else {
+            Self::Primary
         }
     }
 }

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -426,21 +426,31 @@ impl EventStage {
     }
 }
 
+/// A Kafka topic plus the payload field whose value is used as its partition key.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
+pub struct KafkaTopicConfig {
+    pub topic: String,
+    pub partition_key_field: String,
+}
+
+impl Default for KafkaTopicConfig {
+    fn default() -> Self {
+        Self {
+            topic: String::new(),
+            partition_key_field: "request_id".to_string(),
+        }
+    }
+}
+
 /// Configuration for events system
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct EventConfig {
     pub enabled: bool,
-    /// Topic for outbound connector-call events. Accepts the legacy key `topic`
-    /// for backward compatibility.
-    // TODO: remove the `topic` alias once configs use `connector_events_topic`.
-    #[serde(alias = "topic")]
-    pub connector_events_topic: String,
-    /// Topic for inbound request events. Single-topic deployments set this equal to
-    /// `connector_events_topic`.
-    #[serde(default)]
-    pub ucs_api_events_topic: String,
     pub brokers: Vec<String>,
-    pub partition_key_field: String,
+    /// Outbound connector-call events.
+    pub connector_events: KafkaTopicConfig,
+    /// Inbound request events.
+    pub api_events: KafkaTopicConfig,
     #[serde(default)]
     pub transformations: HashMap<String, String>, // target_path → source_field
     #[serde(default)]
@@ -449,14 +459,23 @@ pub struct EventConfig {
     pub extractions: HashMap<String, String>, // target_path → extraction_path
 }
 
+impl EventConfig {
+    /// Topic + partition key for the given event stage.
+    pub fn topic_config(&self, stage: &EventStage) -> &KafkaTopicConfig {
+        match stage {
+            EventStage::ConnectorCall => &self.connector_events,
+            EventStage::GrpcRequest => &self.api_events,
+        }
+    }
+}
+
 impl Default for EventConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            connector_events_topic: String::new(),
-            ucs_api_events_topic: String::new(),
             brokers: vec!["localhost:9092".to_string()],
-            partition_key_field: "request_id".to_string(),
+            connector_events: KafkaTopicConfig::default(),
+            api_events: KafkaTopicConfig::default(),
             transformations: HashMap::new(),
             static_values: HashMap::new(),
             extractions: HashMap::new(),
@@ -632,4 +651,32 @@ pub(crate) fn set_nested_value(
     );
 
     result.map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_selects_topic_and_partition_key() {
+        let config = EventConfig {
+            connector_events: KafkaTopicConfig {
+                topic: "connector-events".to_string(),
+                partition_key_field: "request_id".to_string(),
+            },
+            api_events: KafkaTopicConfig {
+                topic: "ucs-api-events".to_string(),
+                partition_key_field: "merchant_id".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let connector = config.topic_config(&EventStage::ConnectorCall);
+        assert_eq!(connector.topic, "connector-events");
+        assert_eq!(connector.partition_key_field, "request_id");
+
+        let ucs_api = config.topic_config(&EventStage::GrpcRequest);
+        assert_eq!(ucs_api.topic, "ucs-api-events");
+        assert_eq!(ucs_api.partition_key_field, "merchant_id");
+    }
 }

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::errors::EventPublisherError;
+use crate::types::ExecutionMode;
 use crate::{
     global_id::{
         customer::GlobalCustomerId,
@@ -425,27 +426,6 @@ impl EventStage {
     }
 }
 
-/// Primary execution or shadow mirror.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExecutionMode {
-    /// Real execution whose result is used.
-    Primary,
-    /// Shadow mirror whose result is discarded (validation only).
-    Shadow,
-}
-
-impl ExecutionMode {
-    /// Map the boolean shadow flag (from the `x-shadow-mode` metadata) to an execution mode.
-    pub fn from_shadow_flag(shadow_mode: bool) -> Self {
-        if shadow_mode {
-            Self::Shadow
-        } else {
-            Self::Primary
-        }
-    }
-}
-
 /// Configuration for events system
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct EventConfig {
@@ -456,8 +436,8 @@ pub struct EventConfig {
     #[serde(alias = "topic")]
     pub connector_events_topic: String,
     /// Topic for inbound requests UCS serves over any transport — gRPC or HTTP
-    /// (`GrpcRequest` stage -> the `ucs_api_events` table). Falls back to
-    /// `connector_events_topic` when empty.
+    /// (`GrpcRequest` stage -> the `ucs_api_events` table). Single-topic deployments set
+    /// this equal to `connector_events_topic`.
     #[serde(default)]
     pub ucs_api_events_topic: String,
     pub brokers: Vec<String>,

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -430,14 +430,13 @@ impl EventStage {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, config_patch_derive::Patch)]
 pub struct EventConfig {
     pub enabled: bool,
-    /// Topic for outbound payment-connector calls (`ConnectorCall` stage -> the
-    /// `connector_events` table). Accepts the legacy key `topic` for backward compatibility.
+    /// Topic for outbound connector-call events. Accepts the legacy key `topic`
+    /// for backward compatibility.
     // TODO: remove the `topic` alias once configs use `connector_events_topic`.
     #[serde(alias = "topic")]
     pub connector_events_topic: String,
-    /// Topic for inbound requests UCS serves over any transport — gRPC or HTTP
-    /// (`GrpcRequest` stage -> the `ucs_api_events` table). Single-topic deployments set
-    /// this equal to `connector_events_topic`.
+    /// Topic for inbound request events. Single-topic deployments set this equal to
+    /// `connector_events_topic`.
     #[serde(default)]
     pub ucs_api_events_topic: String,
     pub brokers: Vec<String>,

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -229,12 +229,10 @@ pub struct Event {
     /// HTTP verb for outbound connector calls; empty string for gRPC-only audit events.
     #[serde(serialize_with = "serialize_method")]
     pub method: Option<String>,
-    // Routing key only; deliberately not serialized (the stream is the discriminator).
+    // Routing key only; not serialized.
     #[serde(skip)]
     pub stage: EventStage,
-    /// Service that produced this event (always `ucs`).
-    pub source: &'static str,
-    /// Whether this leg was the primary execution or a shadow mirror.
+    /// Primary execution or shadow mirror.
     pub execution_mode: ExecutionMode,
     pub latency_ms: Option<u64>,
     pub status_code: Option<i32>,
@@ -429,11 +427,7 @@ impl EventStage {
     }
 }
 
-/// `source` value for events emitted by the connector-service (UCS).
-/// `source` identifies the emitter (`ucs`), never the caller — UCS is caller-agnostic.
-pub const EVENT_SOURCE: &str = "ucs";
-
-/// Whether a leg was the primary execution or a shadow mirror.
+/// Primary execution or shadow mirror.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionMode {

--- a/crates/common/common_utils/src/types.rs
+++ b/crates/common/common_utils/src/types.rs
@@ -471,3 +471,22 @@ impl FromStr for SemanticVersion {
         )?))
     }
 }
+
+/// Primary execution or shadow mirror, derived from the `x-shadow-mode` metadata flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    Primary,
+    Shadow,
+}
+
+impl ExecutionMode {
+    /// Map the boolean shadow flag (from the `x-shadow-mode` metadata) to an execution mode.
+    pub fn from_shadow_flag(shadow_mode: bool) -> Self {
+        if shadow_mode {
+            Self::Shadow
+        } else {
+            Self::Primary
+        }
+    }
+}

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -199,8 +199,6 @@ impl AdditionalHeaders
     }
 }
 use common_utils::events::{Event, EventConfig, FlowName};
-// Only the injector-client build compiles `create_event` (the outbound connector
-// call path), which is the sole user of these event-dimension enums.
 #[cfg(feature = "injector-client")]
 use common_utils::types::ExecutionMode;
 #[cfg(feature = "injector-client")]

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -202,7 +202,7 @@ use common_utils::events::{Event, EventConfig, FlowName};
 // Only the injector-client build compiles `create_event` (the outbound connector
 // call path), which is the sole user of these event-dimension enums.
 #[cfg(feature = "injector-client")]
-use common_utils::events::ExecutionMode;
+use common_utils::types::ExecutionMode;
 #[cfg(feature = "injector-client")]
 // TokenData is now imported from hyperswitch_injector
 use common_utils::{consts, emit_event_with_config};

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -202,7 +202,7 @@ use common_utils::events::{Event, EventConfig, FlowName};
 // Only the injector-client build compiles `create_event` (the outbound connector
 // call path), which is the sole user of these event-dimension enums.
 #[cfg(feature = "injector-client")]
-use common_utils::events::{ExecutionMode, EVENT_SOURCE};
+use common_utils::events::ExecutionMode;
 #[cfg(feature = "injector-client")]
 // TokenData is now imported from hyperswitch_injector
 use common_utils::{consts, emit_event_with_config};
@@ -878,9 +878,7 @@ fn create_event(
         connector: event_params.connector_name.to_string(),
         url,
         method,
-        // Outbound HTTP to the payment connector; routes this event to the connector_events stream.
         stage: EventStage::ConnectorCall,
-        source: EVENT_SOURCE,
         execution_mode: ExecutionMode::from_shadow_flag(event_params.shadow_mode),
         latency_ms,
         status_code,

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -199,6 +199,10 @@ impl AdditionalHeaders
     }
 }
 use common_utils::events::{Event, EventConfig, FlowName};
+// Only the injector-client build compiles `create_event` (the outbound connector
+// call path), which is the sole user of these event-dimension enums.
+#[cfg(feature = "injector-client")]
+use common_utils::events::{CallType, ExecutionMode, EVENT_SOURCE};
 #[cfg(feature = "injector-client")]
 // TokenData is now imported from hyperswitch_injector
 use common_utils::{consts, emit_event_with_config};
@@ -875,6 +879,10 @@ fn create_event(
         url,
         method,
         stage: EventStage::ConnectorCall,
+        source: EVENT_SOURCE,
+        // Connector leg — UCS's outbound HTTP to the payment connector. Derived from the stage.
+        call_type: CallType::from(&EventStage::ConnectorCall),
+        execution_mode: ExecutionMode::from_shadow_flag(event_params.shadow_mode),
         latency_ms,
         status_code,
         request_data: MaskedSerdeValue::from_masked_optional(masked_request, "connector_request"),

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -202,7 +202,7 @@ use common_utils::events::{Event, EventConfig, FlowName};
 // Only the injector-client build compiles `create_event` (the outbound connector
 // call path), which is the sole user of these event-dimension enums.
 #[cfg(feature = "injector-client")]
-use common_utils::events::{CallType, ExecutionMode, EVENT_SOURCE};
+use common_utils::events::{ExecutionMode, EVENT_SOURCE};
 #[cfg(feature = "injector-client")]
 // TokenData is now imported from hyperswitch_injector
 use common_utils::{consts, emit_event_with_config};
@@ -878,10 +878,9 @@ fn create_event(
         connector: event_params.connector_name.to_string(),
         url,
         method,
+        // Outbound HTTP to the payment connector; routes this event to the connector_events stream.
         stage: EventStage::ConnectorCall,
         source: EVENT_SOURCE,
-        // Connector leg — UCS's outbound HTTP to the payment connector. Derived from the stage.
-        call_type: CallType::from(&EventStage::ConnectorCall),
         execution_mode: ExecutionMode::from_shadow_flag(event_params.shadow_mode),
         latency_ms,
         status_code,

--- a/crates/grpc-server/grpc-server/Cargo.toml
+++ b/crates/grpc-server/grpc-server/Cargo.toml
@@ -90,7 +90,7 @@ serial_test = "3.2.0"
 
 [features]
 default = []
-kafka = ["tracing-kafka"]
+kafka = ["tracing-kafka", "common_utils/kafka"]
 connector-request-kafka = ["dep:connector_request_kafka"]
 
 [lints]

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -7,7 +7,7 @@ pub use ucs_interface_common::metadata::*;
 use common_utils::{
     consts::{self, Env},
     errors::CustomResult,
-    events::{Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue, EVENT_SOURCE},
+    events::{Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue},
     lineage::LineageIds,
     superposition_config::{get_connector_urls, ConnectorUrls, SuperpositionConfig},
 };
@@ -429,9 +429,7 @@ fn create_and_emit_grpc_event<R>(
         connector,
         url: None,
         method: None,
-        // Inbound gRPC request UCS serves; routes this event to the ucs_api_events stream.
         stage: EventStage::GrpcRequest,
-        source: EVENT_SOURCE,
         execution_mode: ExecutionMode::from_shadow_flag(
             metadata_payload.map(|md| md.shadow_mode).unwrap_or(false),
         ),

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -7,9 +7,7 @@ pub use ucs_interface_common::metadata::*;
 use common_utils::{
     consts::{self, Env},
     errors::CustomResult,
-    events::{
-        CallType, Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue, EVENT_SOURCE,
-    },
+    events::{Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue, EVENT_SOURCE},
     lineage::LineageIds,
     superposition_config::{get_connector_urls, ConnectorUrls, SuperpositionConfig},
 };
@@ -431,10 +429,9 @@ fn create_and_emit_grpc_event<R>(
         connector,
         url: None,
         method: None,
+        // Inbound gRPC request UCS serves; routes this event to the ucs_api_events stream.
         stage: EventStage::GrpcRequest,
         source: EVENT_SOURCE,
-        // Service leg — the inbound request UCS serves. Derived from the stage above.
-        call_type: CallType::from(&EventStage::GrpcRequest),
         execution_mode: ExecutionMode::from_shadow_flag(
             metadata_payload.map(|md| md.shadow_mode).unwrap_or(false),
         ),

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -7,9 +7,10 @@ pub use ucs_interface_common::metadata::*;
 use common_utils::{
     consts::{self, Env},
     errors::CustomResult,
-    events::{Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue},
+    events::{Event, EventStage, FlowName, MaskedSerdeValue},
     lineage::LineageIds,
     superposition_config::{get_connector_urls, ConnectorUrls, SuperpositionConfig},
+    types::ExecutionMode,
 };
 use domain_types::{
     connector_types, errors::IntegrationError, router_data::ConnectorSpecificConfig,

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -7,7 +7,9 @@ pub use ucs_interface_common::metadata::*;
 use common_utils::{
     consts::{self, Env},
     errors::CustomResult,
-    events::{Event, EventStage, FlowName, MaskedSerdeValue},
+    events::{
+        CallType, Event, EventStage, ExecutionMode, FlowName, MaskedSerdeValue, EVENT_SOURCE,
+    },
     lineage::LineageIds,
     superposition_config::{get_connector_urls, ConnectorUrls, SuperpositionConfig},
 };
@@ -430,6 +432,12 @@ fn create_and_emit_grpc_event<R>(
         url: None,
         method: None,
         stage: EventStage::GrpcRequest,
+        source: EVENT_SOURCE,
+        // Service leg — the inbound request UCS serves. Derived from the stage above.
+        call_type: CallType::from(&EventStage::GrpcRequest),
+        execution_mode: ExecutionMode::from_shadow_flag(
+            metadata_payload.map(|md| md.shadow_mode).unwrap_or(false),
+        ),
         latency_ms: Some(u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX)),
         status_code: None,
         request_data: masked_request_data,

--- a/crates/grpc-server/grpc-server/tests/test_config_override.rs
+++ b/crates/grpc-server/grpc-server/tests/test_config_override.rs
@@ -444,9 +444,11 @@ mod unit {
         let override_json = json!({
             "events": {
                 "enabled": true,
-                "topic": "events-override",
                 "brokers": ["broker1:9092", "broker2:9092"],
-                "partition_key_field": "merchant_id",
+                // connector_events overrides both fields; api_events overrides only the topic,
+                // so its partition_key_field must be preserved from the base config.
+                "connector_events": { "topic": "connector-override", "partition_key_field": "merchant_id" },
+                "api_events": { "topic": "api-override" },
                 "transformations": { "order_id": "payment_id" },
                 "static_values": { "app": "grpc" },
                 "extractions": { "path": "metadata.path" }
@@ -454,20 +456,24 @@ mod unit {
         });
         let new_config = apply_override(override_json);
         assert!(new_config.events.enabled);
-        // The override JSON above intentionally uses the legacy `topic` key; this asserts it
-        // still applies through the patch layer via the `#[serde(alias = "topic")]` on the
-        // renamed `connector_events_topic` field (backward compatibility).
+        // Each topic carries its own topic name and partition key.
         assert_eq!(
-            new_config.events.connector_events_topic.as_str(),
-            "events-override"
+            new_config.events.connector_events.topic.as_str(),
+            "connector-override"
+        );
+        assert_eq!(
+            new_config.events.connector_events.partition_key_field.as_str(),
+            "merchant_id"
+        );
+        assert_eq!(new_config.events.api_events.topic.as_str(), "api-override");
+        // Untouched by the override, so it keeps the base config's partition key.
+        assert_eq!(
+            new_config.events.api_events.partition_key_field.as_str(),
+            "request_id"
         );
         assert_eq!(
             new_config.events.brokers,
             vec!["broker1:9092".to_string(), "broker2:9092".to_string()]
-        );
-        assert_eq!(
-            new_config.events.partition_key_field.as_str(),
-            "merchant_id"
         );
         assert_eq!(
             new_config

--- a/crates/grpc-server/grpc-server/tests/test_config_override.rs
+++ b/crates/grpc-server/grpc-server/tests/test_config_override.rs
@@ -454,7 +454,13 @@ mod unit {
         });
         let new_config = apply_override(override_json);
         assert!(new_config.events.enabled);
-        assert_eq!(new_config.events.topic.as_str(), "events-override");
+        // The override JSON above intentionally uses the legacy `topic` key; this asserts it
+        // still applies through the patch layer via the `#[serde(alias = "topic")]` on the
+        // renamed `connector_events_topic` field (backward compatibility).
+        assert_eq!(
+            new_config.events.connector_events_topic.as_str(),
+            "events-override"
+        );
         assert_eq!(
             new_config.events.brokers,
             vec!["broker1:9092".to_string(), "broker2:9092".to_string()]

--- a/crates/grpc-server/grpc-server/tests/test_config_override.rs
+++ b/crates/grpc-server/grpc-server/tests/test_config_override.rs
@@ -462,7 +462,11 @@ mod unit {
             "connector-override"
         );
         assert_eq!(
-            new_config.events.connector_events.partition_key_field.as_str(),
+            new_config
+                .events
+                .connector_events
+                .partition_key_field
+                .as_str(),
             "merchant_id"
         );
         assert_eq!(new_config.events.api_events.topic.as_str(), "api-override");


### PR DESCRIPTION
## What

Splits UCS audit events into two Kafka streams by stage, so each lands in the matching analytics table without a discriminator field in the payload. Each stream has its own topic **and** partition key, configured independently.

| stage | config | table | `source` | `destination` | `execution_mode` |
|---|---|---|---|---|---|
| `ConnectorCall` (outbound HTTP to the connector) | `events.connector_events` | `connector_events` | `unified_connector_service` | `connector` | `primary` / `shadow` |
| `GrpcRequest` (inbound request UCS serves) | `events.api_events` | `ucs_api_events` | `unified_connector_service` | _null_ | `primary` / `shadow` |

- The **topic is the discriminator**, so `source` and `destination` are **not** in the payload — they're stamped downstream from the topic.
- `execution_mode` (`primary` / `shadow`) **is** emitted, since the topic can't tell a live call from a shadow mirror.

## How

- `[events]` holds one `KafkaTopicConfig { topic, partition_key_field }` per stage — `connector_events` and `api_events`. Each topic carries its own partition key, so it's configurable per topic rather than shared.
- Stage-based routing in `publish_event_to_kafka`: `EventConfig::topic_config(stage)` returns that stage's topic + partition key (`ConnectorCall` → `connector_events`, `GrpcRequest` → `api_events`). A single emission chokepoint, so all RPC flows are covered.
- The shared `KafkaWriter` is **unchanged**: `publish_event(topic, key, …)` already takes the topic and partition key per call, so multi-topic publishing needs no change to the writer — only the per-stage selection above.
- `ExecutionMode` (`primary` / `shadow`, derived from the `x-shadow-mode` flag) lives in `common_utils::types`, reusable beyond events.
- Field names match the Hyperswitch producer, so both feed the same tables.

## Config change (one-time)

The flat `topic` / `ucs_api_events_topic` / `partition_key_field` keys are replaced by nested per-topic tables:

```toml
[events]
enabled = false
brokers = ["localhost:9092"]

[events.connector_events]
topic = "unified-connector-service-connector-events"
partition_key_field = "request_id"

[events.api_events]
topic = "unified-connector-service-api-events"
partition_key_field = "request_id"
```

A single-topic deployment sets both `topic`s to the same value — the pre-split behaviour, by config rather than magic. Empty topics are rejected at init (the publisher logs a warning and drops events rather than mis-routing). No legacy alias is kept; a deployment updates this config once when adopting the tag.

## Testing

### Manual end-to-end (local Kafka)

Ran a real Adyen `Authorize` through the gRPC server (built `--features kafka`) against a local broker. A single Authorize produced both stage events, each on its own topic:

> _Screenshots were captured before the topic rename, so the broker still shows the earlier `ucs-connector-events` / `ucs-api-events` names; the config now ships the `unified-connector-service-*` defaults._

**`ConnectorCall` → `unified-connector-service-connector-events`** — the outbound call to Adyen (real `401` response):

<img width="1400" height="662" alt="image (6)" src="https://github.com/user-attachments/assets/35439fbe-eeab-400f-b30f-fd5c21894a27" />


```json
{
  "request_id": "adyen-...", "flow_type": "Authorize", "connector": "adyen",
  "url": "https://checkout-test.adyen.com/v68/payments", "method": "POST",
  "stage": "ConnectorCall", "execution_mode": "primary", "status_code": 401
}
```

**`GrpcRequest` → `unified-connector-service-api-events`** — the inbound gRPC request:

<img width="1400" height="662" alt="image (5)" src="https://github.com/user-attachments/assets/fa4865d0-4e25-4acb-bba5-dbce0bafc15e" />

```json
{
  "request_id": "adyen-...", "flow_type": "Authorize", "connector": "adyen",
  "url": null, "method": "", "stage": "GrpcRequest",
  "execution_mode": "primary", "status_code": 16
}
```

Confirms per-stage topic routing, `execution_mode` in the payload, and `source`/`destination` correctly **absent** (stamped downstream from the topic).

## Companion

Hyperswitch side: juspay/hyperswitch#12714