### PR TITLE
fix(ci): harden SDK release workflows (tag-gated publish, version, deadlock, idempotent tags)

### DIFF
--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -76,8 +76,10 @@ on:
       NPM_TOKEN:
         required: true
 
+# Literal group, not ${{ github.workflow }}: when called via `uses:` that resolves
+# to the caller's name and collides with the caller's group, deadlocking the run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-sdks-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -99,6 +101,7 @@ jobs:
       publish_java: ${{ steps.norm.outputs.publish_java }}
       publish_python: ${{ steps.norm.outputs.publish_python }}
       publish_javascript: ${{ steps.norm.outputs.publish_javascript }}
+      version: ${{ steps.norm.outputs.version }}
     steps:
       - name: Normalize and validate inputs
         id: norm
@@ -119,19 +122,36 @@ jobs:
           echo "publish_python=$(norm "${{ inputs.publish_python }}")" >> "$GITHUB_OUTPUT"
           echo "publish_javascript=$(norm "${{ inputs.publish_javascript }}")" >> "$GITHUB_OUTPUT"
 
-          # A valid SemVer version is required when actually publishing.
+          VERSION="${{ inputs.version }}"
+          REF="${{ inputs.ref }}"
+
           if [ "${PREVIEW}" = "false" ]; then
-            VERSION="${{ inputs.version }}"
+            # Publishing: a real SemVer is mandatory.
             if [ -z "${VERSION}" ]; then
-              echo "::error::version input is required when preview_only is false"
+              echo "::error::version input is required when publishing (preview_only=false)"
               exit 1
             fi
             if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "::error::version '${VERSION}' is not valid SemVer (expected X.Y.Z)"
               exit 1
             fi
-            echo "Version ${VERSION} is valid SemVer"
+            # Tag-only: publish must build from the matching release tag, not a branch.
+            if [ "${REF}" != "v${VERSION}" ] && [ "${REF}" != "${VERSION}" ]; then
+              echo "::error::publishing requires ref to be the release tag 'v${VERSION}' (got '${REF}'); publishing from a branch is not allowed"
+              exit 1
+            fi
+            echo "Publishing version ${VERSION} from tag ${REF}"
+          else
+            # Preview: empty version is fine; default to a plain "0.0.0" so the
+            # builders never see "" (which breaks the Java jar name). Avoid suffixes
+            # like "-preview" — PEP 440 rewrites them and renames the Python wheel.
+            if [ -z "${VERSION}" ]; then
+              VERSION="0.0.0"
+              echo "No version supplied for preview — defaulting to ${VERSION}"
+            fi
           fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   build-binaries:
     name: Build Binaries (${{ matrix.os }} ${{ matrix.arch }})
@@ -252,7 +272,7 @@ jobs:
     needs: [setup, build-binaries]
     if: ${{ needs.setup.outputs.preview_only == 'true' || needs.setup.outputs.publish_java == 'true' }}
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -299,7 +319,7 @@ jobs:
     needs: [setup, build-binaries]
     if: ${{ needs.setup.outputs.preview_only == 'true' || needs.setup.outputs.publish_python == 'true' }}
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -340,7 +360,7 @@ jobs:
     needs: [setup, build-binaries]
     if: ${{ needs.setup.outputs.preview_only == 'true' || needs.setup.outputs.publish_javascript == 'true' }}
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -462,7 +482,7 @@ jobs:
     needs: [setup, collect-sdks]
     if: always() && needs.collect-sdks.result == 'success' && (needs.setup.outputs.preview_only == 'true' || needs.setup.outputs.publish_java == 'true' || needs.setup.outputs.publish_python == 'true' || needs.setup.outputs.publish_javascript == 'true')
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -695,7 +715,7 @@ jobs:
     needs: [setup, preview-publish, pre-publish-check]
     if: always() && needs.setup.outputs.publish_java == 'true' && needs.setup.outputs.preview_only == 'false' && needs.pre-publish-check.result == 'success'
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -765,7 +785,7 @@ jobs:
     needs: [setup, preview-publish, pre-publish-check]
     if: always() && needs.setup.outputs.publish_python == 'true' && needs.setup.outputs.preview_only == 'false' && needs.pre-publish-check.result == 'success'
     env:
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -134,14 +134,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CONNECTOR_SERVICE_CI_PAT }}
         run: |
+          TAG="${{ steps.version.outputs.next_tag }}"
           CALVER_SHA="$(git rev-parse HEAD)"
