### PR TITLE
feat(medusa): add Klarna (Pay later) via Mollie

### DIFF
--- a/plugins/medusa/app/client/src/pages/CheckoutPage.tsx
+++ b/plugins/medusa/app/client/src/pages/CheckoutPage.tsx
@@ -7,6 +7,8 @@ import {
   PayPalWrapper,
   GlobalPayWrapper,
   MollieWrapper,
+  MollieKlarnaForm,
+  type MollieKlarnaBilling,
 } from "@juspay-tech/medusa-custom-payments-react";
 
 // The Stripe publishable key and Adyen client key are delivered by the server
@@ -219,17 +221,128 @@ function ConnectorUI({ connector, sessionId, sessionData, onComplete, onError }:
       );
 
     case "mollie":
-      // Mollie Components: card fields are entered in-page and tokenized to a
-      // single-use cardToken. We persist it on the session (reinitiate), then
-      // authorize (cart complete). One-off cards still return a 3DS redirect,
-      // which we follow; on return, /order/:id PSyncs the final status.
+      // Mollie supports two methods here: in-page Card (Components, USD) and
+      // Klarna (PayLater redirect, EUR). MollieCheckout renders a toggle.
       return (
+        <MollieCheckout
+          sessionId={sessionId}
+          sessionData={sessionData}
+          onError={onError}
+        />
+      );
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Mollie checkout with a Card | Klarna toggle.
+ * - Card: in-page Components → cardToken → reinitiate → complete → 3DS redirect.
+ * - Klarna: PayLater redirect. Klarna requires an EU currency, so it spins up a
+ *   fresh EUR Mollie session (the page-load session is USD for card), persists
+ *   the billing + paymentMethodType, completes, and follows the Klarna redirect.
+ */
+function MollieCheckout({
+  sessionId,
+  sessionData,
+  onError,
+}: {
+  sessionId: string;
+  sessionData: Record<string, any>;
+  onError: (e: Error) => void;
+}) {
+  const [method, setMethod] = useState<"card" | "klarna">("card");
+
+  const payKlarna = async (billing: MollieKlarnaBilling) => {
+    // Klarna via Mollie is EU-only → create a fresh EUR Mollie session for the
+    // cart. createSession overwrites cartToSession, so this becomes the active
+    // session that /complete authorizes.
+    const collRes = await fetch("/store/payment-collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cart_id: CART.cartId,
+        currency_code: "EUR",
+        amount: CART.amount,
+      }),
+    });
+    const coll = await collRes.json();
+    const collectionId = coll.payment_collection.id;
+
+    const sessRes = await fetch(
+      `/store/payment-collections/${collectionId}/payment-sessions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider_id: "mollie" }),
+      }
+    );
+    const sess = await sessRes.json();
+    const ps = sess.payment_collection.payment_sessions[0];
+    const klarnaSessionId = ps.id;
+
+    // Persist the Klarna billing + method on the (EUR) session.
+    await fetch(`/store/payment-sessions/${klarnaSessionId}/reinitiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: {
+          paymentMethodType: "klarna",
+          billing,
+          id: ps.data?.id,
+          returnUrl: `${window.location.origin}/order/${klarnaSessionId}`,
+        },
+      }),
+    });
+
+    // Authorize (cart complete) → Klarna hosted-checkout redirect.
+    const res = await fetch(`/store/carts/${CART.cartId}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(body.error ?? `Authorize failed (${res.status})`);
+    }
+    if (body.redirectUrl) {
+      window.location.assign(body.redirectUrl);
+      return;
+    }
+    window.location.assign(`/order/${klarnaSessionId}`);
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+        {(["card", "klarna"] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            data-testid={`mollie-method-${m}`}
+            onClick={() => setMethod(m)}
+            style={{
+              flex: 1,
+              padding: "10px 12px",
+              borderRadius: 6,
+              border: method === m ? "2px solid #0b051d" : "1px solid #ddd",
+              background: method === m ? "#f5f5f5" : "#fff",
+              fontWeight: method === m ? 600 : 400,
+              cursor: "pointer",
+            }}
+          >
+            {m === "card" ? "Card" : "Klarna (Pay later)"}
+          </button>
+        ))}
+      </div>
+
+      {method === "card" ? (
         <MollieWrapper
           profileId={sessionData.profileId ?? ""}
           testmode
           onError={onError}
           onSubmit={async ({ cardToken }) => {
-            // 1. store the card token + storefront return URL on the session
             await fetch(`/store/payment-sessions/${sessionId}/reinitiate`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -241,8 +354,6 @@ function ConnectorUI({ connector, sessionId, sessionData, onComplete, onError }:
                 },
               }),
             });
-
-            // 2. authorize the payment (cart complete)
             const res = await fetch(`/store/carts/${CART.cartId}/complete`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -252,8 +363,6 @@ function ConnectorUI({ connector, sessionId, sessionData, onComplete, onError }:
             if (!res.ok) {
               throw new Error(body.error ?? `Authorize failed (${res.status})`);
             }
-
-            // 3. follow the 3DS redirect if present; else go to the order page
             if (body.redirectUrl) {
               window.location.assign(body.redirectUrl);
               return;
@@ -261,9 +370,14 @@ function ConnectorUI({ connector, sessionId, sessionData, onComplete, onError }:
             window.location.assign(`/order/${sessionId}`);
           }}
         />
-      );
-
-    default:
-      return null;
-  }
+      ) : (
+        <MollieKlarnaForm
+          amount={CART.amount}
+          currency="EUR"
+          onError={onError}
+          onSubmit={payKlarna}
+        />
+      )}
+    </div>
+  );
 }

--- a/plugins/medusa/app/client/src/pages/CheckoutPage.tsx
+++ b/plugins/medusa/app/client/src/pages/CheckoutPage.tsx
@@ -254,10 +254,26 @@ function MollieCheckout({
 }) {
   const [method, setMethod] = useState<"card" | "klarna">("card");
 
+  // Parse a JSON response, surfacing a clear error if the request failed.
+  // Without this, a non-2xx body silently flows on and derefs `undefined`
+  // (e.g. coll.payment_collection.id), crashing with an opaque message — or, for
+  // the reinitiate call, loses the billing data and fails later as "missing
+  // billing" at authorize. Mirrors the /complete handling below.
+  const readJson = async (res: Response, what: string) => {
+    const body = await res.json().catch(() => ({} as any));
+    if (!res.ok) {
+      throw new Error(body.error ?? `${what} failed (${res.status})`);
+    }
+    return body;
+  };
+
   const payKlarna = async (billing: MollieKlarnaBilling) => {
     // Klarna via Mollie is EU-only → create a fresh EUR Mollie session for the
     // cart. createSession overwrites cartToSession, so this becomes the active
-    // session that /complete authorizes.
+    // session that /complete authorizes. NOTE: the original USD session created
+    // on page load is left as-is (not voided) — harmless here since /complete
+    // authorizes whichever session is active, but a production flow should cancel
+    // the abandoned session.
     const collRes = await fetch("/store/payment-collections", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -267,7 +283,7 @@ function MollieCheckout({
         amount: CART.amount,
       }),
     });
-    const coll = await collRes.json();
+    const coll = await readJson(collRes, "Create payment collection");
     const collectionId = coll.payment_collection.id;
 
     const sessRes = await fetch(
@@ -278,23 +294,27 @@ function MollieCheckout({
         body: JSON.stringify({ provider_id: "mollie" }),
       }
     );
-    const sess = await sessRes.json();
+    const sess = await readJson(sessRes, "Create payment session");
     const ps = sess.payment_collection.payment_sessions[0];
     const klarnaSessionId = ps.id;
 
     // Persist the Klarna billing + method on the (EUR) session.
-    await fetch(`/store/payment-sessions/${klarnaSessionId}/reinitiate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        data: {
-          paymentMethodType: "klarna",
-          billing,
-          id: ps.data?.id,
-          returnUrl: `${window.location.origin}/order/${klarnaSessionId}`,
-        },
-      }),
-    });
+    const reinitRes = await fetch(
+      `/store/payment-sessions/${klarnaSessionId}/reinitiate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          data: {
+            paymentMethodType: "klarna",
+            billing,
+            id: ps.data?.id,
+            returnUrl: `${window.location.origin}/order/${klarnaSessionId}`,
+          },
+        }),
+      }
+    );
+    await readJson(reinitRes, "Persist Klarna billing");
 
     // Authorize (cart complete) → Klarna hosted-checkout redirect.
     const res = await fetch(`/store/carts/${CART.cartId}/complete`, {
@@ -343,17 +363,21 @@ function MollieCheckout({
           testmode
           onError={onError}
           onSubmit={async ({ cardToken }) => {
-            await fetch(`/store/payment-sessions/${sessionId}/reinitiate`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                data: {
-                  cardToken,
-                  id: sessionData.id,
-                  returnUrl: `${window.location.origin}/order/${sessionId}`,
-                },
-              }),
-            });
+            const reinitRes = await fetch(
+              `/store/payment-sessions/${sessionId}/reinitiate`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  data: {
+                    cardToken,
+                    id: sessionData.id,
+                    returnUrl: `${window.location.origin}/order/${sessionId}`,
+                  },
+                }),
+              }
+            );
+            await readJson(reinitRes, "Persist card token");
             const res = await fetch(`/store/carts/${CART.cartId}/complete`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },

--- a/plugins/medusa/medusa-custom-payments-react/README.md
+++ b/plugins/medusa/medusa-custom-payments-react/README.md
@@ -15,7 +15,7 @@ React UI components for Hyperswitch Prism payment connectors. Ships two layers o
 | `paypal` | ✅ | ✅ | CAPTURED |
 | `stripe` | — | ✅ | AUTHORIZED |
 | `globalpay` | ✅ | ✅ | CAPTURED |
-| `mollie` | ✅ | ✅ | CAPTURED (after 3DS) |
+| `mollie` | ✅ | ✅ | CAPTURED (Card after 3DS; Klarna after redirect) |
 | `braintree` | ○ | ○ | — |
 | `cybersource` | ○ | ○ | — |
 
@@ -75,6 +75,8 @@ NEXT_PUBLIC_ADYEN_CLIENT_KEY=test_...
 | `GlobalPayWrapper` | Component | Low-level GlobalPay hosted card fields wrapper |
 | `StripeWrapper` | Component | Low-level Stripe Payment Element wrapper |
 | `MollieWrapper` | Component | Low-level Mollie Components (in-page card tokenization) wrapper |
+| `MollieKlarnaForm` | Component | Klarna (Pay later) billing form for the Mollie redirect flow — collects name/email/postal address (Netherlands test defaults, all fields editable) and submits a `MollieKlarnaBilling`. Pair with a EUR session (Klarna via Mollie is EU-only) |
+| `MollieKlarnaBilling` | Type | Shape of the Klarna billing the form collects: `firstName`, `lastName`, `email`, `line1`, `city`, `postalCode`, `country` (ISO 3166-1 alpha-2) |
 | `StripePaymentButton` | Component | Place-order button for Stripe |
 | `AdyenPaymentButton` | Component | Place-order button for Adyen |
 | `PayPalPaymentButton` | Component | Place-order button for PayPal |

--- a/plugins/medusa/medusa-custom-payments-react/src/connectors/mollie/MollieKlarnaForm.tsx
+++ b/plugins/medusa/medusa-custom-payments-react/src/connectors/mollie/MollieKlarnaForm.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+
+export interface MollieKlarnaBilling {
+  firstName: string;
+  lastName: string;
+  email: string;
+  line1: string;
+  city: string;
+  postalCode: string;
+  /** ISO 3166-1 alpha-2 (e.g. "NL"). Klarna via Mollie is EU-only. */
+  country: string;
+}
+
+interface MollieKlarnaFormProps {
+  /** Amount in major units, for the button label. */
+  amount: number;
+  /** ISO 4217 currency (Klarna via Mollie requires an EU currency, e.g. EUR). */
+  currency: string;
+  /** Pre-fill the billing form (defaults to a Netherlands test address). */
+  defaultBilling?: Partial<MollieKlarnaBilling>;
+  /** Submit the billing details to start the Klarna redirect. Awaited. */
+  onSubmit: (billing: MollieKlarnaBilling) => void | Promise<void>;
+  onError: (error: Error) => void;
+}
+
+// Klarna via Mollie only operates in EU markets. Default to a Netherlands test
+// address so the sandbox redirect works out of the box; all fields are editable.
+const NL_DEFAULTS: MollieKlarnaBilling = {
+  firstName: "Test",
+  lastName: "Klarna",
+  email: "test.klarna@example.com",
+  line1: "Keizersgracht 313",
+  city: "Amsterdam",
+  postalCode: "1016 EE",
+  country: "NL",
+};
+
+const FIELDS: Array<{
+  key: keyof MollieKlarnaBilling;
+  label: string;
+  type?: string;
+  half?: boolean;
+}> = [
+  { key: "firstName", label: "First name", half: true },
+  { key: "lastName", label: "Last name", half: true },
+  { key: "email", label: "Email", type: "email" },
+  { key: "line1", label: "Address" },
+  { key: "city", label: "City", half: true },
+  { key: "postalCode", label: "Postal code", half: true },
+  { key: "country", label: "Country (ISO-2)", half: true },
+];
+
+/**
+ * Klarna (Pay later) via Mollie is a redirect flow with no client-side
+ * tokenization — Klarna requires the buyer's billing details up front. This form
+ * collects them and hands them to the host, which persists them on the session
+ * and triggers the authorize that returns the Klarna hosted-checkout redirect.
+ */
+export function MollieKlarnaForm({
+  amount,
+  currency,
+  defaultBilling,
+  onSubmit,
+  onError,
+}: MollieKlarnaFormProps) {
+  const [billing, setBilling] = useState<MollieKlarnaBilling>({
+    ...NL_DEFAULTS,
+    ...defaultBilling,
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const set = (key: keyof MollieKlarnaBilling, value: string) =>
+    setBilling((b) => ({ ...b, [key]: value }));
+
+  const handlePay = async () => {
+    const missing = (Object.keys(NL_DEFAULTS) as Array<keyof MollieKlarnaBilling>).filter(
+      (k) => !billing[k]?.trim()
+    );
+    if (missing.length) {
+      onError(new Error(`Klarna billing: missing ${missing.join(", ")}`));
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await onSubmit({ ...billing, country: billing.country.toUpperCase() });
+    } catch (err) {
+      onError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mollie-klarna-form" data-testid="mollie-klarna-form">
+      <p style={{ color: "#666", fontSize: 13, margin: "0 0 12px" }}>
+        Pay later with Klarna. Enter your billing details (EU only).
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {FIELDS.map((f) => (
+          <div
+            key={f.key}
+            style={{ flex: f.half ? "1 1 calc(50% - 4px)" : "1 1 100%" }}
+          >
+            <label
+              style={{ display: "block", fontSize: 12, color: "#555", marginBottom: 4 }}
+            >
+              {f.label}
+            </label>
+            <input
+              data-testid={`klarna-${f.key}`}
+              type={f.type ?? "text"}
+              value={billing[f.key]}
+              onChange={(e) => set(f.key, e.target.value)}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                border: "1px solid #ddd",
+                borderRadius: 6,
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        data-testid="klarna-pay"
+        disabled={submitting}
+        onClick={handlePay}
+        style={{
+          width: "100%",
+          marginTop: 16,
+          padding: "14px 20px",
+          border: "none",
+          borderRadius: 8,
+          background: submitting ? "#ffb3c7aa" : "#ffb3c7", // Klarna pink
+          color: "#0b051d",
+          fontSize: 16,
+          fontWeight: 700,
+          cursor: submitting ? "not-allowed" : "pointer",
+        }}
+      >
+        {submitting ? "Redirecting…" : `Pay ${amount} ${currency} with Klarna`}
+      </button>
+    </div>
+  );
+}

--- a/plugins/medusa/medusa-custom-payments-react/src/index.ts
+++ b/plugins/medusa/medusa-custom-payments-react/src/index.ts
@@ -21,6 +21,8 @@ export { StripeWrapper } from "./connectors/stripe/StripeWrapper";
 export { PayPalWrapper } from "./connectors/paypal/PayPalWrapper";
 export { GlobalPayWrapper } from "./connectors/globalpay/GlobalPayWrapper";
 export { MollieWrapper } from "./connectors/mollie/MollieWrapper";
+export { MollieKlarnaForm } from "./connectors/mollie/MollieKlarnaForm";
+export type { MollieKlarnaBilling } from "./connectors/mollie/MollieKlarnaForm";
 
 // Payment button components
 export {

--- a/plugins/medusa/medusa-custom-payments/README.md
+++ b/plugins/medusa/medusa-custom-payments/README.md
@@ -43,6 +43,10 @@ PAYPAL_WEBHOOK_ID=...       # webhook ID — required for webhook processing
 # GlobalPay
 GLOBALPAY_APP_ID=...
 GLOBALPAY_APP_KEY=...
+
+# Mollie
+MOLLIE_API_KEY=test_...          # Mollie API key (test_… / live_…)
+MOLLIE_PROFILE_TOKEN=pfl_...     # public profile id; surfaced to the storefront for Mollie Components
 ```
 
 ### 2. Register providers in `medusa-config.ts`
@@ -111,6 +115,21 @@ export default defineConfig({
               connectorConfig: {
                 appId: { value: process.env.GLOBALPAY_APP_ID ?? "" },
                 appKey: { value: process.env.GLOBALPAY_APP_KEY ?? "" },
+              },
+              environment: "SANDBOX",
+            },
+          },
+          {
+            resolve: "@juspay-tech/medusa-custom-payments",
+            id: "mollie",
+            options: {
+              connector: "mollie",
+              connectorConfig: {
+                apiKey: { value: process.env.MOLLIE_API_KEY ?? "" },
+                // Public profile id (pfl_…), not a secret — surfaced in the
+                // payment session as `profileId` for the storefront's Mollie
+                // Components. The same credentials serve Card and Klarna.
+                profileToken: { value: process.env.MOLLIE_PROFILE_TOKEN ?? "" },
               },
               environment: "SANDBOX",
             },
@@ -185,7 +204,7 @@ Each credential value is provided as `{ value: string }` to support secret manag
 
 > **Authorize result by connector**
 > - `adyen`, `stripe`, `braintree`, `cybersource` → payment lands as **AUTHORIZED** (funds reserved; Capture or Void available next)
-> - `paypal`, `globalpay`, `mollie` → payment lands as **CAPTURED** (funds collected immediately via `CaptureMethod.AUTOMATIC`; Refund only). For `mollie` this is reached after the customer completes the 3DS redirect.
+> - `paypal`, `globalpay`, `mollie` → payment lands as **CAPTURED** (funds collected immediately via `CaptureMethod.AUTOMATIC`; Refund only). For `mollie` this is reached after the customer completes the redirect — the 3DS page for Card, or the Mollie-hosted Klarna checkout for Klarna (Pay later, EUR-only).
 
 > **Note:** All flows in the matrix above are tested and verified under the **sandbox / test environment** of each connector. Production behavior should be validated separately before go-live.
 

--- a/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/README.md
+++ b/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/README.md
@@ -1,12 +1,17 @@
 # Mollie Connector
 
-Server-side provider logic for **Mollie** via the Hyperswitch Prism connector service. Mollie uses **Mollie Components** (in-page card tokenization): the card is entered and tokenized client-side into a single-use `cardToken` (card data never touches the server, PCI SAQ-A), the token is persisted to the session, and the server then charges it. One-off card payments complete via a **3DS redirect**, after which the order is finalised.
+Server-side provider logic for **Mollie** via the Hyperswitch Prism connector service. Two payment methods are supported:
+
+- **Card (Mollie Components)** — in-page card tokenization: the card is entered and tokenized client-side into a single-use `cardToken` (card data never touches the server, PCI SAQ-A), the token is persisted to the session, and the server then charges it. One-off card payments complete via a **3DS redirect**, after which the order is finalised.
+- **Klarna (Pay later)** — a **redirect** method with **no client-side tokenization**. The storefront collects billing (name + email + postal address) and re-initiates with `paymentMethodType: "klarna"`; `authorizePayment` builds the Klarna payment and Mollie returns a **hosted Klarna checkout URL** to redirect to. Klarna via Mollie is **EUR-only / EU markets**.
+
+Both methods capture automatically (`CaptureMethod.AUTOMATIC`) and surface the next step as `data.redirectUrl` for the storefront to follow; the post-redirect retry PSyncs to the terminal status.
 
 ## Files
 
 | File | Role |
 |------|------|
-| `index.ts` | `initiatePayment`, `reInitiatePayment`, `authorizePayment`, `shouldSkipVoid` |
+| `index.ts` | `initiatePayment`, `reInitiatePayment`, `authorizePayment`, `shouldSkipVoid`; `KlarnaBilling` + `toKlarnaBillingAddress` (maps the storefront billing form to the SDK billing address for the Klarna arm) |
 
 ## Payment flow
 
@@ -50,6 +55,44 @@ Storefront              Medusa backend               UCS / Prism            Moll
 6. **Idempotent retry (PSync)** — on the retry, `authorizePayment` sees an existing `connectorTransactionId` and **syncs status via `getPaymentStatus`** instead of re-authorizing (the `cardToken` is single-use). Mollie `paid` → `CAPTURED` and the order is created.
 7. **Refund / Cancel** — go through UCS synchronously. `shouldSkipVoid` skips the void when no real Mollie payment exists yet (`data.id` still equals the Medusa session id).
 
+## Klarna (Pay later) flow
+
+Klarna is a redirect method — there is no in-page tokenization. The storefront collects billing in a form (`MollieKlarnaForm`) and Klarna via Mollie requires a **EUR** session.
+
+```
+Storefront              Medusa backend               UCS / Prism            Mollie
+    |                        |                            |                    |
+    |== create EUR session ==|  initiatePayment (mollie)  |                    |
+    |   (Klarna is EU-only)  |  returns profileId         |                    |
+    |                        |                            |                    |
+    |== Klarna billing form: name + email + address =========================>|
+    |                        |                            |                    |
+    |-- re-initiate session->|  reInitiatePayment:        |                    |
+    |   { paymentMethodType: |  persist billing + method  |                    |
+    |     "klarna", billing, |  in session.data (no call) |                    |
+    |     returnUrl }        |                            |                    |
+    |                        |                            |                    |
+    |-- place order -------->|-- authorizePayment ------->|                    |
+    |                        |   paymentMethod.klarna {}  |--- POST /payments ->|
+    |                        |   + billingAddress         |   (Klarna order)    |
+    |                        |   CaptureMethod.AUTOMATIC  |                    |
+    |<- requires_more -------|<-- redirectUrl ------------|<- hosted checkout --|
+    |                        |                            |                    |
+    |== Redirect to Mollie-hosted Klarna checkout ==========================>|
+    |   customer completes Klarna                                              |
+    |<== Redirect back to returnUrl ========================================|
+    |                        |                            |                    |
+    |-- place order (retry)->|-- authorizePayment (PSync)>|--- GET /payments ->|
+    |<-- order --------------|<-- CAPTURED ---------------|<-- status: paid ----|
+```
+
+### Notes
+
+- **EUR-only** — Klarna via Mollie is restricted to EU markets, so the storefront must create the payment session in **EUR**. (Card has no such restriction.)
+- **Billing is required** — `authorizePayment` validates that `firstName`, `email`, and `line1` are present and returns `PaymentSessionStatus.ERROR` otherwise. The connector reads billing via `get_payment_method_billing()`, which falls back to the request `billing_address`, so the top-level `billingAddress` built by `toKlarnaBillingAddress` is sufficient. An unknown/unmappable country code is logged and omitted (Klarna's risk check needs a valid billing country).
+- **No client token** — the Klarna arm sends `paymentMethod.klarna {}`; the connector builds the order line itself from the amount + description.
+- **Idempotent retry** — identical to Card: once a `connectorTransactionId` exists, the retry PSyncs instead of re-authorizing.
+
 ## Session data
 
 Produced by `initiatePayment`:
@@ -59,19 +102,27 @@ Produced by `initiatePayment`:
 | `profileId` | Public Mollie profile id (`pfl_…`) for the Mollie Components form |
 | `minorAmount`, `currency` | Amount in minor units and ISO currency code |
 
-Added after re-initiation:
+Added after re-initiation (Card):
 
 | Field | Description |
 |-------|-------------|
 | `cardToken` | Single-use Mollie Components card token |
 | `returnUrl` | Storefront URL Mollie redirects to after 3DS |
 
+Added after re-initiation (Klarna):
+
+| Field | Description |
+|-------|-------------|
+| `paymentMethodType` | `"klarna"` — routes `authorizePayment` to the Klarna arm |
+| `billing` | `KlarnaBilling`: `firstName`, `lastName`, `email`, `line1`, `line2?`, `city`, `postalCode`, `country` (ISO 3166-1 alpha-2) |
+| `returnUrl` | Storefront URL Mollie redirects to after the Klarna hosted checkout |
+
 Added after `authorizePayment`:
 
 | Field | Description |
 |-------|-------------|
 | `id`, `connectorTransactionId` | Mollie payment reference (`tr_…`) — drives the idempotent PSync on retry |
-| `redirectUrl` | 3DS GET URL the storefront must send the customer to |
+| `redirectUrl` | GET URL the storefront must send the customer to — Card: the 3DS page; Klarna: the Mollie-hosted Klarna checkout |
 | `prismStatus` | Raw connector status (diagnostics) |
 
 ## Webhooks

--- a/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/index.ts
+++ b/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/index.ts
@@ -90,10 +90,46 @@ export type MollieAuthorizeDeps = {
   ) => Promise<AuthorizePaymentOutput>
 }
 
-// Authorize a Mollie card payment with the client-tokenized cardToken (Mollie
-// Components). The connector-service maps paymentMethod.token -> creditcard.cardToken.
-// One-off cards come back as status `open` with a 3DS redirect, surfaced here as
-// data.redirectUrl (redirectionData.form.endpoint) for the storefront to follow.
+// Billing the storefront collects for the Klarna (PayLater) redirect flow.
+// Klarna risk-assessment requires name + email + a postal address.
+export type KlarnaBilling = {
+  firstName?: string
+  lastName?: string
+  email?: string
+  line1?: string
+  line2?: string
+  city?: string
+  postalCode?: string
+  country?: string
+}
+
+// Map the storefront billing form to the SDK billing address. The connector's
+// Klarna arm reads it via get_payment_method_billing(), which falls back to the
+// request billing_address when no payment-method billing is set.
+function toKlarnaBillingAddress(b: KlarnaBilling): any {
+  const sec = (v?: string) => (v ? { value: v } : undefined)
+  const countryAlpha2Code = b.country
+    ? (types.CountryAlpha2 as any)[b.country.toUpperCase()]
+    : undefined
+  return {
+    firstName: sec(b.firstName),
+    lastName: sec(b.lastName),
+    line1: sec(b.line1),
+    ...(b.line2 ? { line2: sec(b.line2) } : {}),
+    city: sec(b.city),
+    zipCode: sec(b.postalCode),
+    ...(countryAlpha2Code !== undefined ? { countryAlpha2Code } : {}),
+    email: sec(b.email),
+  }
+}
+
+// Authorize a Mollie payment. Two methods are supported:
+//  - Card (Mollie Components): paymentMethod.token -> creditcard.cardToken; one-off
+//    cards return status `open` with a 3DS redirect.
+//  - Klarna (PayLater): paymentMethod.klarna {} + full billing; Mollie returns a
+//    hosted Klarna checkout URL.
+// Either way the connector surfaces the next step as data.redirectUrl
+// (redirectionData) for the storefront to follow; the post-redirect retry PSyncs.
 export async function authorizePayment(
   input: AuthorizePaymentInput,
   { options, paymentClient, getPaymentStatus }: MollieAuthorizeDeps
@@ -114,13 +150,8 @@ export async function authorizePayment(
     return await getPaymentStatus(input)
   }
 
-  const cardToken = data?.cardToken as string | undefined
-  if (!cardToken) {
-    logger.error(
-      "[PrismService.authorizePayment] mollie: missing cardToken in session data"
-    )
-    return { data: input.data, status: PaymentSessionStatus.ERROR }
-  }
+  const isKlarna =
+    String(data?.paymentMethodType ?? "").toLowerCase() === "klarna"
 
   const minorAmount = (data?.minorAmount as number | undefined) ?? 0
   const currency = (data?.currency as string | undefined) ?? "USD"
@@ -128,20 +159,50 @@ export async function authorizePayment(
     (data?.returnUrl as string | undefined) ??
     ((options.connectorConfig as any)?.returnUrl as string | undefined)
 
+  // Build the payment-method arm + billing address per method.
+  // - Card: paymentMethod.token (Mollie Components cardToken); billing ignored,
+  //   so a minimal country suffices.
+  // - Klarna (PayLater redirect): paymentMethod.klarna {}; the connector requires
+  //   full billing (name/email/postal address) which it reads via the request
+  //   billing_address, and builds the order line itself from amount + description.
+  let paymentMethod: any
+  let address: any
+  if (isKlarna) {
+    const billing = (data?.billing ?? data?.klarnaBilling) as
+      | KlarnaBilling
+      | undefined
+    if (!billing?.firstName || !billing?.email || !billing?.line1) {
+      logger.error(
+        "[PrismService.authorizePayment] mollie klarna: missing billing (name/email/address)"
+      )
+      return { data: input.data, status: PaymentSessionStatus.ERROR }
+    }
+    paymentMethod = { klarna: {} }
+    address = { billingAddress: toKlarnaBillingAddress(billing) }
+  } else {
+    const cardToken = data?.cardToken as string | undefined
+    if (!cardToken) {
+      logger.error(
+        "[PrismService.authorizePayment] mollie: missing cardToken in session data"
+      )
+      return { data: input.data, status: PaymentSessionStatus.ERROR }
+    }
+    paymentMethod = { token: { token: { value: cardToken } } }
+    // The SDK requires an address on authorize. The Mollie token branch
+    // ignores billing_address connector-side, so a minimal country suffices.
+    address = { billingAddress: { countryAlpha2Code: types.CountryAlpha2.US } }
+  }
+
   try {
     const res: any = await paymentClient.authorize({
       merchantTransactionId: data?.id || `mollie_${Date.now()}`,
       amount: { minorAmount, currency: toCurrency(currency) },
       // Mollie requires a payment description.
       description: "Medusa Hyperswitch Prism order",
-      paymentMethod: { token: { token: { value: cardToken } } },
+      paymentMethod,
       captureMethod: types.CaptureMethod.AUTOMATIC,
       ...(returnUrl ? { returnUrl } : {}),
-      // The SDK requires an address on authorize. The Mollie token branch
-      // ignores billing_address connector-side, so a minimal country suffices.
-      address: {
-        billingAddress: { countryAlpha2Code: types.CountryAlpha2.US },
-      },
+      address,
       testMode: options.environment !== "PRODUCTION",
     } as any)
 

--- a/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/index.ts
+++ b/plugins/medusa/medusa-custom-payments/src/providers/connector/prism-mollie/index.ts
@@ -106,11 +106,31 @@ export type KlarnaBilling = {
 // Map the storefront billing form to the SDK billing address. The connector's
 // Klarna arm reads it via get_payment_method_billing(), which falls back to the
 // request billing_address when no payment-method billing is set.
-function toKlarnaBillingAddress(b: KlarnaBilling): any {
-  const sec = (v?: string) => (v ? { value: v } : undefined)
-  const countryAlpha2Code = b.country
-    ? (types.CountryAlpha2 as any)[b.country.toUpperCase()]
-    : undefined
+function toKlarnaBillingAddress(b: KlarnaBilling): types.IAddress {
+  const sec = (v?: string): types.ISecretString | undefined =>
+    v ? { value: v } : undefined
+  // CountryAlpha2 is a numeric enum keyed by ISO 3166-1 alpha-2 code; index it by
+  // the (uppercased) storefront value. An unknown/invalid code resolves to
+  // undefined — surface that instead of silently dropping the country, since
+  // Klarna's risk assessment needs the billing country and would otherwise reject
+  // the order with an opaque error.
+  let countryAlpha2Code: types.CountryAlpha2 | undefined
+  if (b.country) {
+    const key = b.country.toUpperCase()
+    // Double-cast: CountryAlpha2 is a numeric enum (it carries a reverse
+    // number→string map), so it isn't directly a Record<string, …>.
+    const code = (
+      types.CountryAlpha2 as unknown as Record<string, types.CountryAlpha2 | undefined>
+    )[key]
+    if (code === undefined) {
+      logger.error(
+        "[PrismService.authorizePayment] mollie klarna: unknown country code %s — omitting from billing address",
+        key
+      )
+    } else {
+      countryAlpha2Code = code
+    }
+  }
   return {
     firstName: sec(b.firstName),
     lastName: sec(b.lastName),

--- a/plugins/medusa/medusa-custom-payments/src/providers/prism.ts
+++ b/plugins/medusa/medusa-custom-payments/src/providers/prism.ts
@@ -161,8 +161,13 @@ class PrismService {
     // Mollie Components: in-page card fields tokenize client-side. Skip the hosted
     // client-auth (which would create an orphan redirect payment). The first init
     // returns the public profileId for mollie.js; reinitiate stores the cardToken.
+    // Klarna (PayLater redirect) has no client-side tokenization: the storefront
+    // reinitiates with paymentMethodType="klarna" + billing, which is stored as-is
+    // and consumed by authorizePayment (which builds the Klarna redirect payment).
     if (this.options_.connector === "mollie") {
-      if ((data as any)?.cardToken) {
+      const isKlarnaReinit =
+        String((data as any)?.paymentMethodType ?? "").toLowerCase() === "klarna"
+      if ((data as any)?.cardToken || isKlarnaReinit) {
         return connectors.mollie.reInitiatePayment({
           data,
           merchantClientSessionId,


### PR DESCRIPTION
## Summary

Adds **Klarna (Pay later)** to the Mollie connector in the Medusa plugin, building on the connector-side Mollie Klarna Authorize (#1579). Klarna is a redirect flow (no client-side tokenization); Card and Klarna are selectable via a toggle in the Mollie checkout.

## What changed

**Server — `medusa-custom-payments`**
- `prism-mollie/index.ts` `authorizePayment` now branches by method: card → `paymentMethod.token` (Components cardToken); **Klarna → `paymentMethod.klarna {}` + full billing address + description + return URL** (AUTOMATIC capture). The connector builds the order line itself and reads billing via `get_payment_method_billing()` (which falls back to the request `billing_address`), so the top-level `address.billingAddress` is sufficient. Reuses the existing redirect extraction + PSync-on-return idempotency.
- `prism.ts` Mollie short-circuit also fires for `paymentMethodType === "klarna"`, storing the billing + method via `reInitiatePayment`.

**React — `medusa-custom-payments-react`**
- New `connectors/mollie/MollieKlarnaForm.tsx` — an editable billing form (Netherlands/EUR defaults), exported from the barrel.

**Harness — `app/`**
- `CheckoutPage.tsx` `MollieCheckout` adds a **Card | Klarna** toggle. The Klarna path runs in **EUR** (Klarna via Mollie is EU-only; card stays USD): it spins up a fresh EUR Mollie session, persists the billing + method, completes, and follows the Klarna redirect → `/order/:id` → PSync.

## Verification

Full browser E2E in the Mollie sandbox reached **`captured`**: Mollie checkout → Klarna toggle → billing form → Pay 100 EUR → Mollie Klarna test checkout → Paid → return → order page `status: captured`. API gate confirms `complete` returns a real Mollie Klarna checkout URL (`…/checkout/test-mode?…&method=klarna`) and a real `tr_…` payment id. Both plugins + client build clean.

## Deployment note

The plugin reaches the connector **in-process via the SDK's FFI dylib** (`libconnector_service_ffi.dylib`), not the gRPC server. The published `hyperswitch-prism` dylib predates #1579, so completing this E2E required rebuilding it locally (`cargo build -p ffi`). That rebuild is **not** part of this PR (node_modules is gitignored) — a real deploy needs the **published SDK republished from `main`** so its bundled dylib includes the Mollie Klarna connector (and the proto→domain `Klarna → PayLater(KlarnaRedirect)` mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
