### PR TITLE
fix(novalnet): preserve attempt status on repeat_payment API failure (#17033)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -1032,10 +1032,6 @@ impl<
                     transaction_id,
                 ));
                 Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status: common_enums::AttemptStatus::Failure,
-                        ..item.router_data.resource_common_data
-                    },
                     response,
                     ..item.router_data
                 })


### PR DESCRIPTION
## What

Fixes the shadow-validation **router diff** `router.valueDiff:status` for **novalnet / `repeat_payment`** (`17033`, child of `17005`, merchant `bu_de_getolo`).

## Root cause

When novalnet returns an API-level failure on a recurring/MIT charge (`result.status = FAILURE`, e.g. a card decline — returned over **HTTP 200** with the decline in the body), the UCS novalnet `repeat_payment` transformer **overrode** the attempt status:

```rust
NovalnetAPIStatus::Failure => {
    let response = Err(get_error_response(...));
    Ok(Self {
        resource_common_data: PaymentFlowData {
            status: common_enums::AttemptStatus::Failure,   // <-- diverges from Direct
            ..item.router_data.resource_common_data
        },
        response,
        ..item.router_data
    })
}
```

The **native (Direct) novalnet flow** does *not* do this — its failure arm returns the error response and leaves the attempt status untouched (`Ok(Self { response, ..item.data })`), relying on the core error path to drive the final payment status. Since novalnet replies with HTTP 200, `get_attempt_status_for_grpc` propagates this `Failure` into the gRPC `status`, which the router then reads back as `attempt_status = Failure`.

Result — the router-data snapshot diverged:

```
router.valueDiff:status = { "hyperswitch": "pending", "ucs": "failure" }
```

(UCS is the only side that should change; Direct is the source of truth.)

## Fix

Mirror Direct in the failure arm — drop the `status: Failure` override so the incoming status is preserved. One connector, one flow; the success arm is unchanged, and the final payment still fails via the `Err` response (verified `status: "failed"` end-to-end).

## Verification (local shadow stack)

Reproduced a novalnet `repeat_payment` decline (`result.status=FAILURE`) and read the router-data comparison (VS_48) from the validation service:

| | router-data `status` | VS_51 |
|---|---|---|
| **BEFORE** (`main`, req `019ef86d-…`) | `valueDiff: {"status": {"hyperswitch":"pending","ucs":"failure"}}` | `hyperswitch_status: pending, ucs_status: failure` → diff |
| **AFTER** (this PR, req `019ef875-…`) | `valueDiff: {}` ✅ | `hyperswitch_status: pending, ucs_status: pending` → match |

The `router.valueDiff:status` diff that defines `17033` is gone.

## Out of scope (separate, generic divergence — not in this issue's signature)

After this fix the router-data comparison still reports two **typeDiffs** that are **not** novalnet-specific and **not** part of the ``17033`` signature:

- `response.Err.attempt_status` `{hyperswitch:null, ucs:string}`
- `response.Err.connector_response_reference_id` `{hyperswitch:null, ucs:string}`

These stem from the **generic UCS machinery**, independent of the novalnet connector:
- the router UCS-client error branch derives `attempt_status` from the gRPC status and sets `connector_response_reference_id = merchant_charge_id` (`crates/router/src/core/unified_connector_service/transformers.rs:2997,2999`), and
- the generic repeat-response encoder maps `merchant_charge_id = err.connector_transaction_id` (`crates/types-traits/domain_types/src/types.rs:13105`).

They affect every connector whose Direct error path returns HTTP 200 with `attempt_status: None` / `connector_response_reference_id: None`, were absent from the prod issue signature, and should be addressed in the shared machinery rather than in a novalnet connector PR.

Closes #1691

