### PR TITLE
fix(novalnet): carry auth_type into SetupMandate flow so enforce_3d matches HS

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4870,7 +4870,9 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            // Honour the auth type sent by Hyperswitch (defaults to NoThreeDs when unset/unspecified)
+            // so connectors keying request fields off it (e.g. Novalnet enforce_3d) match HS.
+            auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
             connector_request_reference_id: extract_connector_request_reference_id(&Some(
                 value.merchant_recurring_payment_id.clone(),
             )),


### PR DESCRIPTION
## What

For the **SetupMandate** flow, the `SetupRecurringRequest → PaymentFlowData` conversion
hardcoded `auth_type` to `AuthenticationType::default()` (i.e. `NoThreeDs`), discarding the
authentication type Hyperswitch sends over gRPC (`PaymentServiceSetupRecurringRequest.auth_type`,
field 6).

Connectors that derive request fields from `resource_common_data.auth_type` therefore produced
the wrong value for 3DS mandate setups. For **Novalnet**, `enforce_3d` is keyed off `auth_type`
(`ThreeDs → Some(1)`, `NoThreeDs → None`), so UCS emitted `null` while Hyperswitch emitted the
number — a shadow-validation type diff.

## Fix

Carry the request's `auth_type` through the conversion, mirroring how the RepeatPayment
(MIT) conversion already does it:

```rust
auth_type: common_enums::AuthenticationType::foreign_try_from(value.auth_type)?,
```

Layer category: **L2 — domain / proto↔domain conversion** (UCS-only). The proto already carries
`auth_type` and Hyperswitch already populates it; only the domain conversion dropped it.

## Diff signature

```
body.typeDiff.transaction.enforce_3d = {"hyperswitch":"number","ucs":"null"}
```
connector=novalnet, flow=setup_mandate, merchant=bu_de_getolo

## Repro + verification (local HS↔UCS shadow stack)

Zero-amount mandate setup with `authentication_type=three_ds` (triggers `enforce_3d`) against
Novalnet on the SetupMandate flow:

```
POST /payments  amount=0, payment_type=setup_mandate, setup_future_usage=off_session,
                authentication_type=three_ds, mandate_data{...}, customer_id, card
rollout key: ucs_rollout_config_<mid>_novalnet_card_SetupMandate
```

| | Validation-service verdict |
|---|---|
| **Before** | `typeDiff: {"transaction.enforce_3d": {"hyperswitch":"number","ucs":"null"}}` |
| **After**  | `keyDiff: {}`, `typeDiff: {}` (no_diff) |

Local checks: `cargo build --bin grpc-server` ✓, `cargo fmt -p domain_types --check` ✓,
`cargo clippy -p domain_types --all-targets -- -D warnings` ✓.
---
### Also resolves #16975 — novalnet/setup_mandate `connector_response_reference_id` (router typeDiff)

`#16975` is a **downstream symptom of this same `enforce_3d` request diff** (same connector,
flow, merchant `bu_de_getolo`; confirmed on the same prod request `019ef3d5-…`, where RP_05
shows `transaction.enforce_3d {hs:number, ucs:null}` and VS_48 shows
`response.Ok.TransactionResponse.connector_response_reference_id {hs:null, ucs:string}`).

Causal chain: HS sends `enforce_3d=1` → Novalnet returns a **3DS challenge** response (no
completed `transaction.tid`) → `connector_response_reference_id = null`. UCS dropped `auth_type`
→ `enforce_3d=null` → Novalnet **completes synchronously** → returns a `tid` →
`connector_response_reference_id = string`. The connector transformers derive this field
identically from `transaction.tid` on both sides (HS `novalnet/transformers.rs` and UCS
`novalnet/transformers.rs`), so there is **no separate response-side bug** — carrying `auth_type`
here makes Novalnet return identical responses, closing the response diff too.

Closes #1649
