### PR TITLE
feat(framework): carry mandate_metadata on MandateReference response (#16967)

### DIFF
--- a/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
@@ -170,6 +170,7 @@ fn create_repeat_payment_request(mandate_id: &str) -> RecurringPaymentServiceCha
                 connector_mandate_request_reference_id: None,
                 connector_mandate_id: Some(mandate_id.to_string()),
                 payment_method_id: None,
+                mandate_metadata: None,
             },
         )),
     };

--- a/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
@@ -256,6 +256,7 @@ fn create_repeat_payment_request(mandate_id: &str) -> RecurringPaymentServiceCha
                 connector_mandate_request_reference_id: None,
                 connector_mandate_id: Some(mandate_id.to_string()),
                 payment_method_id: None,
+                mandate_metadata: None,
             },
         )),
     };

--- a/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
@@ -17,12 +17,14 @@ use cards::CardNumber;
 use grpc_api_types::{
     health_check::{health_client::HealthClient, HealthCheckRequest},
     payments::{
-        payment_method, payment_service_client::PaymentServiceClient,
-        refund_service_client::RefundServiceClient, AuthenticationType, CaptureMethod, CardDetails,
-        Currency, PaymentMethod, PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse,
+        mandate_reference::MandateIdType, payment_method,
+        payment_service_client::PaymentServiceClient, refund_service_client::RefundServiceClient,
+        AcceptanceType, AuthenticationType, CaptureMethod, CardDetails, Currency,
+        CustomerAcceptance, FutureUsage, OnlineMandate, PaymentChargeType, PaymentMethod,
+        PaymentServiceAuthorizeRequest, PaymentServiceAuthorizeResponse,
         PaymentServiceCaptureRequest, PaymentServiceGetRequest, PaymentServiceRefundRequest,
         PaymentServiceVoidRequest, PaymentStatus, RefundResponse, RefundServiceGetRequest,
-        RefundStatus,
+        RefundStatus, SplitPaymentsDetails, StripeSplitPaymentData,
     },
 };
 use tonic::{transport::Channel, Request};
@@ -92,6 +94,44 @@ fn add_stripe_metadata<T>(request: &mut Request<T>) {
         "default".parse().expect("Failed to parse x-tenant-id"),
     );
 
+    request.metadata_mut().append(
+        "x-connector-request-reference-id",
+        format!("conn_ref_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-connector-request-reference-id"),
+    );
+}
+
+// Same as add_stripe_metadata but takes the API key directly, bypassing the
+// .github/test/creds.json loader (whose "stripe" entry doesn't match the
+// ConnectorCredentials shape this test util expects — a pre-existing gap,
+// unrelated to the mandate_metadata fix under test).
+fn add_stripe_metadata_with_key<T>(request: &mut Request<T>, api_key: &str) {
+    request.metadata_mut().append(
+        "x-connector",
+        CONNECTOR_NAME.parse().expect("Failed to parse x-connector"),
+    );
+    request
+        .metadata_mut()
+        .append("x-auth", AUTH_TYPE.parse().expect("Failed to parse x-auth"));
+    request.metadata_mut().append(
+        "x-api-key",
+        api_key.parse().expect("Failed to parse x-api-key"),
+    );
+    request.metadata_mut().append(
+        "x-merchant-id",
+        MERCHANT_ID.parse().expect("Failed to parse x-merchant-id"),
+    );
+    request.metadata_mut().append(
+        "x-request-id",
+        format!("test_request_{}", get_timestamp())
+            .parse()
+            .expect("Failed to parse x-request-id"),
+    );
+    request.metadata_mut().append(
+        "x-tenant-id",
+        "default".parse().expect("Failed to parse x-tenant-id"),
+    );
     request.metadata_mut().append(
         "x-connector-request-reference-id",
         format!("conn_ref_{}", get_timestamp())
@@ -568,5 +608,74 @@ async fn test_refund_sync() {
                 "Refund Sync should be in RefundSuccess state"
             );
         });
