### PR TITLE
fix(cybersource): emit consumerAuthenticationInformation on setup_mandate (#16922)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -95,6 +95,8 @@ pub struct CybersourceZeroMandateRequest<
     payment_information: PaymentInformation<T>,
     order_information: OrderInformationWithBill,
     client_reference_information: ClientReferenceInformation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    consumer_authentication_information: Option<CybersourceConsumerAuthInformation>,
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -360,11 +362,18 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             payment_solution: solution.map(String::from),
             bank_transfer_options: None,
         };
+        let consumer_authentication_information = item
+            .router_data
+            .request
+            .authentication_data
+            .clone()
+            .map(From::from);
         Ok(Self {
             processing_information,
             payment_information,
             order_information,
             client_reference_information,
+            consumer_authentication_information,
         })
     }
 }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -3195,6 +3195,9 @@ pub struct SetupMandateRequestData<T: PaymentMethodDataTypes> {
     /// `Recurring`, `Installment`). Mirrors `RepeatPaymentData.mit_category`.
     pub mit_category: Option<common_enums::MitCategory>,
     pub split_payments: Option<SplitPaymentsDetails>,
+    /// External-authentication (3DS) result threaded into the CIT setup request,
+    /// rendered by connectors such as Cybersource as `consumerAuthenticationInformation`.
+    pub authentication_data: Option<router_request_types::AuthenticationData>,
 }
 
 impl<T: PaymentMethodDataTypes> SetupMandateRequestData<T> {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4050,6 +4050,12 @@ impl<
             .map(|m| ForeignTryFrom::foreign_try_from((m, "connector_testing_data")))
             .transpose()?;
 
+        let authentication_data = value
+            .authentication_data
+            .clone()
+            .map(router_request_types::AuthenticationData::try_from)
+            .transpose()?;
+
         Ok(Self {
             currency: common_enums::Currency::foreign_try_from(amount.currency())?,
             payment_method_data,
@@ -4122,6 +4128,7 @@ impl<
             mit_category: value.mit_category,
             connector_testing_data,
             split_payments: None,
+            authentication_data,
         })
     }
 }
@@ -10036,6 +10043,12 @@ impl<
             other => Some(common_enums::MitCategory::foreign_from(other)),
         };
 
+        let authentication_data = value
+            .authentication_data
+            .clone()
+            .map(router_request_types::AuthenticationData::try_from)
+            .transpose()?;
+
         Ok(Self {
             currency: amount.currency,
             payment_method_data,
@@ -10105,6 +10118,7 @@ impl<
             }),
             mit_category,
             split_payments: None,
+            authentication_data,
         })
     }
 }


### PR DESCRIPTION
## What

Resolves shadow-validation `request_diff` for **cybersource / setup_mandate** (juspay/hyperswitch-cloud#16922).

Prod diff signature:
```
body.keyDiff.consumerAuthenticationInformation = {"hyperswitch": true, "ucs": false}
```
The Direct gateway sent `consumerAuthenticationInformation` (3DS data) on the zero-dollar CIT setup, but the UCS path omitted it.

## Root cause

The proto already carries `AuthenticationData authentication_data = 8` on `PaymentServiceSetupRecurringRequest`, and the domain `SetupRecurringRequest` already copies it from the proto. **But it was never threaded into `SetupMandateRequestData`**, so the cybersource `CybersourceZeroMandateRequest` builder had no `authentication_data` to read and emitted no `consumerAuthenticationInformation`. (The authorize path threads this correctly — setup_mandate was simply missing the same wiring.)

## Fix (no proto change — field already exists)

- `connector_types.rs`: add `authentication_data` to `SetupMandateRequestData`.
- `types.rs`: populate it in **both** proto→domain `ForeignTryFrom` impls that build `SetupMandateRequestData` (from domain `SetupRecurringRequest` — the live `handle_setup_recurring_internal` path — and from `PaymentServiceSetupRecurringRequest`), mirroring the authorize idiom (`AuthenticationData::try_from`).
- `cybersource/transformers.rs`: emit `consumer_authentication_information` in `CybersourceZeroMandateRequest` (`#[serde(skip_serializing_if="Option::is_none")]`), mirroring the cybersource authorize builder.

Pairs with the hyperswitch client PR that sends `authentication_data` on `PaymentServiceSetupRecurringRequest` (the client previously hardcoded it to `None`).

## Verification (real outbound cybersource body via mitm, BEFORE→AFTER)

Direct gRPC `SetupRecurring` to prism (shadow mode) with `authentication_data` populated, captured outbound body to `api.cybersource.com`:

**BEFORE** (main binary) — top-level keys: `clientReferenceInformation, orderInformation, paymentInformation, processingInformation`
→ `keyDiff = {"consumerAuthenticationInformation": {"hyperswitch": true, "ucs": false}}` (reproduces prod)

**AFTER** (this branch) — adds `consumerAuthenticationInformation`:
```json
{
  "ucafCollectionIndicator": "2",
  "cavv": "AAABCSIIAAAAAAAAAAAAAAAAAAA=",
  "ucafAuthenticationData": "AAABCSIIAAAAAAAAAAAAAAAAAAA=",
  "directoryServerTransactionId": "f38e6948-5388-41a6-bca4-b49723c19437",
  "paSpecificationVersion": "2.2.0"
}
```
→ `keyDiff = {}` ✅ (only added key is `consumerAuthenticationInformation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
