### PR TITLE
fix(finix): align repeat_payment connector_response_reference_id with Direct (#17007)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -1839,7 +1839,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 connector_metadata: None,
                 network_txn_id: None,
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(response.id.clone()),
+                // Mirror Direct finix, which routes repeat payments through the Authorize
+                // ConnectorIntegration and leaves connector_response_reference_id as None.
+                // Finix's /transfers response has no dedicated reference field (only `id`,
+                // already surfaced as resource_id), so emitting Some(id) here produced a
+                // null-vs-string typeDiff against Direct (#17007).
+                connector_response_reference_id: None,
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,


### PR DESCRIPTION
## What

Aligns the finix **repeat_payment** (MIT) response mapping with the Direct gateway for `connector_response_reference_id`.

Fixes the shadow-validation router-data **typeDiff** observed on `golfdistrict / finix / repeat_payment`.

## Root cause

On the Direct side, finix has **no** dedicated `RepeatPayment` flow registration — repeat (MIT) payments run through the **Authorize** `ConnectorIntegration`, whose response transformer sets `connector_response_reference_id: None` (`crates/hyperswitch_connectors/src/connectors/finix/transformers.rs:645`).

The UCS finix `RepeatPayment` transformer instead set `connector_response_reference_id: Some(response.id.clone())`. `response.id` is the finix transfer/auth id (`TR*`/`AU*`), already surfaced as `resource_id` (and `connector_transaction_id`). Finix's `POST /transfers` response carries no dedicated reference field, so emitting `Some(id)` here diverged from Direct's `None`, producing the shadow-validation router-data **typeDiff**:

```
router.typeDiff:response.Ok.TransactionResponse.connector_response_reference_id
  { "hyperswitch": "null", "ucs": "string" }
```

## Fix

Drop the override — set `connector_response_reference_id: None` in the finix `RepeatPayment` response transformer to mirror Direct. UCS-only change; no proto change, no hyperswitch-client change (the client read-back at `unified_connector_service/transformers.rs` is an optional passthrough and already correct).

## Verification (local shadow stack, real finix sandbox)

Merchant `finix_repro`, card tokenized via a CIT, then a repeat MIT (`recurring_details: payment_method_id`). The MIT goes through shadow UCS as `repeat_payment` (flow-mapped to authorize), driving the router-data comparison.

**BEFORE** (prism `main`, req `019ef885-cf79-7911-9f53-6f6968801fba`, payment `pay_Zr1YhGn497X4Tp9z4Qh6`):
```
VS_48 Router data comparison – differences found  (56/56 keys)
typeDiff: { "response.Ok.TransactionResponse.connector_response_reference_id": { "hyperswitch": "null", "ucs": "string" } }
```

**AFTER** (this branch, req `019ef886-d30a-7db2-b429-e2de3bfe13ac`, payment `pay_wu5d0opj47K5D35aN14m`):
```
VS_46 Router data comparison completed successfully – no differences found
summary: total_key_differences:0, total_value_differences:0, total_type_differences:0  (56/56 keys)
```

The `connector_response_reference_id` typeDiff is eliminated; both sides agree on all 56 router-data keys.

> Note: request-side (outbound HTTP) diffs on the repeat payment (`tags`, `fraud_session_id`, `3d_secure_authentication`, `statement_descriptor`) are a **separate** `request_diff` signature, not the `router_diff` this PR addresses, and are out of scope for this PR.
