### PR TITLE
fix(repeat_payment): map bank-redirect payment method types in gRPC conversion

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -2441,6 +2441,17 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMeth
             grpc_api_types::payments::PaymentMethodType::Netbanking => {
                 Ok(PaymentMethodType::Netbanking)
             }
+            grpc_api_types::payments::PaymentMethodType::Ideal => Ok(PaymentMethodType::Ideal),
+            grpc_api_types::payments::PaymentMethodType::BancontactCard => {
+                Ok(PaymentMethodType::BancontactCard)
+            }
+            grpc_api_types::payments::PaymentMethodType::Sofort => Ok(PaymentMethodType::Sofort),
+            grpc_api_types::payments::PaymentMethodType::Blik => Ok(PaymentMethodType::Blik),
+            grpc_api_types::payments::PaymentMethodType::Giropay => Ok(PaymentMethodType::Giropay),
+            grpc_api_types::payments::PaymentMethodType::Eps => Ok(PaymentMethodType::Eps),
+            grpc_api_types::payments::PaymentMethodType::Przelewy24 => {
+                Ok(PaymentMethodType::Przelewy24)
+            }
             _ => Err(IntegrationError::InvalidDataFormat {
                 field_name: "payment_method_type",
                 context: IntegrationErrorContext {


### PR DESCRIPTION
## What

The `ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMethodType`
conversion in `domain_types/src/types.rs` had **no arms for bank-redirect payment method
types**. A `RepeatPayment` (recurring/MIT) request carrying e.g. `ideal` therefore fell into
the catch-all and failed with:

```
UCS_400 — Invalid data format: "This payment method type is not yet supported"
```

…before the connector was ever reached. This blocks recurring charges for mandates created
via bank redirects (ideal / bancontact), which stripe charges as **SEPA direct debit** using
the stored `connector_mandate_id`.

## Change

Add the missing arms — `Ideal`, `BancontactCard`, `Sofort`, `Blik`, `Giropay`, `Eps`,
`Przelewy24` — so the request deserializes and reaches the stripe connector's **existing**
`get_payment_method_type_for_saved_payment_method_payment`, which already maps
`Ideal | Bancontact | Sofort -> Sepa` for the recurring charge.

11 lines, conversion-layer only; no connector logic changed.

## Testing

Verified end-to-end against a local stack (HS shadow → UCS → stripe sandbox):

1. ideal Authorize with `mandate_data` (CIT) → bank redirect completed → SEPA mandate active.
2. Recurring MIT (`recurring_details: payment_method_id`, `off_session`) against the mandate.

| | Before | After |
|---|---|---|
| RepeatPayment (ideal) | `UCS_400 "payment method type not yet supported"` | charges the SEPA mandate — stripe `payment_intent` `type: sepa_debit`, `processing` |

The recurring charge now succeeds and produces a RouterData matching the native path.

> Practically only `Ideal` and `BancontactCard` are recurring-capable bank redirects; the
> remaining arms are added for completeness/consistency.
