### PR TITLE
fix(adyen): emit additionalData.captureDelayHours and strip it from metadata (#16707)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -923,6 +923,7 @@ pub struct AdditionalData {
     #[serde(flatten)]
     riskdata: Option<RiskData>,
     sca_exemption: Option<AdyenExemptionValues>,
+    capture_delay_hours: Option<u64>,
     pub auth_code: Option<String>,
 }
 
@@ -5777,6 +5778,15 @@ fn get_additional_data<
         Some("false".to_string())
     };
 
+    // Mirror HS adyen: extract capture_delay_hours from metadata → additionalData.captureDelayHours.
+    // Manual capture must not carry it (HS rejects a present value); for automatic capture HS only
+    // permits None/0, so pass the metadata value straight through (non-zero never reaches comparison
+    // because HS errors the request before building it).
+    let capture_delay_hours = match item.request.capture_method.unwrap_or_default() {
+        common_enums::CaptureMethod::Manual | common_enums::CaptureMethod::ManualMultiple => None,
+        _ => get_adyen_metadata(item.request.metadata.clone().expose_option()).capture_delay_hours,
+    };
+
     Some(AdditionalData {
         authorisation_type,
         manual_capture,
@@ -5791,6 +5801,7 @@ fn get_additional_data<
                 .as_ref()
                 .and_then(to_adyen_exemption)
         }),
+        capture_delay_hours,
         ..AdditionalData::default()
     })
 }
@@ -7277,6 +7288,8 @@ struct AdyenMetadata {
     pub store: Option<String>,
     #[serde(alias = "platform_chargeback_logic")]
     pub platform_chargeback_logic: Option<AdyenPlatformChargeBackLogicMetadata>,
+    #[serde(alias = "capture_delay_hours")]
+    pub capture_delay_hours: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -7312,6 +7325,8 @@ fn filter_adyen_metadata(metadata: serde_json::Value) -> serde_json::Value {
         map.remove("platform_chargeback_logic");
         map.remove("platformChargebackLogic");
         map.remove("store");
+        map.remove("capture_delay_hours");
+        map.remove("captureDelayHours");
 
         serde_json::Value::Object(map)
     } else {


### PR DESCRIPTION
## What

UCS omits Adyen's `additionalData.captureDelayHours` and leaves `capture_delay_hours`
raw in the forwarded `metadata`, while hyperswitch-native extracts it from metadata,
emits it under `additionalData`, and removes it from `metadata`.

### Diff signature (reproduced locally on `main`)

```
body.keyDiff.additionalData.captureDelayHours = {"hyperswitch": true,  "ucs": false}
body.keyDiff.metadata.capture_delay_hours     = {"hyperswitch": false, "ucs": true}
```

(The issue's truncated summary also listed `applicationInfo`; that field was already
resolved by the #16710 fix and is `no_diff` in the current build — the remaining gap is
`capture_delay_hours`.)

## Root cause (L3 — connector transformer only)

HS-native adyen (`hyperswitch_connectors/.../adyen/transformers.rs`) reads
`metadata.capture_delay_hours`, maps it to `AdditionalData.capture_delay_hours`
(`captureDelayHours`), and strips both `capture_delay_hours`/`captureDelayHours` from the
forwarded metadata. UCS adyen had **no** capture-delay handling at all: the value never
reached `AdditionalData`, and `filter_adyen_metadata` did not strip it, so it leaked back
out in `metadata`.

`capture_delay_hours` already transits to UCS inside the generic gRPC `metadata` field, so
this is a connector-transformer-only (L3) fix — no proto or domain change required.

## Change

`crates/integrations/connector-integration/src/connectors/adyen/transformers.rs`:
- add `capture_delay_hours: Option<u64>` to `AdditionalData` (camelCase → `captureDelayHours`)
- add `capture_delay_hours` (with snake_case alias) to the `AdyenMetadata` parse struct
- in authorize `get_additional_data`, derive it from metadata, mirroring HS: `None` for
  manual capture; pass the metadata value through for automatic capture (HS only permits
  `None`/`0` there and errors the request otherwise, so non-zero never reaches comparison)
- in `filter_adyen_metadata`, drop `capture_delay_hours` / `captureDelayHours`

## Repro & verification (local shadow stack, HS:8080 ↔ UCS:8001 via MITM → VS:9000)

Trigger: automatic capture + `metadata.capture_delay_hours = 0`. (Only **non-zero** values
are rejected by HS; `Some(0)` on automatic capture is permitted and emits `captureDelayHours: 0`.)

```
POST /payments  { ..., "capture_method": "automatic",
                  "metadata": { "capture_delay_hours": 0 }, ... }
```

| | `additionalData.captureDelayHours` | `metadata.capture_delay_hours` |
|---|---|---|
| **before** | `{hs:true, ucs:false}` | `{hs:false, ucs:true}` |
| **after**  | identical (both emit `0`) | identical (both stripped) |

After the fix the VS verdict is **`no_diff`**: `keyDiff {}` / `valueDiff {}`;
`captureDelayHours` now present on **both** outbound requests, `capture_delay_hours` absent
from both `metadata` blocks.

**Category:** L3 (connector transformer) — UCS-only.

Closes #1559
Fixes an internal validation-diff issue (linked via the Development sidebar).
