### PR TITLE
fix(ci): avoid concurrency deadlock between release-stable-version and release-sdks

### DIFF
--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -76,8 +76,15 @@ on:
       NPM_TOKEN:
         required: true
 
+# Key this group to a literal that identifies *this* workflow, not
+# ${{ github.workflow }}. When release-sdks is reached via `uses:` (e.g. from
+# release-stable-version), github.workflow resolves to the *caller's* name, so a
+# github.workflow-based group collides with the caller's own group — the parent
+# holds the slot and the called workflow can never acquire it, which GitHub
+# reports as a concurrency deadlock. A self-identifying literal still serializes
+# direct dispatches of this workflow on the same ref, without colliding with any caller.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-sdks-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Description

`release-stable-version.yml` cancels itself with **"deadlock detected for concurrency group `Release a stable version-refs/heads/main` between a top level workflow and 'Publish SDKs'"** on any real (`dry_run: false`) run.

### Root cause
Both workflows declare a workflow-level concurrency group built from `${{ github.workflow }}`:

- `release-stable-version.yml` → `group: ${{ github.workflow }}-${{ github.ref }}` (`cancel-in-progress: false`)
- `release-sdks.yml` → `group: ${{ github.workflow }}-${{ github.ref }}` (`cancel-in-progress: true`)

When `release-sdks` is invoked via `uses:` (the `Publish SDKs` job), **`github.workflow` resolves to the caller's name**, not its own. So the called workflow computes the *same* group as its parent. The parent holds the slot and will not yield (`cancel-in-progress: false`); the child can never acquire it and cannot cancel its own ancestor — GitHub detects the cycle and cancels the run.

This is latent since the pipeline was introduced (#1252): it only triggers when the `Publish SDKs` reusable-workflow job actually starts, i.e. a non-dry-run stable release.

### Fix
Key the reusable workflow's concurrency group to a **literal that identifies this workflow** instead of the caller-dependent `${{ github.workflow }}`:

```yaml
concurrency:
  group: release-sdks-${{ github.ref }}
  cancel-in-progress: true
```

- Called from a parent workflow → distinct group, no collision, no deadlock.
- Dispatched directly → still serialized per ref.

This is the correct identifier for a reusable workflow, since `github.workflow` is ambiguous (names the caller) in `workflow_call` context.

## How did you test it?
Static reasoning about concurrency-group evaluation in `workflow_call` vs `workflow_dispatch` context; single-line change scoped to the `concurrency` block, no job logic touched.