### PR TITLE
chore: add logger for integrity check when it passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,6 +4098,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "time 0.3.47",
+ "tracing",
  "tracing-actix-web",
  "ucs_common_enums",
  "ucs_common_utils",

--- a/crates/types-traits/interfaces/Cargo.toml
+++ b/crates/types-traits/interfaces/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 time = "0.3.41"
 tracing-actix-web = "0.7.18"
+tracing = "0.1.41"
 async-trait = "0.1.88"
 actix-web = "4.11.0"
 

--- a/crates/types-traits/interfaces/Cargo.toml
+++ b/crates/types-traits/interfaces/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 time = "0.3.41"
 tracing-actix-web = "0.7.18"
-tracing = "0.1.41"
+tracing = { workspace = true }
 async-trait = "0.1.88"
 actix-web = "4.11.0"
 

--- a/crates/types-traits/interfaces/src/integrity.rs
+++ b/crates/types-traits/interfaces/src/integrity.rs
@@ -1263,6 +1263,7 @@ fn check_integrity_result(
     connector_transaction_id: Option<String>,
 ) -> Result<(), IntegrityCheckError> {
     if mismatched_fields.is_empty() {
+        tracing::info!("Integrity check passed");
         Ok(())
     } else {
         let field_names = mismatched_fields.join(", ");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Added `tracing::info!("Integrity check passed")` logging in `check_integrity_result()` to replace the hardcoded debug output.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Adding proper logging instrumentation to the integrity check flow for observability in production environments.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

The change was verified by running `cargo check -p interfaces` which compiles successfully without errors.

<img width="912" height="291" alt="image" src="https://github.com/user-attachments/assets/4d4fe013-b254-4400-863a-b067e810ac58" />

---

**Files changed:**
- `crates/types-traits/interfaces/Cargo.toml` - Added `tracing = "0.1.41"` dependency
- `crates/types-traits/interfaces/src/integrity.rs` - Added `tracing::info!("Integrity check passed")` logging