### PR TITLE
fix(redsys): use webhook_url as 3DS method notification URL on pre_authenticate (shadow parity #16982)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -612,7 +612,9 @@ fn build_threeds_invoke_response(
         .ok_or_else(|| {
             Report::new(ConnectorError::response_handling_failed_with_context(
                 http_status,
-                Some("webhook_url / continue_redirection_url missing for 3DS method URL".to_string()),
+                Some(
+                    "webhook_url / continue_redirection_url missing for 3DS method URL".to_string(),
+                ),
             ))
         })?;
 

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -538,6 +538,7 @@ fn build_threeds_form(
 
 fn get_preauthenticate_response(
     response_data: &responses::RedsysPaymentsResponse,
+    webhook_url: Option<&str>,
     continue_redirection_url: Option<&url::Url>,
     existing_connector_meta: Option<Secret<serde_json::Value>>,
     http_status: u16,
@@ -584,6 +585,7 @@ fn get_preauthenticate_response(
             response_data,
             &three_d_s_server_trans_i_d,
             three_ds_method_url,
+            webhook_url,
             continue_redirection_url,
             semantic_version,
             http_status,
@@ -596,16 +598,21 @@ fn build_threeds_invoke_response(
     response_data: &responses::RedsysPaymentsResponse,
     three_d_s_server_trans_i_d: &str,
     three_ds_method_url: &str,
+    webhook_url: Option<&str>,
     continue_redirection_url: Option<&url::Url>,
     protocol_version: common_utils::types::SemanticVersion,
     http_status: u16,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
-    let notification_url = continue_redirection_url
+    // Mirror the native gateway: the 3DS method notification URL is the merchant
+    // webhook URL. Fall back to continue_redirection_url for older clients that do
+    // not send webhook_url.
+    let notification_url = webhook_url
         .map(|url| url.to_string())
+        .or_else(|| continue_redirection_url.map(|url| url.to_string()))
         .ok_or_else(|| {
             Report::new(ConnectorError::response_handling_failed_with_context(
                 http_status,
-                Some("continue_redirection_url missing for 3DS method URL".to_string()),
+                Some("webhook_url / continue_redirection_url missing for 3DS method URL".to_string()),
             ))
         })?;
 
@@ -928,6 +935,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                     authentication_data,
                 } = get_preauthenticate_response(
                     &response_data,
+                    item.router_data.request.webhook_url.as_deref(),
                     item.router_data.request.continue_redirection_url.as_ref(),
                     item.router_data
                         .resource_common_data

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -517,6 +517,7 @@ impl
             connector_feature_data: item.connector_feature_data.clone(),
             return_url: item.return_url.clone(),
             continue_redirection_url: item.continue_redirection_url.clone(),
+            webhook_url: item.webhook_url.clone(),
             browser_info: item.browser_info.clone(),
             state: resolved_state,
             capture_method: item.capture_method,

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2014,6 +2014,7 @@ pub struct PaymentsPreAuthenticateData<T: PaymentMethodDataTypes> {
     pub payment_method_type: Option<PaymentMethodType>,
     pub router_return_url: Option<Url>,
     pub continue_redirection_url: Option<Url>,
+    pub webhook_url: Option<String>,
     pub browser_info: Option<BrowserInformation>,
     pub enrolled_for_3ds: bool,
     pub redirect_response: Option<ContinueRedirectionResponse>,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -14208,6 +14208,7 @@ impl<
                     })
                 })
                 .transpose()?,
+            webhook_url: value.webhook_url,
             browser_info: value
                 .browser_info
                 .map(BrowserInformation::foreign_try_from)

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3398,6 +3398,10 @@ message PaymentMethodAuthenticationServicePreAuthenticateRequest {
 
   // Description
   optional string description = 14;
+
+  // Webhook URL used as the 3DS method notification URL (mirrors the native
+  // gateway's webhook_url so the embedded threeDSMethodNotificationURL matches)
+  optional string webhook_url = 15;
 }
 
 // Response message for pre-authentication step


### PR DESCRIPTION
## Issue
Shadow validation — `bu_es / redsys / pre_authenticate` (juspay/hyperswitch-cloud#16982).

```
router.valueDiff: response.Ok.TransactionResponse.connector_metadata.three_ds_method_data
```

This is the residual **valueDiff** explicitly deferred as a follow-up by #1616 ("fully byte-matching that base64 value would require threading the webhook URL through the PreAuthenticate proto"). #1616 fixes the `connector_metadata` *typeDiff* (null → object); this PR fixes the *value* of the `three_ds_method_data` blob inside it.

## Root cause
On the redsys 3DS-**method (invoke)** path, `connector_metadata.three_ds_method_data` is a base64-encoded JSON blob that embeds a `threeDSMethodNotificationURL`. The native gateway builds this URL from the merchant **webhook_url** (`get_webhook_url()` → `/api/webhooks/<mid>/<mca_id>`), whereas UCS derived it from `continue_redirection_url` (`/api/payments/<pid>/<mid>/redirect/complete/redsys`). Because the differing URL is base64-encoded into the blob, the whole `three_ds_method_data` string differs → valueDiff.

Prod RCA (sample req `019ef311-5942-7f30-b2c3-1a471b946503`, payment `zoesqavScfe`), decoded `three_ds_method_data`:
- **hyperswitch (native):** `{"threeDSMethodNotificationURL":"https://live.hyperswitch.io/api/webhooks/bu_es/mca_ox5UaUXMQooZ8rh63uqa","threeDSServerTransID":"5315de6b-..."}`
- **UCS (before):** `{"threeDSMethodNotificationURL":"https://live.hyperswitch.io/api/payments/zoesqavScfe/bu_es/redirect/complete/redsys","threeDSServerTransID":"5315de6b-..."}`

The proto `PaymentMethodAuthenticationServicePreAuthenticateRequest` carried `continue_redirection_url` but **no** webhook URL, so prism had no source for the native URL.

## Fix
- **proto:** add `optional string webhook_url = 15` to `PaymentMethodAuthenticationServicePreAuthenticateRequest`.
- **domain:** add `webhook_url: Option<String>` to `PaymentsPreAuthenticateData`, mapped from the new proto field.
- **redsys transformer:** `build_threeds_invoke_response` now uses `webhook_url` for `threeDSMethodNotificationURL` (preferring it over `continue_redirection_url`, which it falls back to for older clients that don't send it). The exempt path is unchanged.
- **composite-service:** thread `webhook_url` through the composite PreAuthenticate request (already available on `CompositeAuthorizeRequest`).

Pairs with hyperswitch PR (sets `webhook_url` on the PreAuthenticate gRPC request from `router_data.request.webhook_url`, the same source native uses) + rev-pin.

## Verification
The redsys **sandbox returns only the 3DS-exempt path** (no `threeDSMethodURL`), so the 3DS-method/invoke path that carries `three_ds_method_data` is not locally reproducible — same constraint #1616 documented. Verification is therefore:
- `cargo build -p grpc-server` ✅ (prism) and `cargo build -p router` ✅ (hyperswitch, against the rev-pinned proto) — the `webhook_url` field flows proto → domain → redsys transformer and proto → gRPC client end-to-end.
- **Runtime proof (local shadow stack, req `019ef664-ca84-7433-8af0-7d7707340ea2`):** the PreAuthenticate gRPC request received by prism now carries `webhook_url`, with the native-matching shape `http://.../webhooks/redsys_repro_4224/mca_1Dc7BJnWmf9AM1I7W72H` (i.e. `/webhooks/<mid>/<mca_id>`, exactly the URL family the prod native gateway used — `/api/webhooks/bu_es/mca_ox5UaUXMQooZ8rh63uqa`). On the invoke path `build_threeds_invoke_response` now uses this for `threeDSMethodNotificationURL`.
- The change is a **no-op on the exempt path** (the only sandbox-reproducible path); the same payment shows only the unrelated pre-existing `resource_id`/`connector_metadata` typeDiffs (#16981/#16979, fixed by #1616) and **no new diff** — no regression.
- Prod RCA (above) is the before evidence; after the fix UCS sources the notification URL from `webhook_url` — identical to native — so the base64 `three_ds_method_data` matches byte-for-byte.

Fixes #16982.
