### PR TITLE
fix(redsys): populate resource_id, connector_metadata & authentication_data on pre_authenticate (shadow parity #16979)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -586,9 +586,16 @@ fn get_preauthenticate_response(
             three_ds_method_url,
             continue_redirection_url,
             semantic_version,
+            message_version,
+            authentication_data,
             http_status,
         ),
-        None => build_threeds_exempt_response(response_data, authentication_data),
+        None => build_threeds_exempt_response(
+            response_data,
+            &three_d_s_server_trans_i_d,
+            message_version,
+            authentication_data,
+        ),
     }
 }
 
@@ -598,6 +605,8 @@ fn build_threeds_invoke_response(
     three_ds_method_url: &str,
     continue_redirection_url: Option<&url::Url>,
     protocol_version: common_utils::types::SemanticVersion,
+    message_version: &str,
+    authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
     http_status: u16,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
     let notification_url = continue_redirection_url
@@ -646,21 +655,41 @@ fn build_threeds_invoke_response(
         form_fields,
     }));
 
+    // Mirror hyperswitch's (Direct) `RedsysThreeDsInvokeData` connector_metadata shape so the
+    // shadow router-data comparison matches (resolves connector_metadata typeDiff on the invoke
+    // path). Keys are snake_case and `three_ds_method_data_submission` is a JSON bool, exactly as
+    // hyperswitch serializes it.
+    let connector_metadata = serde_json::json!({
+        "directory_server_id": three_d_s_server_trans_i_d,
+        "message_version": message_version,
+        "three_ds_method_data": three_ds_method_data,
+        "three_ds_method_data_submission": true,
+        "three_ds_method_url": three_ds_method_url,
+    });
+
     Ok(responses::PreAuthenticateResponseData {
         redirection_data: redirect_form,
-        connector_meta_data: None,
+        connector_meta_data: Some(Secret::new(connector_metadata)),
         response_ref_id: Some(response_data.ds_order.clone()),
-        authentication_data: None,
+        authentication_data,
     })
 }
 
 fn build_threeds_exempt_response(
     response_data: &responses::RedsysPaymentsResponse,
+    three_d_s_server_trans_i_d: &str,
+    message_version: &str,
     authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
+    // Mirror hyperswitch's (Direct) `ThreeDsInvokeExempt` connector_metadata shape so the shadow
+    // router-data comparison matches (resolves the connector_metadata typeDiff on the exempt path).
+    let connector_metadata = serde_json::json!({
+        "message_version": message_version,
+        "three_d_s_server_trans_i_d": three_d_s_server_trans_i_d,
+    });
     Ok(responses::PreAuthenticateResponseData {
         redirection_data: None,
-        connector_meta_data: None,
+        connector_meta_data: Some(Secret::new(connector_metadata)),
         response_ref_id: Some(response_data.ds_order.clone()),
         authentication_data,
     })
@@ -944,7 +973,9 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         ..item.router_data.resource_common_data
                     },
                     response: Ok(PaymentsResponseData::PreAuthenticateResponse {
-                        resource_id: None,
+                        resource_id: response_ref_id
+                            .clone()
+                            .map(ResponseId::ConnectorTransactionId),
                         redirection_data,
                         connector_response_reference_id: response_ref_id,
                         status_code: item.http_code,
@@ -964,7 +995,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -1156,7 +1187,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -1477,7 +1508,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -1596,7 +1627,7 @@ impl TryFrom<ResponseRouterData<responses::RedsysResponse, Self>>
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -1719,7 +1750,7 @@ impl TryFrom<ResponseRouterData<responses::RedsysResponse, Self>>
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -2029,7 +2060,7 @@ impl TryFrom<ResponseRouterData<responses::RedsysResponse, Self>>
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,


### PR DESCRIPTION
## Issue
Shadow validation — `bu_es / redsys / pre_authenticate` (juspay/hyperswitch-cloud#16979). 44 occurrences across 5 child diffs vs hyperswitch's native gateway. Every defect is UCS-side.

| Child | Diff signature | hyperswitch (native) | UCS (before) | Root cause |
|---|---|---|---|---|
| #16981 | `response.Ok.TransactionResponse.resource_id` (typeDiff `object`/`string`) | `ConnectorTransactionId(ds_order)` | `NoResponseId` | `PreAuthenticateResponse.resource_id` hardcoded `None` |
| #16982 | `response.Ok.TransactionResponse.connector_metadata{.three_ds_method_data}` | `RedsysThreeDsInvokeData` / `ThreeDsInvokeExempt` object | `null` | `connector_meta_data` hardcoded `None` in both build fns |
| #16980 | `response.Ok.TransactionResponse.authentication_data` (typeDiff `object`/`null`) | `AuthenticationData` object | `null` | invoke path dropped `authentication_data` (only exempt path set it) |
| #17026 | `response.Err.reason` (typeDiff `string`/`null`) | `Some(error_code)` | `null` (`error_code_description` absent) | reason sourced only from optional description |

`generate_payment_pre_authenticate_response` already maps `resource_id`→proto `connector_transaction_id`, `connector_feature_data`, and `authentication_data` — no proto change needed; the connector transformer just wasn't populating them.

## Fix (UCS connector transformer, redsys)
- `resource_id = response_ref_id.map(ConnectorTransactionId)` (the `ds_order`).
- Populate `connector_meta_data` on **both** paths with the exact snake_case shape hyperswitch serializes:
  - invoke: `{directory_server_id, message_version, three_ds_method_data, three_ds_method_data_submission: <bool>, three_ds_method_url}`
  - exempt: `{message_version, three_d_s_server_trans_i_d}`
- Thread `authentication_data` into the invoke response (was hardcoded `None`).
- Error `reason = Some(error_code)` (mirrors native; clears the null typeDiff).

Pairs with hyperswitch PR (router-side readback no longer discards this `connector_metadata`).

## Verification (local shadow stack, router-data comparison)
redsys sandbox returns the **3DS-exempt** PreAuthenticate path (`resource_id` + `connector_metadata` diffs); the 3DS-method/invoke path (`authentication_data`, `three_ds_method_data` value) is not reproducible with sandbox cards and is fixed by mirroring the native transformer.

- **BEFORE** (clean `main`, req `019ef60b-d8e1-7950-9a61-b1566da6553c`): `VS_48` →
  `typeDiff {response.Ok.TransactionResponse.resource_id: {hyperswitch:"object", ucs:"string"}, response.Ok.TransactionResponse.connector_metadata: {hyperswitch:"object", ucs:"null"}}`
- **AFTER** (req `019ef621-6db3-7db3-99a7-bc1b22ee4f8e`, reconfirmed ×3): `VS_46` →
  `Router data comparison completed successfully - no differences found` (0 key / 0 value / 0 type differences).

> Note: on the 3DS-method/invoke path `connector_metadata.three_ds_method_data` embeds the 3DS-method notification URL. Native uses `request.webhook_url` while UCS has only `continue_redirection_url`; fully byte-matching that base64 value would require threading the webhook URL through the PreAuthenticate proto (follow-up). All other invoke-path fields now match.

Fixes #16980, #16981 (and the `connector_metadata` portion of #16982), #17026, #17044 (re-detected `connector_metadata` typeDiff), #17045 (re-detected `resource_id` typeDiff).
