### PR TITLE
feat(grpc): carry connector_response on PaymentServiceVoidResponse

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -6718,6 +6718,23 @@ pub fn generate_payment_void_response(
         .resource_common_data
         .get_raw_connector_request();
 
+    let connector_response = router_data_v2
+        .resource_common_data
+        .connector_response
+        .as_ref()
+        .and_then(|connector_response_data| {
+            grpc_api_types::payments::ConnectorResponseData::foreign_try_from(
+                connector_response_data.clone(),
+            )
+            .map_err(|error| {
+                tracing::warn!(
+                    ?error,
+                    "Failed to convert connector_response for void response; omitting it"
+                );
+            })
+            .ok()
+        });
+
     match transaction_response {
         Ok(response) => match response {
             PaymentsResponseData::TransactionResponse {
@@ -6771,6 +6788,7 @@ pub fn generate_payment_void_response(
                             split_response,
                         )
                     }),
+                    connector_response,
                 })
             }
             _ => Err(report!(ConnectorError::UnexpectedResponseError {
@@ -6819,6 +6837,7 @@ pub fn generate_payment_void_response(
                 incremental_authorization_allowed: None,
                 connector_feature_data: None,
                 splits: None,
+                connector_response,
             })
         }
     }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -2608,6 +2608,11 @@ message PaymentServiceVoidResponse {
 
   // Split payment response data from connector
   optional ConnectorSplitResponseData splits = 12;
+
+  // Additional payment-method-specific data from the connector response
+  // (e.g. AVS / payment_checks). Mirrors PaymentServiceCaptureResponse.connector_response
+  // so the void router-data carries connector_response identically to the native flow.
+  optional ConnectorResponseData connector_response = 13;
 }
 
 // Request message for reversing a captured payment if not yet settled (similar

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -399,7 +399,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   PaymentServiceGetRequest: { "amount": "Money", "state": "ConnectorState", "splitPayments": "SplitPaymentsDetails" },
   PaymentServiceGetResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "mandateReference": "MandateReference", "amount": "Money", "connectorResponse": "ConnectorResponseData", "state": "ConnectorState", "redirectionData": "RedirectForm", "paymentMethodUpdate": "PaymentMethodUpdate", "splits": "ConnectorSplitResponseData" },
   PaymentServiceVoidRequest: { "browserInfo": "BrowserInformation", "amount": "Money", "state": "ConnectorState" },
-  PaymentServiceVoidResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference", "splits": "ConnectorSplitResponseData" },
+  PaymentServiceVoidResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry", "state": "ConnectorState", "mandateReference": "MandateReference", "splits": "ConnectorSplitResponseData", "connectorResponse": "ConnectorResponseData" },
   PaymentServiceReverseRequest: { "browserInfo": "BrowserInformation" },
   PaymentServiceReverseResponse: { "error": "ErrorInfo", "responseHeaders": "ResponseHeadersEntry" },
   MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse: { "error": "ErrorInfo" },


### PR DESCRIPTION
## What

Add `connector_response` to `PaymentServiceVoidResponse` and populate it in the void
response builder, so the void flow carries connector-response data (AVS / `payment_checks`)
over gRPC — exactly as `PaymentServiceCaptureResponse` already does (field 13).

## Why — shadow-validation diff

Shadow validation reports a **router-data** diff on `payload` / **Void**:

```
router.typeDiff: connector_response = { hyperswitch: "object", ucs: "null" }
```

- HS-native void builds `RouterData.connector_response` from the connector's `avs` data
  (`ConnectorResponseData::Card { payment_checks: { avs_result } }`) in the shared
  `PayloadCardsResponse` transformer.
- On the UCS-shadow path HS builds its `RouterData` from the UCS gRPC
  `PaymentServiceVoidResponse`, which had **no** `connector_response` field — so the field
  came back `null` while the native flow produced an object → `typeDiff`.

The UCS connector layer already computes `connector_response` for void
(`handle_payment_response` sets `PaymentFlowData.connector_response` from `card_response.avs`);
it was simply never carried into the gRPC void response. This change wires it through,
mirroring the existing capture implementation.
## Changes

- `proto/payment.proto`: add `optional ConnectorResponseData connector_response = 13;` to
  `PaymentServiceVoidResponse` (next free field number; capture uses the same type at field 13).
- `domain_types/src/types.rs` (`generate_payment_void_response`): convert
  `resource_common_data.connector_response` into the gRPC type and set it on both the success
  and error `PaymentServiceVoidResponse` constructors — identical to
  `generate_payment_capture_response`.

## Verification

- `cargo build --bin grpc-server` ✅
- `cargo clippy -p domain_types -p grpc-api-types --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- Live shadow re-run was **not** possible locally: `payload` sandbox (`api.payload.com`) serves
  a leaf-only TLS chain that the local MITM/openssl cannot verify (`unable to get local issuer
  certificate`), so HS-native authorize fails before a cancellable payment exists — the same
  environmental block seen on `finix`. Verified instead by **source parity** with the capture
  flow (which produces this field correctly in prod) + clean compile/clippy/fmt.

## Cross-repo

Paired with hyperswitch PR **juspay/hyperswitch#12939** (HS→UCS mapping) which reads this new field in
`handle_unified_connector_service_response_for_payment_cancel` / `cancel_gateway`. The HS PR
pins this PR's head commit via `rev` until it merges to `main`.

Closes #1637
