### PR TITLE
fix(connector): mirror hyperswitch DLOCAL for OXXO + Card

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/dlocal.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal.rs
@@ -492,8 +492,11 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             let base_url = self.connector_base_url_payments(req);
+            // hyperswitch dlocal routes all Authorize traffic to /secure_payments. Mirror
+            // that for the in-scope HS-parity flows (Card + Voucher/OXXO) while leaving
+            // wallet / bank-transfer / bank-debit on /payments, where they currently work.
             match &req.request.payment_method_data {
-                PaymentMethodData::Card(_) => {
+                PaymentMethodData::Card(_) | PaymentMethodData::Voucher(_) => {
                     Ok(format!("{base_url}secure_payments"))
                 }
                 _ => Ok(format!("{base_url}payments")),

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -138,6 +138,8 @@ pub struct ThreeDSecureReqData {
 pub enum PaymentMethodId {
     #[default]
     Card,
+    #[serde(rename = "OX")]
+    Oxxo,
     #[serde(untagged)]
     Other(String),
 }
@@ -375,16 +377,22 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     Ok(payment_request)
                 }
             }
-            // Redirect-flow cash vouchers (e.g. OXXO, Boleto, Efecty, PagoEfectivo,
-            // RedPagos, Indomaret).
+            // OXXO uses Direct flow (mirroring hyperswitch dlocal); other cash vouchers
+            // (Boleto, Efecty, PagoEfectivo, RedPagos, Indomaret) are UCS-only and use
+            // Redirect. All vouchers keep notification_url so dLocal can webhook the
+            // merchant when the cash payment is settled out-of-band at the store.
             PaymentMethodData::Voucher(ref voucher_data) => {
                 let payment_method_id = get_voucher_payment_method_id(voucher_data)?;
-                let webhook_url = item.router_data.request.webhook_url.clone();
+                let payment_method_flow = match voucher_data {
+                    payment_method_data::VoucherData::Oxxo => PaymentMethodFlow::Direct,
+                    _ => PaymentMethodFlow::Redirect,
+                };
+                let notification_url = item.router_data.request.webhook_url.clone();
                 let payment_request = Self {
                     amount,
                     currency: item.router_data.request.currency,
                     payment_method_id,
-                    payment_method_flow: PaymentMethodFlow::Redirect,
+                    payment_method_flow,
                     country,
                     payer: Payer {
                         name,
@@ -399,7 +407,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     three_dsecure: None,
                     callback_url,
                     description,
-                    notification_url: webhook_url,
+                    notification_url,
                 };
                 Ok(payment_request)
             }
@@ -1166,6 +1174,11 @@ pub struct ThreeDSecureResData {
     pub redirect_url: Option<url::Url>,
 }
 
+#[derive(Eq, Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TicketData {
+    pub image_url: Option<url::Url>,
+}
+
 #[derive(Debug, Default, Eq, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DlocalPaymentsResponse {
     status: DlocalPaymentStatus,
@@ -1173,6 +1186,7 @@ pub struct DlocalPaymentsResponse {
     three_dsecure: Option<ThreeDSecureResData>,
     order_id: Option<String>,
     redirect_url: Option<url::Url>,
+    ticket: Option<TicketData>,
 }
 
 impl<F, T> TryFrom<ResponseRouterData<DlocalPaymentsResponse, Self>>
@@ -1182,11 +1196,18 @@ impl<F, T> TryFrom<ResponseRouterData<DlocalPaymentsResponse, Self>>
     fn try_from(
         item: ResponseRouterData<DlocalPaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Check for redirect URL from both 3DS (card) and top-level (bank transfer/APM) responses
+        // Check for redirect URL from 3DS (card), ticket.image_url (vouchers, e.g. OXXO,
+        // mirroring hyperswitch dlocal), and top-level redirect_url (UCS-only APMs such as
+        // bank transfer / wallet).
         let redirection_data = item
             .response
             .three_dsecure
             .and_then(|three_secure_data| three_secure_data.redirect_url)
+            .or_else(|| {
+                item.response
+                    .ticket
+                    .and_then(|ticket_data| ticket_data.image_url)
+            })
             .or(item.response.redirect_url)
             .map(|redirect_url| RedirectForm::from((redirect_url, Method::Get)));
 
@@ -1501,7 +1522,7 @@ fn get_voucher_payment_method_id(
     voucher_data: &payment_method_data::VoucherData,
 ) -> Result<PaymentMethodId, error_stack::Report<IntegrationError>> {
     match voucher_data {
-        payment_method_data::VoucherData::Oxxo => Ok(PaymentMethodId::Other("OX".to_string())),
+        payment_method_data::VoucherData::Oxxo => Ok(PaymentMethodId::Oxxo),
         payment_method_data::VoucherData::Boleto(_) => Ok(PaymentMethodId::Other("BL".to_string())),
         payment_method_data::VoucherData::Efecty => Ok(PaymentMethodId::Other("EY".to_string())),
         payment_method_data::VoucherData::PagoEfectivo => {


### PR DESCRIPTION
## Summary

Bring UCS `dlocal` to one-to-one parity with hyperswitch `dlocal` for **OXXO** and **Card**, without disturbing UCS-only PMTs (wallets, bank-transfer, bank-debit).

Four changes:

1. **Authorize URL** routes Card *and* Voucher (OXXO) to `/secure_payments`; UCS-only redirect APMs continue to use `/payments`.
2. **OXXO request** now sends `payment_method_flow=Direct` (was `Redirect`), matching the hyperswitch OXXO arm. Other vouchers (Boleto / Efecty / PagoEfectivo / RedPagos / Indomaret) stay on `Redirect`.
3. **`PaymentMethodId::Oxxo`** typed variant added with `#[serde(rename = "OX")]`. `get_voucher_payment_method_id` uses it; other vouchers continue with `PaymentMethodId::Other(...)`.
4. **`DlocalPaymentsResponse.ticket: Option<TicketData>`** added; response redirect-extraction now falls back to `ticket.image_url` between 3DS (`three_dsecure.redirect_url`) and the top-level `redirect_url`, so the OXXO barcode surfaces as `RedirectForm` and status maps to `AuthenticationPending`.

OXXO retains `notification_url` (kept on top of HS) so dLocal can webhook the merchant when the cash payment settles out-of-band at the convenience store.

## HS → UCS parity proof

<details>
<summary><b>1. Authorize URL — HS unconditional <code>/secure_payments</code></b></summary>

`hyperswitch/crates/hyperswitch_connectors/src/connectors/dlocal.rs:222-227`
```rust
fn get_url(
    &self,
    _req: &PaymentsAuthorizeRouterData,
    connectors: &Connectors,
) -> CustomResult<String, errors::ConnectorError> {
    Ok(format!("{}secure_payments", self.base_url(connectors)))
}
```

UCS now (Card + Voucher → `/secure_payments`, others unchanged):
```rust
match &req.request.payment_method_data {
    PaymentMethodData::Card(_) | PaymentMethodData::Voucher(_) => {
        Ok(format!("{base_url}secure_payments"))
    }
    _ => Ok(format!("{base_url}payments")),
}
```
</details>

<details>
<summary><b>2. OXXO <code>payment_method_flow</code> — HS uses Direct</b></summary>

`hyperswitch/crates/hyperswitch_connectors/src/connectors/dlocal/transformers.rs:151-166`
```rust
PaymentMethodData::Voucher(voucher_data) => match voucher_data {
    VoucherData::Oxxo => {
        let payment_request = Self {
            amount: item.amount,
            currency: item.router_data.request.currency,
            payment_method_id: PaymentMethodId::Oxxo,
            payment_method_flow: PaymentMethodFlow::Direct,
            ...
        };
```

UCS now (OXXO `Direct`, other vouchers stay `Redirect`):
```rust
let payment_method_flow = match voucher_data {
    payment_method_data::VoucherData::Oxxo => PaymentMethodFlow::Direct,
    _ => PaymentMethodFlow::Redirect,
};
```
</details>

<details>
<summary><b>3. Typed <code>PaymentMethodId::Oxxo</code> variant</b></summary>

`hyperswitch/crates/hyperswitch_connectors/src/connectors/dlocal/transformers.rs:43-50`
```rust
pub enum PaymentMethodId {
    #[default]
    Card,
    #[serde(rename = "OX")]
    Oxxo,
}
```

UCS now (typed variant added; `Other(String)` kept for UCS-only vouchers BL / EY / EF / RE / IM):
```rust
pub enum PaymentMethodId {
    #[default]
    Card,
    #[serde(rename = "OX")]
    Oxxo,
    #[serde(untagged)]
    Other(String),
}
```
</details>

<details>
<summary><b>4. Response <code>ticket.image_url</code> for OXXO barcode</b></summary>

`hyperswitch/crates/hyperswitch_connectors/src/connectors/dlocal/transformers.rs:299-333`
```rust
pub struct DlocalPaymentsResponse {
    status: DlocalPaymentStatus,
    id: String,
    three_dsecure: Option<ThreeDSecureResData>,
    order_id: Option<String>,
    ticket: Option<TicketData>,
}

pub struct TicketData { pub image_url: Option<Url> }

// ... in From impl:
enums::PaymentMethod::Voucher => item
    .response
    .ticket
    .and_then(|ticket_data| ticket_data.image_url)
    .map(|image_url| RedirectForm::from((image_url, Method::Get))),
```

UCS now (TicketData added, redirect-extraction priority: 3DS → ticket → top-level `redirect_url`):
```rust
let redirection_data = item
    .response
    .three_dsecure
    .and_then(|three_secure_data| three_secure_data.redirect_url)
    .or_else(|| {
        item.response
            .ticket
            .and_then(|ticket_data| ticket_data.image_url)
    })
    .or(item.response.redirect_url)
    .map(|redirect_url| RedirectForm::from((redirect_url, Method::Get)));
```

UCS uses a fallback chain (no `match payment_method` available in the generic `TryFrom`); HS card / voucher behavior is preserved, and UCS-only APMs continue to fall through to the top-level `redirect_url`.
</details>

## gRPC test — live dLocal sandbox

Method: `types.PaymentService/Authorize` against locally rebuilt `grpc-server` (binary built from this branch).

<details>
<summary><b>gRPC request body</b> (creds passed as gRPC metadata headers, not body)</summary>

```json
{
  "merchant_transaction_id": "oxxo_test_001",
  "amount": { "minor_amount": 5000, "currency": "MXN" },
  "payment_method": { "oxxo": {} },
  "capture_method": "AUTOMATIC",
  "customer": {
    "name": "Maria Garcia",
    "email": { "value": "maria.garcia@example.com" },
    "id": "cust_oxxo_test_001",
    "first_name": "Maria",
    "last_name": "Garcia",
    "customer_document_details": {
      "document_type": "OTHER",
      "document_number": { "value": "<redacted MX RFC>" }
    }
  },
  "address": {
    "billing_address": {
      "first_name": { "value": "Maria" },
      "last_name": { "value": "Garcia" },
      "line1": { "value": "Av Reforma 100" },
      "city": { "value": "Mexico City" },
      "state": { "value": "CDMX" },
      "zip_code": { "value": "06600" },
      "country_alpha2_code": "MX",
      "email": { "value": "maria.garcia@example.com" }
    }
  },
  "auth_type": "NO_THREE_DS",
  "return_url": "https://example.com/return",
  "webhook_url": "https://example.com/webhook",
  "description": "OXXO sandbox parity test"
}
```

Metadata headers used (values omitted): `x-connector: dlocal`, `x-auth: signature-key`, `x-api-key`, `x-key1`, `x-api-secret`, `x-merchant-id`, `x-tenant-id`, `x-request-id`, `x-connector-request-reference-id`.
</details>

<details>
<summary><b>gRPC response</b></summary>

```json
{
  "merchantTransactionId": "oxxo_test_001",
  "connectorTransactionId": "D-1454629-g1l3lg91-1um4lbne116gr1-okttjjsoka8g",
  "status": "AUTHENTICATION_PENDING",
  "statusCode": 200,
  "redirectionData": {
    "form": {
      "endpoint": "https://sandbox.dlocal.com/gmf-apm/payments/N-e710d1ed-e4ad-490e-9ef4-7cc22d95eac4",
      "method": "HTTP_METHOD_GET"
    }
  }
}
```
</details>

<details>
<summary><b>Wire-level proof from server logs — each fix exercised</b></summary>

| Fix | Wire evidence |
|---|---|
| URL → `/secure_payments` | Outbound URL: `https://sandbox.dlocal.com/secure_payments` |
| `payment_method_flow = Direct` | Request body: `"payment_method_flow":"DIRECT"` |
| Typed `PaymentMethodId::Oxxo` (`rename = "OX"`) | Request body: `"payment_method_id":"OX"` |
| OXXO retains `notification_url` | Request body: `"notification_url":"https://example.com/webhook"` |
| `ticket.image_url` extracted from response | Response body: `"ticket":{"image_url":"https://sandbox.dlocal.com/gmf-apm/payments/N-e710d1ed-..."}` → surfaced as `redirectionData.form.endpoint`, status promoted to `AUTHENTICATION_PENDING` |
</details>

## Test plan

- [x] `cargo check -p connector-integration` clean
- [x] `cargo build -p grpc-server` clean
- [x] Live OXXO `PaymentService/Authorize` against dLocal sandbox → `AUTHENTICATION_PENDING` + barcode `redirectionData`
- [x] Card flow unchanged (URL already `/secure_payments`, body identical to HS)
- [ ] Other UCS-only voucher (Boleto / Efecty / PagoEfectivo / RedPagos / Indomaret) regression check — bodies still emit `payment_method_flow=Redirect` + `notification_url`; URL routes to `/payments` (no code path changed for them, but a sandbox run would confirm)