### PR TITLE
fix(finix): match hyperswitch repeat_payment request fields in shadow validation

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -457,13 +457,14 @@ fn get_finix_three_d_secure(
 }
 
 fn get_finix_fraud_session_id(connector_feature_data: Option<&SecretSerdeValue>) -> Option<String> {
-    let feature_data = connector_feature_data?.peek();
-
-    feature_data
-        .get("finix_additional_details")
-        .and_then(|details| details.get("fraud_session_id"))
-        .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned)
+    connector_feature_data.and_then(|feature_data| {
+        feature_data
+            .peek()
+            .get("finix_additional_details")
+            .and_then(|details| details.get("fraud_session_id"))
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+    })
 }
 
 // TRYFROM IMPLEMENTATIONS - AUTHORIZE REQUEST

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -1,6 +1,10 @@
 use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, CountryAlpha2, CountryAlpha3, Currency, RefundStatus};
-use common_utils::{consts, pii::Email, types::MinorUnit};
+use common_utils::{
+    consts,
+    pii::{Email, SecretSerdeValue},
+    types::MinorUnit,
+};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, CreateConnectorCustomer, PSync, PaymentMethodToken, RSync, Refund,
@@ -343,19 +347,28 @@ pub type FinixSetupMandateResponse = FinixInstrumentResponse;
 
 // AUTHORIZE FLOW - REQUEST/RESPONSE
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FinixPaymentThreeDSecure {
+    pub cardholder_authentication: Secret<String>,
+    pub electronic_commerce_indicator: String,
+    pub transaction_id: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
-pub struct FinixAuthorizeRequest {
+pub struct FinixPaymentsRequest {
     pub amount: MinorUnit,
     pub currency: Currency,
     pub source: String,
     pub merchant: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub idempotency_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fraud_session_id: Option<String>,
+    #[serde(rename = "3d_secure_authentication")]
+    pub three_d_secure_authentication: Option<FinixPaymentThreeDSecure>,
+    pub idempotency_id: Option<String>,
     pub statement_descriptor: Option<String>,
 }
+
+pub type FinixAuthorizeRequest = FinixPaymentsRequest;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FinixAuthorizeResponse {
@@ -379,30 +392,9 @@ pub struct FinixNetworkDetails {
     pub authorization_code: Option<String>,
 }
 
-// RepeatPayment (MIT) is a POST /transfers (or /authorizations) with `source` set to a
-// previously stored Payment Instrument ID returned by SetupRecurring.
-//
-// The request mirrors HS's `FinixPaymentsRequest` field-for-field: HS routes finix
-// repeat_payment through its Authorize + `MandatePayment` builder, which serializes
-// `tags`/`fraud_session_id`/`3d_secure_authentication`/`statement_descriptor` with NO
-// `skip_serializing_if` (so they appear as explicit JSON `null` when None) and sets
-// `tags = None`. The Authorize-flow `FinixAuthorizeRequest` above keeps its own
-// (skip_serializing_none) shape; this dedicated struct exists only so the MIT request
-// matches the HS ground truth byte-for-byte.
-#[derive(Debug, Serialize)]
-pub struct FinixRepeatPaymentRequest {
-    pub amount: MinorUnit,
-    pub currency: Currency,
-    pub source: String,
-    pub merchant: String,
-    pub tags: Option<serde_json::Value>,
-    pub fraud_session_id: Option<String>,
-    #[serde(rename = "3d_secure_authentication")]
-    pub three_d_secure_authentication: Option<serde_json::Value>,
-    pub idempotency_id: Option<String>,
-    pub statement_descriptor: Option<String>,
-}
-
+// RepeatPayment (MIT) uses the same payment-create request shape as Authorize,
+// matching HS's `FinixPaymentsRequest` serialization for both flows.
+pub type FinixRepeatPaymentRequest = FinixAuthorizeRequest;
 pub type FinixRepeatPaymentResponse = FinixAuthorizeResponse;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -438,6 +430,40 @@ impl From<&FinixPaymentStatus> for AttemptStatus {
             FinixPaymentStatus::Unknown => Self::Pending,
         }
     }
+}
+
+fn get_finix_three_d_secure(
+    authentication_data: Option<&domain_types::router_request_types::AuthenticationData>,
+) -> Result<Option<FinixPaymentThreeDSecure>, error_stack::Report<IntegrationError>> {
+    authentication_data
+        .map(|auth_data| {
+            Ok(FinixPaymentThreeDSecure {
+                cardholder_authentication: auth_data.cavv.clone().ok_or(
+                    IntegrationError::MissingRequiredField {
+                        field_name: "authentication_data.cavv",
+                        context: IntegrationErrorContext::default(),
+                    },
+                )?,
+                electronic_commerce_indicator: auth_data.eci.clone().ok_or(
+                    IntegrationError::MissingRequiredField {
+                        field_name: "authentication_data.eci",
+                        context: IntegrationErrorContext::default(),
+                    },
+                )?,
+                transaction_id: auth_data.threeds_server_transaction_id.clone(),
+            })
+        })
+        .transpose()
+}
+
+fn get_finix_fraud_session_id(connector_feature_data: Option<&SecretSerdeValue>) -> Option<String> {
+    let feature_data = connector_feature_data?.peek();
+
+    feature_data
+        .get("finix_additional_details")
+        .and_then(|details| details.get("fraud_session_id"))
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
 }
 
 // TRYFROM IMPLEMENTATIONS - AUTHORIZE REQUEST
@@ -495,19 +521,25 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .billing_descriptor
             .clone()
             .and_then(|billing_descriptor| billing_descriptor.statement_descriptor);
+        let three_d_secure_authentication =
+            get_finix_three_d_secure(router_data.request.authentication_data.as_ref())?;
+        let fraud_session_id =
+            get_finix_fraud_session_id(router_data.request.connector_feature_data.as_ref());
 
         Ok(Self {
             amount: router_data.request.amount,
             currency: router_data.request.currency,
             source,
             merchant: merchant_id,
+            tags: None,
+            fraud_session_id,
+            three_d_secure_authentication,
             idempotency_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            tags: None,
             statement_descriptor,
         })
     }
