### PR TITLE
fix(payload): serialize amount as string and emit processing_id on repeat_payment

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/payload/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/requests.rs
@@ -120,6 +120,8 @@ pub struct PayloadMandateRequestData {
     pub payment_method_id: Secret<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<responses::PayloadPaymentStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processing_id: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -29,7 +29,7 @@ use domain_types::{
     router_data_v2::RouterDataV2,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeOptionInterface, Secret};
+use hyperswitch_masking::{ExposeOptionInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use super::{requests, responses};
@@ -53,6 +53,18 @@ type ResponseError = error_stack::Report<ConnectorError>;
 // Helper function to check if capture method is manual
 fn is_manual_capture(capture_method: Option<enums::CaptureMethod>) -> bool {
     matches!(capture_method, Some(enums::CaptureMethod::Manual))
+}
+
+// Mirror of HS's get_processing_account_id_from_metadata: read the Payload
+// `processing_account_id` from the request metadata so the connector request
+// carries the same `processing_id` HS emits.
+fn get_processing_account_id_from_metadata(
+    metadata: Option<&common_utils::pii::SecretSerdeValue>,
+) -> Option<Secret<String>> {
+    metadata
+        .and_then(|m| m.peek().get("processing_account_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| Secret::new(s.to_string()))
 }
 
 // Auth Struct
@@ -623,12 +635,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
+        // HS sources processing_id from the request metadata for the mandate request.
+        let processing_id =
+            get_processing_account_id_from_metadata(router_data.request.metadata.as_ref());
+
         Ok(Self::PayloadMandateRequest(Box::new(
             requests::PayloadMandateRequestData {
                 amount,
                 transaction_types: requests::TransactionTypes::Payment,
                 payment_method_id: Secret::new(mandate_id),
                 status,
+                processing_id,
             },
         )))
     }

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -29,7 +29,7 @@ use domain_types::{
     router_data_v2::RouterDataV2,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeOptionInterface, PeekInterface, Secret};
+use hyperswitch_masking::{ExposeOptionInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use super::{requests, responses};
@@ -55,14 +55,11 @@ fn is_manual_capture(capture_method: Option<enums::CaptureMethod>) -> bool {
     matches!(capture_method, Some(enums::CaptureMethod::Manual))
 }
 
-// Mirror of HS's get_processing_account_id_from_metadata: read the Payload
-// `processing_account_id` from the request metadata so the connector request
-// carries the same `processing_id` HS emits.
 fn get_processing_account_id_from_metadata(
-    metadata: Option<&common_utils::pii::SecretSerdeValue>,
+    metadata: Option<&serde_json::Value>,
 ) -> Option<Secret<String>> {
     metadata
-        .and_then(|m| m.peek().get("processing_account_id"))
+        .and_then(|m| m.get("processing_account_id"))
         .and_then(|v| v.as_str())
         .map(|s| Secret::new(s.to_string()))
 }
@@ -157,6 +154,7 @@ fn get_filtered_metadata(metadata: Option<&serde_json::Value>) -> Option<serde_j
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
     payment_method_data: &PaymentMethodData<T>,
     connector_config: &ConnectorSpecificConfig,
@@ -165,6 +163,7 @@ fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
     resource_common_data: &PaymentFlowData,
     capture_method: Option<enums::CaptureMethod>,
     is_mandate: bool,
+    metadata: Option<&serde_json::Value>,
 ) -> Result<PayloadCardsRequestData<T>, Error> {
     if let PaymentMethodData::Card(req_card) = payment_method_data {
         let payload_auth = PayloadAuth::try_from((connector_config, currency))?;
@@ -213,7 +212,8 @@ fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
             },
             transaction_types: requests::TransactionTypes::Payment,
             status,
-            processing_id: payload_auth.processing_account_id,
+            processing_id: get_processing_account_id_from_metadata(metadata)
+                .or(payload_auth.processing_account_id),
             customer_id: resource_common_data.connector_customer.clone(),
             description: None,
             attrs: None,
@@ -345,7 +345,8 @@ fn build_payload_bank_account_request_data<T: PaymentMethodDataTypes>(
                 },
                 transaction_types: requests::TransactionTypes::Payment,
                 status,
-                processing_id: payload_auth.processing_account_id,
+                processing_id: get_processing_account_id_from_metadata(metadata)
+                    .or(payload_auth.processing_account_id),
                 customer_id: resource_common_data.connector_customer.clone(),
                 description: resource_common_data.description.clone(),
                 attrs: get_filtered_metadata(metadata),
@@ -393,6 +394,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
+        let metadata = router_data.request.metadata.clone().expose_option();
 
         match router_data.request.amount {
             Some(amount) if amount > 0 => Err(IntegrationError::FlowNotSupported {
@@ -409,6 +411,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 &router_data.resource_common_data,
                 None,
                 true,
+                metadata.as_ref(),
             ),
         }
     }
@@ -442,6 +445,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
+        let metadata = router_data.request.metadata.clone().expose_option();
 
         // Convert amount using PayloadAmountConvertor
         let amount = PayloadAmountConvertor::convert(
@@ -461,12 +465,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     &router_data.resource_common_data,
                     router_data.request.capture_method,
                     is_mandate,
+                    metadata.as_ref(),
                 )?;
 
                 Ok(Self::PayloadPaymentRequest(Box::new(payment_data)))
             }
             PaymentMethodData::BankDebit(bank_debit_data) => {
-                let metadata = router_data.request.metadata.clone().expose_option();
                 let payment_data = build_payload_bank_account_request_data(
                     bank_debit_data,
                     &router_data.connector_config,
@@ -635,9 +639,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
-        // HS sources processing_id from the request metadata for the mandate request.
-        let processing_id =
-            get_processing_account_id_from_metadata(router_data.request.metadata.as_ref());
+        let metadata = router_data.request.metadata.clone().expose_option();
+        let processing_id = get_processing_account_id_from_metadata(metadata.as_ref());
 
         Ok(Self::PayloadMandateRequest(Box::new(
             requests::PayloadMandateRequestData {


### PR DESCRIPTION
## What

Closes HS↔UCS shadow-validation diffs on the **Payload** connector across the
`repeat_payment` (MIT), `authorize` (CIT) and `setup_mandate` flows:

```
body.typeDiff.amount       = {"hyperswitch":"string","ucs":"number"}
body.keyDiff.processing_id = {"hyperswitch":true,"ucs":false}
```

## Root cause (L3, UCS-only)

1. **`amount` type.** Hyperswitch's Payload connector uses `StringMajorUnit` (amount
   serialized as a JSON string, e.g. `"60.00"`), but UCS used `FloatMajorUnit`
   (a JSON number, `60.0`). This affected every Payload flow.
2. **`processing_id`.** HS reads `processing_id` from `metadata.processing_account_id`
   (`get_processing_account_id_from_metadata`), with metadata taking precedence over the
   auth-config `processing_account_id`. On the UCS side:
   - `PayloadMandateRequestData` (repeat_payment) had no `processing_id` field at all.
   - The `authorize` / `setup_mandate` request builders
     (`build_payload_card_request_data` / `build_payload_bank_account_request_data`) only
     used the auth-config `processing_account_id` and ignored request metadata.

   So whenever `processing_account_id` arrived via payment metadata, HS emitted
   `processing_id` and UCS omitted it (keyDiff `hyperswitch:true, ucs:false`).

## Fix

- Switch the Payload amount converter and request amount fields to `StringMajorUnit`
  (matches HS; the live connector already accepts string amounts).
- Add `processing_id: Option<Secret<String>>` to `PayloadMandateRequestData`
  (`skip_serializing_if = "Option::is_none"`), populated in the `RepeatPayment` builder
  from `metadata.processing_account_id`, mirroring HS.
- Thread request metadata into the `authorize` / `setup_mandate` builders and set
  `processing_id = get_processing_account_id_from_metadata(metadata).or(auth.processing_account_id)`,
  mirroring HS exactly.

No proto / domain / HS-mapping change required — purely the Payload connector transformer.

## Reproduce

Local stack (HS :8080 + UCS :8001 + MITM :8095 + VS :9000).

**repeat_payment (#16916):** CIT off-session card payment with a `multi_use` mandate →
reusable `mandate_id`; then an MIT (`recurring_details=mandate_id`, `off_session`,
`metadata.processing_account_id` set) routes to the UCS `RepeatPayment` shadow call.

**authorize (#16935):** a single card payment with `metadata.processing_account_id` set
routes to the UCS `Authorize` shadow call.

**Before** (e.g. `diff_result_authorize:payload:…`):
```
bodyComparison.keyDiff:  {"processing_id":{"hyperswitch":true,"ucs":false}}
bodyComparison.typeDiff: {"amount":{"hyperswitch":"string","ucs":"number"}}
```
**After** (same repro, UCS rebuilt + restarted):
```
bodyComparison.keyDiff:  {}
bodyComparison.typeDiff: {}   → verdict: no_diff
```

## Layer

L3 — UCS connector transformer only (`connectors/payload`).
Fixes an internal validation-diff issue (linked via the Development sidebar).
## Downstream validation diffs resolved by this fix

The payload `repeat_payment` request divergence fixed here (amount type + `processing_id`)
was also the root cause of the downstream **error-response** validation diffs on the same
merchant/flow (`innago` / payload / repeat_payment). With the UCS request now byte-identical
to HS, the payload connector returns the same response to both sides, so the UCS shadow no
longer falls into the `parse_struct("PayloadErrorResponse")` failure path (which dropped the
HTTP status and emitted a generic error). These are resolved by this same fix:
