### PR TITLE
feat(repeat-payment): carry auth_type on RecurringPaymentServiceChargeRequest (novalnet enforce_3d)

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5022,7 +5022,9 @@ impl
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card, //TODO
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            // Honour the auth type sent by Hyperswitch (defaults to NoThreeDs when unset/unspecified)
+            // so connectors keying request fields off it (e.g. Novalnet enforce_3d) match HS.
+            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type())?,
             connector_request_reference_id: extract_connector_request_reference_id(
                 &value.merchant_charge_id,
             ),

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3385,6 +3385,11 @@ message RecurringPaymentServiceChargeRequest {
 
   optional PartnerMerchantIdentifierDetails partner_merchant_identifier_details = 35;
 
+  // Authentication Type (3DS / no-3DS) requested for the recurring charge.
+  // Carried so connectors that vary request fields by auth type (e.g. Novalnet's
+  // enforce_3d) build an identical MIT request on the UCS side as on Hyperswitch.
+  optional AuthenticationType auth_type = 36;
+
 }
 
 // Response message for repeat payment operation

--- a/docs-generated/connectors/cybersource.md
+++ b/docs-generated/connectors/cybersource.md
@@ -139,7 +139,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/cybersource/cybersource.py#L280) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L133) · [Rust](../../examples/cybersource/cybersource.rs#L347)
+**Examples:** [Python](../../examples/cybersource/cybersource.py#L276) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L133) · [Rust](../../examples/cybersource/cybersource.rs#L347)
 
 ### Card Payment (Authorize + Capture)
 
@@ -153,25 +153,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/cybersource/cybersource.py#L299) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L149) · [Rust](../../examples/cybersource/cybersource.rs#L363)
+**Examples:** [Python](../../examples/cybersource/cybersource.py#L295) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L149) · [Rust](../../examples/cybersource/cybersource.rs#L363)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/cybersource/cybersource.py#L324) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L171) · [Rust](../../examples/cybersource/cybersource.rs#L386)
+**Examples:** [Python](../../examples/cybersource/cybersource.py#L320) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L171) · [Rust](../../examples/cybersource/cybersource.rs#L386)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/cybersource/cybersource.py#L349) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L193) · [Rust](../../examples/cybersource/cybersource.rs#L409)
+**Examples:** [Python](../../examples/cybersource/cybersource.py#L345) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L193) · [Rust](../../examples/cybersource/cybersource.rs#L409)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/cybersource/cybersource.py#L371) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L212) · [Rust](../../examples/cybersource/cybersource.rs#L428)
+**Examples:** [Python](../../examples/cybersource/cybersource.py#L367) · [JavaScript](../../examples/cybersource/cybersource.js) · [Kotlin](../../examples/cybersource/cybersource.kt#L212) · [Rust](../../examples/cybersource/cybersource.rs#L428)
 
 ## API Reference
 

--- a/docs-generated/connectors/flywire.md
+++ b/docs-generated/connectors/flywire.md
@@ -131,19 +131,19 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L194)
+**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L196)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L210)
+**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L212)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L233)
+**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L235)
 
 ## API Reference
 

--- a/examples/absasanlam/absasanlam.py
+++ b/examples/absasanlam/absasanlam.py
@@ -37,7 +37,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "parse_event"

--- a/examples/absasanlam/absasanlam.py
+++ b/examples/absasanlam/absasanlam.py
@@ -27,7 +27,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{}",  # Body of the HTTP request.
         ),
     )

--- a/examples/absasanlam/absasanlam.py
+++ b/examples/absasanlam/absasanlam.py
@@ -35,7 +35,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/absasanlam/absasanlam.py
+++ b/examples/absasanlam/absasanlam.py
@@ -28,7 +28,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{}",  # Body of the HTTP request.
+            body="{}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_parse_event(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/adyen/adyen.py
+++ b/examples/adyen/adyen.py
@@ -496,7 +496,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/adyen/adyen.py
+++ b/examples/adyen/adyen.py
@@ -498,7 +498,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/adyen/adyen.py
+++ b/examples/adyen/adyen.py
@@ -140,7 +140,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"notificationItems\":[{\"NotificationRequestItem\":{\"pspReference\":\"probe_ref_001\",\"merchantReference\":\"probe_order_001\",\"merchantAccountCode\":\"ProbeAccount\",\"eventCode\":\"AUTHORISATION\",\"success\":\"true\",\"amount\":{\"currency\":\"USD\",\"value\":1000},\"additionalData\":{}}}]}",  # Body of the HTTP request.
+            body="{\"notificationItems\":[{\"NotificationRequestItem\":{\"pspReference\":\"probe_ref_001\",\"merchantReference\":\"probe_order_001\",\"merchantAccountCode\":\"ProbeAccount\",\"eventCode\":\"AUTHORISATION\",\"success\":\"true\",\"amount\":{\"currency\":\"USD\",\"value\":1000},\"additionalData\":{}}}]}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/adyen/adyen.py
+++ b/examples/adyen/adyen.py
@@ -139,7 +139,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"notificationItems\":[{\"NotificationRequestItem\":{\"pspReference\":\"probe_ref_001\",\"merchantReference\":\"probe_order_001\",\"merchantAccountCode\":\"ProbeAccount\",\"eventCode\":\"AUTHORISATION\",\"success\":\"true\",\"amount\":{\"currency\":\"USD\",\"value\":1000},\"additionalData\":{}}}]}",  # Body of the HTTP request.
         ),
     )

