### PR TITLE
fix(finix): match hyperswitch authorize request fields in shadow validation

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -379,10 +379,30 @@ pub struct FinixNetworkDetails {
     pub authorization_code: Option<String>,
 }
 
-// RepeatPayment (MIT) reuses the Authorize request/response shape.
-// A recurring charge is a POST /transfers (or /authorizations) with `source` set to a
+// RepeatPayment (MIT) is a POST /transfers (or /authorizations) with `source` set to a
 // previously stored Payment Instrument ID returned by SetupRecurring.
-pub type FinixRepeatPaymentRequest = FinixAuthorizeRequest;
+//
+// The request mirrors HS's `FinixPaymentsRequest` field-for-field: HS routes finix
+// repeat_payment through its Authorize + `MandatePayment` builder, which serializes
+// `tags`/`fraud_session_id`/`3d_secure_authentication`/`statement_descriptor` with NO
+// `skip_serializing_if` (so they appear as explicit JSON `null` when None) and sets
+// `tags = None`. The Authorize-flow `FinixAuthorizeRequest` above keeps its own
+// (skip_serializing_none) shape; this dedicated struct exists only so the MIT request
+// matches the HS ground truth byte-for-byte.
+#[derive(Debug, Serialize)]
+pub struct FinixRepeatPaymentRequest {
+    pub amount: MinorUnit,
+    pub currency: Currency,
+    pub source: String,
+    pub merchant: String,
+    pub tags: Option<serde_json::Value>,
+    pub fraud_session_id: Option<String>,
+    #[serde(rename = "3d_secure_authentication")]
+    pub three_d_secure_authentication: Option<serde_json::Value>,
+    pub idempotency_id: Option<String>,
+    pub statement_descriptor: Option<String>,
+}
+
 pub type FinixRepeatPaymentResponse = FinixAuthorizeResponse;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1646,23 +1666,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
+        // Mirror HS's repeat request exactly: tags is None (serialized as explicit null),
+        // and fraud_session_id / 3d_secure_authentication / statement_descriptor are
+        // present-but-null. HS's Authorize+MandatePayment builder derives these from
+        // metadata/auth/billing, all absent on the MIT path, so they serialize as null.
         Ok(Self {
             amount: router_data.request.minor_amount,
             currency: router_data.request.currency,
             source,
             merchant: merchant_id,
+            tags: None,
+            fraud_session_id: None,
+            three_d_secure_authentication: None,
             idempotency_id: Some(
                 router_data
                     .resource_common_data
                     .connector_request_reference_id
                     .clone(),
             ),
-            tags: Some(serde_json::json!({
-                FINIX_REFERENCE_TAG_KEY: router_data
-                    .resource_common_data
-                    .connector_request_reference_id
-                    .clone(),
-            })),
             statement_descriptor: None,
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -343,17 +343,22 @@ pub type FinixSetupMandateResponse = FinixInstrumentResponse;
 
 // AUTHORIZE FLOW - REQUEST/RESPONSE
 
+// Mirror HS's `FinixPaymentsRequest` field-for-field. HS routes finix `authorize` through
+// `FinixPaymentsRequest`, which serializes tags/fraud_session_id/3d_secure_authentication/
+// statement_descriptor with NO `skip_serializing_if` (so they appear as explicit JSON `null`
+// when None) and sets `tags = None`. Keep the same field order, no skips, and the
+// `3d_secure_authentication` rename so the built request matches the HS ground truth.
 #[derive(Debug, Serialize)]
 pub struct FinixAuthorizeRequest {
     pub amount: MinorUnit,
     pub currency: Currency,
     pub source: String,
     pub merchant: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub idempotency_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fraud_session_id: Option<String>,
+    #[serde(rename = "3d_secure_authentication")]
+    pub three_d_secure_authentication: Option<serde_json::Value>,
+    pub idempotency_id: Option<String>,
     pub statement_descriptor: Option<String>,
 }
 
@@ -507,7 +512,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .connector_request_reference_id
                     .clone(),
             ),
+            // HS emits these as explicit `null` (no skip_serializing_if) for a non-3DS card
+            // authorize; mirror that so the request shapes match byte-for-byte.
             tags: None,
+            fraud_session_id: None,
+            three_d_secure_authentication: None,
             statement_descriptor,
         })
     }

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -641,7 +641,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"probe-mandate-123\",\"merchant\":\"probe_merchant\",\"idempotency_id\":\"\",\"tags\":{\"merchant_reference\":\"\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"probe-mandate-123\",\"merchant\":\"probe_merchant\",\"tags\":null,\"fraud_session_id\":null,\"3d_secure_authentication\":null,\"idempotency_id\":\"\",\"statement_descriptor\":null}"
         }
       }
     },

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -732,7 +732,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"pm_1AbcXyzStripeTestToken\",\"merchant\":\"probe_merchant\",\"idempotency_id\":\"probe_tokenized_txn_001\"}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"source\":\"pm_1AbcXyzStripeTestToken\",\"merchant\":\"probe_merchant\",\"tags\":null,\"fraud_session_id\":null,\"3d_secure_authentication\":null,\"idempotency_id\":\"probe_tokenized_txn_001\",\"statement_descriptor\":null}"
         }
       }
     },


### PR DESCRIPTION


Closes #1773
