### PR TITLE
fix(redsys): use webhook_url as 3DS method notification URL in pre_authenticate

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -631,6 +631,20 @@ fn build_threeds_invoke_response(
 
     let three_ds_method_data = BASE64_ENGINE.encode(&three_ds_data_string);
 
+    // Mirror hyperswitch-native redsys, which stores the 3DS-method-invoke data on the
+    // PreAuthenticate response `connector_metadata` (serialized `RedsysThreeDsInvokeData`,
+    // snake_case keys, `three_ds_method_data_submission` as a bool). The HS→UCS mapping
+    // reads it back from the gRPC `connector_feature_data` field into
+    // `TransactionResponse.connector_metadata`. Leaving it None made UCS emit a null
+    // connector_metadata while HS emitted an object → response.Ok router typeDiff.
+    let connector_meta_data = Some(Secret::new(serde_json::json!({
+        "directory_server_id": three_d_s_server_trans_i_d.to_string(),
+        "message_version": protocol_version.to_string(),
+        "three_ds_method_data": three_ds_method_data.clone(),
+        "three_ds_method_data_submission": true,
+        "three_ds_method_url": three_ds_method_url.to_string(),
+    })));
+
     let three_ds_invoke_data = requests::RedsysThreeDsInvokeData {
         message_version: protocol_version,
         three_ds_method_data: three_ds_method_data.clone(),
@@ -656,7 +670,7 @@ fn build_threeds_invoke_response(
 
     Ok(responses::PreAuthenticateResponseData {
         redirection_data: redirect_form,
-        connector_meta_data: None,
+        connector_meta_data,
         response_ref_id: Some(response_data.ds_order.clone()),
         authentication_data: None,
     })
@@ -666,9 +680,27 @@ fn build_threeds_exempt_response(
     response_data: &responses::RedsysPaymentsResponse,
     authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
+    // Mirror hyperswitch-native redsys, which stores the 3DS-method-exempt data on the
+    // PreAuthenticate response `connector_metadata` (serialized `ThreeDsInvokeExempt`,
+    // snake_case keys). Same null-vs-object typeDiff class as the invoke path above.
+    let connector_meta_data = authentication_data.as_ref().and_then(|auth| {
+        match (
+            auth.message_version.as_ref(),
+            auth.threeds_server_transaction_id.as_ref(),
+        ) {
+            (Some(message_version), Some(threeds_server_transaction_id)) => {
+                Some(Secret::new(serde_json::json!({
+                    "message_version": message_version.to_string(),
+                    "three_d_s_server_trans_i_d": threeds_server_transaction_id,
+                })))
+            }
+            _ => None,
+        }
+    });
+
     Ok(responses::PreAuthenticateResponseData {
         redirection_data: None,
-        connector_meta_data: None,
+        connector_meta_data,
         response_ref_id: Some(response_data.ds_order.clone()),
         authentication_data,
     })

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -539,6 +539,7 @@ fn build_threeds_form(
 fn get_preauthenticate_response(
     response_data: &responses::RedsysPaymentsResponse,
     continue_redirection_url: Option<&url::Url>,
+    webhook_url: Option<&url::Url>,
     existing_connector_meta: Option<Secret<serde_json::Value>>,
     http_status: u16,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
@@ -585,6 +586,7 @@ fn get_preauthenticate_response(
             &three_d_s_server_trans_i_d,
             three_ds_method_url,
             continue_redirection_url,
+            webhook_url,
             semantic_version,
             http_status,
         ),
@@ -597,15 +599,21 @@ fn build_threeds_invoke_response(
     three_d_s_server_trans_i_d: &str,
     three_ds_method_url: &str,
     continue_redirection_url: Option<&url::Url>,
+    webhook_url: Option<&url::Url>,
     protocol_version: common_utils::types::SemanticVersion,
     http_status: u16,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
-    let notification_url = continue_redirection_url
+    // Hyperswitch embeds the merchant webhook URL as the 3DS method notification
+    // URL inside threeDSMethodData. Mirror that here so the encoded
+    // three_ds_method_data matches hyperswitch byte-for-byte; fall back to the
+    // continue_redirection_url only when no webhook_url is supplied.
+    let notification_url = webhook_url
+        .or(continue_redirection_url)
         .map(|url| url.to_string())
         .ok_or_else(|| {
             Report::new(ConnectorError::response_handling_failed_with_context(
                 http_status,
-                Some("continue_redirection_url missing for 3DS method URL".to_string()),
+                Some("webhook_url/continue_redirection_url missing for 3DS method URL".to_string()),
             ))
         })?;
 
@@ -929,6 +937,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                 } = get_preauthenticate_response(
                     &response_data,
                     item.router_data.request.continue_redirection_url.as_ref(),
+                    item.router_data.request.webhook_url.as_ref(),
                     item.router_data
                         .resource_common_data
                         .connector_feature_data

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -517,6 +517,7 @@ impl
             connector_feature_data: item.connector_feature_data.clone(),
             return_url: item.return_url.clone(),
             continue_redirection_url: item.continue_redirection_url.clone(),
+            webhook_url: item.webhook_url.clone(),
             browser_info: item.browser_info.clone(),
             state: resolved_state,
             capture_method: item.capture_method,

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2014,6 +2014,7 @@ pub struct PaymentsPreAuthenticateData<T: PaymentMethodDataTypes> {
     pub payment_method_type: Option<PaymentMethodType>,
     pub router_return_url: Option<Url>,
     pub continue_redirection_url: Option<Url>,
+    pub webhook_url: Option<Url>,
     pub browser_info: Option<BrowserInformation>,
     pub enrolled_for_3ds: bool,
     pub redirect_response: Option<ContinueRedirectionResponse>,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -14200,6 +14200,15 @@ impl<
                     })
                 })
                 .transpose()?,
+            webhook_url: value
+                .webhook_url
+                .map(|url_str| {
+                    url::Url::parse(&url_str).change_context(IntegrationError::InvalidDataFormat {
+                        field_name: "webhook_url",
+                        context: IntegrationErrorContext::default(),
+                    })
+                })
+                .transpose()?,
             router_return_url: return_url
                 .map(|url_str| {
                     url::Url::parse(&url_str).change_context(IntegrationError::InvalidDataFormat {

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3398,6 +3398,10 @@ message PaymentMethodAuthenticationServicePreAuthenticateRequest {
 
   // Description
   optional string description = 14;
+
+  // Merchant webhook URL (used by some connectors, e.g. Redsys, as the
+  // 3DS method notification URL embedded in threeDSMethodData)
+  optional string webhook_url = 15;
 }
 
 // Response message for pre-authentication step


### PR DESCRIPTION
### What

Redsys **pre_authenticate** (3DS method invoke): use the merchant **`webhook_url`** as the
`threeDSMethodNotificationURL` embedded in the Base64 `threeDSMethodData`, matching Hyperswitch's
native connector behaviour.

### Why — shadow-validation router diff (`bu_es` / redsys / pre_authenticate)

Prod shadow-validation reported:

```
router.valueDiff:response.Ok.TransactionResponse.connector_metadata.three_ds_method_data
```

`three_ds_method_data` is `base64(JSON{ threeDSMethodNotificationURL, threeDSServerTransID })`.

- **Hyperswitch (ground truth):** builds it from `request.get_webhook_url()` (the merchant webhook URL).
- **UCS (before):** built it from `continue_redirection_url`, which the HS→UCS mapping populates from
  `complete_authorize_url` (`router/.../unified_connector_service/transformers.rs`:
  `continue_redirection_url: router_data.request.complete_authorize_url`).

`webhook_url` ≠ `complete_authorize_url`, so the embedded URL differed → the Base64 differed → `valueDiff`.

UCS's `PaymentMethodAuthenticationServicePreAuthenticateRequest` carried no `webhook_url`, so this is a
proto-contract gap.

### Change (proto-category, UCS side)

- **proto** `payment.proto`: add `optional string webhook_url = 15;` to
  `PaymentMethodAuthenticationServicePreAuthenticateRequest`.
- **domain** `PaymentsPreAuthenticateData`: add `webhook_url: Option<Url>`; map it from the proto in
  `domain_types/src/types.rs`.
- **connector** redsys `build_threeds_invoke_response`: use `webhook_url` for the notification URL
  (falling back to `continue_redirection_url` only when absent), so the encoded `three_ds_method_data`
  matches Hyperswitch byte-for-byte.
- **composite-service**: thread `webhook_url` from the authorize request into the PreAuthenticate sub-request.

The paired HS PR populates the new proto field from `router_data.request.webhook_url`.

### Verification

Live redsys 3DS shadow isn't reproducible locally (real ACS + redsys sandbox + the prod merchant config).
Verified by source-parity: both sides serialize the identical struct
(`#[serde(rename_all="camelCase")]`, fields `threeDSMethodNotificationURL`, `threeDSServerTransID`),
so with the same URL the Base64 is byte-identical.

```
HS-native (webhook_url):  eyJ0aHJlZURTTWV0aG9kTm90...d2ViaG9va3MvYnVfZXMvcmVkc3lz...
UCS  BEFORE (complete):   eyJ0aHJlZURTTWV0aG9kTm90...cGF5bWVudHMvem9lc3hDeDVaeUMv...   <- valueDiff
UCS  AFTER  (webhook):    eyJ0aHJlZURTTWV0aG9kTm90...d2ViaG9va3MvYnVfZXMvcmVkc3lz...   <- byte-identical (no_diff)
```

Local checks (touched crates): `cargo build` ✓ · `cargo clippy --all-targets` ✓ · `cargo fmt --check` ✓ ·
`composite_request_schema_check` ✓ · connector-integration tests ✓.
Paired HS PR: juspay/hyperswitch#12936

Closes #1653

---

### Update — also closes the `connector_metadata` typeDiff (#17019)

On `main`, UCS redsys `build_threeds_invoke_response` (and the exempt path) left the
PreAuthenticate response `connector_meta_data: None`. The HS→UCS response mapping reads
the gRPC `connector_feature_data` back into `TransactionResponse.connector_metadata`
(already on `hyperswitch` main), so UCS emitted a **null** `connector_metadata` while
HS-native redsys emits an **object** → shadow-validation router diff:

```
router.typeDiff:response.Ok.TransactionResponse.connector_metadata   (bu_es / redsys / pre_authenticate)
```

(Without this, the webhook_url change above never surfaced — there was no
`connector_metadata.three_ds_method_data` to compare on `main`; it manifested as the
whole-object typeDiff #17019.)

**Change (UCS-only, no proto/HS change):** populate `connector_meta_data` on both PreAuthenticate
3DS paths, mirroring hyperswitch-native redsys:
- **3DS-method-invoke** → serialized `RedsysThreeDsInvokeData`
  `{directory_server_id, message_version, three_ds_method_data, three_ds_method_data_submission (bool), three_ds_method_url}`,
  reusing the **webhook_url**-based `three_ds_method_data` from this PR so the embedded URL matches too.
- **exempt** → serialized `ThreeDsInvokeExempt` `{message_version, three_d_s_server_trans_i_d}`.

The HS→UCS mapping (`router/.../unified_connector_service/transformers.rs`, already on `main`)
parses `connector_feature_data` → `connector_metadata`; no HS change needed for #17019.

**Verification (source-parity — live redsys 3DS not locally reproducible: real ACS + redsys
sandbox + prod merchant config):** the UCS `connector_metadata` object is now byte-identical to
hyperswitch's:

```
HS : {"directory_server_id":"…","message_version":"2.2.0","three_ds_method_data":"…","three_ds_method_data_submission":true,"three_ds_method_url":"…"}
UCS: {"directory_server_id":"…","message_version":"2.2.0","three_ds_method_data":"…","three_ds_method_data_submission":true,"three_ds_method_url":"…"}   → no_diff
```

`message_version` uses `SemanticVersion::to_string()` (canonical semver), equal to HS's raw
`protocol_version` for redsys 3DS versions. Local checks: `cargo build` ✓ ·
`cargo clippy -p connector-integration --all-targets -D warnings` ✓ · `cargo fmt --check` ✓ ·
`cargo test -p connector-integration redsys` ✓.
