### PR TITLE
fix(nexixpay): PSync resource_id + connector_metadata parity vs hyperswitch (shadow validation)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -620,12 +620,32 @@ impl TryFrom<ResponseRouterData<NexixpaySyncResponse, Self>>
         // Map operation result to payment status using From trait
         let status = AttemptStatus::from(item.response.operation_result.clone());
 
+        // Echo back the stored connector metadata blob (mirrors native hyperswitch's
+        // `connector_metadata: request.connector_meta.clone()` on PSync — native re-emits
+        // the persisted `NexixpayConnectorMetaData`, prism was dropping it as `None`).
+        let connector_metadata = item
+            .router_data
+            .request
+            .connector_feature_data
+            .as_ref()
+            .map(|meta| meta.peek().clone());
+
+        // NOTE: #16985 (mandate_reference typeDiff) is intentionally NOT fixed here. Native
+        // sources `mandate_reference.connector_mandate_id` from the stored
+        // `payment_attempt.connector_mandate_detail.connector_mandate_request_reference_id`,
+        // which the HS->UCS PaymentServiceGetRequest does NOT thread through (no mandate_id /
+        // connector_mandate_request_reference_id on the sync request). Emitting an all-None
+        // MandateReference here would only trade the type diff for a value diff. A clean fix
+        // requires threading that stored reference through the PSync gRPC request (proto change).
+
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.operation_id.clone()),
+                // Use the order id (== merchant payment_id) to match native, not the
+                // per-operation `operationId` prism previously surfaced.
+                resource_id: ResponseId::ConnectorTransactionId(item.response.order_id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
+                connector_metadata,
                 network_txn_id: None,
                 network_txn_link_id: None,
                 connector_response_reference_id: Some(item.response.order_id.clone()),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -7105,7 +7105,7 @@ pub fn generate_payment_sync_response(
             PaymentsResponseData::TransactionResponse {
                 resource_id,
                 redirection_data,
-                connector_metadata: _,
+                connector_metadata,
                 network_txn_id,
                 network_txn_link_id,
                 connector_response_reference_id,
@@ -7173,7 +7173,9 @@ pub fn generate_payment_sync_response(
                         .connector_customer
                         .clone(),
                     merchant_order_id: None,
-                    metadata: None,
+                    // Carry connector_metadata through the PSync response so the router-data
+                    // shape matches native (native populates connector_metadata on sync).
+                    metadata: convert_connector_metadata_to_secret_string(connector_metadata),
                     status_code: status_code as u32,
                     raw_connector_response,
                     response_headers: router_data_v2


### PR DESCRIPTION
## What

Closes the nexixpay **PSync** router-data shadow-validation diffs for `bu_it_zie` / `zurich_insurance` (parent juspay/hyperswitch-cloud#16983).

| Child | Signature | Root cause |
|---|---|---|
| #16986 | `valueDiff: response.Ok.TransactionResponse.resource_id.ConnectorTransactionId` | prism set `resource_id` from the per-operation `operationId`; native uses the response `orderId` (== merchant `payment_id`). |
| #16984 | `typeDiff: response.Ok.TransactionResponse.connector_metadata` (object vs null) | prism hardcoded `connector_metadata: None` on the PSync response; native echoes the stored `connector_meta` blob. |

## Changes

- **`connectors/nexixpay/transformers.rs`** (PSync response `TryFrom`):
  - `resource_id` ← `item.response.order_id` (was `operation_id`), matching native.
  - `connector_metadata` ← the stored `request.connector_feature_data` (mirrors native's `connector_metadata: request.connector_meta.clone()`).
- **`domain_types/src/types.rs`** (`generate_payment_sync_response`, generic PSync domain→proto): stop discarding `connector_metadata`; serialize it into the **existing** `PaymentServiceGetResponse.metadata` field via `convert_connector_metadata_to_secret_string`. **No proto field added.** The paired hyperswitch PR reads it back into `connector_metadata`.

`mandate_reference` (#16985) is **intentionally not fixed here** — native sources its `connector_mandate_id` from the stored `payment_attempt.connector_mandate_detail`, which the HS→UCS sync request does not thread through, so emitting an all-`None` MandateReference would only trade the type diff for a value diff. A clean fix needs the stored reference threaded through the PSync gRPC request (proto change); documented inline + tracked on #16985.

## Verification (local shadow stack, real nexixpay sandbox)

Reproduced via a 3DS authorize (stores `connector_meta`) + `force_sync` PSync; router-data compared by the validation service (`VS_48` = diff, `VS_46` = no diff).

**BEFORE** (`x-request-id 019ef687-4822-7542-ac4b-21169a5a4644`, payment `pay_VfT34GfaQ4SHMmTMTqZk`):
```
VS_48  total_key=0 total_value=1 total_type=1
 valueDiff response.Ok.TransactionResponse.resource_id.ConnectorTransactionId:
   { hyperswitch: "pay_VfT34GfaQ4SHMm", ucs: "688254024833461759" }
 typeDiff  response.Ok.TransactionResponse.connector_metadata:
   { hyperswitch: "object", ucs: "null" }
```

**AFTER** (`x-request-id 019ef68e-a6ce-7ec3-8c8b-317d9c938e12`, payment `pay_QvjX1u4dHAkTY5AeqsaH`):
```
VS_46  no differences found
 total_key_differences: 0, total_value_differences: 0, total_type_differences: 0
 data_sizes: { hyperswitch_data_keys: 56, ucs_data_keys: 56 }
```

Fixes juspay/hyperswitch-cloud#16986
Fixes juspay/hyperswitch-cloud#16984