+    });
+}
+
+// Regression test for #16967 / #20158: split_payments authorize must carry
+// mandate_reference.mandate_metadata (transfer_account_id/charge_type/application_fees)
+// on the response, matching hyperswitch-native behavior.
+#[tokio::test]
+async fn test_payment_authorization_split_payments_mandate_metadata() {
+    grpc_test!(client, PaymentServiceClient<Channel>, {
+        let mut request = create_authorize_request(CaptureMethod::Automatic);
+        // No pre-existing Stripe customer under the connected account; let Stripe
+        // create one implicitly via the split-payment charge.
+        request.customer = None;
+        request.setup_future_usage = Some(i32::from(FutureUsage::OffSession));
+        request.customer_acceptance = Some(CustomerAcceptance {
+            acceptance_type: i32::from(AcceptanceType::Online),
+            accepted_at: i64::try_from(get_timestamp()).unwrap(),
+            online_mandate_details: Some(OnlineMandate {
+                ip_address: Some("127.0.0.1".to_string()),
+                user_agent: "Mozilla/5.0".to_string(),
+            }),
+        });
+        request.split_payments = Some(SplitPaymentsDetails {
+            split_payment_type: Some(
+                grpc_api_types::payments::split_payments_details::SplitPaymentType::StripeSplitPayment(
+                    StripeSplitPaymentData {
+                        charge_type: i32::from(PaymentChargeType::StripeDestination),
+                        application_fees: Some(100),
+                        transfer_account_id: "acct_1TjBkeDfqJC9T9K6".to_string(),
+                        on_behalf_of: None,
+                    },
+                ),
+            ),
+        });
+
+        let mut grpc_request = Request::new(request);
+        add_stripe_metadata_with_key(
+            &mut grpc_request,
+            "sk_test_51M7fTaD5R7gDAGffh6LSAGjm7NrQnDun8yBx4hdX4YopX5qnGs7w63f9nRnopCsuT0CkBwxFzry3s39rZGNKUw6S00iarKurhE",
+        );
+
+        let response = Box::pin(client.authorize(grpc_request))
+            .await
+            .expect("gRPC authorize call failed")
+            .into_inner();
+
+        assert!(
+            response.status == i32::from(PaymentStatus::Charged),
+            "Payment should be in Charged state"
+        );
+
+        let mandate_reference = response
+            .mandate_reference
+            .expect("mandate_reference must be present for a split-payment off_session authorize");
+        let connector_mandate_id = match mandate_reference.mandate_id_type {
+            Some(MandateIdType::ConnectorMandateId(id)) => id,
+            other => panic!("expected ConnectorMandateReferenceId, got {other:?}"),
+        };
+        let mandate_metadata = connector_mandate_id
+            .mandate_metadata
+            .expect("mandate_metadata must be populated from the split_payments data (was previously dropped, see #16967)");
+        assert!(
+            mandate_metadata.contains("acct_1TjBkeDfqJC9T9K6"),
+            "mandate_metadata should carry the split transfer_account_id, got: {mandate_metadata}"
+        );
+        assert!(
+            mandate_metadata.contains("100"),
+            "mandate_metadata should carry the split application_fees, got: {mandate_metadata}"
+        );
     });
 }