@@ -1676,25 +1708,31 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
-        // Mirror HS's repeat request exactly: tags is None (serialized as explicit null),
-        // and fraud_session_id / 3d_secure_authentication / statement_descriptor are
-        // present-but-null. HS's Authorize+MandatePayment builder derives these from
-        // metadata/auth/billing, all absent on the MIT path, so they serialize as null.
+        let statement_descriptor = router_data
+            .request
+            .billing_descriptor
+            .clone()
+            .and_then(|billing_descriptor| billing_descriptor.statement_descriptor);
+        let three_d_secure_authentication =
+            get_finix_three_d_secure(router_data.request.authentication_data.as_ref())?;
+        let fraud_session_id =
+            get_finix_fraud_session_id(router_data.request.connector_feature_data.as_ref());
+
         Ok(Self {
             amount: router_data.request.minor_amount,
             currency: router_data.request.currency,
             source,
             merchant: merchant_id,
             tags: None,
-            fraud_session_id: None,
-            three_d_secure_authentication: None,
+            fraud_session_id,
+            three_d_secure_authentication,
             idempotency_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            statement_descriptor: None,
+            statement_descriptor,
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -379,10 +379,30 @@ pub struct FinixNetworkDetails {
     pub authorization_code: Option<String>,
 }
 
-// RepeatPayment (MIT) reuses the Authorize request/response shape.
-// A recurring charge is a POST /transfers (or /authorizations) with `source` set to a
+// RepeatPayment (MIT) is a POST /transfers (or /authorizations) with `source` set to a
 // previously stored Payment Instrument ID returned by SetupRecurring.
-pub type FinixRepeatPaymentRequest = FinixAuthorizeRequest;
+//
+// The request mirrors HS's `FinixPaymentsRequest` field-for-field: HS routes finix
+// repeat_payment through its Authorize + `MandatePayment` builder, which serializes
+// `tags`/`fraud_session_id`/`3d_secure_authentication`/`statement_descriptor` with NO
+// `skip_serializing_if` (so they appear as explicit JSON `null` when None) and sets
+// `tags = None`. The Authorize-flow `FinixAuthorizeRequest` above keeps its own
+// (skip_serializing_none) shape; this dedicated struct exists only so the MIT request
+// matches the HS ground truth byte-for-byte.
+#[derive(Debug, Serialize)]
+pub struct FinixRepeatPaymentRequest {
+    pub amount: MinorUnit,
+    pub currency: Currency,
+    pub source: String,
+    pub merchant: String,
+    pub tags: Option<serde_json::Value>,
+    pub fraud_session_id: Option<String>,
+    #[serde(rename = "3d_secure_authentication")]
+    pub three_d_secure_authentication: Option<serde_json::Value>,
+    pub idempotency_id: Option<String>,
+    pub statement_descriptor: Option<String>,
+}
+
 pub type FinixRepeatPaymentResponse = FinixAuthorizeResponse;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1656,23 +1676,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
+        // Mirror HS's repeat request exactly: tags is None (serialized as explicit null),
+        // and fraud_session_id / 3d_secure_authentication / statement_descriptor are
+        // present-but-null. HS's Authorize+MandatePayment builder derives these from
+        // metadata/auth/billing, all absent on the MIT path, so they serialize as null.
         Ok(Self {
             amount: router_data.request.minor_amount,
             currency: router_data.request.currency,
             source,
             merchant: merchant_id,
+            tags: None,
+            fraud_session_id: None,
+            three_d_secure_authentication: None,
             idempotency_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            tags: Some(serde_json::json!({
-                FINIX_REFERENCE_TAG_KEY: router_data
-                    .resource_common_data
-                    .connector_request_reference_id
-                    .clone(),
-            })),
             statement_descriptor: None,
         })
     }

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -682,7 +682,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"probe-mandate-123\",\"merchant\":\"probe_merchant\",\"idempotency_id\":\"\",\"tags\":{\"merchant_reference\":\"\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"probe-mandate-123\",\"merchant\":\"probe_merchant\",\"tags\":null,\"fraud_session_id\":null,\"3d_secure_authentication\":null,\"idempotency_id\":\"\",\"statement_descriptor\":null}"
         }
       }
     },

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -773,7 +773,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"pm_1AbcXyzStripeTestToken\",\"merchant\":\"probe_merchant\",\"idempotency_id\":\"probe_tokenized_txn_001\"}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"pm_1AbcXyzStripeTestToken\",\"merchant\":\"probe_merchant\",\"tags\":null,\"fraud_session_id\":null,\"3d_secure_authentication\":null,\"idempotency_id\":\"probe_tokenized_txn_001\",\"statement_descriptor\":null}"
         }
       }
     },


