### PR TITLE
fix(connector): [authorizedotnet] omit customer on stored-profile repeat (#16774)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -888,8 +888,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let currency = item.router_data.request.currency;
 
-        // Handle different mandate reference types with appropriate MIT structures
-        let (profile, processing_options, subsequent_auth_information) = match &item
+        let customer_id_string = validate_customer_id_length(
+            item.router_data
+                .resource_common_data
+                .customer_id
+                .as_ref()
+                .map(|cid| cid.get_string_repr().to_owned()),
+        );
+
+        let customer_details = customer_id_string.map(|cid| CustomerDetails {
+            id: cid,
+            email: item.router_data.request.email.clone(),
+        });
+
+        // Handle different mandate reference types with appropriate MIT structures.
+        // Direct (hyperswitch) omits `customer` on the stored-profile (ConnectorMandateId)
+        // repeat path and only emits it on the NetworkMandateId path; mirror that here so the
+        // UCS request body matches Direct (issue #16774).
+        let (profile, processing_options, subsequent_auth_information, customer) = match &item
             .router_data
             .request
             .mandate_reference
@@ -929,6 +945,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         is_subsequent_auth: true,
                     }),
                     None, // No network transaction ID for mandate-based flow
+                    None, // Direct omits `customer` on the stored-profile MIT path
                 )
             }
 
@@ -942,6 +959,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     original_network_trans_id: Secret::new(network_trans_id.clone()),
                     reason: Reason::Resubmission,
                 }),
+                customer_details,
             ),
 
             // Case 3: Network token with NTI - NOT SUPPORTED (same as Hyperswitch)
@@ -993,19 +1011,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         )
         .filter(|id| id.len() <= MAX_ID_LENGTH);
 
-        let customer_id_string = validate_customer_id_length(
-            item.router_data
-                .resource_common_data
-                .customer_id
-                .as_ref()
-                .map(|cid| cid.get_string_repr().to_owned()),
-        );
-
-        let customer_details = customer_id_string.map(|cid| CustomerDetails {
-            id: cid,
-            email: item.router_data.request.email.clone(),
-        });
-
         let transaction_type = match item.router_data.request.capture_method {
             Some(enums::CaptureMethod::Manual) => TransactionType::AuthOnlyTransaction,
             Some(enums::CaptureMethod::Automatic)
@@ -1040,7 +1045,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             currency_code: currency,
             profile,
             order: Some(order),
-            customer: customer_details,
+            customer,
             user_fields,
             processing_options,
             subsequent_auth_information,

--- a/fixtures/authorizedotnet/repeat_payment/16774.json
+++ b/fixtures/authorizedotnet/repeat_payment/16774.json
@@ -1,0 +1,19 @@
+{
+  "_issue": "juspay/hyperswitch-cloud#16774 (child #16706)",
+  "_desc": "MIT/repeat ConnectorMandateId path: UCS must NOT emit transactionRequest.customer (Direct omits it on stored-profile repeat). token contains '-' to hit the CustomerProfileDetails branch.",
+  "amount": 2199,
+  "currency": "USD",
+  "confirm": true,
+  "off_session": true,
+  "capture_method": "automatic",
+  "customer_id": "innago_cust_16774",
+  "email": "shadow16774@example.com",
+  "payment_type": "recurring_mandate",
+  "payment_method": "card",
+  "payment_method_type": "credit",
+  "recurring_details": {
+    "type": "processor_payment_token",
+    "data": {"processor_payment_token": "1234567890-9876543210", "merchant_connector_id": "<mca>"}
+  },
+  "routing": {"type": "single", "data": {"connector": "authorizedotnet", "merchant_connector_id": "<mca>"}}
+}


### PR DESCRIPTION
## What

On the **ConnectorMandateId** (stored customer-profile) MIT / `repeat_payment` path, the UCS
authorizedotnet connector emitted `createTransactionRequest.transactionRequest.customer` while
the Direct (hyperswitch) connector does **not** — producing a shadow-validation request diff.

Fixes juspay/hyperswitch-cloud#16774
Closes juspay/hyperswitch-cloud#16706

## Diff signature (prod — `innago`, 1996 occ)

```
body.keyDiff.createTransactionRequest.transactionRequest.customer = {"hyperswitch": false, "ucs": true}
```

## Root cause

Direct's authorizedotnet repeat flow reuses the Authorize `TransactionRequest` builders and is
split by mandate type:
- **NetworkMandateId** builder → `customer: Some(...)`
- **ConnectorMandateId** builder (stored profile) → `customer: None` — it relies solely on
  `profile.customerProfileDetails`.

The UCS `AuthorizedotnetRepeatPaymentRequest` builder, by contrast, derived `CustomerDetails`
from `customer_id` **unconditionally** and assigned it for every repeat (both mandate cases),
so it always emitted `customer`. On the stored-profile path Direct omits it → keyDiff.

## Fix

Fold `customer` into the existing `(profile, processing_options, subsequent_auth_information)`
mandate-case match so it mirrors Direct exactly:
- `ConnectorMandateId` → `None`
- `NetworkMandateId` → `customer_details` (unchanged behaviour)

UCS-only change; no proto / contract change, so no hyperswitch PR is required.

## Before / After (local shadow repro, merchant `authnet_repro`, `repeat_payment`)

Reproduced by firing an off-session `recurring_mandate` payment whose
`processor_payment_token` contains `-` (so it parses into customerProfile/paymentProfile and
hits the ConnectorMandateId branch).

**BEFORE** (prism on `origin/main`) — reproduces the prod signature byte-for-byte:
```
req 019ed58c-1f42-...  bodyComparison.keyDiff:
  {"createTransactionRequest.transactionRequest.customer": {"hyperswitch": false, "ucs": true}}
req 019ed58c-3390-...  (same)
```

**AFTER** (this fix) — clean:
```
req 019ed58d-81c9-...  bodyComparison.keyDiff: {}   valueDiff: {}
req 019ed58d-8f9f-...  bodyComparison.keyDiff: {}   valueDiff: {}
```
Only `headerComparison.keyDiff` retains the standard ignore-listed `x-merchant-id` header.

The fixed UCS outbound body now contains only `profile` / `order` / `processingOptions` under
`transactionRequest` — no `customer` — matching Direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