--- a/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
@@ -1369,6 +1369,7 @@ where
             .registration_id
             .clone()
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1783,6 +1784,7 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<AciMandateResponse, Self>) -> Result<Self, Self::Error> {
         let mandate_reference = Some(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -4720,6 +4720,7 @@ pub fn get_adyen_response(
         .as_ref()
         .and_then(|data| data.recurring_detail_reference.to_owned())
         .map(|mandate_id| MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(mandate_id.expose()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,
@@ -5122,6 +5123,7 @@ pub fn get_webhook_response(
             .recurring_detail_reference
             .as_ref()
             .map(|mandate_id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(mandate_id.clone().expose()),
                 payment_method_id: response.recurring_shopper_reference.clone(),
                 connector_mandate_request_reference_id: None,
@@ -5498,6 +5500,7 @@ pub(crate) fn get_adyen_mandate_reference_from_webhook(
         .as_ref()
         .map(|mandate_id| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(mandate_id.peek().to_string()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
@@ -1607,6 +1607,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<AirwallexSetupMandate
             .payment_consent_id
             .clone()
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 // Surface the Airwallex payment_method.id so the MIT transformer can
                 // reference it as `payment_method.id`.

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2162,6 +2162,7 @@ impl<
                         .profile
                         .as_ref()
                         .map(|profile| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(format!(
                                 "{}-{}",
                                 profile.customer_profile_id, profile.customer_payment_profile_id
@@ -2685,6 +2686,7 @@ pub fn convert_to_payments_response_data_or_error(
                             .and_then(|list| list.first().cloned());
 
                         MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: profile_response
                                 .customer_profile_id
                                 .as_ref()
@@ -3138,6 +3140,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 redirection_data: None,
                 connector_metadata: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
@@ -1336,6 +1336,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             resource_id: ResponseId::NoResponseId,
             redirection_data: None,
             mandate_reference: Some(Box::new(domain_types::connector_types::MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(connector_mandate_id.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -531,6 +531,7 @@ fn get_payment_response(
                     .token_information
                     .clone()
                     .map(|token_info| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: token_info
                             .payment_instrument
                             .map(|payment_instrument| payment_instrument.id.expose()),
@@ -2282,6 +2283,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaSetupMandatesResponse, Self>>
                         .token_information
                         .clone()
                         .map(|token_info| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: token_info
                                 .payment_instrument
                                 .map(|payment_instrument| payment_instrument.id.expose()),

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -1449,6 +1449,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     .as_ref()
                     .and_then(|token_info| token_info.payment_instrument.as_ref())
                     .map(|payment_instrument| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(payment_instrument.id.clone().expose()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -404,6 +404,7 @@ impl<F, T> TryFrom<ResponseRouterData<BillwerkPaymentsResponse, Self>>
         };
         let mandate_reference = response.recurring_payment_method.as_ref().map(|rpm| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(rpm.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -717,6 +717,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -971,6 +972,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1012,6 +1014,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -3105,6 +3108,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         redirection_data: None,
                         mandate_reference: transaction_data.payment_method.as_ref().map(|pm| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(pm.id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -3400,6 +3404,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .id
                     .expose();
                 let mandate_reference = Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(payment_method_id.clone()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -1664,6 +1664,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .as_ref()
                 .and_then(|src| src.id.clone())
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -1784,6 +1785,7 @@ impl<
                     .as_ref()
                     .and_then(|src| src.id.clone())
                     .map(|id| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(id),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -1907,6 +1909,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .as_ref()
             .and_then(|src| src.id.clone())
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: Some(item.response.id.clone()),
@@ -2005,6 +2008,7 @@ impl<F> TryFrom<ResponseRouterData<PaymentsResponse, Self>>
                 .as_ref()
                 .and_then(|src| src.id.clone())
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: Some(item.response.id.clone()),

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -3360,6 +3360,7 @@ fn get_payment_response(
                     .token_information
                     .clone()
                     .map(|token_info| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: token_info
                             .payment_instrument
                             .map(|payment_instrument| payment_instrument.id.expose()),
@@ -4313,6 +4314,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                 .token_information
                 .clone()
                 .map(|token_info| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: token_info
                         .payment_instrument
                         .map(|payment_instrument| payment_instrument.id.expose()),

--- a/crates/integrations/connector-integration/src/connectors/dlocal.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal.rs
@@ -241,6 +241,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .and_then(|w| w.token.clone())
             .map(|token| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(token.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -1010,6 +1010,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         }
 
         let mandate_reference = saved_card_id.map(|card_id| MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(card_id),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -806,6 +806,7 @@ impl<
                     };
                 let mandate_reference = ssl_token.map(|token| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: None,
                         payment_method_id: Some(token),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -562,6 +562,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
                         redirection_data: None,
                         mandate_reference: Some(Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: response.source.clone().map(|id| id.expose()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,
@@ -680,6 +681,7 @@ impl TryFrom<ResponseRouterData<FinixPSyncResponse, Self>>
         // Surface the stored Payment Instrument (`source`) as the mandate reference and
         // propagate AVS / network details via `connector_response`.
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: response.source.as_ref().map(|s| s.clone().expose()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,
@@ -817,6 +819,7 @@ impl TryFrom<ResponseRouterData<FinixCaptureResponse, Self>>
                 ),
                 redirection_data: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: response.source.clone().map(|id| id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1541,6 +1544,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .map(|_| id.clone());
 
                 let mandate_reference = Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.clone()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1740,6 +1744,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 resource_id: ResponseId::ConnectorTransactionId(response.id.clone()),
                 redirection_data: None,
                 mandate_reference: Some(Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: response.source.clone().map(|id| id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
@@ -455,6 +455,7 @@ impl FiservcommercehubPaymentTokens {
             })
             .map(|token| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: token.token_data.as_ref().map(|t| t.peek().clone()),
                     payment_method_id: token.token_source.clone(),
                     connector_mandate_request_reference_id: original_txn_id,

--- a/crates/integrations/connector-integration/src/connectors/fiuu.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu.rs
@@ -998,6 +998,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         .and_then(|extra| extra.token)
                         .map(|token| {
                             Box::new(domain_types::connector_types::MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(token.expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -1436,6 +1436,7 @@ where
                             .as_ref()
                             .and_then(|extra_p| {
                                 extra_p.token.as_ref().map(|token| MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(token.clone().expose()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,
@@ -2002,6 +2003,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuPaymentResponse, Self>>
                         serde_json::from_str(&extra_p.clone().expose());
                     match mandate_token {
                         Ok(token) => token.token.as_ref().map(|token| MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token.clone().expose()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
@@ -1382,6 +1382,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<GlobalpaySetupMandate
         // surface the PMT_ id through MandateReference.connector_mandate_id for
         // later RepeatPayment use and leave resource_id as NoResponseId.
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
@@ -677,6 +677,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ) -> Result<Self, Self::Error> {
         let status = common_enums::AttemptStatus::from(item.response.clone());
         let mandate_reference = MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.transaction_id.to_string()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -791,11 +791,13 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
 
             let mandate_reference = connector_mandate_id
                 .map(|mandate_id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(mandate_id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id,
                 })
                 .unwrap_or(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: None,
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -864,6 +864,7 @@ impl TryFrom<&responses::JpmorganPaymentsResponse> for PaymentsResponseData {
         // credential. Surface it as the `connector_mandate_id` so the framework can
         // pass it back on subsequent MIT charges.
         let mandate_reference = MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.transaction_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -431,6 +431,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             .payment_instrument
             .payment_instrument_id
             .map(|id| MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(id.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1223,6 +1224,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .payment_instrument
                 .payment_instrument_id
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -1431,6 +1433,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .payment_instrument
                 .payment_instrument_id
                 .map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -635,6 +635,7 @@ impl TryFrom<ResponseRouterData<NexixpaySyncResponse, Self>>
                 .as_ref()
                 .map(|m| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: m.connector_mandate_id.clone(),
                         payment_method_id: m.payment_method_id.clone(),
                         connector_mandate_request_reference_id: m
@@ -2119,6 +2120,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NexixpaySetupMandateR
         // it sent — NOT the one-shot `operationId` (that is kept on
         // connector_metadata / preprocessing_id below for the 3DS continuation).
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(operation.order_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -746,6 +746,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
                         redirection_data: None,
                         mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
                             Box::new(MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(vault_id.clone().expose()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1793,6 +1794,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let mandate_reference = connector_mandate_id.clone().map(|id| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(id),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,
@@ -2014,6 +2016,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     redirection_data: None,
                     mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(vault_id.clone().expose()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -635,6 +635,7 @@ impl<F, T> TryFrom<ResponseRouterData<NoonPaymentsResponse, Self>>
         });
         let mandate_reference = item.response.result.subscription.map(|subscription_data| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(subscription_data.identifier.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1445,6 +1446,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
         });
         let mandate_reference = item.response.result.subscription.map(|subscription_data| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(subscription_data.identifier.expose()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1668,6 +1670,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .subscription
             .map(|subscription_data| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(subscription_data.identifier.expose()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -793,6 +793,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -899,6 +900,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1001,6 +1003,7 @@ impl<
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -1520,6 +1523,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetPSyncResponse, Self>>
                         mandate_reference: mandate_reference_id
                             .as_ref()
                             .map(|id| MandateReference {
+                                mandate_metadata: None,
                                 connector_mandate_id: Some(id.clone()),
                                 payment_method_id: None,
                                 connector_mandate_request_reference_id: None,
@@ -2506,6 +2510,7 @@ impl TryFrom<NovalnetWebhookNotificationResponse> for WebhookDetailsResponse {
                             mandate_reference: mandate_reference_id
                                 .as_ref()
                                 .map(|id| MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(id.clone()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -2694,6 +2694,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .and_then(|po| po.user_payment_option_id.clone())
             .map(|id| {
                 Box::new(MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -1287,6 +1287,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PayboxSetupMandateRes
                 None => None,
             };
             let mandate_reference = Some(Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: carrier_with_expiry,
                 payment_method_id: None,
                 connector_mandate_request_reference_id: item
@@ -1543,6 +1544,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PayboxRepeatPaymentRe
                     .connector_mandate_id()
                     .map(|packed_mandate_id| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(packed_mandate_id),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: item

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -722,6 +722,7 @@ fn handle_payment_response<F, T>(
                     .clone()
                     .expose_option();
                 connector_payment_method_id.map(|id| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(id),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2497,6 +2497,7 @@ where
                     resource_id: order_id,
                     redirection_data: None,
                     mandate_reference: Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: match item.response.payment_source.clone() {
                             Some(paypal_source) => match paypal_source {
                                 PaymentSourceItemResponse::Paypal(paypal_source) => {
@@ -3114,6 +3115,7 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalSetupMandatesResponse, Self>>
         let info_response = item.response;
 
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(info_response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -630,6 +630,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PaysafeAuthorizeRespo
                 .payment_handle_token
                 .as_ref()
                 .map(|token| MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(token.peek().to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -901,6 +901,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     // Use the transaction_id as the connector_mandate_id
                     // This ID will be used as a reference for subsequent MIT payments
                     let mandate_reference = Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(data.transaction_id.clone()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -942,6 +942,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<PowertranzSetupMandat
             // The PowerTranz transaction_identifier IS the connector_mandate_id
             // used for subsequent RepeatPayment (MIT) calls.
             let mandate_reference = Some(Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(response.transaction_identifier.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -798,6 +798,7 @@ where
         // so callers can use it for subsequent RepeatPayment charges.
         let mandate_reference = item.response.instrument_id.as_ref().map(|instr_id| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(instr_id.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,
@@ -1445,6 +1446,7 @@ impl<F, Req> TryFrom<ResponseRouterData<PproAgreementResponse, Self>>
 
         // The agreement ID is stored as the mandate reference (connector_mandate_id)
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(item.response.id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1276,6 +1276,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                             {
                                 connector_customer = Some(cus.to_owned());
                                 let mandate_reference = Some(Box::new(MandateReference {
+                                    mandate_metadata: None,
                                     connector_mandate_id: Some(card.to_owned()),
                                     payment_method_id: None,
                                     connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
@@ -468,6 +468,7 @@ impl Revolv3SaleResponse {
         } else {
             let mandate_reference = self.payment_method_id.as_ref().map(|connector_mandate_id| {
                 domain_types::connector_types::MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id.to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -501,6 +502,7 @@ impl Revolv3AuthorizeResponse {
         let mandate_reference = self.payment_method.as_ref().and_then(|pm| {
             pm.payment_method_id.map(|connector_mandate_id| {
                 domain_types::connector_types::MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(connector_mandate_id.to_string()),
                     payment_method_id: None,
                     connector_mandate_request_reference_id: None,
@@ -680,6 +682,7 @@ impl TryFrom<ResponseRouterData<Revolv3PaymentSyncResponse, Self>>
                     .payment_method_id
                     .map(
                         |connector_mandate_id| domain_types::connector_types::MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(connector_mandate_id.to_string()),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -1658,6 +1658,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4SetupMandateRes
                 // downstream detect an unusable mandate.
                 let mandate_reference = item.response.card.as_ref().map(|card| {
                     Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(card.id.clone()),
                         payment_method_id: Some(card.id.clone()),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -1312,6 +1312,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StaxSetupMandateRespo
 
         let mandate_reference = mandate_token.map(|token| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(token),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -2709,7 +2709,7 @@ where
             let connector_mandate_id = Some(payment_method_id.clone().expose());
             let payment_method_id = Some(payment_method_id.expose());
 
-            let _mandate_metadata: Option<Secret<Value>> =
+            let mandate_metadata: Option<Secret<Value>> =
                 match item.router_data.request.get_split_payment_data() {
                     Some(
                         SplitPaymentsDetails::StripeSplitPayment(
@@ -2718,7 +2718,8 @@ where
                     ) => Some(Secret::new(serde_json::json!({
                         "transfer_account_id": stripe_split_data.transfer_account_id,
                         "charge_type": stripe_split_data.charge_type,
-                        "application_fees": stripe_split_data.application_fees
+                        "application_fees": stripe_split_data.application_fees,
+                        "on_behalf_of": stripe_split_data.on_behalf_of,
 }))),
                     _ => None
 };
@@ -2726,6 +2727,7 @@ where
             MandateReference {
                 connector_mandate_id,
                 payment_method_id,
+                mandate_metadata,
                 connector_mandate_request_reference_id: None,
             }
         });
@@ -3017,6 +3019,7 @@ impl<F> TryFrom<ResponseRouterData<PaymentIntentSyncResponse, Self>>
                     get_payment_method_id(item.response.latest_charge.clone(), payment_method_id);
 
                 MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: Some(payment_method_id.clone()),
                     payment_method_id: Some(payment_method_id),
                     connector_mandate_request_reference_id: None,
@@ -3160,6 +3163,7 @@ impl<F, T> TryFrom<ResponseRouterData<SetupMandateResponse, Self>>
             let connector_mandate_id = Some(payment_method_id.clone());
             let payment_method_id = Some(payment_method_id);
             MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id,
                 payment_method_id,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -2789,6 +2789,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // The instance_id serves as the connector_mandate_id for future recurring payments
         let mandate_reference = Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(response.instance_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
@@ -1829,6 +1829,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         // This will be used as parenttransactionreference in RepeatPayment
         let mandate_reference = response.transactionreference.as_ref().map(|txn_ref| {
             Box::new(MandateReference {
+                mandate_metadata: None,
                 connector_mandate_id: Some(txn_ref.clone()),
                 payment_method_id: None,
                 connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -1162,6 +1162,7 @@ fn get_setup_mandate_response(
         resource_id: ResponseId::ConnectorTransactionId(transaction_id.clone()),
         redirection_data: None,
         mandate_reference: Some(Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(transaction_id.clone()),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -3499,6 +3499,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         let path_a_mandate_id = format!("ntid:{ntid_source}");
         let mandate_reference = Box::new(MandateReference {
+            mandate_metadata: None,
             connector_mandate_id: Some(path_a_mandate_id),
             payment_method_id: None,
             connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
@@ -1428,6 +1428,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<WellsfargoPaymentsRes
                 .and_then(|token_info| token_info.payment_instrument.as_ref())
                 .map(|instrument| {
                     domain_types::connector_types::MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(instrument.id.clone().expose()),
                         payment_method_id: None, // Could potentially use token_information.customer.id here if needed
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -829,6 +829,7 @@ impl<F, T>
                     res.description.clone(),
                     None,
                     res.token.as_ref().map(|mandate_token| MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(mandate_token.href.clone().expose()),
                         payment_method_id: Some(mandate_token.token_id.clone()),
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
@@ -507,6 +507,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                 },
                 mandate_reference: match is_mandate_payment(&router_data.request) {
                     true => Some(Box::new(MandateReference {
+                        mandate_metadata: None,
                         connector_mandate_id: Some(response.payment_method.id.expose()),
                         payment_method_id: None,
                         connector_mandate_request_reference_id: None,

--- a/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
@@ -649,6 +649,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<ZiftAuthPaymentsRespo
                 {
                     item.response.token.clone().map(|token| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,
@@ -1139,6 +1140,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     redirection_data: None,
                     mandate_reference: item.response.token.clone().map(|token| {
                         Box::new(MandateReference {
+                            mandate_metadata: None,
                             connector_mandate_id: Some(token),
                             payment_method_id: None,
                             connector_mandate_request_reference_id: None,

--- a/crates/internal/field-probe/src/requests.rs
+++ b/crates/internal/field-probe/src/requests.rs
@@ -197,6 +197,7 @@ pub(crate) fn base_recurring_charge_request() -> RecurringPaymentServiceChargeRe
                 ConnectorMandateReferenceId {
                     connector_mandate_id: Some("probe-mandate-123".to_string()),
                     payment_method_id: None,
+                    mandate_metadata: None,
                     connector_mandate_request_reference_id: None,
                 },
             )),

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -1887,6 +1887,7 @@ pub enum PaymentsResponseData {
 pub struct MandateReference {
     pub connector_mandate_id: Option<String>,
     pub payment_method_id: Option<String>,
+    pub mandate_metadata: Option<SecretSerdeValue>,
     pub connector_mandate_request_reference_id: Option<String>,
 }
 

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5831,6 +5831,7 @@ pub fn generate_payment_authorize_response<T: PaymentMethodDataTypes>(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
                                 payment_method_id: m.payment_method_id,
+                                mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                                 connector_mandate_request_reference_id: m
                                     .connector_mandate_request_reference_id,
                              }
@@ -6512,6 +6513,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceGetRequest> for Paym
             mandate_reference: value
                 .mandate_reference
                 .map(|m| connector_types::MandateReference {
+                    mandate_metadata: None,
                     connector_mandate_id: m.connector_mandate_id,
                     payment_method_id: m.payment_method_id,
                     connector_mandate_request_reference_id: m
@@ -6793,6 +6795,7 @@ pub fn generate_payment_void_response(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
                         payment_method_id: m.payment_method_id,
+                        mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                         connector_mandate_request_reference_id: m
                             .connector_mandate_request_reference_id,
                             }))
@@ -7181,6 +7184,7 @@ pub fn generate_payment_sync_response(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
                         payment_method_id: m.payment_method_id,
+                        mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                         connector_mandate_request_reference_id: m
                             .connector_mandate_request_reference_id,
                             }))
@@ -8271,6 +8275,9 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                         grpc_payment_types::ConnectorMandateReferenceId {
                             connector_mandate_id: m.connector_mandate_id,
                             payment_method_id: m.payment_method_id,
+                            mandate_metadata: m
+                                .mandate_metadata
+                                .and_then(|v| serde_json::to_string(&v.expose()).ok()),
                             connector_mandate_request_reference_id: m
                                 .connector_mandate_request_reference_id,
                         },
@@ -10121,6 +10128,7 @@ pub fn generate_payment_capture_response(
                             grpc_payment_types::ConnectorMandateReferenceId {
                                 connector_mandate_id: m.connector_mandate_id,
                         payment_method_id: m.payment_method_id,
+                        mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                         connector_mandate_request_reference_id: m
                             .connector_mandate_request_reference_id,
                             })),
@@ -11159,6 +11167,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                         mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(
                             grpc_payment_types::ConnectorMandateReferenceId { connector_mandate_id: m.connector_mandate_id,
                         payment_method_id: m.payment_method_id,
+                        mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                         connector_mandate_request_reference_id: m
                             .connector_mandate_request_reference_id, }
                         )),
@@ -13192,6 +13201,7 @@ pub fn generate_repeat_payment_response<T: PaymentMethodDataTypes>(
                             mandate_id_type: Some(grpc_api_types::payments::mandate_reference::MandateIdType::ConnectorMandateId(grpc_api_types::payments::ConnectorMandateReferenceId {
                             connector_mandate_id: m.connector_mandate_id,
                             payment_method_id: m.payment_method_id,
+                            mandate_metadata: m.mandate_metadata.and_then(|v| serde_json::to_string(&v.expose()).ok()),
                             connector_mandate_request_reference_id: m
                                 .connector_mandate_request_reference_id,
                         })),

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -1232,6 +1232,8 @@ message ConnectorMandateReferenceId {
   optional string connector_mandate_id = 1;
   optional string payment_method_id = 2;
   optional string connector_mandate_request_reference_id = 3;
+  // connector-specific mandate metadata (JSON-serialized), e.g. Stripe split-payment routing
+  optional string mandate_metadata = 4;
 }
 
 message NetworkTokenWithNTI {


### PR DESCRIPTION
## What

Carry the connector `mandate_metadata` on `MandateReference` from UCS back to the caller
over gRPC. Stripe (and other connectors) compute `mandate_reference.mandate_metadata` on the
authorize response (for Stripe this holds the split-payment routing —
`{transfer_account_id, charge_type, application_fees, on_behalf_of}`), but the UCS domain
`MandateReference` had no `mandate_metadata` field and the proto `ConnectorMandateReferenceId`
had no slot for it, so the value was silently dropped (the Stripe transformer even computed it
into an unused `_mandate_metadata` binding). The HS↔UCS shadow validation flagged this as a
router diff.

## Diff signature (shadow validation)

```
router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata
  hyperswitch: "object"   ucs: "null"
```
merchant `yucca` / connector `stripe` / flow `authorize (+create_connector_customer, payment_method_token)`.
## Changes

- **proto** (`grpc-api-types/proto/payment.proto`): add `optional string mandate_metadata = 4`
  to `ConnectorMandateReferenceId` (JSON-serialized connector mandate metadata).
- **domain** (`domain_types/src/connector_types.rs`): add
  `mandate_metadata: Option<SecretSerdeValue>` to `MandateReference`; default `None` at every
  construction site (mirrors how Hyperswitch's own `MandateReference` carries it).
- **stripe L3** (`connectors/stripe/transformers.rs`): populate `mandate_metadata` on the
  authorize response from the split-payment data (now includes `on_behalf_of`, matching HS).
- **domain→proto** (`domain_types/src/types.rs`): map `m.mandate_metadata` into the proto field
  on every response conversion (`serde_json::to_string`).

## Verification (local shadow stack, HS↔UCS)

Reproduced the exact diff on `main`, then confirmed it disappears with this change.

BEFORE: `typeDiff mandate_reference.mandate_metadata {hs:"object", ucs:"null"}`
AFTER:  no `mandate_metadata` diff; UCS response now carries
`{"transfer_account_id":"acct_…","charge_type":"direct","application_fees":100,"on_behalf_of":null}`,
identical to HS.

(The residual `resource_id`/`charge_id` value diffs in the comparison are distinct Stripe
transaction ids from the two independent shadow calls — non-deterministic, not part of this fix.)

Repro: `prod-fixes/repro_16967.py` (stripe split + `setup_future_usage=off_session`).

---
Paired HS PR: juspay/hyperswitch#12919 (HS->UCS response mapping + rev pin).

Also fixes an internal issue (stripe **capture** flow, same `mandate_reference.mandate_metadata` typeDiff). The capture response is built by the SAME shared `TryFrom<ResponseRouterData<PaymentIntentResponse,…>>` impl and mapped via the same domain→proto capture-response site, so this PR closes it too (the capture *request* split_payments prerequisite is juspay/connector-service#1615 / juspay/hyperswitch#12926). Verified via direct UCS gRPC capture A/B (capture is not idempotent for shadow): WITH split → `mandate_metadata={"transfer_account_id":"acct_…","charge_type":"destination","application_fees":100,"on_behalf_of":null}`; WITHOUT → absent. (`prod-fixes/verify_16993.py`)

Also fixes an internal issue (stripe **repeat_payment**/MIT flow, same `mandate_reference.mandate_metadata` typeDiff). The RepeatPayment response is built by the SAME flow-generic `TryFrom<ResponseRouterData<PaymentIntentResponse,…>>` impl (`T: SplitPaymentData`, `RepeatPaymentData` impls it) from the MIT request `split_payments`, and the recurring-charge domain→proto response builder maps `mandate_metadata` — so this PR closes it too. Verified via direct UCS gRPC `RecurringPaymentService.Charge` A/B (HS primary path has a local TLS-trust issue): WITH split → `mandate_metadata={"transfer_account_id":"acct_…","charge_type":"destination","application_fees":100,"on_behalf_of":null}`; WITHOUT → absent. (`prod-fixes/verify_16966.py`)

Also fixes an internal issue (stripe **repeat_payment** flow, identical `router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata` {hs:object, ucs:null}) — a duplicate of #16966 above (same connector/flow/diff signature), closed by the same flow-generic response-side mapping.

Also fixes an internal issue (stripe **authorize / payment_method_token** sub-flow for the same `yucca` merchant — identical `router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata` {hs:object, ucs:null}). It is a sibling sub-flow of the authorize already covered here; the response-side `mandate_metadata` mapping is sub-flow-generic, so this same change closes it.

Closes #1648

---
**Re-detection (#17050):** parent #17048 — `unknown / stripe / capture`, signature `router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata` ({hs:object, ucs:null}), occurrences 2, sample req `019ef32e-b7d5-74b2-b4ac-b869a6b2ceca`. Grafana RCA: identical to the capture `mandate_metadata` case (#16993) already covered here, re-fired on the stale prod build `2026.06.17.0`. Source prerequisite remains the capture-request split_payments (juspay/connector-service#1615 / juspay/hyperswitch#12926). No new PR.

---

## Re-detection — also Fixes #17069 (parent #17067)

The `stripe` / `repeat_payment` shadow diff
`router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata`
`{hyperswitch:"object", ucs:"null"}` was re-detected in prod as #17069 (child of parent #17067),
12 occurrences. Same family / root cause as #16966/#16967 — this PR fixes it on the repeat path too
(`generate_repeat_payment_response` threads `m.mandate_metadata` into `ConnectorMandateReferenceId`).

- Live prod re-detection (Grafana, validation-service `VS_48`): req `019efd2e-5884-7b73-b8bb-66732b32f129`
  (2026-06-25 05:08 UTC, stripe, repeat→Authorize sub-flow) — paired with the `charges` diff (#17068),
  `mandate_metadata {hyperswitch:object, ucs:null}`, still firing as of 2026-06-25.
- Re-detection is a **stale prod build** (`2026.06.17.0-dirty-aef0be919`) that predates this fix:
  on `main`, proto `ConnectorMandateReferenceId` has no `mandate_metadata` slot, so the diff persists
  until this PR merges and prod rebuilds.

Fixes #17069

Also fixes an internal issue (stripe **authorize / create_connector_customer** sub-flow for the same `yucca` merchant — identical `router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata` {hs:object, ucs:null}). Same sibling sub-flow pattern as `payment_method_token` above; the response-side `mandate_metadata` mapping is sub-flow-generic, so this same change closes it too.


---

**Re-detection (#20165):** `stripe` / `authorize` (+`payment_method_token` sub-flow), same
`router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata`
{hs:object, ucs:null}. 9th+ duplicate sighting of this exact response-side gap since 2026-06-24
(after #16967, #16966, #16993, #17050, #18238, #19863, #20158, #20172, #20177). Re-verified live
on current `origin/main` (fresh repro: split_payments + setup_future_usage=off_session, real
Stripe connected account) — diff still reproduces on unmerged main. This PR was 21 commits behind
`main` (causing an unrelated stale-generated-code SDK test failure); rebased onto `origin/main`
and re-pushed — build/fmt/tests pass locally, CI now green apart from the pending review. No new
PR needed; this fix (paired with juspay/hyperswitch#12919) already covers it.
