### PR TITLE
feat(stripe): carry mandate_metadata on payment response MandateReference (#16966)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
@@ -1369,6 +1369,7 @@ where
             .registration_id
             .clone()
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1783,6 +1784,7 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<AciMandateResponse, Self>) -> Result<Self, Self::Error> {
         let mandate_reference = Some(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -4715,6 +4715,7 @@ pub fn get_adyen_response(
         .as_ref()
         .and_then(|data| data.recurring_detail_reference.to_owned())
         .map(|mandate_id| MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(mandate_id.expose()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,
@@ -5117,6 +5118,7 @@ pub fn get_webhook_response(
             .recurring_detail_reference
             .as_ref()
             .map(|mandate_id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(mandate_id.clone().expose()),
                 payment_method_id: response.recurring_shopper_reference.clone(),
                 connector_mandate_request_reference_id: None,
@@ -5493,6 +5495,7 @@ pub(crate) fn get_adyen_mandate_reference_from_webhook(
         .as_ref()
         .map(|mandate_id| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(mandate_id.peek().to_string()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
@@ -1607,6 +1607,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<AirwallexSetupMandate
             .payment_consent_id
             .clone()
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 // Surface the Airwallex payment_method.id so the MIT transformer can
                 // reference it as `payment_method.id`.

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2162,6 +2162,7 @@ impl<
                         .profile
                         .as_ref()
                         .map(|profile| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(format!(
                                 "{}-{}",
                                 profile.customer_profile_id, profile.customer_payment_profile_id
@@ -2685,6 +2686,7 @@ pub fn convert_to_payments_response_data_or_error(
                             .and_then(|list| list.first().cloned());
 
                         MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: profile_response
                                 .customer_profile_id
                                 .as_ref()
@@ -3136,6 +3138,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 redirection_data: None,
                 connector_metadata: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
@@ -1336,6 +1336,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             resource_id: ResponseId::NoResponseId,
             redirection_data: None,
             mandate_reference: Some(Box::new(domain_types::connector_types::MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(connector_mandate_id.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -531,6 +531,7 @@ fn get_payment_response(
                     .token_information
                     .clone()
                     .map(|token_info| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: token_info
                             .payment_instrument
                             .map(|payment_instrument| payment_instrument.id.expose()),
@@ -2282,6 +2283,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaSetupMandatesResponse, Self>>
                         .token_information
                         .clone()
                         .map(|token_info| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: token_info
                                 .payment_instrument
                                 .map(|payment_instrument| payment_instrument.id.expose()),

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -1093,6 +1093,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     .as_ref()
                     .and_then(|token_info| token_info.payment_instrument.as_ref())
                     .map(|payment_instrument| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(payment_instrument.id.clone().expose()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -404,6 +404,7 @@ impl<F, T> TryFrom<ResponseRouterData<BillwerkPaymentsResponse, Self>>
         };
         let mandate_reference = response.recurring_payment_method.as_ref().map(|rpm| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(rpm.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -698,6 +698,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -952,6 +953,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -993,6 +995,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -2937,6 +2940,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -3232,6 +3236,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .id
                     .expose();
                 let mandate_reference = Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(payment_method_id.clone()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -1664,6 +1664,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .as_ref()
                 .and_then(|src| src.id.clone())
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -1784,6 +1785,7 @@ impl<
                     .as_ref()
                     .and_then(|src| src.id.clone())
                     .map(|id| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(id),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -1907,6 +1909,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .as_ref()
             .and_then(|src| src.id.clone())
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -2005,6 +2008,7 @@ impl<F> TryFrom<ResponseRouterData<PaymentsResponse, Self>>
                 .as_ref()
                 .and_then(|src| src.id.clone())
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: Some(item.response.id.clone()),

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -3357,6 +3357,7 @@ fn get_payment_response(
                     .token_information
                     .clone()
                     .map(|token_info| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: token_info
                             .payment_instrument
                             .map(|payment_instrument| payment_instrument.id.expose()),
@@ -4310,6 +4311,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                 .token_information
                 .clone()
                 .map(|token_info| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: token_info
                         .payment_instrument
                         .map(|payment_instrument| payment_instrument.id.expose()),

--- a/crates/integrations/connector-integration/src/connectors/dlocal.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal.rs
@@ -241,6 +241,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .and_then(|w| w.token.clone())
             .map(|token| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(token.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -1002,6 +1002,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         }
 
         let mandate_reference = saved_card_id.map(|card_id| MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(card_id),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -806,6 +806,7 @@ impl<
                     };
                 let mandate_reference = ssl_token.map(|token| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: None,
                         payment_method_id: Some(token),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -562,6 +562,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
                         redirection_data: None,
                         mandate_reference: Some(Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: response.source.clone().map(|id| id.expose()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,
@@ -680,6 +681,7 @@ impl TryFrom<ResponseRouterData<FinixPSyncResponse, Self>>
         // Surface the stored Payment Instrument (`source`) as the mandate reference and
         // propagate AVS / network details via `connector_response`.
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: response.source.as_ref().map(|s| s.clone().expose()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,
@@ -817,6 +819,7 @@ impl TryFrom<ResponseRouterData<FinixCaptureResponse, Self>>
                 ),
                 redirection_data: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: response.source.clone().map(|id| id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1541,6 +1544,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .map(|_| id.clone());
 
                 let mandate_reference = Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.clone()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1740,6 +1744,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 resource_id: ResponseId::ConnectorTransactionId(response.id.clone()),
                 redirection_data: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: response.source.clone().map(|id| id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
@@ -455,6 +455,7 @@ impl FiservcommercehubPaymentTokens {
             })
             .map(|token| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: token.token_data.as_ref().map(|t| t.peek().clone()),
                     payment_method_id: token.token_source.clone(),
                     connector_mandate_request_reference_id: original_txn_id,

--- a/crates/integrations/connector-integration/src/connectors/fiuu.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu.rs
@@ -998,6 +998,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         .and_then(|extra| extra.token)
                         .map(|token| {
                             Box::new(domain_types::connector_types::MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(token.expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -1436,6 +1436,7 @@ where
                             .as_ref()
                             .and_then(|extra_p| {
                                 extra_p.token.as_ref().map(|token| MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(token.clone().expose()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,
@@ -2002,6 +2003,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuPaymentResponse, Self>>
                         serde_json::from_str(&extra_p.clone().expose());
                     match mandate_token {
                         Ok(token) => token.token.as_ref().map(|token| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token.clone().expose()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
@@ -1382,6 +1382,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<GlobalpaySetupMandate
         // surface the PMT_ id through MandateReference.connector_mandate_id for
         // later RepeatPayment use and leave resource_id as NoResponseId.
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
@@ -677,6 +677,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ) -> Result<Self, Self::Error> {
         let status = common_enums::AttemptStatus::from(item.response.clone());
         let mandate_reference = MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.transaction_id.to_string()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -536,11 +536,13 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
 
             let mandate_reference = connector_mandate_id
                 .map(|mandate_id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(mandate_id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id,
                 })
                 .unwrap_or(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: None,
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -864,6 +864,7 @@ impl TryFrom<&responses::JpmorganPaymentsResponse> for PaymentsResponseData {
         // credential. Surface it as the `connector_mandate_id` so the framework can
         // pass it back on subsequent MIT charges.
         let mandate_reference = MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.transaction_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -431,6 +431,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             .payment_instrument
             .payment_instrument_id
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1223,6 +1224,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .payment_instrument
                 .payment_instrument_id
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1431,6 +1433,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .payment_instrument
                 .payment_instrument_id
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -2093,6 +2093,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NexixpaySetupMandateR
         // it sent — NOT the one-shot `operationId` (that is kept on
         // connector_metadata / preprocessing_id below for the 3DS continuation).
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(operation.order_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -753,6 +753,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
                 redirection_data: None,
                 mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(vault_id.clone().expose()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,
@@ -1789,6 +1790,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let mandate_reference = connector_mandate_id.clone().map(|id| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(id),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -635,6 +635,7 @@ impl<F, T> TryFrom<ResponseRouterData<NoonPaymentsResponse, Self>>
         });
         let mandate_reference = item.response.result.subscription.map(|subscription_data| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(subscription_data.identifier.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1445,6 +1446,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
         });
         let mandate_reference = item.response.result.subscription.map(|subscription_data| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(subscription_data.identifier.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1668,6 +1670,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .subscription
             .map(|subscription_data| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(subscription_data.identifier.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -793,6 +793,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -899,6 +900,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1001,6 +1003,7 @@ impl<
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1520,6 +1523,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetPSyncResponse, Self>>
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -2506,6 +2510,7 @@ impl TryFrom<NovalnetWebhookNotificationResponse> for WebhookDetailsResponse {
                             mandate_reference: mandate_reference_id
                                 .as_ref()
                                 .map(|id| MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(id.clone()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -2694,6 +2694,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .and_then(|po| po.user_payment_option_id.clone())
             .map(|id| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -1287,6 +1287,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PayboxSetupMandateRes
                 None => None,
             };
             let mandate_reference = Some(Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: carrier_with_expiry,
                 payment_method_id: None,
                 connector_mandate_request_reference_id: item
@@ -1543,6 +1544,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PayboxRepeatPaymentRe
                     .connector_mandate_id()
                     .map(|packed_mandate_id| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(packed_mandate_id),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: item

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -702,6 +702,7 @@ fn handle_payment_response<F, T>(
                     .clone()
                     .expose_option();
                 connector_payment_method_id.map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2488,6 +2488,7 @@ where
                     resource_id: order_id,
                     redirection_data: None,
                     mandate_reference: Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: match item.response.payment_source.clone() {
                             Some(paypal_source) => match paypal_source {
                                 PaymentSourceItemResponse::Paypal(paypal_source) => {
@@ -3105,6 +3106,7 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalSetupMandatesResponse, Self>>
         let info_response = item.response;
 
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(info_response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -630,6 +630,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PaysafeAuthorizeRespo
                 .payment_handle_token
                 .as_ref()
                 .map(|token| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(token.peek().to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -901,6 +901,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     // Use the transaction_id as the connector_mandate_id
                     // This ID will be used as a reference for subsequent MIT payments
                     let mandate_reference = Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(data.transaction_id.clone()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -942,6 +942,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PowertranzSetupMandat
             // The PowerTranz transaction_identifier IS the connector_mandate_id
             // used for subsequent RepeatPayment (MIT) calls.
             let mandate_reference = Some(Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(response.transaction_identifier.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -790,6 +790,7 @@ impl<F, Req> TryFrom<ResponseRouterData<PproPaymentsResponse, Self>>
         // so callers can use it for subsequent RepeatPayment charges.
         let mandate_reference = item.response.instrument_id.as_ref().map(|instr_id| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(instr_id.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1420,6 +1421,7 @@ impl<F, Req> TryFrom<ResponseRouterData<PproAgreementResponse, Self>>
 
         // The agreement ID is stored as the mandate reference (connector_mandate_id)
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1276,6 +1276,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                             {
                                 connector_customer = Some(cus.to_owned());
                                 let mandate_reference = Some(Box::new(MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(card.to_owned()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
@@ -468,6 +468,7 @@ impl Revolv3SaleResponse {
         } else {
             let mandate_reference = self.payment_method_id.as_ref().map(|connector_mandate_id| {
                 domain_types::connector_types::MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id.to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -501,6 +502,7 @@ impl Revolv3AuthorizeResponse {
         let mandate_reference = self.payment_method.as_ref().and_then(|pm| {
             pm.payment_method_id.map(|connector_mandate_id| {
                 domain_types::connector_types::MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id.to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -680,6 +682,7 @@ impl TryFrom<ResponseRouterData<Revolv3PaymentSyncResponse, Self>>
                     .payment_method_id
                     .map(
                         |connector_mandate_id| domain_types::connector_types::MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(connector_mandate_id.to_string()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -1658,6 +1658,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4SetupMandateRes
                 // downstream detect an unusable mandate.
                 let mandate_reference = item.response.card.as_ref().map(|card| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(card.id.clone()),
                         payment_method_id: Some(card.id.clone()),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -1312,6 +1312,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StaxSetupMandateRespo
 
         let mandate_reference = mandate_token.map(|token| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(token),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -2704,7 +2704,7 @@ where
             let connector_mandate_id = Some(payment_method_id.clone().expose());
             let payment_method_id = Some(payment_method_id.expose());
 
-            let _mandate_metadata: Option<Secret<Value>> =
+            let mandate_metadata: Option<Secret<Value>> =
                 match item.router_data.request.get_split_payment_data() {
                     Some(
                         SplitPaymentsDetails::StripeSplitPayment(
@@ -2713,12 +2713,14 @@ where
                     ) => Some(Secret::new(serde_json::json!({
                         "transfer_account_id": stripe_split_data.transfer_account_id,
                         "charge_type": stripe_split_data.charge_type,
-                        "application_fees": stripe_split_data.application_fees
+                        "application_fees": stripe_split_data.application_fees,
+                        "on_behalf_of": stripe_split_data.on_behalf_of,
 }))),
                     _ => None
 };
 
             MandateReference {
+                mandate_metadata,
                 connector_mandate_id,
                 payment_method_id,
                 connector_mandate_request_reference_id: None
@@ -3012,6 +3014,7 @@ impl<F> TryFrom<ResponseRouterData<PaymentIntentSyncResponse, Self>>
                     get_payment_method_id(item.response.latest_charge.clone(), payment_method_id);
 
                 MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(payment_method_id.clone()),
                     payment_method_id: Some(payment_method_id),
                     connector_mandate_request_reference_id: None,
@@ -3155,6 +3158,7 @@ impl<F, T> TryFrom<ResponseRouterData<SetupMandateResponse, Self>>
             let connector_mandate_id = Some(payment_method_id.clone());
             let payment_method_id = Some(payment_method_id);
             MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id,
                 payment_method_id,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -2789,6 +2789,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // The instance_id serves as the connector_mandate_id for future recurring payments
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(response.instance_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
@@ -1829,6 +1829,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         // This will be used as parenttransactionreference in RepeatPayment
         let mandate_reference = response.transactionreference.as_ref().map(|txn_ref| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(txn_ref.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -1162,6 +1162,7 @@ fn get_setup_mandate_response(
         resource_id: ResponseId::ConnectorTransactionId(transaction_id.clone()),
         redirection_data: None,
         mandate_reference: Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(transaction_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -3643,6 +3643,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         let path_a_mandate_id = format!("ntid:{ntid_source}");
         let mandate_reference = Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(path_a_mandate_id),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
@@ -1428,6 +1428,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<WellsfargoPaymentsRes
                 .and_then(|token_info| token_info.payment_instrument.as_ref())
                 .map(|instrument| {
                     domain_types::connector_types::MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(instrument.id.clone().expose()),
                         payment_method_id: None, // Could potentially use token_information.customer.id here if needed
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -829,6 +829,7 @@ impl<F, T>
                     res.description.clone(),
                     None,
                     res.token.as_ref().map(|mandate_token| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(mandate_token.href.clone().expose()),
                         payment_method_id: Some(mandate_token.token_id.clone()),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
@@ -507,6 +507,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                 },
                 mandate_reference: match is_mandate_payment(&router_data.request) {
                     true => Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(response.payment_method.id.expose()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
@@ -649,6 +649,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<ZiftAuthPaymentsRespo
                 {
                     item.response.token.clone().map(|token| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,
@@ -1139,6 +1140,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     redirection_data: None,
                     mandate_reference: item.response.token.clone().map(|token| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/internal/field-probe/src/requests.rs
+++ b/crates/internal/field-probe/src/requests.rs
@@ -193,6 +193,7 @@ pub(crate) fn base_recurring_charge_request() -> RecurringPaymentServiceChargeRe
         return_url: Some("https://example.com/recurring-return".to_string()),
         payment_method_type: Some(proto::PaymentMethodType::PayPal as i32),
         connector_recurring_payment_id: Some(MandateReference {
+            mandate_metadata: None,
             mandate_id_type: Some(MandateIdType::ConnectorMandateId(
                 ConnectorMandateReferenceId {
                     connector_mandate_id: Some("probe-mandate-123".to_string()),

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -1815,6 +1815,7 @@ pub struct MandateReference {
     pub connector_mandate_id: Option<String>,
     pub payment_method_id: Option<String>,
     pub connector_mandate_request_reference_id: Option<String>,
+    pub mandate_metadata: Option<SecretSerdeValue>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8175,12 +8175,11 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                     .collect()
             })
             .unwrap_or_default();
-        let mandate_reference_grpc =
-            value
-                .mandate_reference
-                .map(|m| {
-                    grpc_api_types::payments::MandateReference {
-                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
+        let mandate_reference_grpc = value.mandate_reference.map(|m| {
+            grpc_api_types::payments::MandateReference {
+                mandate_metadata: convert_connector_metadata_to_secret_string(
+                    m.mandate_metadata.map(|v| v.expose()),
+                ),
                 mandate_id_type: Some(
                     grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                         grpc_payment_types::ConnectorMandateReferenceId {
@@ -8192,7 +8191,7 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                     ),
                 ),
             }
-                });
+        });
         let payment_method_update_grpc = value.payment_method_update.map(|update| {
             grpc_api_types::payments::PaymentMethodUpdate {
                 payment_method_update_data: Some(match update {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8175,8 +8175,11 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                     .collect()
             })
             .unwrap_or_default();
-        let mandate_reference_grpc = value.mandate_reference.map(|m| {
-            grpc_api_types::payments::MandateReference {
+        let mandate_reference_grpc =
+            value
+                .mandate_reference
+                .map(|m| {
+                    grpc_api_types::payments::MandateReference {
                 mandate_metadata: convert_connector_metadata_to_secret_string(
                     m.mandate_metadata.map(|v| v.expose()),
                 ),
@@ -8191,7 +8194,7 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                     ),
                 ),
             }
-        });
+                });
         let payment_method_update_grpc = value.payment_method_update.map(|update| {
             grpc_api_types::payments::PaymentMethodUpdate {
                 payment_method_update_data: Some(match update {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5788,6 +5788,7 @@ pub fn generate_payment_authorize_response<T: PaymentMethodDataTypes>(
             } => {
                 let mandate_reference_grpc =
                     mandate_reference.map(|m| grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
@@ -6738,6 +6739,7 @@ pub fn generate_payment_void_response(
 
                 let mandate_reference_grpc =
                     mandate_reference.map(|m| grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
@@ -7120,6 +7122,7 @@ pub fn generate_payment_sync_response(
 
                 let mandate_reference_grpc =
                     mandate_reference.map(|m| grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
@@ -8177,6 +8180,7 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                 .mandate_reference
                 .map(|m| {
                     grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                 mandate_id_type: Some(
                     grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                         grpc_payment_types::ConnectorMandateReferenceId {
@@ -10010,6 +10014,7 @@ pub fn generate_payment_capture_response(
 
                 let mandate_reference_grpc =
                     mandate_reference.map(|m| grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
@@ -11065,6 +11070,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
             } => {
                 let mandate_reference_grpc =
                     mandate_reference.map(|m| grpc_api_types::payments::MandateReference {
+                        mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId { connector_mandate_id: m.connector_mandate_id,
                         payment_method_id: m.payment_method_id,
@@ -13090,6 +13096,7 @@ pub fn generate_repeat_payment_response<T: PaymentMethodDataTypes>(
                     ),
                     mandate_reference: mandate_reference.map(|m| {
                         grpc_api_types::payments::MandateReference {
+                            mandate_metadata: convert_connector_metadata_to_secret_string(m.mandate_metadata.map(|v| v.expose())),
                             mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(grpc_api_types::payments::ConnectorMandateReferenceId {
                             connector_mandate_id: m.connector_mandate_id,
                             payment_method_id: m.payment_method_id,

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -1205,6 +1205,11 @@ message MandateReference {
     // txns along with network token data
     NetworkTokenWithNTI network_token_with_nti = 3;
   }
+
+  // Connector-specific metadata associated with the mandate (e.g. Stripe
+  // split-payment details). Serialized JSON object; mirrors hyperswitch's
+  // MandateReference.mandate_metadata on the Direct gateway.
+  optional SecretString mandate_metadata = 4;
 }
 
 message ConnectorMandateReferenceId {

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -115,6 +115,7 @@ const _SECRET_STRING_FIELDS: Record<string, readonly string[]> = {
   Address: ["firstName", "lastName", "line1", "line2", "line3", "city", "state", "zipCode", "email", "phoneNumber"],
   AccessToken: ["token"],
   BillingDescriptor: ["name", "city", "phone"],
+  MandateReference: ["mandateMetadata"],
   NetworkTokenWithNTI: ["tokenExpMonth", "tokenExpYear"],
   TaxInfo: ["customerTaxRegistrationId", "merchantTaxRegistrationId"],
   AirlinePassenger: ["passportNumber", "ticketNumber"],


### PR DESCRIPTION
## What

Fixes #16966 — shadow-validation `router_diff` for **yucca / stripe / repeat_payment**:

```
router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata
```
(hyperswitch=`object`, ucs=`null`)

## Root cause

On the Direct gateway, hyperswitch's Stripe connector populates
`MandateReference.mandate_metadata` with the Stripe split-payment details
(`transfer_account_id` / `charge_type` / `application_fees` / `on_behalf_of`)
whenever a mandate is created on the payment response. The UCS path dropped it
at every layer:

- the proto `MandateReference` message had **no** `mandate_metadata` field;
- the domain `MandateReference` response struct had no such field, and the
  Stripe transformer computed the value into a throwaway `_mandate_metadata`;
- so hyperswitch's UCS client mapped it back to `None` → serialized `null`.

## Fix

- proto: add `optional SecretString mandate_metadata = 4` to `MandateReference`.
- domain: add `mandate_metadata: Option<SecretSerdeValue>` to the response
  `MandateReference`; thread it through all domain→proto conversions
  (serialized via the existing `convert_connector_metadata_to_secret_string`).
- Stripe transformer: populate it from the split-payment data (now including
  `on_behalf_of`, matching the Direct gateway).
- All other connectors default the new field to `None` (no behaviour change).

Paired hyperswitch PR (UCS client mapping + rev-pin): juspay/hyperswitch#PENDING.

## Verification (local shadow stack)

Repeat payment fired with Stripe split-payment data; a synthetic Stripe success
was injected at the mitm proxy so both Direct and UCS produce a real
`MandateReference` (sandbox creds can't drive a Connect split — same approach as
the `charges` sibling #16965). Router-data comparison for the Authorize sub-flow
of the repeat_payment, x-request-id `019ef547-3f98-7b00-a7f2-d51a86ec34ff`:

**Before** (prod): `typeDiff` includes
`response.Ok.TransactionResponse.mandate_reference.mandate_metadata {hyperswitch:"object", ucs:"null"}`.

**After** (this PR):
```json
"keyDiff": {}, "valueDiff": {},
"typeDiff": {
  "request.integrity_object": {"hyperswitch":"object","ucs":"null"},
  "response.Ok.TransactionResponse.charges": {"hyperswitch":"object","ucs":"null"}
}
```
`mandate_reference.mandate_metadata` is **gone** — UCS now emits
`mandate_reference.mandate_metadata` matching Direct, with no new key/value diff.
The two remaining type diffs are out of scope: `request.integrity_object` is a
pre-existing benign diff, and `response...charges` is the separate sibling
#16965 (its fix is not in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
