### PR TITLE
feat(capture): carry minor_amount_captured in PaymentServiceCaptureResponse

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -10620,6 +10620,10 @@ pub fn generate_payment_capture_response(
                     mandate_reference: mandate_reference_grpc,
                     mandate_reference_details,
                     captured_amount: router_data_v2.resource_common_data.amount_captured,
+                    minor_amount_captured: router_data_v2
+                        .resource_common_data
+                        .minor_amount_captured
+                        .map(|amount| amount.get_amount_as_i64()),
                     connector_feature_data: convert_connector_metadata_to_secret_string(
                         connector_metadata,
                     ),
@@ -10687,6 +10691,7 @@ pub fn generate_payment_capture_response(
                 mandate_reference: None,
                 mandate_reference_details: None,
                 captured_amount: None,
+                minor_amount_captured: None,
                 connector_feature_data: None,
                 connector_response,
                 splits: None,

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3039,6 +3039,12 @@ message PaymentServiceCaptureResponse {
 
   // Raw Response for debugging
   optional SecretString raw_connector_response = 16;
+
+  // Captured amount in minor currency units, as set by the connector transformer.
+  // Distinct from captured_amount (field 9): this mirrors the connector's
+  // minor_amount_captured, which some connectors (e.g. PayPal) leave unset even
+  // when captured_amount is present. Lets the caller avoid re-deriving it.
+  optional int64 minor_amount_captured = 18;
 }
 
 // Request message for creating an order

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3034,6 +3034,7 @@ message PaymentServiceCaptureResponse {
 
   // Mandate reference details returned by the connector for future recurring payments.
   optional MandateReferenceDetails mandate_reference_details = 15;
+
   // The connector's reported status (code/message/reason).
   optional RawConnectorStatus raw_connector_status = 17;
 


### PR DESCRIPTION
Closes #1690

---
**Re-detection — also fixes internal tracking issues / #17118, #20698** (paypal / `capture, server_authentication_token`, signature `router.typeDiff:minor_amount_captured`).
Same paypal-capture `minor_amount_captured` family as #16970/#16995/#17051/#17052/#20698.
This PR adds `minor_amount_captured` to `PaymentServiceCaptureResponse` (field number **18**
after a rebase onto main required renumbering past newly-added fields 15-17) plus the
`generate_payment_capture_response` mapping. Re-verified GREEN locally on latest main — see
proof comment.

Verified locally: paired with the matching HS-side `capture_gateway.rs` mapping fix
(hyperswitch PR #12903), a fresh capture repro shows `differences_found: false` with
`minor_amount_captured: null` and `amount_captured: 6000` identical on both the native
HS and UCS-shadow sides.
