### PR TITLE
fix(nmi): map declined/errored authorize response to Err (issue #17004)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -706,9 +706,13 @@ fn create_ach_data<T: PaymentMethodDataTypes>(
 
 // ===== PAYMENT RESPONSE =====
 
+const NMI_RESPONSE_APPROVED: &str = "1";
+const NMI_RESPONSE_DECLINED: &str = "2";
+const NMI_RESPONSE_ERROR: &str = "3";
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct StandardResponse {
-    pub response: String, // "1" = approved, "2" = declined, "3" = error
+    pub response: String,
     pub responsetext: String,
     pub authcode: Option<String>,
     pub transactionid: String,
@@ -730,28 +734,23 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
     fn try_from(item: ResponseRouterData<StandardResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Determine status based on response code
         let status = match response.response.as_str() {
-            "1" => {
-                // Approved - check if it was auth or sale
-                // For auth type, status is Authorized
-                // For sale type, status is Charged
-                // We need to check the original request's auto_capture flag
+            NMI_RESPONSE_APPROVED => {
                 if item.router_data.request.is_auto_capture() {
                     AttemptStatus::Charged
                 } else {
                     AttemptStatus::Authorized
                 }
             }
-            "2" | "3" => AttemptStatus::Failure, // Declined or Error
+            NMI_RESPONSE_DECLINED | NMI_RESPONSE_ERROR => AttemptStatus::Failure,
             _ => AttemptStatus::Pending,
         };
 
-        // A declined ("2") or errored ("3") NMI response must surface as `Err(ErrorResponse)`,
-        // mirroring the HS NMI connector (`get_standard_error_response`). Returning `Ok` with
-        // only status=Failure makes the router response variant diverge from HS — observed as
-        // `response.Ok` (ucs) vs `response.Err` (hs) in the router-data comparison (#17004).
-        let payment_response = if matches!(response.response.as_str(), "2" | "3") {
+        // Mirror HS: a declined/errored NMI response surfaces as `Err`, not `Ok` (#17004).
+        let payment_response = if matches!(
+            response.response.as_str(),
+            NMI_RESPONSE_DECLINED | NMI_RESPONSE_ERROR
+        ) {
             Err(domain_types::router_data::ErrorResponse {
                 code: response.response_code.clone(),
                 message: response.responsetext.clone(),

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -706,13 +706,9 @@ fn create_ach_data<T: PaymentMethodDataTypes>(
 
 // ===== PAYMENT RESPONSE =====
 
-const NMI_RESPONSE_APPROVED: &str = "1";
-const NMI_RESPONSE_DECLINED: &str = "2";
-const NMI_RESPONSE_ERROR: &str = "3";
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct StandardResponse {
-    pub response: String,
+    pub response: Response,
     pub responsetext: String,
     pub authcode: Option<String>,
     pub transactionid: String,
@@ -734,53 +730,51 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
     fn try_from(item: ResponseRouterData<StandardResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        let status = match response.response.as_str() {
-            NMI_RESPONSE_APPROVED => {
-                if item.router_data.request.is_auto_capture() {
+        let (status, payment_response) = match response.response {
+            Response::Approved => {
+                let status = if item.router_data.request.is_auto_capture() {
                     AttemptStatus::Charged
                 } else {
                     AttemptStatus::Authorized
-                }
+                };
+                (
+                    status,
+                    Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: ResponseId::ConnectorTransactionId(
+                            response.transactionid.clone(),
+                        ),
+                        redirection_data: None,
+                        mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
+                            Box::new(MandateReference {
+                                connector_mandate_id: Some(vault_id.clone().expose()),
+                                payment_method_id: None,
+                                connector_mandate_request_reference_id: None,
+                            })
+                        }),
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        network_txn_link_id: None,
+                        connector_response_reference_id: Some(response.orderid.clone()),
+                        incremental_authorization_allowed: None,
+                        status_code: item.http_code,
+                        splits: None,
+                    }),
+                )
             }
-            NMI_RESPONSE_DECLINED | NMI_RESPONSE_ERROR => AttemptStatus::Failure,
-            _ => AttemptStatus::Pending,
-        };
-
-        // Mirror HS: a declined/errored NMI response surfaces as `Err`, not `Ok` (#17004).
-        let payment_response = if matches!(
-            response.response.as_str(),
-            NMI_RESPONSE_DECLINED | NMI_RESPONSE_ERROR
-        ) {
-            Err(domain_types::router_data::ErrorResponse {
-                code: response.response_code.clone(),
-                message: response.responsetext.clone(),
-                reason: Some(response.responsetext.clone()),
-                status_code: item.http_code,
-                attempt_status: Some(FlowStatus::Payment(AttemptStatus::Failure)),
-                connector_transaction_id: Some(response.transactionid.clone()),
-                network_decline_code: None,
-                network_advice_code: None,
-                network_error_message: None,
-            })
-        } else {
-            Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(response.transactionid.clone()),
-                redirection_data: None,
-                mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
-                    Box::new(MandateReference {
-                        connector_mandate_id: Some(vault_id.clone().expose()),
-                        payment_method_id: None,
-                        connector_mandate_request_reference_id: None,
-                    })
+            Response::Declined | Response::Error => (
+                AttemptStatus::Failure,
+                Err(domain_types::router_data::ErrorResponse {
+                    code: response.response_code.clone(),
+                    message: response.responsetext.clone(),
+                    reason: Some(response.responsetext.clone()),
+                    status_code: item.http_code,
+                    attempt_status: Some(FlowStatus::Payment(AttemptStatus::Failure)),
+                    connector_transaction_id: Some(response.transactionid.clone()),
+                    network_decline_code: None,
+                    network_advice_code: None,
+                    network_error_message: None,
                 }),
-                connector_metadata: None,
-                network_txn_id: None,
-                network_txn_link_id: None,
-                connector_response_reference_id: Some(response.orderid.clone()),
-                incremental_authorization_allowed: None,
-                status_code: item.http_code,
-                splits: None,
-            })
+            ),
         };
 
         Ok(Self {
@@ -993,12 +987,9 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
     fn try_from(item: ResponseRouterData<StandardResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Capture success = Charged status
-        // Capture failure = Failure status
-        let status = match response.response.as_str() {
-            "1" => AttemptStatus::Charged,       // Capture successful
-            "2" | "3" => AttemptStatus::Failure, // Capture failed
-            _ => AttemptStatus::Pending,
+        let status = match response.response {
+            Response::Approved => AttemptStatus::Charged,
+            Response::Declined | Response::Error => AttemptStatus::Failure,
         };
 
         Ok(Self {
@@ -1113,12 +1104,9 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
     fn try_from(item: ResponseRouterData<StandardResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Map response code to RefundStatus
-        // "1" = Success, "2"/"3" = Failure
-        let status = match response.response.as_str() {
-            "1" => RefundStatus::Success,
-            "2" | "3" => RefundStatus::Failure,
-            _ => RefundStatus::Pending,
+        let status = match response.response {
+            Response::Approved => RefundStatus::Success,
+            Response::Declined | Response::Error => RefundStatus::Failure,
         };
 
         Ok(Self {
@@ -1297,12 +1285,9 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
     fn try_from(item: ResponseRouterData<StandardResponse, Self>) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Void success = Voided status
-        // Void failure = VoidFailed status
-        let status = match response.response.as_str() {
-            "1" => AttemptStatus::Voided,           // Void successful
-            "2" | "3" => AttemptStatus::VoidFailed, // Void failed
-            _ => AttemptStatus::Pending,
+        let status = match response.response {
+            Response::Approved => AttemptStatus::Voided,
+            Response::Declined | Response::Error => AttemptStatus::VoidFailed,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -747,8 +747,24 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
             _ => AttemptStatus::Pending,
         };
 
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
+        // A declined ("2") or errored ("3") NMI response must surface as `Err(ErrorResponse)`,
+        // mirroring the HS NMI connector (`get_standard_error_response`). Returning `Ok` with
+        // only status=Failure makes the router response variant diverge from HS — observed as
+        // `response.Ok` (ucs) vs `response.Err` (hs) in the router-data comparison (#17004).
+        let payment_response = if matches!(response.response.as_str(), "2" | "3") {
+            Err(domain_types::router_data::ErrorResponse {
+                code: response.response_code.clone(),
+                message: response.responsetext.clone(),
+                reason: Some(response.responsetext.clone()),
+                status_code: item.http_code,
+                attempt_status: Some(FlowStatus::Payment(AttemptStatus::Failure)),
+                connector_transaction_id: Some(response.transactionid.clone()),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            })
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(response.transactionid.clone()),
                 redirection_data: None,
                 mandate_reference: response.customer_vault_id.as_ref().map(|vault_id| {
@@ -765,7 +781,11 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<StandardResponse, Sel
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response: payment_response,
             resource_common_data: PaymentFlowData {
                 status,
                 ..item.router_data.resource_common_data


### PR DESCRIPTION
## What

NMI **Authorize** response handler returned `Ok(PaymentsResponseData::TransactionResponse{..})`
for **every** response code, only varying the attempt status. For a declined (`response = "2"`)
or errored (`response = "3"`) NMI response it set `status = Failure` but still wrapped the payload
in `Ok`. Hyperswitch's NMI connector instead maps declined/error to `Err(ErrorResponse{..})`
(`get_standard_error_response`). The router-data response variant therefore diverged between the
two stacks.

This makes the declined-authorize response variant match Hyperswitch: declined/error → `Err`.

## Diff (shadow-validation, prod)

- merchant: `merchant_1771364887457` · connector: `nmi` · flow: `authorize`
- result type: `router_diff`
- signature: `router.keyDiff:response.Ok`
- actual router-data keyDiff (VS_48):
  ```json
  "keyDiff": {
    "response.Err": { "hyperswitch": true,  "ucs": false },
    "response.Ok":  { "hyperswitch": false, "ucs": true  }
  }
  ```
  i.e. for a declined NMI authorize HS produced `response: Err(..)` while UCS produced
  `response: Ok(..)` (with `status = Failure`).

## Layer

**L3 — connector transformer only** (`connectors/nmi/transformers.rs`,
`TryFrom<ResponseRouterData<StandardResponse>>` for `Authorize`). No proto/domain/HS change.

## Fix

Build the router response based on the NMI response code: `"2"`/`"3"` → `Err(ErrorResponse{..})`
(mirroring the HS connector and this file's existing PreAuthenticate/SetupMandate error path);
`"1"` (and the unchanged `_ => Pending` fallback) → `Ok(TransactionResponse{..})`. The status
mapping is unchanged.

## Verification (local stack on `main`)

The HS primary outbound to `secure.nmi.com` is TLS-blocked in this environment, so the divergence
was verified at the exact diverging field via a **direct UCS gRPC `PaymentService.Authorize` A/B**
(UCS routes through the MITM proxy and reaches NMI fine). NMI test-mode rule: amount `< $1.00`
⇒ `DECLINE` (`response = 2`).

```
# decline ($0.50) — the buggy field
grpcurl -plaintext -H 'x-connector: nmi' -H 'x-auth: body-key' \
  -H 'x-api-key: <nmi security_key>' -H 'x-key1: <nmi public_key>' \
  -H 'x-merchant-id: merchant_1771364887457' -H 'x-tenant-id: default' \
  -d '{"amount":{"minorAmount":"50","currency":"USD"}, ...card 4111..., captureMethod:"AUTOMATIC"}' \
  localhost:8001 types.PaymentService/Authorize
```

| case (amount) | NMI `response` | before fix | after fix |
|---|---|---|---|
| decline ($0.50) | `2` (DECLINE) | `status=FAILURE`, **gRPC `error` absent** → internal `Ok` (bug) | `status=FAILURE`, **gRPC `error` populated** (`code=200,message=DECLINE`) → internal `Err` ✅ matches HS |
| approve (unique >$1) | `1` | `status=CHARGED`, no error → `Ok` | `status=CHARGED`, no error → `Ok` (unchanged) |

So the declined authorize now yields `response: Err` on the UCS side, matching HS, and the
`response.Ok`/`response.Err` router-data keyDiff disappears (no new diff; the approved/`Ok` path
is untouched).

Local checks: `cargo build -p connector-integration`, `cargo clippy -p connector-integration`,
`cargo fmt -- --check` all clean.
<!-- #17003 is the `router.keyDiff:response.Err` half of the same VS_48 router-data keyDiff
(same merchant `merchant_1771364887457`, connector `nmi`, flow `authorize`); #17004 fingerprinted
the `response.Ok` half. Both are the single declined-authorize Ok-vs-Err divergence this PR fixes. -->

Closes #1652