--- a/examples/authorizedotnet/authorizedotnet.py
+++ b/examples/authorizedotnet/authorizedotnet.py
@@ -98,7 +98,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"eventType\":\"net.authorize.payment.authcapture.created\",\"payload\":{\"id\":\"probe_txn_001\",\"responseCode\":1,\"authCode\":\"probe_auth\"}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/authorizedotnet/authorizedotnet.py
+++ b/examples/authorizedotnet/authorizedotnet.py
@@ -404,7 +404,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/authorizedotnet/authorizedotnet.py
+++ b/examples/authorizedotnet/authorizedotnet.py
@@ -99,7 +99,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"eventType\":\"net.authorize.payment.authcapture.created\",\"payload\":{\"id\":\"probe_txn_001\",\"responseCode\":1,\"authCode\":\"probe_auth\"}}",  # Body of the HTTP request.
+            body="{\"eventType\":\"net.authorize.payment.authcapture.created\",\"payload\":{\"id\":\"probe_txn_001\",\"responseCode\":1,\"authCode\":\"probe_auth\"}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/authorizedotnet/authorizedotnet.py
+++ b/examples/authorizedotnet/authorizedotnet.py
@@ -402,7 +402,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/bluesnap/bluesnap.py
+++ b/examples/bluesnap/bluesnap.py
@@ -90,7 +90,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="transactionType=CHARGE&referenceNumber=probe_ref_001&merchantTransactionId=probe_txn_001&invoiceId=probe_invoice_001&cardLastFourDigits=1111&amount=10.00&currency=USD",  # Body of the HTTP request.
+            body="transactionType=CHARGE&referenceNumber=probe_ref_001&merchantTransactionId=probe_txn_001&invoiceId=probe_invoice_001&cardLastFourDigits=1111&amount=10.00&currency=USD".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/bluesnap/bluesnap.py
+++ b/examples/bluesnap/bluesnap.py
@@ -309,7 +309,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/bluesnap/bluesnap.py
+++ b/examples/bluesnap/bluesnap.py
@@ -311,7 +311,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/bluesnap/bluesnap.py
+++ b/examples/bluesnap/bluesnap.py
@@ -89,7 +89,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="transactionType=CHARGE&referenceNumber=probe_ref_001&merchantTransactionId=probe_txn_001&invoiceId=probe_invoice_001&cardLastFourDigits=1111&amount=10.00&currency=USD",  # Body of the HTTP request.
         ),
     )

--- a/examples/braintree/braintree.py
+++ b/examples/braintree/braintree.py
@@ -213,7 +213,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/braintree/braintree.py
+++ b/examples/braintree/braintree.py
@@ -76,7 +76,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="bt_signature=dummy_public_key%7Cdummy_signature&bt_payload=PG5vdGlmaWNhdGlvbj48a2luZD5kaXNwdXRlX29wZW5lZDwva2luZD48dGltZXN0YW1wPjIwMjQtMDEtMDFUMDA6MDA6MDBaPC90aW1lc3RhbXA%2BPGRpc3B1dGU%2BPGFtb3VudF9kaXNwdXRlZD4xMDAwPC9hbW91bnRfZGlzcHV0ZWQ%2BPGN1cnJlbmN5X2lzb19jb2RlPlVTRDwvY3VycmVuY3lfaXNvX2NvZGU%2BPGlkPmR1bW15X2Rpc3B1dGVfaWRfMDAxPC9pZD48a2luZD5DSEFSR0VCQUNLPC9raW5kPjxzdGF0dXM%2Bb3Blbjwvc3RhdHVzPjxyZWFzb24%2BZnJhdWQ8L3JlYXNvbj48cmVhc29uX2NvZGU%2BODM8L3JlYXNvbl9jb2RlPjx0cmFuc2FjdGlvbj48YW1vdW50PjEwLjAwPC9hbW91bnQ%2BPGlkPmR1bW15X3R4bl9pZF8wMDE8L2lkPjwvdHJhbnNhY3Rpb24%2BPC9kaXNwdXRlPjwvbm90aWZpY2F0aW9uPg%3D%3D",  # Body of the HTTP request.
         ),
     )

--- a/examples/braintree/braintree.py
+++ b/examples/braintree/braintree.py
@@ -211,7 +211,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/braintree/braintree.py
+++ b/examples/braintree/braintree.py
@@ -77,7 +77,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="bt_signature=dummy_public_key%7Cdummy_signature&bt_payload=PG5vdGlmaWNhdGlvbj48a2luZD5kaXNwdXRlX29wZW5lZDwva2luZD48dGltZXN0YW1wPjIwMjQtMDEtMDFUMDA6MDA6MDBaPC90aW1lc3RhbXA%2BPGRpc3B1dGU%2BPGFtb3VudF9kaXNwdXRlZD4xMDAwPC9hbW91bnRfZGlzcHV0ZWQ%2BPGN1cnJlbmN5X2lzb19jb2RlPlVTRDwvY3VycmVuY3lfaXNvX2NvZGU%2BPGlkPmR1bW15X2Rpc3B1dGVfaWRfMDAxPC9pZD48a2luZD5DSEFSR0VCQUNLPC9raW5kPjxzdGF0dXM%2Bb3Blbjwvc3RhdHVzPjxyZWFzb24%2BZnJhdWQ8L3JlYXNvbj48cmVhc29uX2NvZGU%2BODM8L3JlYXNvbl9jb2RlPjx0cmFuc2FjdGlvbj48YW1vdW50PjEwLjAwPC9hbW91bnQ%2BPGlkPmR1bW15X3R4bl9pZF8wMDE8L2lkPjwvdHJhbnNhY3Rpb24%2BPC9kaXNwdXRlPjwvbm90aWZpY2F0aW9uPg%3D%3D",  # Body of the HTTP request.
+            body="bt_signature=dummy_public_key%7Cdummy_signature&bt_payload=PG5vdGlmaWNhdGlvbj48a2luZD5kaXNwdXRlX29wZW5lZDwva2luZD48dGltZXN0YW1wPjIwMjQtMDEtMDFUMDA6MDA6MDBaPC90aW1lc3RhbXA%2BPGRpc3B1dGU%2BPGFtb3VudF9kaXNwdXRlZD4xMDAwPC9hbW91bnRfZGlzcHV0ZWQ%2BPGN1cnJlbmN5X2lzb19jb2RlPlVTRDwvY3VycmVuY3lfaXNvX2NvZGU%2BPGlkPmR1bW15X2Rpc3B1dGVfaWRfMDAxPC9pZD48a2luZD5DSEFSR0VCQUNLPC9raW5kPjxzdGF0dXM%2Bb3Blbjwvc3RhdHVzPjxyZWFzb24%2BZnJhdWQ8L3JlYXNvbj48cmVhc29uX2NvZGU%2BODM8L3JlYXNvbl9jb2RlPjx0cmFuc2FjdGlvbj48YW1vdW50PjEwLjAwPC9hbW91bnQ%2BPGlkPmR1bW15X3R4bl9pZF8wMDE8L2lkPjwvdHJhbnNhY3Rpb24%2BPC9kaXNwdXRlPjwvbm90aWZpY2F0aW9uPg%3D%3D".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/calida/calida.py
+++ b/examples/calida/calida.py
@@ -58,7 +58,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/calida/calida.py
+++ b/examples/calida/calida.py
@@ -41,7 +41,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"id\":1,\"order_id\":\"probe_order_001\",\"status\":\"succeeded\",\"amount\":10.0,\"currency\":\"EUR\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/calida/calida.py
+++ b/examples/calida/calida.py
@@ -42,7 +42,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"id\":1,\"order_id\":\"probe_order_001\",\"status\":\"succeeded\",\"amount\":10.0,\"currency\":\"EUR\"}",  # Body of the HTTP request.
+            body="{\"id\":1,\"order_id\":\"probe_order_001\",\"status\":\"succeeded\",\"amount\":10.0,\"currency\":\"EUR\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/calida/calida.py
+++ b/examples/calida/calida.py
@@ -60,7 +60,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "get"