-          gh api \
-            --method POST \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            '/repos/{owner}/{repo}/git/refs' \
-            --raw-field "ref=refs/tags/${{ steps.version.outputs.next_tag }}" \
-            --raw-field "sha=${CALVER_SHA}"
+          # Idempotent so a partial-failure re-run works: reuse the tag if it
+          # already points at this SHA; fail only if it points elsewhere.
+          if EXISTING_SHA="$(gh api "/repos/{owner}/{repo}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null)"; then
+            if [ "${EXISTING_SHA}" = "${CALVER_SHA}" ]; then
+              echo "Tag ${TAG} already exists on ${CALVER_SHA} — reusing it."
+            else
+              echo "::error::tag ${TAG} already exists but points at ${EXISTING_SHA}, not ${CALVER_SHA}. Refusing to move a release tag."
+              exit 1
+            fi
+          else
+            gh api \
+              --method POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              '/repos/{owner}/{repo}/git/refs' \
+              --raw-field "ref=refs/tags/${TAG}" \
+              --raw-field "sha=${CALVER_SHA}"
+            echo "Created tag ${TAG} on ${CALVER_SHA}."
+          fi
 
       - name: Create GitHub release (draft)
         if: ${{ inputs.dry_run == false }}
@@ -149,14 +162,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CONNECTOR_SERVICE_CI_PAT }}
         run: |
+          TAG="${{ steps.version.outputs.next_tag }}"
           if [ "$(wc -c < release-notes.md)" -gt 124000 ]; then
             truncate -s 124000 release-notes.md
             printf '\n\n_Full changelog available in the release artifact._\n' >> release-notes.md
           fi
-          gh release create "${{ steps.version.outputs.next_tag }}" \
-            --title "${{ steps.version.outputs.next_tag }}" \
-            --notes-file release-notes.md \
-            --draft
+          # Idempotent: refresh notes if a draft from a previous run already exists.
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists — updating its notes."
+            gh release edit "${TAG}" --title "${TAG}" --notes-file release-notes.md
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --notes-file release-notes.md \
+              --draft
+          fi
 
 
   publish-sdks:


### PR DESCRIPTION
## Description

Hardens the two SDK release workflows (`release-sdks.yml`, `release-stable-version.yml`) against four distinct defects — two already observed in production runs, two latent. Scope is deliberately limited to real/deterministic issues (speculative hardening was left out).

### 1. Concurrency deadlock *(observed — run 27615073923)*
`release-sdks.yml` keyed its concurrency group on `${{ github.workflow }}`. For a workflow invoked via `uses:`, `github.workflow` resolves to the **caller’s** name, so the called workflow computed the *same* group as `release-stable-version` (its parent). The parent held the slot (`cancel-in-progress: false`) and the child could never acquire it → GitHub cancelled the run as a deadlock.
**Fix:** key the group to a self-identifying literal `release-sdks-${{ github.ref }}`. Direct dispatches still serialize per ref; calls from a parent no longer collide. *(supersedes #1533, which I will close in favour of this PR.)*

### 2. Empty version → `prism-.jar` *(observed — run 27545400028)*
The package jobs read `inputs.version` directly. On a preview with no version, `VERSION=""` is exported; Gradle’s `System.getenv("VERSION") ?: "0.0.0-dev"` only falls back on *null*, not empty string, so it built an unnamed `prism-.jar` and the Makefile `cp` failed.
**Fix:** `setup` now emits a normalized `version` output and every job consumes `needs.setup.outputs.version`. Blank defaults to **`0.0.0`** for preview — chosen because it is canonical and un-normalized across Maven, npm *and* PEP 440 (`0.0.0-preview` would be rewritten to `0.0.0rc0` by PEP 440 and rename the Python wheel, re-introducing the same class of bug).

### 3. Tag-only publishing *(security)*
A manual dispatch could publish SDKs to Maven/PyPI/npm from an **arbitrary branch** with a typed version. Publishing now requires `ref` to be the release tag matching the version (`v<version>`), so published artifacts always trace to an immutable tag. Preview from any ref is still allowed; `release-stable-version` already passes `ref=v<version>`, so it is unaffected. A non-existent tag fails at checkout, so no separate tag-existence check is needed.

### 4. Idempotent tag + release *(latent — re-run after partial failure)*
`release-stable-version` created the tag and draft release with plain `POST`/`gh release create`, which hard-fail if the object already exists — making a re-run after a partial failure impossible. Both now reuse/refresh existing objects (and refuse to *move* an existing tag to a different SHA).

## How did you test it?
YAML validated; logic reasoned through for both `workflow_dispatch` and `workflow_call` paths. No job graph or secret wiring changed; `release-stable-version`’s inputs/outputs and all `workflow_call` inputs are unchanged. Out of scope by decision: environment-based publish protection (needs repo-admin settings) and non-essential cosmetic cleanups.