### PR TITLE
fix(connector): payload repeat_payment — string amount + processing_id

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/payload/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/requests.rs
@@ -120,6 +120,8 @@ pub struct PayloadMandateRequestData {
     pub payment_method_id: Secret<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<responses::PayloadPaymentStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processing_id: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -29,7 +29,7 @@ use domain_types::{
     router_data_v2::RouterDataV2,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeOptionInterface, Secret};
+use hyperswitch_masking::{ExposeOptionInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use super::{requests, responses};
@@ -623,12 +623,25 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
+        // processing_id mirrors hyperswitch's Direct mandate path: it is sourced
+        // solely from the payment metadata's `processing_account_id` (the recurring
+        // flow has no connector-auth fallback), so the shadow UCS request matches
+        // the Direct request byte-for-byte.
+        let processing_id = router_data
+            .request
+            .metadata
+            .as_ref()
+            .and_then(|m| m.peek().get("processing_account_id"))
+            .and_then(|v| v.as_str())
+            .map(|s| Secret::new(s.to_string()));
+
         Ok(Self::PayloadMandateRequest(Box::new(
             requests::PayloadMandateRequestData {
                 amount,
                 transaction_types: requests::TransactionTypes::Payment,
                 payment_method_id: Secret::new(mandate_id),
                 status,
+                processing_id,
             },
         )))
     }

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -145,6 +145,18 @@ fn get_filtered_metadata(metadata: Option<&serde_json::Value>) -> Option<serde_j
     })
 }
 
+/// Source `processing_id` the same way hyperswitch's Direct authorize path does:
+/// the merchant metadata's `processing_account_id` takes precedence, falling back
+/// to the connector auth's `processing_account_id`. Without this the shadow UCS
+/// request omits `processing_id` whenever the id is supplied via metadata (and the
+/// connector auth has none), producing the `keyDiff{processing_id}` shadow diff.
+fn get_processing_id_from_metadata(metadata: Option<&serde_json::Value>) -> Option<Secret<String>> {
+    metadata
+        .and_then(|m| m.get("processing_account_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| Secret::new(s.to_string()))
+}
+
 fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
     payment_method_data: &PaymentMethodData<T>,
     connector_config: &ConnectorSpecificConfig,
@@ -153,6 +165,7 @@ fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
     resource_common_data: &PaymentFlowData,
     capture_method: Option<enums::CaptureMethod>,
     is_mandate: bool,
+    metadata: Option<&serde_json::Value>,
 ) -> Result<PayloadCardsRequestData<T>, Error> {
     if let PaymentMethodData::Card(req_card) = payment_method_data {
         let payload_auth = PayloadAuth::try_from((connector_config, currency))?;
@@ -201,7 +214,8 @@ fn build_payload_card_request_data<T: PaymentMethodDataTypes>(
             },
             transaction_types: requests::TransactionTypes::Payment,
             status,
-            processing_id: payload_auth.processing_account_id,
+            processing_id: get_processing_id_from_metadata(metadata)
+                .or(payload_auth.processing_account_id),
             customer_id: resource_common_data.connector_customer.clone(),
             description: None,
             attrs: None,
@@ -333,7 +347,8 @@ fn build_payload_bank_account_request_data<T: PaymentMethodDataTypes>(
                 },
                 transaction_types: requests::TransactionTypes::Payment,
                 status,
-                processing_id: payload_auth.processing_account_id,
+                processing_id: get_processing_id_from_metadata(metadata)
+                    .or(payload_auth.processing_account_id),
                 customer_id: resource_common_data.connector_customer.clone(),
                 description: resource_common_data.description.clone(),
                 attrs: get_filtered_metadata(metadata),
@@ -381,6 +396,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
+        let metadata = router_data.request.metadata.clone().expose_option();
 
         match router_data.request.amount {
             Some(amount) if amount > 0 => Err(IntegrationError::FlowNotSupported {
@@ -397,6 +413,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 &router_data.resource_common_data,
                 None,
                 true,
+                metadata.as_ref(),
             ),
         }
     }
@@ -440,6 +457,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         match &router_data.request.payment_method_data {
             PaymentMethodData::Card(_) => {
                 let is_mandate = router_data.request.is_mandate_payment();
+                let metadata = router_data.request.metadata.clone().expose_option();
 
                 let payment_data = build_payload_card_request_data(
                     &router_data.request.payment_method_data,
@@ -449,6 +467,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     &router_data.resource_common_data,
                     router_data.request.capture_method,
                     is_mandate,
+                    metadata.as_ref(),
                 )?;
 
                 Ok(Self::PayloadPaymentRequest(Box::new(payment_data)))


### PR DESCRIPTION
## What

Resolves the production shadow-validation diff on **payload / repeat_payment** ([juspay/hyperswitch-cloud#16916](https://github.com/juspay/hyperswitch-cloud/issues/16916)) — two fields where the UCS (prism) outbound request diverged from the proven hyperswitch **Direct** request.

### Diff signature (prod, merchant `innago`)
```
body.keyDiff.processing_id = {"hyperswitch": true, "ucs": false}
body.typeDiff.amount       = {"hyperswitch": "string", "ucs": "number"}
```

## Root cause & fix

1. **`amount` type (`number` → `string`).** prism's payload amount converter was `FloatMajorUnit`, so `amount` serialized as a JSON number (`1344.0`). Direct — and the Payload `/transactions` API — use a quoted string (`"1344.00"`, `StringMajorUnit`). Switched the payload amount converter macro and all request structs to `StringMajorUnit`, matching the hyperswitch reference connector. (Responses are untouched.)

2. **`processing_id` missing.** The `RepeatPayment` builder constructed `PayloadMandateRequestData` without `processing_id`. hyperswitch's Direct mandate path sources it **solely from the payment metadata's `processing_account_id`** (note: the recurring path has *no* connector-auth fallback, unlike Authorize). Added the field and populate it the same way, so the shadow request matches Direct byte-for-byte.

## Verification (local shadow validation service, payload/repeat_payment)

Reproduced a repeat payment (`recurring_details.processor_payment_token` MIT, `metadata.processing_account_id` set, $1344.00 — matching the prod sample) and read the diff from the validation service:

| | `bodyComparison.keyDiff` | `bodyComparison.typeDiff` | `valueDiff` |
|---|---|---|---|
| **BEFORE** (`main`) | `{"processing_id":{"hyperswitch":true,"ucs":false}}` | `{"amount":{"hyperswitch":"string","ucs":"number"}}` | `{}` |
| **AFTER** (this PR) | `{}` | `{}` | `{}` |

BEFORE reproduces the prod signature exactly; AFTER is fully clean. (The only remaining header key is the ignore-listed `x-merchant-id`.)

Fixes juspay/hyperswitch-cloud#16916