--- a/examples/cashtocode/cashtocode.py
+++ b/examples/cashtocode/cashtocode.py
@@ -39,7 +39,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "parse_event"

--- a/examples/cashtocode/cashtocode.py
+++ b/examples/cashtocode/cashtocode.py
@@ -30,7 +30,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"amount\":10.0,\"currency\":\"EUR\",\"foreignTransactionId\":\"probe_foreign_001\",\"type\":\"payment\",\"transactionId\":\"probe_txn_001\"}",  # Body of the HTTP request.
+            body="{\"amount\":10.0,\"currency\":\"EUR\",\"foreignTransactionId\":\"probe_foreign_001\",\"type\":\"payment\",\"transactionId\":\"probe_txn_001\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_parse_event(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/cashtocode/cashtocode.py
+++ b/examples/cashtocode/cashtocode.py
@@ -29,7 +29,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"amount\":10.0,\"currency\":\"EUR\",\"foreignTransactionId\":\"probe_foreign_001\",\"type\":\"payment\",\"transactionId\":\"probe_txn_001\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/cashtocode/cashtocode.py
+++ b/examples/cashtocode/cashtocode.py
@@ -37,7 +37,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/cryptopay/cryptopay.py
+++ b/examples/cryptopay/cryptopay.py
@@ -43,7 +43,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"type\":\"Invoice\",\"event\":\"status_changed\",\"data\":{\"id\":\"probe_invoice_001\",\"status\":\"completed\",\"price_amount\":\"10.00\",\"price_currency\":\"USD\",\"name\":\"probe_charge\"}}",  # Body of the HTTP request.
+            body="{\"type\":\"Invoice\",\"event\":\"status_changed\",\"data\":{\"id\":\"probe_invoice_001\",\"status\":\"completed\",\"price_amount\":\"10.00\",\"price_currency\":\"USD\",\"name\":\"probe_charge\"}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/cryptopay/cryptopay.py
+++ b/examples/cryptopay/cryptopay.py
@@ -61,7 +61,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "get"

--- a/examples/cryptopay/cryptopay.py
+++ b/examples/cryptopay/cryptopay.py
@@ -42,7 +42,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"type\":\"Invoice\",\"event\":\"status_changed\",\"data\":{\"id\":\"probe_invoice_001\",\"status\":\"completed\",\"price_amount\":\"10.00\",\"price_currency\":\"USD\",\"name\":\"probe_charge\"}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/cryptopay/cryptopay.py
+++ b/examples/cryptopay/cryptopay.py
@@ -59,7 +59,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/cybersource/cybersource.py
+++ b/examples/cybersource/cybersource.py
@@ -57,9 +57,7 @@ def _build_authenticate_request():
         continue_redirection_url="https://example.com/3ds-continue",
         redirection_response=payment_pb2.RedirectionResponse(  # Redirection Information after DDC step.
             params="probe_redirect_params",
-            payload=payment_pb2.PayloadEntry(
-                transaction_id="probe_txn_123",
-            ),
+            payload={"transaction_id": "probe_txn_123"},
         ),
     )
 
@@ -141,9 +139,7 @@ def _build_post_authenticate_request():
         ),
         redirection_response=payment_pb2.RedirectionResponse(  # Redirection Information after DDC step.
             params="probe_redirect_params",
-            payload=payment_pb2.PayloadEntry(
-                transaction_id="probe_txn_123",
-            ),
+            payload={"transaction_id": "probe_txn_123"},
         ),
     )
 

--- a/examples/dlocal/dlocal.py
+++ b/examples/dlocal/dlocal.py
@@ -55,7 +55,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"id\":\"F-probe-001\",\"status\":\"PAID\",\"status_code\":\"200\",\"order_id\":\"probe_order_001\",\"payment_method_id\":\"RG\",\"payment_method_type\":\"WALLET\",\"payment_method_flow\":\"REDIRECT\"}",  # Body of the HTTP request.
+            body="{\"id\":\"F-probe-001\",\"status\":\"PAID\",\"status_code\":\"200\",\"order_id\":\"probe_order_001\",\"payment_method_id\":\"RG\",\"payment_method_type\":\"WALLET\",\"payment_method_flow\":\"REDIRECT\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/dlocal/dlocal.py
+++ b/examples/dlocal/dlocal.py
@@ -105,7 +105,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/dlocal/dlocal.py
+++ b/examples/dlocal/dlocal.py
@@ -107,7 +107,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/dlocal/dlocal.py
+++ b/examples/dlocal/dlocal.py
@@ -54,7 +54,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"id\":\"F-probe-001\",\"status\":\"PAID\",\"status_code\":\"200\",\"order_id\":\"probe_order_001\",\"payment_method_id\":\"RG\",\"payment_method_type\":\"WALLET\",\"payment_method_flow\":\"REDIRECT\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/fiuu/fiuu.py
+++ b/examples/fiuu/fiuu.py
@@ -367,7 +367,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/fiuu/fiuu.py
+++ b/examples/fiuu/fiuu.py
@@ -365,7 +365,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/fiuu/fiuu.py
+++ b/examples/fiuu/fiuu.py
@@ -82,7 +82,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="tranID=probe_txn_001&orderid=probe_order_001&status=00&domain=probe_domain&amount=10.00&currency=USD&channel=Credit&skey=probe_skey&appcode=probe_appcode&error_code=&error_desc=",  # Body of the HTTP request.
+            body="tranID=probe_txn_001&orderid=probe_order_001&status=00&domain=probe_domain&amount=10.00&currency=USD&channel=Credit&skey=probe_skey&appcode=probe_appcode&error_code=&error_desc=".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/fiuu/fiuu.py
+++ b/examples/fiuu/fiuu.py
@@ -81,7 +81,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="tranID=probe_txn_001&orderid=probe_order_001&status=00&domain=probe_domain&amount=10.00&currency=USD&channel=Credit&skey=probe_skey&appcode=probe_appcode&error_code=&error_desc=",  # Body of the HTTP request.
         ),
     )

--- a/examples/flywire/flywire.py
+++ b/examples/flywire/flywire.py
@@ -222,7 +222,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/flywire/flywire.py
+++ b/examples/flywire/flywire.py
@@ -69,7 +69,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/flywire/flywire.py
+++ b/examples/flywire/flywire.py
@@ -70,7 +70,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}",  # Body of the HTTP request.
+            body="{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/flywire/flywire.py
+++ b/examples/flywire/flywire.py
@@ -220,7 +220,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/flywire/flywire.rs
+++ b/examples/flywire/flywire.rs
@@ -98,14 +98,15 @@ pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetReq
     }
 }
 
+#[allow(dead_code)]
 pub fn build_handle_event_request() -> EventServiceHandleRequest {
     EventServiceHandleRequest {
         merchant_event_id: Some("probe_event_001".to_string()),  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
         ..Default::default()
@@ -115,10 +116,10 @@ pub fn build_handle_event_request() -> EventServiceHandleRequest {
 pub fn build_parse_event_request() -> EventServiceParseRequest {
     EventServiceParseRequest {
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
     }
@@ -199,6 +200,7 @@ pub fn build_token_authorize_request() -> PaymentServiceTokenAuthorizeRequest {
     }
 }
 
+#[allow(dead_code)]
 pub fn build_verify_redirect_request() -> PaymentServiceVerifyRedirectResponseRequest {
     PaymentServiceVerifyRedirectResponseRequest {
         ..Default::default()
@@ -356,10 +358,8 @@ pub async fn process_parse_event(
     client: &ConnectorClient,
     _merchant_transaction_id: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .parse_event(build_parse_event_request(), &HashMap::new(), None)
-        .await?;
-    Ok(format!("status: {:?}", response.status()))
+    let response = client.parse_event(build_parse_event_request())?;
+    Ok(format!("{response:?}"))
 }
 
 // Flow: PaymentService.ProxyAuthorize

--- a/examples/hyperswitch/hyperswitch.py
+++ b/examples/hyperswitch/hyperswitch.py
@@ -58,7 +58,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/hyperswitch/hyperswitch.py
+++ b/examples/hyperswitch/hyperswitch.py
@@ -41,7 +41,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"merchant_id\":\"probe_merchant\",\"event_id\":\"evt_probe_001\",\"event_type\":\"payment_succeeded\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_probe001\",\"status\":\"succeeded\",\"connector_transaction_id\":\"txn_probe001\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/hyperswitch/hyperswitch.py
+++ b/examples/hyperswitch/hyperswitch.py
@@ -42,7 +42,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"merchant_id\":\"probe_merchant\",\"event_id\":\"evt_probe_001\",\"event_type\":\"payment_succeeded\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_probe001\",\"status\":\"succeeded\",\"connector_transaction_id\":\"txn_probe001\"}}}",  # Body of the HTTP request.
+            body="{\"merchant_id\":\"probe_merchant\",\"event_id\":\"evt_probe_001\",\"event_type\":\"payment_succeeded\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_probe001\",\"status\":\"succeeded\",\"connector_transaction_id\":\"txn_probe001\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/hyperswitch/hyperswitch.py
+++ b/examples/hyperswitch/hyperswitch.py
@@ -60,7 +60,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "get"

--- a/examples/imerchantsolutions/imerchantsolutions.py
+++ b/examples/imerchantsolutions/imerchantsolutions.py
@@ -77,7 +77,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"type\": \"payment.completed\",\"paymentId\": \"cmml1234abcd\",\"pspReference\": \"ABC123DEF456\",\"reference\": \"order-12345\",\"amount\": 5000,\"currency\": \"USD\",\"status\": \"captured\",\"processor\": \"Adyen\",\"cardLast4\": \"1111\",\"cardBrand\": \"visa\",\"customerEmail\": \"customer@example.com\",\"partnerId\": \"your_partner_id\",\"merchantId\": \"merchant_id\",\"timestamp\": \"2026-03-30T15:45:00.000Z\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/imerchantsolutions/imerchantsolutions.py
+++ b/examples/imerchantsolutions/imerchantsolutions.py
@@ -275,7 +275,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/imerchantsolutions/imerchantsolutions.py
+++ b/examples/imerchantsolutions/imerchantsolutions.py
@@ -78,7 +78,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"type\": \"payment.completed\",\"paymentId\": \"cmml1234abcd\",\"pspReference\": \"ABC123DEF456\",\"reference\": \"order-12345\",\"amount\": 5000,\"currency\": \"USD\",\"status\": \"captured\",\"processor\": \"Adyen\",\"cardLast4\": \"1111\",\"cardBrand\": \"visa\",\"customerEmail\": \"customer@example.com\",\"partnerId\": \"your_partner_id\",\"merchantId\": \"merchant_id\",\"timestamp\": \"2026-03-30T15:45:00.000Z\"}}}",  # Body of the HTTP request.
+            body="{\"type\": \"payment.completed\",\"paymentId\": \"cmml1234abcd\",\"pspReference\": \"ABC123DEF456\",\"reference\": \"order-12345\",\"amount\": 5000,\"currency\": \"USD\",\"status\": \"captured\",\"processor\": \"Adyen\",\"cardLast4\": \"1111\",\"cardBrand\": \"visa\",\"customerEmail\": \"customer@example.com\",\"partnerId\": \"your_partner_id\",\"merchantId\": \"merchant_id\",\"timestamp\": \"2026-03-30T15:45:00.000Z\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/imerchantsolutions/imerchantsolutions.py
+++ b/examples/imerchantsolutions/imerchantsolutions.py
@@ -273,7 +273,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/noon/noon.py
+++ b/examples/noon/noon.py
@@ -338,7 +338,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/noon/noon.py
+++ b/examples/noon/noon.py
@@ -82,7 +82,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"orderId\":12345,\"orderStatus\":\"CAPTURED\",\"eventType\":\"SALE\",\"eventId\":\"probe-event-001\",\"timeStamp\":\"2024-01-01T00:00:00Z\"}",  # Body of the HTTP request.
+            body="{\"orderId\":12345,\"orderStatus\":\"CAPTURED\",\"eventType\":\"SALE\",\"eventId\":\"probe-event-001\",\"timeStamp\":\"2024-01-01T00:00:00Z\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/noon/noon.py
+++ b/examples/noon/noon.py
@@ -336,7 +336,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/noon/noon.py
+++ b/examples/noon/noon.py
@@ -81,7 +81,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"orderId\":12345,\"orderStatus\":\"CAPTURED\",\"eventType\":\"SALE\",\"eventId\":\"probe-event-001\",\"timeStamp\":\"2024-01-01T00:00:00Z\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/novalnet/novalnet.py
+++ b/examples/novalnet/novalnet.py
@@ -402,7 +402,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/novalnet/novalnet.py
+++ b/examples/novalnet/novalnet.py
@@ -400,7 +400,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/novalnet/novalnet.py
+++ b/examples/novalnet/novalnet.py
@@ -96,7 +96,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"event\":{\"checksum\":\"probe_checksum\",\"tid\":12345678901234,\"type\":\"PAYMENT\"},\"result\":{\"status\":\"SUCCESS\",\"status_code\":100,\"status_text\":\"Success\"},\"transaction\":{\"tid\":12345678901234,\"payment_type\":\"CREDITCARD\",\"status\":\"CONFIRMED\",\"status_code\":100,\"order_no\":\"probe_order_001\",\"amount\":1000,\"currency\":\"EUR\"}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/novalnet/novalnet.py
+++ b/examples/novalnet/novalnet.py
@@ -97,7 +97,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"event\":{\"checksum\":\"probe_checksum\",\"tid\":12345678901234,\"type\":\"PAYMENT\"},\"result\":{\"status\":\"SUCCESS\",\"status_code\":100,\"status_text\":\"Success\"},\"transaction\":{\"tid\":12345678901234,\"payment_type\":\"CREDITCARD\",\"status\":\"CONFIRMED\",\"status_code\":100,\"order_no\":\"probe_order_001\",\"amount\":1000,\"currency\":\"EUR\"}}",  # Body of the HTTP request.
+            body="{\"event\":{\"checksum\":\"probe_checksum\",\"tid\":12345678901234,\"type\":\"PAYMENT\"},\"result\":{\"status\":\"SUCCESS\",\"status_code\":100,\"status_text\":\"Success\"},\"transaction\":{\"tid\":12345678901234,\"payment_type\":\"CREDITCARD\",\"status\":\"CONFIRMED\",\"status_code\":100,\"order_no\":\"probe_order_001\",\"amount\":1000,\"currency\":\"EUR\"}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/payload/payload.py
+++ b/examples/payload/payload.py
@@ -125,7 +125,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"object\":\"transaction\",\"trigger\":\"payment\",\"webhook_id\":\"probe_wh_001\",\"triggered_at\":\"2024-01-01T00:00:00Z\",\"triggered_on\":{\"id\":\"probe_txn_001\",\"object\":\"transaction\"},\"url\":\"https://example.com/webhook\"}",  # Body of the HTTP request.
+            body="{\"object\":\"transaction\",\"trigger\":\"payment\",\"webhook_id\":\"probe_wh_001\",\"triggered_at\":\"2024-01-01T00:00:00Z\",\"triggered_on\":{\"id\":\"probe_txn_001\",\"object\":\"transaction\"},\"url\":\"https://example.com/webhook\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/payload/payload.py
+++ b/examples/payload/payload.py
@@ -124,7 +124,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"object\":\"transaction\",\"trigger\":\"payment\",\"webhook_id\":\"probe_wh_001\",\"triggered_at\":\"2024-01-01T00:00:00Z\",\"triggered_on\":{\"id\":\"probe_txn_001\",\"object\":\"transaction\"},\"url\":\"https://example.com/webhook\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/payload/payload.py
+++ b/examples/payload/payload.py
@@ -507,7 +507,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/payload/payload.py
+++ b/examples/payload/payload.py
@@ -505,7 +505,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/paypal/paypal.py
+++ b/examples/paypal/paypal.py
@@ -132,7 +132,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"event_type\":\"PAYMENT.CAPTURE.COMPLETED\",\"resource\":{\"id\":\"probe_capture_001\",\"status\":\"COMPLETED\",\"amount\":{\"value\":\"10.00\",\"currency_code\":\"USD\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/paypal/paypal.py
+++ b/examples/paypal/paypal.py
@@ -484,7 +484,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/paypal/paypal.py
+++ b/examples/paypal/paypal.py
@@ -133,7 +133,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"event_type\":\"PAYMENT.CAPTURE.COMPLETED\",\"resource\":{\"id\":\"probe_capture_001\",\"status\":\"COMPLETED\",\"amount\":{\"value\":\"10.00\",\"currency_code\":\"USD\"}}}",  # Body of the HTTP request.
+            body="{\"event_type\":\"PAYMENT.CAPTURE.COMPLETED\",\"resource\":{\"id\":\"probe_capture_001\",\"status\":\"COMPLETED\",\"amount\":{\"value\":\"10.00\",\"currency_code\":\"USD\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/paypal/paypal.py
+++ b/examples/paypal/paypal.py
@@ -482,7 +482,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/peachpayments/peachpayments.py
+++ b/examples/peachpayments/peachpayments.py
@@ -80,7 +80,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"webhookId\":\"probe_wh_001\",\"webhookType\":\"PAYMENT\",\"transaction\":{\"transactionId\":\"probe_txn_001\",\"referenceId\":\"probe_ref_001\",\"transactionResult\":\"ACK\",\"transactionType\":\"DEBIT\",\"paymentMethod\":\"probe_pm\"}}",  # Body of the HTTP request.
+            body="{\"webhookId\":\"probe_wh_001\",\"webhookType\":\"PAYMENT\",\"transaction\":{\"transactionId\":\"probe_txn_001\",\"referenceId\":\"probe_ref_001\",\"transactionResult\":\"ACK\",\"transactionType\":\"DEBIT\",\"paymentMethod\":\"probe_pm\"}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/peachpayments/peachpayments.py
+++ b/examples/peachpayments/peachpayments.py
@@ -79,7 +79,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"webhookId\":\"probe_wh_001\",\"webhookType\":\"PAYMENT\",\"transaction\":{\"transactionId\":\"probe_txn_001\",\"referenceId\":\"probe_ref_001\",\"transactionResult\":\"ACK\",\"transactionType\":\"DEBIT\",\"paymentMethod\":\"probe_pm\"}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/peachpayments/peachpayments.py
+++ b/examples/peachpayments/peachpayments.py
@@ -337,7 +337,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/peachpayments/peachpayments.py
+++ b/examples/peachpayments/peachpayments.py
@@ -335,7 +335,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/phonepe/phonepe.py
+++ b/examples/phonepe/phonepe.py
@@ -136,7 +136,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/phonepe/phonepe.py
+++ b/examples/phonepe/phonepe.py
@@ -77,7 +77,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{}",  # Body of the HTTP request.
+            body="{}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/phonepe/phonepe.py
+++ b/examples/phonepe/phonepe.py
@@ -138,7 +138,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/phonepe/phonepe.py
+++ b/examples/phonepe/phonepe.py
@@ -76,7 +76,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{}",  # Body of the HTTP request.
         ),
     )

--- a/examples/ppro/ppro.py
+++ b/examples/ppro/ppro.py
@@ -73,7 +73,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"specversion\":\"1.0\",\"type\":\"PAYMENT_CHARGE_SUCCESS\",\"source\":\"probe_source\",\"id\":\"probe_event_001\",\"time\":\"2024-01-01T00:00:00Z\",\"data\":{\"charge\":{\"id\":\"probe_txn_001\",\"status\":\"SUCCEEDED\",\"amount\":1000,\"currency\":\"EUR\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/ppro/ppro.py
+++ b/examples/ppro/ppro.py
@@ -74,7 +74,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"specversion\":\"1.0\",\"type\":\"PAYMENT_CHARGE_SUCCESS\",\"source\":\"probe_source\",\"id\":\"probe_event_001\",\"time\":\"2024-01-01T00:00:00Z\",\"data\":{\"charge\":{\"id\":\"probe_txn_001\",\"status\":\"SUCCEEDED\",\"amount\":1000,\"currency\":\"EUR\"}}}",  # Body of the HTTP request.
+            body="{\"specversion\":\"1.0\",\"type\":\"PAYMENT_CHARGE_SUCCESS\",\"source\":\"probe_source\",\"id\":\"probe_event_001\",\"time\":\"2024-01-01T00:00:00Z\",\"data\":{\"charge\":{\"id\":\"probe_txn_001\",\"status\":\"SUCCEEDED\",\"amount\":1000,\"currency\":\"EUR\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/ppro/ppro.py
+++ b/examples/ppro/ppro.py
@@ -161,7 +161,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/ppro/ppro.py
+++ b/examples/ppro/ppro.py
@@ -159,7 +159,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/razorpay/razorpay.py
+++ b/examples/razorpay/razorpay.py
@@ -69,7 +69,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"account_id\":\"probe_acct\",\"contains\":[\"payment\"],\"entity\":\"event\",\"event\":\"payment.captured\",\"payload\":{\"payment\":{\"entity\":{\"id\":\"pay_probe001\",\"entity\":\"payment\",\"amount\":1000,\"currency\":\"USD\",\"status\":\"captured\",\"order_id\":\"order_probe001\"}}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/razorpay/razorpay.py
+++ b/examples/razorpay/razorpay.py
@@ -70,7 +70,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"account_id\":\"probe_acct\",\"contains\":[\"payment\"],\"entity\":\"event\",\"event\":\"payment.captured\",\"payload\":{\"payment\":{\"entity\":{\"id\":\"pay_probe001\",\"entity\":\"payment\",\"amount\":1000,\"currency\":\"USD\",\"status\":\"captured\",\"order_id\":\"order_probe001\"}}}}",  # Body of the HTTP request.
+            body="{\"account_id\":\"probe_acct\",\"contains\":[\"payment\"],\"entity\":\"event\",\"event\":\"payment.captured\",\"payload\":{\"payment\":{\"entity\":{\"id\":\"pay_probe001\",\"entity\":\"payment\",\"amount\":1000,\"currency\":\"USD\",\"status\":\"captured\",\"order_id\":\"order_probe001\"}}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/razorpay/razorpay.py
+++ b/examples/razorpay/razorpay.py
@@ -132,7 +132,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/razorpay/razorpay.py
+++ b/examples/razorpay/razorpay.py
@@ -134,7 +134,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/revolut/revolut.py
+++ b/examples/revolut/revolut.py
@@ -90,7 +90,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"event\":\"ORDER_COMPLETED\",\"order_id\":\"probe_order_001\"}",  # Body of the HTTP request.
+            body="{\"event\":\"ORDER_COMPLETED\",\"order_id\":\"probe_order_001\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/revolut/revolut.py
+++ b/examples/revolut/revolut.py
@@ -281,7 +281,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/revolut/revolut.py
+++ b/examples/revolut/revolut.py
@@ -283,7 +283,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/revolut/revolut.py
+++ b/examples/revolut/revolut.py
@@ -89,7 +89,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"event\":\"ORDER_COMPLETED\",\"order_id\":\"probe_order_001\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/stripe/stripe.py
+++ b/examples/stripe/stripe.py
@@ -111,7 +111,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"id\":\"evt_probe_001\",\"type\":\"payment_intent.succeeded\",\"data\":{\"object\":{\"id\":\"pi_probe_001\",\"object\":\"payment_intent\",\"amount\":1000,\"currency\":\"usd\",\"created\":1700000000,\"status\":\"succeeded\"}}}",  # Body of the HTTP request.
+            body="{\"id\":\"evt_probe_001\",\"type\":\"payment_intent.succeeded\",\"data\":{\"object\":{\"id\":\"pi_probe_001\",\"object\":\"payment_intent\",\"amount\":1000,\"currency\":\"usd\",\"created\":1700000000,\"status\":\"succeeded\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/stripe/stripe.py
+++ b/examples/stripe/stripe.py
@@ -446,7 +446,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/stripe/stripe.py
+++ b/examples/stripe/stripe.py
@@ -448,7 +448,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/stripe/stripe.py
+++ b/examples/stripe/stripe.py
@@ -110,7 +110,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"id\":\"evt_probe_001\",\"type\":\"payment_intent.succeeded\",\"data\":{\"object\":{\"id\":\"pi_probe_001\",\"object\":\"payment_intent\",\"amount\":1000,\"currency\":\"usd\",\"created\":1700000000,\"status\":\"succeeded\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/tamara/tamara.py
+++ b/examples/tamara/tamara.py
@@ -53,7 +53,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{}",  # Body of the HTTP request.
+            body="{}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/tamara/tamara.py
+++ b/examples/tamara/tamara.py
@@ -99,7 +99,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/tamara/tamara.py
+++ b/examples/tamara/tamara.py
@@ -97,7 +97,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/tamara/tamara.py
+++ b/examples/tamara/tamara.py
@@ -52,7 +52,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{}",  # Body of the HTTP request.
         ),
     )

--- a/examples/truelayer/truelayer.py
+++ b/examples/truelayer/truelayer.py
@@ -60,7 +60,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"type\":\"payment_executed\",\"payment_id\":\"probe_payment_001\"}",  # Body of the HTTP request.
         ),
     )

