### PR TITLE
fix(cybersource): align merchantDefinedInformation ordering and merchant_order_reference_id label with Hyperswitch

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5604,7 +5604,15 @@ fn convert_metadata_to_merchant_defined_info(
     let mut result: Vec<utils::MerchantDefinedInformation> = metadata
         .and_then(|value| value.as_object().cloned())
         .map(|map| {
-            map.into_iter()
+            // Match Hyperswitch's ordering: HS parses the metadata into a
+            // `BTreeMap<String, Value>` (key-sorted) before building the entries,
+            // whereas serde_json here runs with the `preserve_order` feature, so
+            // `as_object()` keeps insertion order. Collect into a BTreeMap so the
+            // merchantDefinedInformation positions are identical on both sides.
+            let sorted: std::collections::BTreeMap<String, serde_json::Value> =
+                map.into_iter().collect();
+            sorted
+                .into_iter()
                 .map(|(key, value)| {
                     let mdi = utils::MerchantDefinedInformation {
                         key: iter,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5620,7 +5620,7 @@ fn convert_metadata_to_merchant_defined_info(
     if let Some(merchant_ref_id) = merchant_order_id {
         result.push(utils::MerchantDefinedInformation {
             key: iter,
-            value: format!("merchant_order_id={merchant_ref_id}"),
+            value: format!("merchant_order_reference_id={merchant_ref_id}"),
         });
     }
 


### PR DESCRIPTION
## What

Cybersource builds `merchantDefinedInformation` entries from the payment metadata plus the
merchant order reference id. Two things diverged from Hyperswitch (the ground truth), both in
`convert_metadata_to_merchant_defined_info` (cybersource `transformers.rs`):

1. **Entry ordering.** HS parses the metadata into a key-sorted `BTreeMap<String, Value>` before
   building the entries. UCS iterated the metadata object in insertion order (serde_json runs with
   the `preserve_order` feature), so the `merchantDefinedInformation` positions — and therefore
   each entry's `key` index — were swapped vs HS (e.g. `brand` vs `kind` at index 0/1).
2. **Trailing entry label.** HS emits `merchant_order_reference_id=<id>`; UCS emitted
   `merchant_order_id=<id>`.

This PR aligns both: collect the metadata into a `BTreeMap` (sorted, like HS) and emit the
`merchant_order_reference_id=` label. The value already flows to UCS over gRPC
(`request.merchant_order_id`) — only the ordering and the literal label were wrong, so this is an
**L3 connector-transformer-only** change.

## Diff signatures (shadow validation)

`#16917` — cybersource · authorize · merchant=flowbird:
```
body.valueDiff.merchantDefinedInformation[3].value =
  { "hyperswitch": "merchant_order_reference_id=23022105", "ucs": "merchant_order_id=23022105" }
```

`#16940` — cybersource · repeat_payment · merchant=flowbird:
```
merchantDefinedInformation[0].value = {hs:'brand="flowbird"',                 ucs:'kind="hourly"'}
merchantDefinedInformation[1].value = {hs:'kind="hourly"',                    ucs:'brand="flowbird"'}
merchantDefinedInformation[2].value = {hs:'merchant_order_reference_id=23022105', ucs:'merchant_order_id=23022105'}
```

## The fix

```rust
// crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
// 1) order metadata entries like HS (key-sorted)
-            map.into_iter()
+            let sorted: std::collections::BTreeMap<String, serde_json::Value> =
+                map.into_iter().collect();
+            sorted
+                .into_iter()
                 .map(|(key, value)| { /* key={value} */ })
// 2) label
-            value: format!("merchant_order_id={merchant_ref_id}"),
+            value: format!("merchant_order_reference_id={merchant_ref_id}"),
```

## Reproduction (local HS↔UCS shadow stack)

```bash
# authorize (#16917): payment carries merchant_order_reference_id
python3 prod-fixes/repro_16917.py

# repeat_payment (#16940): CIT off_session multi_use mandate -> MIT recurring_details(mandate_id)
# carrying metadata{kind,brand} + merchant_order_reference_id
python3 prod-fixes/repro_16940.py
```
The validation service compares the HS vs UCS outbound Cybersource bodies for the flow.

## Verification

| flow | merchantDefinedInformation valueDiff before | after |
|---|---|---|
| authorize (#16917) | `[3].value = {hs:"merchant_order_reference_id=…", ucs:"merchant_order_id=…"}` | `{}` — **no_diff** |
| repeat_payment (#16940) | `[0]/[1]` order swap + `[2]` label diff | `{}` — **no_diff**, no new diffs |
| authorize (#16941) | both: `[0]/[1]` order swap (`brand`/`kind`) + trailing label diff | `{}` — **no_diff** (repro_16941.py) |

Local checks: `cargo fmt --all -- --check`, `cargo build -p connector-integration`,
`cargo clippy -p connector-integration --all-targets -- -D warnings` — all green.



Closes #1730
