### PR TITLE
fix(redsys): emit authentication_data on pre_authenticate 3DS invoke response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -586,6 +586,7 @@ fn get_preauthenticate_response(
             three_ds_method_url,
             continue_redirection_url,
             semantic_version,
+            authentication_data,
             http_status,
         ),
         None => build_threeds_exempt_response(response_data, authentication_data),
@@ -598,6 +599,7 @@ fn build_threeds_invoke_response(
     three_ds_method_url: &str,
     continue_redirection_url: Option<&url::Url>,
     protocol_version: common_utils::types::SemanticVersion,
+    authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
     http_status: u16,
 ) -> Result<responses::PreAuthenticateResponseData, ResponseError> {
     let notification_url = continue_redirection_url
@@ -650,7 +652,7 @@ fn build_threeds_invoke_response(
         redirection_data: redirect_form,
         connector_meta_data: None,
         response_ref_id: Some(response_data.ds_order.clone()),
-        authentication_data: None,
+        authentication_data,
     })
 }
 


### PR DESCRIPTION
## What

Redsys `pre_authenticate` (3DS method invoke path) dropped `authentication_data` in the UCS response, causing a shadow-validation router-data diff against HS-native.

**Diff signature:** `router.typeDiff:response.Ok.TransactionResponse.authentication_data`
(merchant `bu_es`, connector `redsys`, flow `pre_authenticate`)

## Root cause

`get_preauthenticate_response` computes the `AuthenticationData` (with `threeds_server_transaction_id` + `message_version`) but only forwards it to `build_threeds_exempt_response`. The 3DS-method-invoke branch, `build_threeds_invoke_response`, hard-coded `authentication_data: None` in its returned `PreAuthenticateResponseData`.

HS-native redsys (`build_threeds_invoke_response`) instead populates it via `UcsAuthenticationData::foreign_try_from(&RedsysThreeDsInvokeData)` →
`{ threeds_server_transaction_id: Some(directory_server_id /* = threeDSServerTransID */), message_version: Some(<protocol_version>), .. all None }`.

So for a 3DS-method-invoke response: HS emits an object, UCS emits `null` → **typeDiff (object vs null)**.

## Fix (L3, UCS-only)

Thread the already-computed `authentication_data` into `build_threeds_invoke_response` and return it (instead of `None`). The value is field-for-field identical to HS's `UcsAuthenticationData`:
- `threeds_server_transaction_id = three_d_s_server_trans_i_d`
- `message_version = semantic_version`
- everything else `None`

No proto / domain / HS-mapping change needed — the field already flows end-to-end (`PaymentsResponseData::PreAuthenticateResponse.authentication_data` → proto → HS read-back); the exempt path already returns this exact struct with no diff, proving the round-trip is parity.

```diff
         Some(three_ds_method_url) => build_threeds_invoke_response(
             ...
             semantic_version,
+            authentication_data,
             http_status,
         ),
 ...
     protocol_version: common_utils::types::SemanticVersion,
+    authentication_data: Option<domain_types::router_request_types::AuthenticationData>,
     http_status: u16,
 ...
-        authentication_data: None,
+        authentication_data,
```

## Verification

Live redsys 3DS shadow is not locally reproducible (real ACS + redsys sandbox + prod merchant creds — same constraint noted on sibling diffs #16981/#16982). Verified by **source-parity**:

- **before:** invoke path → `authentication_data: None` → HS reads back `None`; HS-native emits `Some({threeds_server_transaction_id, message_version})` → typeDiff.
- **after:** invoke path → `Some(AuthenticationData{ threeds_server_transaction_id, message_version, .. None })`, field-for-field identical to HS's `UcsAuthenticationData::foreign_try_from` → byte-identical → no_diff.

Local checks (worktree off `origin/main` cd7b17474):
- `cargo build -p connector-integration` ✅
- `cargo clippy -p connector-integration --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test -p connector-integration redsys` ✅

Sibling of #16981 (resource_id) and #16982 (three_ds_method_data) under parent group #16979.

Closes #1642