--- a/examples/truelayer/truelayer.py
+++ b/examples/truelayer/truelayer.py
@@ -102,7 +102,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_refund_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/truelayer/truelayer.py
+++ b/examples/truelayer/truelayer.py
@@ -100,7 +100,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/truelayer/truelayer.py
+++ b/examples/truelayer/truelayer.py
@@ -61,7 +61,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"type\":\"payment_executed\",\"payment_id\":\"probe_payment_001\"}",  # Body of the HTTP request.
+            body="{\"type\":\"payment_executed\",\"payment_id\":\"probe_payment_001\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/trustly/trustly.py
+++ b/examples/trustly/trustly.py
@@ -32,7 +32,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"method\":\"charge\",\"params\":{\"data\":{\"orderid\":\"probe_order_001\",\"amount\":\"10.00\",\"currency\":\"EUR\",\"enduserid\":\"probe_user\"}}}",  # Body of the HTTP request.
         ),
     )

--- a/examples/trustly/trustly.py
+++ b/examples/trustly/trustly.py
@@ -33,7 +33,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"method\":\"charge\",\"params\":{\"data\":{\"orderid\":\"probe_order_001\",\"amount\":\"10.00\",\"currency\":\"EUR\",\"enduserid\":\"probe_user\"}}}",  # Body of the HTTP request.
+            body="{\"method\":\"charge\",\"params\":{\"data\":{\"orderid\":\"probe_order_001\",\"amount\":\"10.00\",\"currency\":\"EUR\",\"enduserid\":\"probe_user\"}}}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 async def process_parse_event(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/trustly/trustly.py
+++ b/examples/trustly/trustly.py
@@ -42,7 +42,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "parse_event"

