### PR TITLE
fix(stripe): emit Stripe-Account header on capture for Connect Direct charges (#16719)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe.rs
@@ -748,6 +748,17 @@ macros::macro_connector_implementation!(
             )];
             let mut api_key = self.get_auth_header(&req.connector_config)?;
             header.append(&mut api_key);
+
+            if let Some(domain_types::connector_types::SplitPaymentsDetails::StripeSplitPayment(
+                stripe_split_payment,
+            )) = &req.request.split_payments
+            {
+                transformers::transform_headers_for_connect_platform(
+                    stripe_split_payment.charge_type.clone(),
+                    Secret::new(stripe_split_payment.transfer_account_id.clone()),
+                    &mut header,
+                );
+            }
             Ok(header)
         }
         fn get_url(

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -663,6 +663,7 @@ impl
             merchant_order_id: item.merchant_order_id.clone(),
             merchant_request_id: item.merchant_request_id.clone(),
             order_tax_amount: item.order_tax_amount,
+            split_payments: None,
         }
     }
 }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -9721,7 +9721,10 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCaptureRequest>
             order_tax_amount: value
                 .order_tax_amount
                 .map(|amount| common_utils::types::MinorUnit::new(amount.minor_amount)),
-            split_payments: None,
+            split_payments: value
+                .split_payments
+                .map(connector_types::SplitPaymentsDetails::foreign_try_from)
+                .transpose()?,
         })
     }
 }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2790,6 +2790,10 @@ message PaymentServiceCaptureRequest {
   // Order-level tax amount. Some processors require this again on capture so
   // settlement receives the Level II sales tax value.
   optional Money order_tax_amount = 13;
+
+  // Split payment routing details (e.g. Stripe Connect). Required on capture so
+  // Direct charges emit the `Stripe-Account` header on the connected account.
+  optional SplitPaymentsDetails split_payments = 14;
 }
 
 // Response message for a payment capture operation

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -409,7 +409,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest: { "payment": "PaymentClientAuthenticationContext", "permissions": "Permissions" },
   PaymentClientAuthenticationContext: { "amount": "Money", "customer": "Customer" },
   MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse: { "sessionData": "ClientAuthenticationTokenData", "error": "ErrorInfo" },
-  PaymentServiceCaptureRequest: { "amountToCapture": "Money", "multipleCaptureData": "MultipleCaptureRequestData", "browserInfo": "BrowserInformation", "state": "ConnectorState", "orderTaxAmount": "Money" },
+  PaymentServiceCaptureRequest: { "amountToCapture": "Money", "multipleCaptureData": "MultipleCaptureRequestData", "browserInfo": "BrowserInformation", "state": "ConnectorState", "orderTaxAmount": "Money", "splitPayments": "SplitPaymentsDetails" },
   PaymentServiceCaptureResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference", "connectorResponse": "ConnectorResponseData", "splits": "ConnectorSplitResponseData" },
   PaymentServiceCreateOrderRequest: { "amount": "Money", "state": "ConnectorState" },
   PaymentServiceCreateOrderResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "sessionData": "ClientAuthenticationTokenData" },


### PR DESCRIPTION
## What

Emit the Stripe Connect `Stripe-Account` header on the **capture** flow for Direct
charges, closing the production shadow-validation diff
`internal tracking issue` (merchant `yucca`, connector `stripe`, flow `capture`):

```
header.keyDiff.stripe-account = {"hyperswitch": true, "ucs": false}
```

HS's stripe capture `get_headers` emits `Stripe-Account` from `split_payments`, but the
UCS capture path had no way to: (a) receive the split details (the gRPC
`PaymentServiceCaptureRequest` had no split field), nor (b) emit the header (the capture
`get_headers` only set Content-Type + auth). So Direct-charge captures were sent on the
platform account instead of the connected account.

This mirrors the authorize / psync / customer / tokenize / repeat handling already added
in #1565 — capture was the remaining gap.

## Changes (UCS, layer: proto + L2 + L3)

- **proto** `payment.proto`: add `optional SplitPaymentsDetails split_payments = 14;` to
  `PaymentServiceCaptureRequest`.
- **L2** `domain_types/types.rs`: populate `PaymentsCaptureData.split_payments` from the new
  proto field in `ForeignTryFrom<PaymentServiceCaptureRequest>` (was hardcoded `None`).
- **L3** `connectors/stripe.rs`: in the Capture `get_headers`, emit `Stripe-Account` via
  `transform_headers_for_connect_platform` when `split_payments` is a `StripeSplitPayment`
  — identical to the psync/authorize builders.
- `composite-service/transformers.rs`: `split_payments: None` in the composite capture
  builder (composite has no split field).
- regenerated the JavaScript gRPC client.

## Repro

```
header.keyDiff.stripe-account = {"hyperswitch": true, "ucs": false}   # stripe / capture / yucca
```

## Verify (before → after)

Live HS shadow is TLS-blocked on the shared stack, so verified by a **direct gRPC
`PaymentService.Capture` A/B** against this build, routed through the MITM proxy that mirrors
the outbound request:

| case | outbound `POST /v1/payment_intents/{id}/capture` |
|------|---------------------------------------------------|
| **with** `split_payments` (Direct) | `stripe-account: acct_1TjBkeDfqJC9T9K6` **present** |
| **without** `split_payments` (control) | header **absent** |

So UCS now emits `Stripe-Account` on capture **iff** the payment carries Stripe-Connect
split details — byte-for-byte matching HS. Diff `stripe-account` → gone.

## Local checks

`cargo build` · `cargo clippy --all-targets -- -D warnings` · `cargo fmt --all -- --check` ·
JS client regenerated.

Closes #1700
