### PR TITLE
fix(finix): emit card_brand/card_type/additional_data/merchant_identity/third_party_token on payment instrument

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -266,9 +266,14 @@ pub struct FinixCreatePaymentInstrumentRequest {
     pub tags: Option<FinixTags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<FinixAddress>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // HS emits these as explicit `null` (no skip_serializing_if) for card payment instruments;
+    // mirror that so the shadow request bodies match. Finix derives card_brand/card_type from the
+    // PAN, so they stay None for cards; merchant_identity/third_party_token carry values only for
+    // wallet (Google/Apple Pay) tokenization.
+    pub card_brand: Option<String>,
+    pub card_type: Option<String>,
+    pub additional_data: Option<HashMap<String, String>>,
     pub merchant_identity: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub third_party_token: Option<Secret<String>>,
     // Bank account specific fields for ACH
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1164,6 +1169,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 address: get_billing_address_as_finix_address(
                     &item.router_data.resource_common_data,
                 ),
+                card_brand: None,
+                card_type: None,
+                additional_data: None,
                 merchant_identity: None,
                 third_party_token: None,
                 account_number: None,
@@ -1197,6 +1205,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             identity: customer_id,
                             tags: None,
                             address: None,
+                            card_brand: None,
+                            card_type: None,
+                            additional_data: None,
                             merchant_identity: None,
                             third_party_token: None,
                             account_number: Some(account_number.clone()),
@@ -1237,6 +1248,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             identity: customer_id,
                             tags: None,
                             address: None,
+                            card_brand: None,
+                            card_type: None,
+                            additional_data: None,
                             merchant_identity: Some(Secret::new(merchant_identity)),
                             third_party_token: Some(Secret::new(third_party_token.token.clone())),
                             account_number: None,
@@ -1402,6 +1416,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 address: get_billing_address_as_finix_address(
                     &item.router_data.resource_common_data,
                 ),
+                card_brand: None,
+                card_type: None,
+                additional_data: None,
                 merchant_identity: None,
                 third_party_token: None,
                 account_number: None,
@@ -1435,6 +1452,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             identity: customer_id,
                             tags,
                             address: None,
+                            card_brand: None,
+                            card_type: None,
+                            additional_data: None,
                             merchant_identity: None,
                             third_party_token: None,
                             account_number: Some(account_number.clone()),
@@ -1475,6 +1495,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             identity: customer_id,
                             tags,
                             address: None,
+                            card_brand: None,
+                            card_type: None,
+                            additional_data: None,
                             merchant_identity: Some(Secret::new(merchant_identity)),
                             third_party_token: Some(Secret::new(third_party_token.token.clone())),
                             account_number: None,


### PR DESCRIPTION
## What

Finix **payment instrument creation** (`PaymentMethodToken` / `create_connector_customer`
tokenization flow) built a request body that diverged from Hyperswitch's ground-truth request.

HS↔UCS shadow-validation diff (`diff_result_payment_method_token:finix:*`):

```
body.keyDiff.additional_data    = {hyperswitch:true, ucs:false}
body.keyDiff.card_brand         = {hyperswitch:true, ucs:false}
body.keyDiff.card_type          = {hyperswitch:true, ucs:false}
body.keyDiff.merchant_identity  = {hyperswitch:true, ucs:false}
body.keyDiff.third_party_token  = {hyperswitch:true, ucs:false}
```

HS emits all five keys as explicit JSON `null` for a card payment instrument; UCS omitted them.

## Root cause (L3 — UCS connector transformer only)

HS's `FinixCreatePaymentInstrumentRequest` (`hyperswitch_connectors/.../finix`) serializes
`card_brand` / `card_type` / `additional_data` / `merchant_identity` / `third_party_token`
**without** `#[serde(skip_serializing_if = "Option::is_none")]`, so each appears as `null` when
`None` (Finix derives `card_brand`/`card_type` from the PAN, and the wallet-only fields are unset
for cards).

UCS's `FinixCreatePaymentInstrumentRequest` was **missing** `card_brand`/`card_type`/
`additional_data` entirely and marked `merchant_identity`/`third_party_token` with
`skip_serializing_if`, so all five keys were dropped from the card request — the
`skip_serializing_none` keyDiff pattern plus three absent fields.

## Fix

In `crates/integrations/connector-integration/src/connectors/finix/transformers.rs`:
- Add `card_brand: Option<String>`, `card_type: Option<String>`,
  `additional_data: Option<HashMap<String, String>>` to `FinixCreatePaymentInstrumentRequest`
  (no `skip_serializing_if`, mirroring HS's null-emit).
- Drop `skip_serializing_if` from `merchant_identity` / `third_party_token` so they serialize as
  `null` for cards (still carry their value for wallet tokenization).
- Set the three new fields to `None` at every construction site (card / bank / Google Pay across
  the `PaymentMethodToken` and `SetupMandate` builders).

No proto, domain, or HS-side change — the values are connector-derived, so this is UCS-only.

## Reproduce / verify (local shadow stack)

`prod-fixes/repro_16919.py`: create finix merchant + MCA (MultiAuthKey), enroll the card rollout
for `PaymentMethodToken`/`CreateConnectorCustomer`, fire an off_session multi_use-mandate CIT
(which tokenizes the card), then read the VS verdict for the `payment_method_token` sub-flow.

| | `payment_method_token` keyDiff |
|---|---|
| **Before** | `{card_brand, card_type, additional_data, merchant_identity, third_party_token}` all `{hs:true, ucs:false}` |
| **After** | `{}` — **no_diff**, no new diffs |

Verified after `cargo build --bin grpc-server` + restart. `cargo fmt --check` and
`cargo clippy -p connector-integration` clean.

Closes #1635