--- a/examples/trustly/trustly.py
+++ b/examples/trustly/trustly.py
@@ -40,7 +40,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/trustpay/trustpay.py
+++ b/examples/trustpay/trustpay.py
@@ -333,7 +333,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
     """Flow: EventService.ParseEvent"""
     event_client = EventClient(config)
 
-    parse_response = await event_client.parse_event(_build_parse_event_request())
+    parse_response = event_client.parse_event(_build_parse_event_request())
 
     return {"status": parse_response.status}
 

--- a/examples/trustpay/trustpay.py
+++ b/examples/trustpay/trustpay.py
@@ -119,7 +119,7 @@ def _build_parse_event_request():
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
             headers={},  # Headers of the HTTP request.
-            body="{\"PaymentInformation\":{\"CreditDebitIndicator\":\"CRDT\",\"References\":{\"EndToEndId\":\"probe_txn_001\"},\"Status\":\"Paid\",\"Amount\":{\"InstructedAmount\":10.00,\"Currency\":\"EUR\"}},\"Signature\":\"probe_sig\"}",  # Body of the HTTP request.
+            body="{\"PaymentInformation\":{\"CreditDebitIndicator\":\"CRDT\",\"References\":{\"EndToEndId\":\"probe_txn_001\"},\"Status\":\"Paid\",\"Amount\":{\"InstructedAmount\":10.00,\"Currency\":\"EUR\"}},\"Signature\":\"probe_sig\"}".encode("utf-8"),  # Body of the HTTP request.
         ),
     )
 

