### PR TITLE
fix(finix): leave connector_response_reference_id None on Authorize + RepeatPayment (#17011, #17007)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -627,7 +627,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 connector_metadata: None,
                 network_txn_id: None,
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(response.id.clone()),
+                // Match Hyperswitch's `get_finix_response`, which leaves
+                // `connector_response_reference_id` as `None` for the Authorize flow.
+                connector_response_reference_id: None,
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,


### PR DESCRIPTION
### Summary
Align the Finix **Authorize** and **RepeatPayment (MIT)** success response mappings with
Hyperswitch (HS): leave `connector_response_reference_id` as `None` instead of echoing the
connector resource id.

### Diff signature (HS ↔ UCS shadow validation)
```
router.typeDiff: response.Ok.TransactionResponse.connector_response_reference_id
```
- **HS (ground truth):** `None`  (type `null`)
- **UCS (before this change):** `Some(response.id)`  (type `string`)

→ a `typeDiff` (null vs string) on every successful Finix Authorize and recurring
charge / RepeatPayment.

### Root cause
HS routes every Finix payment success — Authorize **and** the MIT/RepeatPayment charge (which HS
handles via its Authorize + `MandatePayment` builder) — through the flow-generic `get_finix_response`
(`crates/hyperswitch_connectors/src/connectors/finix/transformers.rs`), which sets
`connector_response_reference_id: None`. The UCS Authorize transformer
(`TryFrom<ResponseRouterData<FinixAuthorizeResponse, …>>`) and the RepeatPayment transformer
(`TryFrom<ResponseRouterData<FinixRepeatPaymentResponse, …>>`) instead populated it with
`Some(response.id.clone())`. Finix does not echo the merchant reference on the `/transfers`
response, so there is nothing to assert a link against — matching HS and emitting `None` is correct.

### Fix
`crates/integrations/connector-integration/src/connectors/finix/transformers.rs`:
- Authorize success branch → `connector_response_reference_id: None`
- RepeatPayment success branch → `connector_response_reference_id: None`

### Verification
- `cargo build -p connector-integration` ✅ · `cargo clippy -p connector-integration --all-targets -- -D warnings` ✅ · `cargo fmt --all -- --check` ✅
- The field is now a literal `None` on both branches, identical to HS's confirmed-`None`
  mapping, so both sides emit `null` and the `typeDiff` closes deductively (the fix is a
  structural / data-independent change — any successful Finix authorize or recurring charge
  now matches HS, no runtime input dependency).
- A live shadow `no_diff` verdict could not be captured locally: the Finix **sandbox**
  (`finix.sandbox-payments-api.com`) is currently serving **leaf-only TLS chains** on some
  backends, and the HS/UCS TLS stack cannot supply the missing `Amazon RSA 2048 M01`
  intermediate (it is absent from the box's system trust store and `SSL_CERT_FILE` is not
  honored), so both the HS primary call and the MITM upstream fail certificate verification.
  This is an environmental issue unrelated to the change; the prod diff signatures already
  confirm the divergence.

Closes #1654

---
### Re-detection (2026-06-26)
The same signature family was re-detected on the **stale prod build 2026.05.25.0-hotfix7**
(Grafana req `019ef783-ea40-7430-a13e-ece7f43c607f`, also reproduced locally req `019f0020`).
Child `router.typeDiff:response.Ok.TransactionResponse.connector_response_reference_id`
(HS `null` vs UCS `string`) is exactly the Authorize signature this PR fixes. Rebased on
latest `main` (`c417c0edd`); no code change.
