### PR TITLE
fix(redsys): preserve attempt status on PSync via PaymentServiceGetRequest.status (#16987)

### DIFF
--- a/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/authorizedotnet_payment_flows_test.rs
@@ -394,6 +394,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_get_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         capture_method: None,

--- a/crates/grpc-server/grpc-server/tests/beta_tests/aci_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/aci_payment_flows_test.rs
@@ -221,6 +221,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/barclaycard_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/barclaycard_payment_flows_test.rs
@@ -179,6 +179,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 
 fn create_payment_sync_request(transaction_id: &str, amount: i64) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/bluecode_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/bluecode_payment_flows_test.rs
@@ -248,6 +248,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/bluesnap_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/bluesnap_payment_flows_test.rs
@@ -161,6 +161,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 
 fn create_payment_sync_request(transaction_id: &str, amount: i64) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/braintree_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/braintree_payment_flows_test.rs
@@ -172,6 +172,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/checkout_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/checkout_payment_flows_test.rs
@@ -170,6 +170,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/cryptopay_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/cryptopay_payment_flows_test.rs
@@ -123,6 +123,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 // Helper function to create a payment sync request
 fn create_payment_sync_request(request_ref_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id("not_required".to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/dlocal_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/dlocal_payment_flows_test.rs
@@ -219,6 +219,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/elavon_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/elavon_payment_flows_test.rs
@@ -266,6 +266,7 @@ async fn test_health() {
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/fiserv_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/fiserv_payment_flows_test.rs
@@ -219,6 +219,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/mifinity_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/mifinity_payment_flows_test.rs
@@ -154,6 +154,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/nexinets_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/nexinets_payment_flows_test.rs
@@ -163,6 +163,7 @@ fn create_payment_sync_request(
     request_ref_id: &str,
 ) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/noon_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/noon_payment_flows_test.rs
@@ -177,6 +177,7 @@ fn create_payment_sync_request(
     request_ref_id: &str,
 ) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/peachpayments_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/peachpayments_payment_flows_test.rs
@@ -201,6 +201,7 @@ fn create_refund_request(transaction_id: &str) -> PaymentServiceRefundRequest {
 
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/placetopay_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/placetopay_payment_flows_test.rs
@@ -214,6 +214,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/beta_tests/rapyd_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/beta_tests/rapyd_payment_flows_test.rs
@@ -212,6 +212,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         transaction_id: Some(Identifier {
             id_type: Some(IdType::Id(transaction_id.to_string())),
         }),

--- a/crates/grpc-server/grpc-server/tests/fiuu_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/fiuu_payment_flows_test.rs
@@ -166,6 +166,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         capture_method: None,

--- a/crates/grpc-server/grpc-server/tests/helcim_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/helcim_payment_flows_test.rs
@@ -264,6 +264,7 @@ fn create_payment_sync_request(
     amount: i64,
 ) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         capture_method: None,

--- a/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
@@ -168,6 +168,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 
 fn create_payment_sync_request(transaction_id: &str, amount: i64) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         capture_method: None,
@@ -524,6 +525,7 @@ async fn test_authorize_capture_refund_rsync() {
 
         // Step 4: RSync (Refund Sync)
         let rsync_request = PaymentServiceGetRequest {
+            status: None,
             connector_transaction_id: refund_id,
             encoded_data: None,
             capture_method: None,

--- a/crates/grpc-server/grpc-server/tests/paysafe_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/paysafe_payment_flows_test.rs
@@ -262,6 +262,7 @@ fn create_payment_authorize_request(
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         capture_method: None,
         amount: Some(grpc_api_types::payments::Money {

--- a/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/stripe_payment_flows_test.rs
@@ -168,6 +168,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         capture_method: None,

--- a/crates/grpc-server/grpc-server/tests/xendit_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/xendit_payment_flows_test.rs
@@ -159,6 +159,7 @@ fn create_authorize_request(capture_method: CaptureMethod) -> PaymentServiceAuth
 // Helper function to create a payment sync request
 fn create_payment_sync_request(transaction_id: &str) -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: transaction_id.to_string(),
         encoded_data: None,
         merchant_transaction_id: None,

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -274,7 +274,7 @@ impl
             merchant_request_id: item.merchant_request_id.clone(),
             payment_method_type: item.payment_method_type,
             split_payments: item.split_payments.clone(),
-            status: None,
+            status: item.status,
         }
     }
 }

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -274,6 +274,7 @@ impl
             merchant_request_id: item.merchant_request_id.clone(),
             payment_method_type: item.payment_method_type,
             split_payments: item.split_payments.clone(),
+            status: None,
         }
     }
 }

--- a/crates/internal/field-probe/src/requests.rs
+++ b/crates/internal/field-probe/src/requests.rs
@@ -132,6 +132,7 @@ pub(crate) fn base_void_request() -> PaymentServiceVoidRequest {
 
 pub(crate) fn base_get_request() -> PaymentServiceGetRequest {
     PaymentServiceGetRequest {
+        status: None,
         connector_transaction_id: "probe_connector_txn_001".to_string(),
         merchant_transaction_id: Some("probe_merchant_txn_001".to_string()),
         amount: Some(usd_money(1000)),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -5066,7 +5066,16 @@ impl
             merchant_id: merchant_id_from_header,
             payment_id: "IRRELEVANT_PAYMENT_ID".to_string(),
             attempt_id: "IRRELEVANT_ATTEMPT_ID".to_string(),
-            status: common_enums::AttemptStatus::Pending,
+            // Use the caller-supplied attempt status when present so connectors that
+            // preserve the prior status on sync (e.g. Redsys on an errored
+            // consultaOperaciones) keep the real status; fall back to Pending when absent.
+            status: value
+                .status
+                .and_then(|s| grpc_api_types::payments::PaymentStatus::try_from(s).ok())
+                .filter(|s| *s != grpc_api_types::payments::PaymentStatus::Unspecified)
+                .map(common_enums::AttemptStatus::foreign_try_from)
+                .transpose()?
+                .unwrap_or(common_enums::AttemptStatus::Pending),
             payment_method: PaymentMethod::Card, //TODO
             address,
             auth_type: common_enums::AuthenticationType::default(),

--- a/crates/types-traits/grpc-api-types/proto/composite_payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/composite_payment.proto
@@ -198,6 +198,11 @@ message CompositeGetRequest {
 
   // Split payment configuration (platform fees, transfers, etc.)
   optional SplitPaymentsDetails split_payments = 19;
+
+  // Current attempt status, supplied by the caller so connectors that preserve
+  // the prior status on sync (e.g. Redsys on an errored consultaOperaciones)
+  // keep the real status instead of defaulting to PENDING.
+  optional PaymentStatus status = 20;
 }
 
 // Response message for composite get flow.

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2484,6 +2484,11 @@ message PaymentServiceGetRequest {
 
   // Split payment configuration (platform fees, transfers, etc.)
   optional SplitPaymentsDetails split_payments = 17;
+
+  // Current attempt status, supplied by the caller so connectors that preserve
+  // the prior status on sync (e.g. Redsys on an errored consultaOperaciones)
+  // keep the real status instead of defaulting to PENDING.
+  optional PaymentStatus status = 18;
 }
 
 // Response message for a payment status synchronization


### PR DESCRIPTION
## What

Redsys `psync` shadow-validation parity (internal tracking issue, children #16988 + #16989).

On an errored Redsys `consultaOperaciones` sync (e.g. `xml0024` — order has no completed operation while the payment is still `authentication_pending`), the native gateway preserves the prior attempt status. The UCS path could not, because the PSync gRPC contract carried **no attempt status**: `PaymentServiceGetRequest` had no status field, so prism hardcoded `resource_common_data.status = AttemptStatus::Pending`. On the error branch (which preserves the prior status) this surfaced the wrong status (`pending` instead of `authentication_pending`) — diff **#16989** (`router.valueDiff:status`).

## Change (prism / connector-service)

- `proto/payment.proto`: add `optional PaymentStatus status = 18` to `PaymentServiceGetRequest`.
- `domain_types/src/types.rs`: read it into `PaymentFlowData.status` (the sync `resource_common_data.status`), falling back to `Pending` when absent/`Unspecified` (backward compatible).
- `composite-service`: set the new field to `None` in the composite get-request builder (mechanical).

The hyperswitch client change (populate the field from `router_data.status`) + the `connector_transaction_id` empty-string fix (#16988) ride in the paired hyperswitch PR.

## Proof

**Before (prod, req `019ef455-70bc-76b2-ab73-ee1aed417ee1`, VS_48):**
```
valueDiff: { "status": { hyperswitch: "authentication_pending", ucs: "pending" } }          # #16989
typeDiff:  { "response.Err.connector_transaction_id": { hyperswitch:"null", ucs:"string" } } # #16988
```

**After (local shadow repro, redsys 3DS authorize → force_sync PSync with a synthetic `xml0024` error):**
```
VS_46 Router data comparison completed - no differences found
hyperswitch_status = authentication_pending, ucs_status = authentication_pending
keyDiff {} valueDiff {} typeDiff {}
```

Closes #1683
