### PR TITLE
fix(cybersource): map connector txn id + network decline code on setup_mandate error response (#17014, #17015)

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11145,13 +11145,33 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                 }
                 None => grpc_api_types::payments::PaymentStatus::Unspecified,
             };
+            // Surface the connector transaction id and the card-network decline
+            // details on the error path so the router maps them back onto
+            // `ErrorResponse.connector_transaction_id` / `network_decline_code`
+            // (matching the Direct gateway). See juspay/hyperswitch-cloud#17014, #17015.
+            let has_network_details = err.network_decline_code.is_some()
+                || err.network_advice_code.is_some()
+                || err.network_error_message.is_some();
+            let issuer_details = has_network_details.then(|| {
+                grpc_api_types::payments::IssuerErrorDetails {
+                    code: None,
+                    message: err.network_error_message.clone(),
+                    network_details: Some(grpc_api_types::payments::NetworkErrorDetails {
+                        advice_code: err.network_advice_code.clone(),
+                        decline_code: err.network_decline_code.clone(),
+                        error_message: err.network_error_message.clone(),
+                    }),
+                }
+            });
             PaymentServiceSetupRecurringResponse {
-                connector_recurring_payment_id: None,
+                connector_recurring_payment_id: err.connector_transaction_id.clone(),
                 redirection_data: None,
                 network_transaction_id: None,
-                merchant_recurring_payment_id: extract_connector_request_reference_id(
-                    &err.connector_transaction_id,
-                ),
+                // The native gateway leaves `connector_response_reference_id` as
+                // `None` on the error path, so do not echo the connector transaction
+                // id here (the router maps this onto that field). Keeps UCS at parity
+                // with Direct — see juspay/hyperswitch-cloud#17014, #17015.
+                merchant_recurring_payment_id: String::new(),
                 status: status as i32,
                 mandate_reference: None,
                 incremental_authorization_allowed: None,
@@ -11164,7 +11184,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                         connector_transaction_id: err.connector_transaction_id.clone(),
                         status: None,
                     }),
-                    issuer_details: None,
+                    issuer_details,
                 }),
                 status_code: err.status_code as u32,
                 response_headers: router_data_v2

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11152,8 +11152,8 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
             let has_network_details = err.network_decline_code.is_some()
                 || err.network_advice_code.is_some()
                 || err.network_error_message.is_some();
-            let issuer_details = has_network_details.then(|| {
-                grpc_api_types::payments::IssuerErrorDetails {
+            let issuer_details =
+                has_network_details.then(|| grpc_api_types::payments::IssuerErrorDetails {
                     code: None,
                     message: err.network_error_message.clone(),
                     network_details: Some(grpc_api_types::payments::NetworkErrorDetails {
@@ -11161,8 +11161,7 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                         decline_code: err.network_decline_code.clone(),
                         error_message: err.network_error_message.clone(),
                     }),
-                }
-            });
+                });
             PaymentServiceSetupRecurringResponse {
                 connector_recurring_payment_id: err.connector_transaction_id.clone(),
                 redirection_data: None,


### PR DESCRIPTION
## What

Fixes the cybersource `setup_mandate` (zero-dollar) **error-path** router-data divergence between the Direct gateway and UCS.

`generate_setup_mandate_response` builds the `PaymentServiceSetupRecurringResponse` for the `Err` branch by hand and dropped three fields that the native (Direct) cybersource connector populates on its `ErrorResponse`:

| Field (RouterData `response.Err.*`) | Direct (hyperswitch) | UCS before | UCS after |
|---|---|---|---|
| `connector_transaction_id` | connector txn id (string) | `null` ← `connector_recurring_payment_id: None` | connector txn id |
| `network_decline_code` | scheme decline code (string) | `null` ← `issuer_details: None` | scheme decline code |
| `connector_response_reference_id` | `null` | string ← `merchant_recurring_payment_id` echoed the txn id | `null` |

All three stem from the same hand-rolled `Err(...)` construction. The domain `ErrorResponse` already carries `connector_transaction_id` and the network decline details (prism's `get_error_response` sets them from the cybersource response) — they were simply not threaded into the proto response.

## Fix

- `connector_recurring_payment_id` ← `err.connector_transaction_id` (router maps this onto `ErrorResponse.connector_transaction_id`).
- `error.issuer_details` ← populated from `err.network_{decline_code,advice_code,error_message}` (mirrors the central `ForeignFrom<&ErrorResponse> for Option<ErrorInfo>` helper), gated on having any network detail.
- `merchant_recurring_payment_id` no longer echoes the connector txn id (Direct leaves `connector_response_reference_id` `None` on errors).

Generic to all connectors' setup_mandate error path; data-gated, so it only adds fields when the connector actually returned them.

## Issues

- Fixes juspay/hyperswitch-cloud#17014 — `router.typeDiff:response.Err.connector_transaction_id`
- Fixes juspay/hyperswitch-cloud#17015 — `router.typeDiff:response.Err.network_decline_code`
- Fixes juspay/hyperswitch-cloud#17057 — `router.typeDiff:response.Err.connector_transaction_id` (re-detection of #17014)
- Fixes juspay/hyperswitch-cloud#17058 — `router.typeDiff:response.Err.network_decline_code` (re-detection of #17015)
- Parent: juspay/hyperswitch-cloud#16972 (the third child #16922 — request-side `consumerAuthenticationInformation` — is a separate fix: prism #1605 / hyperswitch #12894)

## Verification (local shadow stack, cybersource `setup_mandate`, real router → shadow-UCS comparison)

A zero-dollar setup mandate was driven through the router with a deterministic cybersource decline so both Direct and UCS built their `ErrorResponse` from the same upstream.

**BEFORE** (main prism) — `VS_48`, 3 type differences:
```json
"typeDiff":{
  "response.Err.connector_transaction_id":{"hyperswitch":"string","ucs":"null"},
  "response.Err.connector_response_reference_id":{"hyperswitch":"null","ucs":"string"},
  "response.Err.network_decline_code":{"hyperswitch":"string","ucs":"null"}
}
```

**AFTER** (this branch) — `VS_46`, no differences:
```json
"summary":{"total_key_differences":0,"total_value_differences":0,"total_type_differences":0}
"Router data comparison completed successfully - no differences found"
```
Verified request-id `019ef5c8-5f1c-7ce2-8a58-4e2b970c2275` (`keyDiff {}`, `valueDiff {}`, `typeDiff {}`).

The production diff (Grafana/Loki RCA on the prod `validation-service` namespace, 9 occurrences over the last 2 days) is byte-identical to the BEFORE block above for the two tracked fields.

_No credentials or local config are included; `config/development.toml` is intentionally excluded._