### PR TITLE
fix(external-services): bound outbound connector API calls with a request timeout

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -36,6 +36,7 @@ enabled = false
 
 [proxy]
 idle_pool_connection_timeout = 90
+connector_request_timeout = 30
 bypass_urls = []
 
 [test]

--- a/config/production.toml
+++ b/config/production.toml
@@ -19,6 +19,7 @@ port = 8080
 
 [proxy]
 idle_pool_connection_timeout = 90
+connector_request_timeout = 30
 bypass_urls = ["localhost", "local"]
 
 [connectors]

--- a/config/sandbox.toml
+++ b/config/sandbox.toml
@@ -19,6 +19,7 @@ port = 8080
 
 [proxy]
 idle_pool_connection_timeout = 90
+connector_request_timeout = 30
 bypass_urls = ["localhost", "local"]
 
 [connectors]

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -1261,6 +1261,9 @@ pub fn create_client(
     }
 }
 
+/// Default total timeout (seconds) for a single connector API call.
+const DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS: u64 = 30;
+
 static DEFAULT_CLIENT: OnceCell<Client> = OnceCell::new();
 static PROXY_CLIENT_CACHE: OnceCell<RwLock<HashMap<(Proxy, String), Client>>> = OnceCell::new();
 
@@ -1383,6 +1386,11 @@ fn get_client_builder(
             proxy_config
                 .idle_pool_connection_timeout
                 .unwrap_or_default(),
+        ))
+        .timeout(Duration::from_secs(
+            proxy_config
+                .connector_request_timeout
+                .unwrap_or(DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS),
         ));
 
     // Disable automatic gzip decompression in test mode

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -764,6 +764,8 @@ impl Proxy {
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, Default, config_patch_derive::Patch)]
 pub struct ProxyConfig {
     pub idle_pool_connection_timeout: Option<u64>,
+    /// Total timeout (seconds) for a single connector API call.
+    pub connector_request_timeout: Option<u64>,
     pub bypass_urls: Vec<String>,
     /// Named proxy entries. Treated as a full replacement on config override (same as api_tags.tags).
     pub proxies: HashMap<String, Proxy>,
@@ -774,6 +776,8 @@ pub struct ProxyConfig {
 #[derive(Deserialize)]
 struct ProxyConfigLegacy {
     idle_pool_connection_timeout: Option<u64>,
+    #[serde(default)]
+    connector_request_timeout: Option<u64>,
     // `bypass_proxy_urls` is the pre-named-proxy-map field name; accepted as an alias so old configs keep working.
     #[serde(default, alias = "bypass_proxy_urls")]
     bypass_urls: Vec<String>,
@@ -806,6 +810,7 @@ impl<'de> Deserialize<'de> for ProxyConfig {
         }
         Ok(ProxyConfig {
             idle_pool_connection_timeout: raw.idle_pool_connection_timeout,
+            connector_request_timeout: raw.connector_request_timeout,
             bypass_urls: raw.bypass_urls,
             proxies,
         })


### PR DESCRIPTION
## What

The outbound connector HTTP client (`get_client_builder`) only configured
`pool_idle_timeout`, which evicts idle pooled connections — it does **not** bound
the duration of an in-flight request. As a result a single connector call had no
total deadline: a hung or very slow connector could hold the request open
indefinitely, and with it the upstream gRPC call that triggered it.

## Change

- Add a `connector_request_timeout` knob under `[proxy]` (`ProxyConfig`), applied
  as reqwest's `.timeout()` in `get_client_builder`.
- Defaults to `30s` (`DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS`) when unset, so the
  bound applies even without explicit config; overridable per environment via TOML.
- Wired into `config/{development,sandbox,production}.toml`.

The field is optional and backward-compatible — existing configs without the key
fall back to the 30s default.

## Why 30s

Matches the conventional request timeout used by the caller for connector calls,
so behaviour is consistent whether a connector is reached directly or via this
service.

## Testing

- `cargo check -p domain_types -p external-services` passes.
- Optional/`#[serde(default)]` field; existing config-override tests unaffected.
