### PR TITLE
fix(connector): [Trustly] add payout webhook classification using messageID

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/trustly.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly.rs
@@ -280,8 +280,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .body
             .parse_struct("TrustlyWebhookBody")
             .change_context(errors::WebhookError::WebhookBodyDecodingFailed)?;
+        let message_id = webhook_body.params.data.messageid.clone();
 
-        Ok(trustly::get_webhook_event(webhook_body.method))
+        Ok(trustly::get_webhook_event(
+            webhook_body.method,
+            message_id.expose(),
+        ))
     }
 
     fn get_webhook_event_reference(

--- a/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
@@ -829,25 +829,40 @@ pub fn verify_webhook_signature(
         .change_context(errors::WebhookError::WebhookSourceVerificationFailed)
 }
 
-pub fn get_webhook_event(event: TrustlyWebhookMethod) -> domain_types::connector_types::EventType {
-    match event {
-        TrustlyWebhookMethod::Credit => {
+pub fn get_webhook_event(
+    event: TrustlyWebhookMethod,
+    message_id: String,
+) -> domain_types::connector_types::EventType {
+    match (event, !message_id.as_str().starts_with("payout_")) {
+        (TrustlyWebhookMethod::Credit, true) => {
             domain_types::connector_types::EventType::PaymentIntentSuccess
         }
-        TrustlyWebhookMethod::Debit => {
+        (TrustlyWebhookMethod::Credit, false) => {
+            domain_types::connector_types::EventType::PayoutReversed
+        }
+        (TrustlyWebhookMethod::Debit, _) => {
             domain_types::connector_types::EventType::PaymentIntentFailure
         }
-        TrustlyWebhookMethod::Cancel => {
+        (TrustlyWebhookMethod::Cancel, true) => {
             domain_types::connector_types::EventType::PaymentIntentCancelled
         }
-        TrustlyWebhookMethod::Account | TrustlyWebhookMethod::Pending => {
+        (TrustlyWebhookMethod::Cancel, false) => {
+            domain_types::connector_types::EventType::PayoutCancelled
+        }
+        (TrustlyWebhookMethod::Account, _) | (TrustlyWebhookMethod::Pending, _) => {
             domain_types::connector_types::EventType::PaymentIntentProcessing
         }
-        TrustlyWebhookMethod::PayoutConfirmation => {
+        (TrustlyWebhookMethod::PayoutConfirmation, true) => {
             domain_types::connector_types::EventType::RefundSuccess
         }
-        TrustlyWebhookMethod::PayoutFailed => {
+        (TrustlyWebhookMethod::PayoutFailed, true) => {
             domain_types::connector_types::EventType::RefundFailure
+        }
+        (TrustlyWebhookMethod::PayoutConfirmation, false) => {
+            domain_types::connector_types::EventType::PayoutSuccess
+        }
+        (TrustlyWebhookMethod::PayoutFailed, false) => {
+            domain_types::connector_types::EventType::PayoutFailure
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is corresponding to HS PR [#12705](https://github.com/juspay/hyperswitch/pull/12705)
With the HS changes, webhook processing will first determine the event type and then route the webhook through either UCS or HS.

Trustly uses a common WebhookStatus for Payments, Refunds, and Payouts. As a result, after the HS changes, payout webhooks could incorrectly be mapped to payment/refund flows. To address this, an additional check has been introduced using messageID (a reference field that is prefixed with payout_ for payout requests). This allows us to reliably distinguish payout webhooks from payment and refund webhooks, ensuring correct event mapping and processing.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Trustly Payouts:

Request:

```

{
    "amount": 10,
    "currency": "EUR", //eur
    "email": "p@example.com",
    "name": "Steve Smith",
    "description": "Test1",
    "payout_type": "bank",
    "payout_method_data": {
        "bank_transfer": {
            "payout_method_type":"trustly",
            "bank_country_code": "ES",
            "bank_number": null,
            "bank_account_number": null,
            "iban": "ES8701820004756386447000"
        }
    },
    "billing": {
        "address": {
            "city": "Stockholm",
            "country": "SE",
            "line1": "Main street 1",
            "line2": "Main street 2",
            "zip": "SE-11253",
            "state": "SE",
            "first_name": "Steve",
            "last_name": "Smith"
        },
        "email": "abc@gmail.com",
        "phone": {
            "number": "709876543",
            "country_code": "46"
        }
    },
    "entity_type": "Individual",
    "recurring": false,
    "auto_fulfill": true,
    "confirm": true
}

```

Response:

```

{
    "payout_id": "payout_EimDycN0Z9za3aZL6Vy1",
    "merchant_id": "merchant_1781167949",
    "merchant_order_reference_id": null,
    "amount": 10,
    "currency": "EUR",
    "connector": "trustly",
    "payout_type": "bank",
    "payout_method_data": {
        "bank": {
            "iban": "ES8701820004756386447000",
            "country_code": "ES",
            "account_number": null,
            "bank_number": null
        }
    },
    "source_bank_data": null,
    "billing": {
        "address": {
            "city": "Stockholm",
            "country": "SE",
            "line1": "Main street 1",
            "line2": "Main street 2",
            "line3": null,
            "zip": "SE-11253",
            "state": "SE",
            "first_name": "Steve",
            "last_name": "Smith",
            "origin_zip": null
        },
        "phone": {
            "number": "709876543",
            "country_code": "46"
        },
        "email": "abc@gmail.com"
    },
    "auto_fulfill": true,
    "customer_id": "cus_ilQXywt2zMNt16ivw6Ee",
    "customer": {
        "id": "cus_ilQXywt2zMNt16ivw6Ee",
        "name": "Steve Smith",
        "email": "p@example.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "client_secret": "payout_payout_EimDycN0Z9za3aZL6Vy1_secret_26s50g7qSjln25URH6Fp",
    "return_url": null,
    "business_country": null,
    "business_label": null,
    "description": "Test1",
    "entity_type": "Individual",
    "recurring": false,
    "metadata": {},
    "merchant_connector_id": "mca_hNOtD2QnTR3Q4n7G0QzW",
    "status": "initiated",
    "error_message": null,
    "error_code": null,
    "profile_id": "pro_sUfqLjkBfpTC9NaldHlB",
    "created": "2026-06-11T13:14:27.944Z",
    "connector_transaction_id": "13090813992",
    "priority": null,
    "payout_link": null,
    "email": "p@example.com",
    "name": "Steve Smith",
    "phone": null,
    "phone_country_code": null,
    "unified_code": null,
    "unified_message": null,
    "payout_method_id": null
}

```


Webhooks :
Webhooks correctly routed to hyperswitch : 
<img width="1193" height="954" alt="Screenshot 2026-06-11 at 7 00 42 PM" src="https://github.com/user-attachments/assets/dc828234-0d17-4777-87ba-afa910436989" />

<img width="1124" height="236" alt="Screenshot 2026-06-11 at 7 01 47 PM" src="https://github.com/user-attachments/assets/c9ffc1fb-6449-4125-8acc-8ae5b4ddaf72" />

Trustly Payments:

Request:

```

{
    "amount": 100,
    "currency": "GBP",
    "capture_method": "automatic",
    "customer_id": "vani12ssdd",
    "description": "Player deposit from 28197421",
    "confirm": true,
    "return_url": "https://www.google.com",
    "email": "t@example.com",
    "billing": {
        "address": {
            // "line1": "1467",
            // "line2": "Harrison Street",
            // "line3": "Harrison Street",
            // "city": "Helsinki",
            "state": "Helsinki",
            "zip": "94122",
            "country": "GB",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "0401234567",
            "country_code": "+46"
        },
        "email": "guest111@example.com"
    },
    "authentication_type": "no_three_ds",
    "payment_method": "bank_redirect",
    "payment_method_type": "trustly",
    "payment_method_data": {
        "bank_redirect": {
            "trustly": {
            }
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "85.76.1.1",
        "java_enabled": true,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 864,
        "screen_width": 1536,
        "time_zone": 300,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    }
}

```

Response:

```

{
    "payment_id": "pay_RyXIE7NGpKSOfXan69Lw",
    "merchant_id": "merchant_1781167949",
    "status": "requires_customer_action",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 100,
    "amount_received": null,
    "processor_merchant_id": "merchant_1781167949",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fc1VmcUxqa0JmcFRDOU5hbGRIbEIscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mNDE0MDRkN2Y2ZWQ0Yzc1YWFlYzhhOGMzODUzMzc1NixjbGllbnRfc2VjcmV0PXBheV9SeVhJRTdOR3BLU09mWGFuNjlMd19zZWNyZXRfdFBKOGRMMVF6eE12UlM2eU1CeTIsY3VzdG9tZXJfaWQ9dmFuaTEyc3NkZCxjbGllbnRfc2Vzc2lvbl9pZD1jbGllbnRfc2Vzc193U1JwOENOa1gzbnA3MGFsa2RSQyxwYXltZW50X2lkPXBheV9SeVhJRTdOR3BLU09mWGFuNjlMdw==",
    "connector": "trustly",
    "state_metadata": null,
    "client_secret": "pay_RyXIE7NGpKSOfXan69Lw_secret_tPJ8dL1QzxMvRS6yMBy2",
    "created": "2026-06-11T13:13:00.358Z",
    "modified_at": "2026-06-11T13:13:02.376Z",
    "connector_customer_id": "9dd8a22e-9b63-4f3c-8fbf-8d3986e72425",
    "currency": "GBP",
    "customer_id": "vani12ssdd",
    "customer": {
        "id": "vani12ssdd",
        "name": null,
        "email": "t@example.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "Player deposit from 28197421",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_redirect",
    "payment_method_data": {
        "bank_redirect": {
            "type": "BankRedirectResponse",
            "bank_name": null,
            "interac": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": "GB",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": "Helsinki",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "0401234567",
            "country_code": "+46"
        },
        "email": "guest111@example.com"
    },
    "order_details": null,
    "email": "t@example.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_RyXIE7NGpKSOfXan69Lw/merchant_1781167949/pay_RyXIE7NGpKSOfXan69Lw_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "trustly",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "13501994501",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "46feefb0-91a6-46c5-9eca-59b65576a3e6",
    "payment_link": null,
    "profile_id": "pro_sUfqLjkBfpTC9NaldHlB",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_4SyxYpjzExKZcY4enct0",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-11T13:28:00.357Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 300,
        "ip_address": "85.76.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 864,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-11T13:13:02.376Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}

```

Webhooks:
Correctly routed to UCS:

<img width="1124" height="907" alt="Screenshot 2026-06-11 at 7 03 35 PM" src="https://github.com/user-attachments/assets/d50031bb-2790-498c-ba9c-271e6fe7a9dc" />

<img width="1117" height="231" alt="Screenshot 2026-06-11 at 7 04 14 PM" src="https://github.com/user-attachments/assets/c8574e79-2dfa-4c62-9ad0-1d86a5754c70" />

