### PR TITLE
fix(connector): [Stripe] emit Stripe-Account on UCS capture flow (#16719)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe.rs
@@ -736,6 +736,17 @@ macros::macro_connector_implementation!(
             )];
             let mut api_key = self.get_auth_header(&req.connector_config)?;
             header.append(&mut api_key);
+
+            if let Some(domain_types::connector_types::SplitPaymentsRequest::StripeSplitPayment(
+                stripe_split_payment,
+            )) = &req.request.split_payments
+            {
+                transformers::transform_headers_for_connect_platform(
+                    stripe_split_payment.charge_type.clone(),
+                    Secret::new(stripe_split_payment.transfer_account_id.clone()),
+                    &mut header,
+                );
+            }
             Ok(header)
         }
         fn get_url(

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -633,6 +633,7 @@ impl
             merchant_order_id: item.merchant_order_id.clone(),
             merchant_request_id: item.merchant_request_id.clone(),
             order_tax_amount: item.order_tax_amount,
+            stripe_split_payment: None,
         }
     }
 }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -3098,6 +3098,7 @@ pub struct PaymentsCaptureData {
     pub metadata: Option<SecretSerdeValue>,
     pub merchant_order_id: Option<String>,
     pub order_tax_amount: Option<MinorUnit>,
+    pub split_payments: Option<SplitPaymentsRequest>,
 }
 
 impl PaymentsCaptureData {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8618,6 +8618,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCaptureRequest>
             order_tax_amount: value
                 .order_tax_amount
                 .map(|amount| common_utils::types::MinorUnit::new(amount.minor_amount)),
+            split_payments: stripe_split_payment_to_domain(value.stripe_split_payment),
         })
     }
 }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2611,6 +2611,10 @@ message PaymentServiceCaptureRequest {
   // Order-level tax amount. Some processors require this again on capture so
   // settlement receives the Level II sales tax value.
   optional Money order_tax_amount = 13;
+
+  // Stripe Connect split-payment data. Carries the connected-account id used to
+  // emit the `Stripe-Account` header on the capture request for direct charges.
+  optional StripeSplitPaymentRequest stripe_split_payment = 14;
 }
 
 // Response message for a payment capture operation

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -391,7 +391,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest: { "payment": "PaymentClientAuthenticationContext", "permissions": "Permissions" },
   PaymentClientAuthenticationContext: { "amount": "Money", "customer": "Customer" },
   MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse: { "sessionData": "ClientAuthenticationTokenData", "error": "ErrorInfo" },
-  PaymentServiceCaptureRequest: { "amountToCapture": "Money", "multipleCaptureData": "MultipleCaptureRequestData", "browserInfo": "BrowserInformation", "state": "ConnectorState", "orderTaxAmount": "Money" },
+  PaymentServiceCaptureRequest: { "amountToCapture": "Money", "multipleCaptureData": "MultipleCaptureRequestData", "browserInfo": "BrowserInformation", "state": "ConnectorState", "orderTaxAmount": "Money", "stripeSplitPayment": "StripeSplitPaymentRequest" },
   PaymentServiceCaptureResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference", "connectorResponse": "ConnectorResponseData" },
   PaymentServiceCreateOrderRequest: { "amount": "Money", "state": "ConnectorState" },
   PaymentServiceCreateOrderResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "sessionData": "ClientAuthenticationTokenData" },


### PR DESCRIPTION
## What

Thread Stripe Connect split-payment data through the **UCS capture flow** so the
`Stripe-Account` header is emitted on capture requests for direct charges, matching
the hyperswitch Direct gateway.

Continuation of #1543 (#16718), which wired `stripe_split_payment` through
`authorize` / `create_connector_customer` / `payment_method_token`. The **capture**
flow was left out, producing a production shadow-validation diff (juspay/hyperswitch-cloud#16719).

## Why

Shadow diff for merchant `yucca` (Stripe Connect platform), connector `stripe`, flow `capture`:

```
header.keyDiff.stripe-account={"hyperswitch":true,"ucs":false}
```

The hyperswitch Direct Stripe connector emits `Stripe-Account: acct_…` on capture
(read from `PaymentsCaptureData.split_payments` → `transfer_account_id` when
`charge_type == direct`). On the UCS path the value never reached prism:

- `PaymentServiceCaptureRequest` had no `stripe_split_payment` field
- `PaymentsCaptureData` (domain) had no `split_payments`
- the proto→domain capture conversion defaulted it away
- the prism Stripe **capture** `get_headers` never read it (PSync already did)

This is a **proto gap**, not a transformer bug.

## Changes

- **proto**: `stripe_split_payment` on `PaymentServiceCaptureRequest` (field 14, reuses
  the existing `StripeSplitPaymentRequest` message)
- **domain**: `PaymentsCaptureData.split_payments`
- **conversion**: map via the existing `stripe_split_payment_to_domain` helper
- **connector**: emit `Stripe-Account` in the Stripe capture `get_headers`
  (mirrors the PSync block, via `transform_headers_for_connect_platform`)
- **composite-service**: default the new field to `None`

## Proof

**Before** (production, issue #16719): `header.keyDiff.stripe-account={"hyperswitch":true,"ucs":false}`

**After** (local shadow repro via validation service `:9100`, stripe/capture,
x-request-id `019ed29c-d8af-7601-a277-8d1a3f53c9ac`):

```
GET /validation-service/api/results/diff_result_capture:stripe:019ed29c-d8af-7601-a277-8d1a3f53c9ac
  headerComparison.keyDiff: { "x-merchant-id": {"hyperswitch":false,"ucs":true} }   # ignore-listed only; stripe-account GONE
  bodyComparison.keyDiff:   {}
  methodComparison: POST == POST
```

Both Direct and UCS now send identical `Stripe-Account: acct_…` on capture
(the connector then rejects the dummy connected account identically on both
paths — `account_invalid` — confirming request-header parity).

_No credentials included; `config/development.toml` excluded._
