### PR TITLE
fix(authorizedotnet): omit customer on stored-profile repeat payment

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -888,8 +888,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let currency = item.router_data.request.currency;
 
-        // Handle different mandate reference types with appropriate MIT structures
-        let (profile, processing_options, subsequent_auth_information) = match &item
+        // Handle different mandate reference types with appropriate MIT structures.
+        // `omit_customer` mirrors Hyperswitch: the ConnectorMandateId (stored customer
+        // profile) MIT path sends no `customer` object, while the NetworkMandateId path does.
+        let (profile, processing_options, subsequent_auth_information, omit_customer) = match &item
             .router_data
             .request
             .mandate_reference
@@ -929,6 +931,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         is_subsequent_auth: true,
                     }),
                     None, // No network transaction ID for mandate-based flow
+                    true, // Hyperswitch sends customer: None on the stored-profile MIT path
                 )
             }
 
@@ -942,6 +945,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     original_network_trans_id: Secret::new(network_trans_id.clone()),
                     reason: Reason::Resubmission,
                 }),
+                false, // Network-trans-id path includes the customer object
             ),
 
             // Case 3: Network token with NTI - NOT SUPPORTED (same as Hyperswitch)
@@ -1001,10 +1005,14 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .map(|cid| cid.get_string_repr().to_owned()),
         );
 
-        let customer_details = customer_id_string.map(|cid| CustomerDetails {
-            id: cid,
-            email: item.router_data.request.email.clone(),
-        });
+        let customer_details = if omit_customer {
+            None
+        } else {
+            customer_id_string.map(|cid| CustomerDetails {
+                id: cid,
+                email: item.router_data.request.email.clone(),
+            })
+        };
 
         let transaction_type = match item.router_data.request.capture_method {
             Some(enums::CaptureMethod::Manual) => TransactionType::AuthOnlyTransaction,


### PR DESCRIPTION
## What

Authorize.Net **repeat payment (MIT)** on the stored-customer-profile path
(`ConnectorMandateId`) was sending a `customer` object that Hyperswitch does **not** send,
producing a shadow-validation request diff:

```
body.keyDiff.createTransactionRequest.transactionRequest.customer = {"hyperswitch": false, "ucs": true}
```

## Root cause (L3 — connector transformer only)

For the `RepeatPayment` flow, the UCS authorize.net transformer always built the `customer`
object from `resource_common_data.customer_id`, regardless of the mandate path.

Hyperswitch (the ground truth) only sends `customer` on the **NetworkMandateId** path; on the
**ConnectorMandateId** (stored customer/payment profile) path it sets `customer: None`
(`hyperswitch_connectors/.../authorizedotnet/transformers.rs`, `TransactionRequest` for
`ConnectorMandateReferenceId` → `customer: None`). On that path the profile is already
identified by `profile.customerProfileId` / `paymentProfile.paymentProfileId`, so the extra
`customer` object is redundant.

## Fix

Gate the repeat `customer` object on the mandate path so it mirrors Hyperswitch:
- `ConnectorMandateId` (stored profile MIT) → omit `customer`
- `NetworkMandateId` (network-trans-id MIT) → keep `customer`

This is a UCS-only change — the field already exists in the request; UCS was simply
over-populating it. No proto / HS-mapping change required.

## Verification (direct gRPC A/B, `RecurringPaymentService.Charge`, ConnectorMandateId)

The HS shadow path to authorize.net is TLS-blocked on the local stack, so the fix was verified
by driving UCS directly and capturing the outbound authorize.net request body from UCS's
"Golden Log Line (outgoing)". Same request both runs:

```
grpcurl -plaintext \
  -H "x-connector: authorizedotnet" -H "x-auth: body-key" \
  -H "x-api-key: <api_key>" -H "x-key1: <transaction_key>" \
  -H "x-merchant-id: autofix_17047" -H "x-connector-request-reference-id: <ref>" \
  -d '{"connectorRecurringPaymentId":{"connectorMandateId":{"connectorMandateId":"1234567890-0987654321"}},
       "amount":{"minorAmount":"6100","currency":"USD"},
       "customer":{"id":"cust_probe123"},"merchantConfiguredCurrency":"USD"}' \
  localhost:8001 types.RecurringPaymentService.Charge
```

Outbound `transactionRequest` body built by UCS:

**BEFORE (bug, matches prod `ucs:true`):**
```json
{"transactionType":"authCaptureTransaction","amount":61.0,"currencyCode":"USD",
 "profile":{"customerProfileId":"***","paymentProfile":{"paymentProfileId":"***"}},
 "order":{...},"customer":{"id":"cust_probe123"},"processingOptions":{"isSubsequentAuth":true}}
```

**AFTER (fixed, matches HS `hyperswitch:false`):**
```json
{"transactionType":"authCaptureTransaction","amount":61.0,"currencyCode":"USD",
 "profile":{"customerProfileId":"***","paymentProfile":{"paymentProfileId":"***"}},
 "order":{...},"processingOptions":{"isSubsequentAuth":true}}
```

→ diff → no_diff: the `customer` object is gone on the ConnectorMandateId path while
`customer.id` is still passed in the gRPC request, exactly matching Hyperswitch.

Closes #1646
