### PR TITLE
fix(authorizedotnet): omit customer on stored-profile repeat payment (#16706)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -888,8 +888,23 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let currency = item.router_data.request.currency;
 
-        // Handle different mandate reference types with appropriate MIT structures
-        let (profile, processing_options, subsequent_auth_information) = match &item
+        let customer_id_string = validate_customer_id_length(
+            item.router_data
+                .resource_common_data
+                .customer_id
+                .as_ref()
+                .map(|cid| cid.get_string_repr().to_owned()),
+        );
+
+        let customer_details = customer_id_string.map(|cid| CustomerDetails {
+            id: cid,
+            email: item.router_data.request.email.clone(),
+        });
+
+        // Handle different mandate reference types with appropriate MIT structures.
+        // `customer` mirrors Hyperswitch: omitted for the ConnectorMandateId (stored
+        // customer profile) path, sent for the NetworkMandateId path.
+        let (profile, processing_options, subsequent_auth_information, customer) = match &item
             .router_data
             .request
             .mandate_reference
@@ -929,6 +944,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         is_subsequent_auth: true,
                     }),
                     None, // No network transaction ID for mandate-based flow
+                    None, // Hyperswitch omits `customer` for the stored-profile MIT path
                 )
             }
 
@@ -942,6 +958,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     original_network_trans_id: Secret::new(network_trans_id.clone()),
                     reason: Reason::Resubmission,
                 }),
+                customer_details, // Hyperswitch sends `customer` on the network-mandate path
             ),
 
             // Case 3: Network token with NTI - NOT SUPPORTED (same as Hyperswitch)
@@ -993,19 +1010,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         )
         .filter(|id| id.len() <= MAX_ID_LENGTH);
 
-        let customer_id_string = validate_customer_id_length(
-            item.router_data
-                .resource_common_data
-                .customer_id
-                .as_ref()
-                .map(|cid| cid.get_string_repr().to_owned()),
-        );
-
-        let customer_details = customer_id_string.map(|cid| CustomerDetails {
-            id: cid,
-            email: item.router_data.request.email.clone(),
-        });
-
         let transaction_type = match item.router_data.request.capture_method {
             Some(enums::CaptureMethod::Manual) => TransactionType::AuthOnlyTransaction,
             Some(enums::CaptureMethod::Automatic)
@@ -1040,7 +1044,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             currency_code: currency,
             profile,
             order: Some(order),
-            customer: customer_details,
+            customer,
             user_fields,
             processing_options,
             subsequent_auth_information,


### PR DESCRIPTION
## Summary

Authorize.net **repeat payment (MIT)** requests built by UCS include a `customer` object in
`createTransactionRequest.transactionRequest` that Hyperswitch (HS) does **not** send when the
mandate is a stored **connector mandate** (`ConnectorMandateId`, i.e. a saved customer/payment
profile). This produces a persistent HS↔UCS shadow-validation request diff.

**Diff signature**

```
body.keyDiff.createTransactionRequest.transactionRequest.customer = {"hyperswitch": false, "ucs": true}
```

(merchant `innago`, connector `authorizedotnet`, flow `repeat_payment`; 1749 occurrences)

## Root cause

In `authorizedotnet/transformers.rs`, `AuthorizedotnetRepeatPaymentRequest::try_from` computed
`customer_details` from the customer id and assigned it **unconditionally** for every mandate
type. Hyperswitch, by contrast, only emits `customer` on the **NetworkMandateId** path and sets
`customer: None` on the **ConnectorMandateId** (stored customer-profile) path
(`hyperswitch_connectors/.../authorizedotnet/transformers.rs`: `customer: None` for the
`ConnectorMandateReferenceId` impl).

## Fix (L3 — UCS connector transformer only)

Fold `customer` into the per-mandate-type match so it mirrors HS exactly:

* `ConnectorMandateId` (stored customer profile) → `customer: None`
* `NetworkMandateId` (network-trans-id flow) → `customer: Some(..)` (unchanged — HS also sends it here, so removing it would create a *new* diff)

No proto / domain / HS-mapping change is required — the field already exists on both sides; only
the connector transformer was populating it on the wrong path.

## Reproduction (local HS↔UCS shadow stack)

1. Create merchant + authorize.net MCA (card credit+debit, `recurring_enabled`), enroll UCS shadow
   rollout key `ucs_rollout_config_{mid}_authorizedotnet_card_Authorize`.
2. **CIT**: `/payments` with `setup_future_usage=off_session` + `customer_acceptance` → authorize.net
   creates a customer profile; HS stores a `ConnectorMandateId` (`customerProfileId-paymentProfileId`).
3. **MIT**: `/payments` with `recurring_details={type:payment_method_id,data:<pm_id>}`, `off_session=true`
   → HS detects `is_mit_payment` and calls the UCS `recurring_payment_charge` (RepeatPayment) endpoint.
4. Read the validation-service verdict for the MIT request.

Full script: `prod-fixes/repro_16706.py`.

## Before → After (validation-service verdict, same repro)

| | `bodyComparison.keyDiff` |
|---|---|
| **Before** | `{"createTransactionRequest.transactionRequest.customer": {"hyperswitch": false, "ucs": true}}` |
| **After**  | `{}` (no_diff — no new diffs introduced) |

Verified locally on `connector-service` @ `origin/main` + this change (rebuilt `grpc-server`,
restarted on :8001, re-ran the identical repro).

Closes #1639