--- a/examples/trustpay/trustpay.py
+++ b/examples/trustpay/trustpay.py
@@ -335,7 +335,7 @@ async def process_parse_event(merchant_transaction_id: str, config: sdk_config_p
 
     parse_response = event_client.parse_event(_build_parse_event_request())
 
-    return {"status": parse_response.status}
+    return {"response": str(parse_response)}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/trustpay/trustpay.py
+++ b/examples/trustpay/trustpay.py
@@ -118,7 +118,7 @@ def _build_parse_event_request():
         request_details=payment_pb2.RequestDetails(
             method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
             uri="https://example.com/webhook",  # URI of the request.
-            headers=payment_pb2.HeadersEntry(),  # Headers of the HTTP request.
+            headers={},  # Headers of the HTTP request.
             body="{\"PaymentInformation\":{\"CreditDebitIndicator\":\"CRDT\",\"References\":{\"EndToEndId\":\"probe_txn_001\"},\"Status\":\"Paid\",\"Amount\":{\"InstructedAmount\":10.00,\"Currency\":\"EUR\"}},\"Signature\":\"probe_sig\"}",  # Body of the HTTP request.
         ),
     )

--- a/scripts/generators/snippet_examples/generate.py
+++ b/scripts/generators/snippet_examples/generate.py
@@ -1550,11 +1550,13 @@ def _py_direct_lines(
     """
     pad = "    " * indent
     lines: list[str] = []
+    msg_map_fields = _PROTO_MAP_FIELDS.get(msg_name, set())
 
     for key, val in obj.items():
         comment   = db.get_comment(msg_name, key)
         child_msg = db.get_type(msg_name, key)
         cmt_part  = f"  # {comment}" if comment else ""
+        is_map    = key in msg_map_fields
 
         if key in variable_fields:
             if child_msg and _is_proto_enum(child_msg):
@@ -1568,7 +1570,10 @@ def _py_direct_lines(
             continue
 
         if isinstance(val, dict):
-            if child_msg and db.is_wrapper(child_msg):
+            if is_map:
+                # Map field — Python protobuf accepts a plain dict literal directly.
+                lines.append(f"{pad}{key}={json.dumps(val)},{cmt_part}")
+            elif child_msg and db.is_wrapper(child_msg):
                 # SecretString-style wrapper: extract .value from probe dict
                 inner_val = val.get("value", "")
                 wm = _py_module_for_type(child_msg)

--- a/scripts/generators/snippet_examples/generate.py
+++ b/scripts/generators/snippet_examples/generate.py
@@ -134,6 +134,15 @@ _UNSUPPORTED_FLOWS: frozenset[str] = frozenset({
     "verify_redirect",
 })
 
+# Flows whose Python SDK client method calls _execute_direct() and returns the
+# response synchronously (not a coroutine) — must NOT be awaited, unlike the
+# _execute_flow()-backed methods for every other flow.
+_PYTHON_SYNC_FLOWS: frozenset[str] = frozenset({
+    "handle_event",
+    "parse_event",
+    "verify_redirect",
+})
+
 
 def _generate_connector_config_rust(connector_name: str) -> str:
     """Generate accurate Rust config code using parsed proto metadata.
@@ -1147,7 +1156,8 @@ def _scenario_step_python(
     
     lines: list[str] = []
     lines.append(f"    # Step {step_num}: {desc}")
-    lines.append(f"    {var_name} = await {client_var}.{method}({type_path}(")
+    awaitkw = "" if flow_key in _PYTHON_SYNC_FLOWS else "await "
+    lines.append(f"    {var_name} = {awaitkw}{client_var}.{method}({type_path}(")
 
     drop_fields = _SCENARIO_DROP_FIELDS.get((scenario_key, flow_key), frozenset())
     # Build a filtered payload, substituting dynamic fields as raw expressions
@@ -1930,7 +1940,8 @@ def render_consolidated_python(
         else:
             call_arg = "authorize_response.connector_transaction_id"
 
-        slines.append(f"{pad}{var_name} = await {client_var}.{method}(_build_{flow_key}_request({call_arg}))")
+        awaitkw = "" if flow_key in _PYTHON_SYNC_FLOWS else "await "
+        slines.append(f"{pad}{var_name} = {awaitkw}{client_var}.{method}(_build_{flow_key}_request({call_arg}))")
         slines.append("")
 
         if flow_key == "authorize":
@@ -2027,13 +2038,14 @@ def render_consolidated_python(
         pm_part    = f" ({pm_label})" if pm_label else ""
 
         body_lines: list[str] = [f"    {client_var} = {client_cls}(config)", ""]
+        awaitkw = "" if flow_key in _PYTHON_SYNC_FLOWS else "await "
         if flow_key in has_builder:
             if flow_key in _FLOW_BUILDER_EXTRA_PARAM:
                 param_name  = _FLOW_BUILDER_EXTRA_PARAM[flow_key][0]
                 default_val = proto_req.get(param_name, "AUTOMATIC" if param_name == "capture_method" else "probe_connector_txn_001")
-                body_lines.append(f'    {resp_var} = await {client_var}.{method}(_build_{flow_key}_request("{default_val}"))')
+                body_lines.append(f'    {resp_var} = {awaitkw}{client_var}.{method}(_build_{flow_key}_request("{default_val}"))')
             else:
-                body_lines.append(f'    {resp_var} = await {client_var}.{method}(_build_{flow_key}_request())')
+                body_lines.append(f'    {resp_var} = {awaitkw}{client_var}.{method}(_build_{flow_key}_request())')
             body_lines.append("")
         else:
             body_lines.extend(_scenario_step_python("_standalone_", flow_key, 1, proto_req, grpc_req, client_var, db))

--- a/scripts/generators/snippet_examples/generate.py
+++ b/scripts/generators/snippet_examples/generate.py
@@ -1622,7 +1622,10 @@ def _py_direct_lines(
         elif isinstance(val, (int, float)):
             lines.append(f"{pad}{key}={val},{cmt_part}")
         elif isinstance(val, str):
-            if child_msg and _is_proto_enum(child_msg):
+            if child_msg == "bytes":
+                # bytes fields require a bytes object, not str, in Python protobuf.
+                lines.append(f'{pad}{key}={json.dumps(val)}.encode("utf-8"),{cmt_part}')
+            elif child_msg and _is_proto_enum(child_msg):
                 em = _py_module_for_type(child_msg)
                 lines.append(f"{pad}{key}={em}.{child_msg}.Value({json.dumps(val)}),{cmt_part}")
             elif child_msg and child_msg in _PYTHON_WRAPPER_TYPES:

--- a/scripts/generators/snippet_examples/generate.py
+++ b/scripts/generators/snippet_examples/generate.py
@@ -2049,7 +2049,10 @@ def render_consolidated_python(
             body_lines.append("")
         else:
             body_lines.extend(_scenario_step_python("_standalone_", flow_key, 1, proto_req, grpc_req, client_var, db))
-        if flow_key == "authorize":
+        if svc == "EventService":
+            # EventService responses (parse/handle) carry no .status; report the response.
+            body_lines.append(f'    return {{"response": str({resp_var})}}')
+        elif flow_key == "authorize":
             body_lines.append(f'    return {{"status": {resp_var}.status, "transaction_id": {resp_var}.connector_transaction_id}}')
         elif flow_key == "setup_recurring":
             body_lines.append(f'    return {{"status": {resp_var}.status, "mandate_id": {resp_var}.connector_recurring_payment_id}}')


### PR DESCRIPTION
## What

Carry the requested **authentication type** on the repeat/MIT
(`RecurringPaymentService.Charge`) request so connectors that vary their request
shape by 3DS/no-3DS rebuild an identical MIT request on the UCS side as on
Hyperswitch.

- `proto`: add `optional AuthenticationType auth_type = 36;` to
  `RecurringPaymentServiceChargeRequest`.
- `domain_types`: honour it in the `RecurringPaymentServiceChargeRequest → domain`
  conversion (`auth_type: foreign_try_from(value.auth_type())`), instead of always
  defaulting to `NoThreeDs`.

Novalnet's connector transformer already keys `enforce_3d` off
`resource_common_data.auth_type`, so no connector change is needed — it now sees
the real auth type.

## Why — shadow-validation diff

(connector=`novalnet`, flow=`repeat_payment`, merchant=`bu_de_getolo`).

```
body.typeDiff.transaction.enforce_3d = {"hyperswitch":"number","ucs":"null"}
```

The repeat charge request had **no** auth_type field, so the UCS server defaulted
`PaymentFlowData.auth_type` to `NoThreeDs`. Hyperswitch's MIT attempt carried
`authentication_type=three_ds` → `enforce_3d = Some(1)` (a number); UCS built
`enforce_3d = None` (null) → diff.

**Layer category:** proto (gRPC contract) + L2 domain conversion. Paired with an
HS PR that populates the new field. The Novalnet L3 transformer already maps
`auth_type → enforce_3d`.

## Repro & verification (local shadow stack on `main`)

`prod-fixes/repro_16914.py`: CIT no-3DS off_session card payment (saves a reusable
PM) → MIT via `recurring_details(payment_method_id)` with
`authentication_type=three_ds` → HS routes the repeat to UCS over gRPC; MITM
mirrors both built requests to the validation service.

| | `transaction.enforce_3d` typeDiff |
|---|---|
| **before** | `{"hyperswitch":"number","ucs":"null"}` (diff) |
| **after** (HS populates `auth_type` + this PR) | keyDiff `{}` / typeDiff `{}` → **no_diff** |

Verified end-to-end on the local stack with HS built against this PR's proto
(`auth_type` finalized to field **36**, since `34`/`35` are now taken by
`split_payments` / `partner_merchant_identifier_details` on `main`).

## Cross-repo

Paired HS PR (populates the field + bumps the UCS git rev to this PR's head):
juspay/hyperswitch#12866.

Closes #1586
Fixes an internal validation-diff issue (linked via the Development sidebar).


## Update (2026-07-06 CI re-verification)

Rebased onto current `main` (several days of unrelated churn had gone stale/DIRTY).
Local build clean; all required checks green — `Compilation Check`, `Run Tests`,
`Clippy check`, `Proto checks`, formatting, spell (scoped). The `SDK Tests` required
check is failing, but this is a **pre-existing, repo-wide** breakage unrelated to this
diff: a Python SDK smoke test (`stripe`/`parse_event`) hits
`AttributeError: module 'payments.generated.payment_pb2' has no attribute 'HeadersEntry'`
— confirmed failing identically on multiple unrelated open PRs on `main` today
(unrelated feature branches), so it isn't something introduced by this change.
