### PR TITLE
chore(docker): add curl to probe outbound connector reachability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,12 @@ FROM public.ecr.aws/docker/library/debian:bookworm-slim AS runtime
 WORKDIR /app
 
 # Install only runtime dependencies and clean up
+# curl: probe outbound connector reachability from inside the pod.
 RUN apt-get update \
     && apt-get install -y \
        libpq-dev \
        ca-certificates \
+       curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What
Add `curl` to the UCS runtime image.

## Why
In-pod debugging of an internal-only service:
- **Outbound** — verify connector reachability (`curl https://<connector>`) from the pod's egress/proxy path. Needed on **both** the gRPC and HTTP deployments (UCS calls connectors over HTTP either way).
- **Inbound** — hit UCS's own HTTP endpoints on the **HTTP/Euler** deployment.


## Cost
~3-5 MB image size, 0 runtime memory.