### PR TITLE
fix(common_utils): Remove vendored OpenSSL feature

### DIFF
--- a/crates/common/common_utils/Cargo.toml
+++ b/crates/common/common_utils/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.8.5"
 nanoid = "0.4.0"
 regex = "1.11.1"
 semver = { version = "1.0.26", features = ["serde"] }
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { version = "0.10" }
 josekit = "0.8.7"
 
 # Optional features


### PR DESCRIPTION
## Summary
Removes the `vendored` feature from the `openssl` dependency in `crates/common/common_utils/Cargo.toml`.

## Problem
The vendored OpenSSL feature causes glibc 2.42 linker errors (`__isoc23_strtoul`, `__isoc23_strtol`, `__isoc23_sscanf`). This happens because vendored OpenSSL compiles against glibc 2.42 which uses ISO C23 symbols that are not available in all linker environments.

## Solution
Remove the `vendored` feature from the `openssl` dependency, allowing the system OpenSSL to be used instead.

## Benefits
- Fixes linker errors in environments without ISO C23 symbol support
- Reduces build time by using system OpenSSL

Closes #1517