### PR TITLE
fix(authorizedotnet/psync): preserve payment state on E00104/E00053 server-maintenance sync

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2327,6 +2327,36 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
                 Ok(new_router_data)
             }
             None => {
+                // E00053 indicates "server too busy" and E00104 indicates "server in
+                // maintenance". In both cases Authorize.Net replies HTTP 200 with no
+                // transaction record while the underlying payment is unchanged. Mirror
+                // hyperswitch native (authorizedotnet/transformers.rs `AuthorizedotnetSyncResponse`
+                // -> RouterData): preserve the already-available payment state (status +
+                // Ok response) instead of forcing the attempt to Failure.
+                let is_transient_server_error = response
+                    .messages
+                    .message
+                    .iter()
+                    .any(|m| m.code == "E00053" || m.code == "E00104");
+
+                if is_transient_server_error {
+                    let mut new_router_data = router_data;
+                    // Leave resource_common_data.status untouched (prior attempt status).
+                    new_router_data.response = Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: new_router_data.request.connector_transaction_id.clone(),
+                        redirection_data: None,
+                        mandate_reference: None,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        network_txn_link_id: None,
+                        connector_response_reference_id: None,
+                        incremental_authorization_allowed: None,
+                        status_code: http_code,
+                        splits: None,
+                    });
+                    return Ok(new_router_data);
+                }
+
                 // Handle missing transaction response
                 let status = match response.messages.result_code {
                     ResultCode::Error => AttemptStatus::Failure,


### PR DESCRIPTION
## Summary
On `authorizedotnet` **psync**, when Authorize.Net's gateway is temporarily unavailable it replies **HTTP 200** with **no transaction record** and `resultCode = "Error"` carrying code **E00053** ("server too busy") or **E00104** ("server in maintenance"):

```json
{"messages":{"resultCode":"Error","message":[{"code":"E00104","text":"Server in maintenance. Please try again later."}]}}
```

The UCS psync transformer treated this transaction-less error envelope as a hard `AttemptStatus::Failure` and returned `response.Err`, **overwriting an already-authorized payment**. Hyperswitch native (`hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs`, `AuthorizedotnetSyncResponse -> RouterData`) special-cases E00053/E00104 and **preserves the already-available payment state** (`Ok(item.data)`), keeping `response.Ok` and the prior status.

This was surfaced in prod shadow-validation as `router_diff` on `innago / authorizedotnet / psync`:
- `router.keyDiff:response.Err` — **#17024**
- `router.keyDiff:response.Ok` — **#17025**
- `router.valueDiff:status` (`authorized` vs `failure`) — part of **#17009**

Refs internal tracking issue
Refs internal tracking issue
Refs internal tracking issue
Refs internal tracking issue

> **Re-detection (parent #17063):** the same single E00104 maintenance event (req `019ef366-f204-7170-b23c-fc4986c8b595`) re-surfaced as `response.Err`→#17064, `response.Ok`→#17065, `status`→#17066 — identical to #17024/#17025. Same fix, no code change. `#17066` status residual (`authorized` vs `pending`) is the proto-status-threading gap owned by #1624 + juspay/hyperswitch#12933.

## Implementation
`crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs` — in the psync `transaction: None` branch, detect E00053/E00104 and mirror native: keep `resource_common_data.status` (prior attempt status) and return an `Ok` `TransactionResponse` (resource_id from the sync request's `connector_transaction_id`, `connector_response_reference_id: None`, matching native's seeded sync response). Any other error code still returns `response.Err` as before. **UCS-only — no proto change.**

## Verification (local shadow replay, router-data comparison VS_48)
Reproduced the exact prod diff locally on merchant `authnet_repro`: auth-only payment (status `authorized`), then `force_sync` with a synthetic E00104 injected on the Authorize.Net `getTransactionDetails` (both Direct + UCS legs; reverted after).

**BEFORE** (unpatched UCS) — req `019ef8b4-4d3f-7d42-9a5f-5e19a39b0933`:
```
keyDiff:   { response.Ok: {hyperswitch:true, ucs:false},
             response.Err:{hyperswitch:false, ucs:true} }
valueDiff: { status: {hyperswitch:"authorized", ucs:"failure"} }
typeDiff:  {}
```

**AFTER** (this PR) — req `019ef8b5-3fb6-7f60-87f7-031a0804e092`:
```
keyDiff:   {}        ← response.Ok / response.Err diffs gone (#17024, #17025 resolved)
valueDiff: { status: {hyperswitch:"authorized", ucs:"pending"} }
typeDiff:  {}
```

The `response.Ok`/`response.Err` key diffs are fully resolved with **no new inner-field diffs** (resource_id, connector_response_reference_id etc. match native's preserved sync response).

### Residual on #17009 (out of scope here)
After this fix the status diff changes from `authorized` vs **`failure`** to `authorized` vs **`pending`**: UCS no longer wrongly fails, but it can't reproduce the prior `authorized` status because `PaymentServiceGetRequest` doesn't carry the prior attempt status (`PaymentFlowData.status` is hardcoded `Pending` for the get flow). That is the connector-agnostic proto-status-threading gap already being addressed by **#1624** (`PaymentServiceGetRequest.status`) + hyperswitch #12933. The other part of #17009 (FDS `unresolved` vs `pending`) is owned by the existing **#1211**.

Closes #1712
