### PR TITLE
fix(authorizedotnet): mirror HS error message on create_connector_customer failure

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2489,7 +2489,7 @@ pub struct ResponseMessage {
     pub text: String,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize, strum::Display)]
 #[serde(rename_all = "PascalCase")]
 pub enum ResultCode {
     #[default]
@@ -3546,11 +3546,15 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetCreateConnectorCustomerResponse, 
                         status_code: http_code,
                     });
                 } else {
-                    // Couldn't extract ID, return error
+                    // Couldn't extract ID, return error.
+                    // Mirror HS native: surface the result_code ("Error") as `message` and
+                    // the connector text as `reason`, and mark the router-level status as
+                    // Failure (HS sets RouterData.status = Failure here).
+                    new_router_data.resource_common_data.status = AttemptStatus::Failure;
                     new_router_data.response = Err(ErrorResponse {
                         status_code: http_code,
                         code: error_code.to_string(),
-                        message: error_text.to_string(),
+                        message: response.messages.result_code.to_string(),
                         reason: Some(error_text.to_string()),
                         attempt_status: Some(FlowStatus::Payment(AttemptStatus::Failure)), // Marking attempt as failure since we couldn't confirm existing profile ID
                         connector_transaction_id: None,
@@ -3560,11 +3564,14 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetCreateConnectorCustomerResponse, 
                     });
                 }
             } else {
-                // Other error - return error response
+                // Other error - return error response.
+                // Mirror HS native: `message` = result_code ("Error"), `reason` = connector
+                // text, and set the router-level status to Failure (HS sets it here too).
+                new_router_data.resource_common_data.status = AttemptStatus::Failure;
                 new_router_data.response = Err(ErrorResponse {
                     status_code: http_code,
                     code: error_code.to_string(),
-                    message: error_text.to_string(),
+                    message: response.messages.result_code.to_string(),
                     reason: Some(error_text.to_string()),
                     attempt_status: Some(FlowStatus::Payment(AttemptStatus::Failure)), // Marking attempt as failure for non-duplicate errors
                     connector_transaction_id: None,


### PR DESCRIPTION
## What

When authorize.net's `createCustomerProfile` fails — e.g. **E00041** `"One or more fields in the profile must contain a value."` (an empty customer profile: no `merchantCustomerId`, no `email`, no `shipTo`) — the UCS `CreateConnectorCustomer` response transformer diverged from HS-native:

| field | HS-native | UCS (before) |
|---|---|---|
| `response.Err.message` | `"Error"` (the `resultCode`) | the verbatim connector text |

HS-native puts the `resultCode` Display string in `message` and the connector text in `reason`. This PR makes UCS do the same:

- derive `strum::Display` on `ResultCode`;
- in both error branches of the `CreateConnectorCustomer` response handler, emit `response.messages.result_code.to_string()` as `message` (so it renders `"Error"`), keeping the connector text in `reason`;
- set `resource_common_data.status = Failure` on the error path, mirroring the existing `SetupMandate` handler (internal parity; the create-customer error is terminal).

## Diff signature
`router.valueDiff:status` (router-data comparison) — the `status` half is closed by the companion HS PR; this PR closes the `response.Err.message` half.

## Repro (local stack)
`createCustomerProfile` forced to fail with E00041 via a mandate-setup CIT whose customer profile is empty (customer_id > 20 chars so `merchantCustomerId` is dropped, no email, no shipping). Reading the router-data comparison for the `CreateConnectorCustomer` sub-flow:

- **before:** `valueDiff = {status:{hs:failure,ucs:payment_method_awaited}, response.Err.message:{hs:"Error",ucs:"One or more fields in the profile must contain a value."}}`
- **after (this PR + HS PR):** `differences_found: false` — `valueDiff/keyDiff/typeDiff` all empty.

## Layer
L3 — connector response transformer only (no proto change).

Companion HS PR: juspay/hyperswitch#12916 (closes the `status` half).

Closes #1638

---
**Re-detection:** also closes the message half re-reported as Fixes internal tracking issue (prod, merchant innago, stale build 2026.06.17.0). Same E00041 empty-customer-profile event as #16990/#16991. The companion status half (#17062) is owned by HS PR juspay/hyperswitch#12916.