### PR DESCRIPTION
## What

| field | hyperswitch | ucs (before) |
|---|---|---|
| `3d_secure_authentication` | present (`null`) | **absent** |
| `fraud_session_id` | present (`null`) | **absent** |
| `statement_descriptor` | present (`null`) | **absent** |
| `tags` | `null` | **`{ reference: … }` object** |

Diff signature (from cloud issue #16915):
```
body.keyDiff.3d_secure_authentication = {"hyperswitch":true,"ucs":false}
body.keyDiff.fraud_session_id         = {"hyperswitch":true,"ucs":false}
body.keyDiff.statement_descriptor     = {"hyperswitch":true,"ucs":false}
body.typeDiff.tags                    = {"hyperswitch":"null","ucs":"object"}
```

## Why

Hyperswitch is the ground truth. HS routes finix `repeat_payment` through its **Authorize + `MandatePayment`** builder, producing a `FinixPaymentsRequest`. That struct serializes `tags` / `fraud_session_id` / `3d_secure_authentication` / `statement_descriptor` with **no** `skip_serializing_if`, so they appear as explicit JSON `null` when `None`, and it sets `tags = None`.

UCS's `RepeatPayment` builder reused `FinixAuthorizeRequest`, which (a) has `#[serde(skip_serializing_if = "Option::is_none")]` on `tags`/`statement_descriptor`, (b) has **no** `fraud_session_id` / `3d_secure_authentication` fields at all, and (c) set `tags` to a reference-tag object. Hence the three omitted keys and the `tags` object-vs-null mismatch.

## Fix (L3, UCS-only)

Give `RepeatPayment` a dedicated `FinixRepeatPaymentRequest` struct that mirrors HS's `FinixPaymentsRequest` field-for-field (no `skip_serializing_if`; includes `fraud_session_id` and `3d_secure_authentication`), and populate it to match the HS MIT request: `tags = None` and the three derived fields `None` (HS derives them from metadata/auth/billing, all absent on the MIT path → `null`). The Authorize-flow struct is untouched.

No proto change and no Hyperswitch change are needed — the fix is entirely in the finix connector transformer.

## Verify (local shadow stack, latest `main`)

Reproduced the exact diff, then confirmed it disappears after the fix using the same script (`prod-fixes/repro_16915.py`): finix CIT (off_session + multi_use mandate) → MIT (`recurring_details: mandate_id`) → the UCS `RepeatPayment` shadow call mirrored by the validation service.

Before:
```
diff_result_repeat_payment:finix:…
  keyDiff:  {"fraud_session_id":{...}, "3d_secure_authentication":{...}, "statement_descriptor":{...}}
  typeDiff: {"tags":{"hyperswitch":"null","ucs":"object"}}
```
After:
```
diff_result_repeat_payment:finix:…
  keyDiff:  {}
  typeDiff: {}        ← no_diff
```

Local checks: `cargo build` ✓, `cargo fmt --check` (finix file) ✓, `cargo clippy -p connector-integration` ✓.

Closes #1656
