### PR TITLE
fix(redsys): authenticate error-path parity — failure status, drop placeholder ctid, populate reason (#17016)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -1156,7 +1156,11 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<responses::RedsysResp
                         .error_code_description
                         .clone()
                         .unwrap_or_else(|| err.error_code.clone()),
-                    reason: err.error_code_description.clone(),
+                    // Always populate `reason` (matching the Direct gateway, which uses the
+                    // error code) — redsys frequently omits `error_code_description`, which
+                    // previously left `reason` null versus Direct's string on the
+                    // authenticate error path.
+                    reason: Some(err.error_code.clone()),
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -15238,12 +15238,22 @@ pub fn generate_payment_authenticate_response<T: PaymentMethodDataTypes>(
             }
         },
         Err(err) => {
+            // Fall back to the flow status (`grpc_status`, derived from
+            // `resource_common_data.status`) when the connector does not set an explicit
+            // `attempt_status` on the error — mirrors the Ok branch. Using
+            // `unwrap_or_default()` here previously emitted PAYMENT_STATUS_UNSPECIFIED,
+            // which the HS readback decoded to `None`, leaving router_data.status at the
+            // prior `authentication_pending` instead of `failure` on a declined authenticate.
             let status = err
                 .attempt_status
                 .map(grpc_api_types::payments::PaymentStatus::foreign_from)
-                .unwrap_or_default();
+                .unwrap_or(grpc_status);
             PaymentMethodAuthenticationServiceAuthenticateResponse {
-                connector_transaction_id: Some("session_created".to_string()),
+                // Echo the connector's transaction id (None when the connector returns a
+                // bare error envelope) instead of the hardcoded "session_created"
+                // placeholder, which surfaced as a spurious connector_transaction_id on the
+                // error path versus Direct's null.
+                connector_transaction_id: err.connector_transaction_id.clone(),
                 redirection_data: None,
                 network_transaction_id: None,
                 merchant_order_id: None,


### PR DESCRIPTION
## What

Resolves the **redsys `authenticate` (post-3DS) error-path** parity diffs under parent #17016. On a declined authenticate, three RouterData fields diverged between the Direct gateway and UCS:

| Field | Direct | UCS (before) | Issue |
|---|---|---|---|
| `status` | `failure` | `authentication_pending` | #17021 |
| `response.Err.connector_transaction_id` | `null` | `"session_created"` | #17017 |
| `response.Err.reason` | `<error code>` (string) | `null` | #17018 |

## Root cause

`generate_payment_authenticate_response`'s `Err` branch (`domain_types/src/types.rs`):
- derived top-level `status` from `err.attempt_status` (which redsys leaves `None`) via `unwrap_or_default()` → `PAYMENT_STATUS_UNSPECIFIED`. The HS readback decodes `UNSPECIFIED → None`, so the router kept the prior `authentication_pending` instead of moving to `failure`.
- hardcoded `connector_transaction_id: Some("session_created")` instead of echoing the connector's id (`None` for a redsys error envelope).

Separately, the redsys authenticate error-envelope mapping set `reason: error_code_description` (often absent → `null`), while Direct uses `Some(error_code)`.

No proto change — all fields already exist on `PaymentMethodAuthenticationServiceAuthenticateResponse`.

## Fix

- `Err` branch: `status` falls back to `grpc_status` (the real flow status = `Failure`) like the `Ok` branch; `connector_transaction_id` echoes `err.connector_transaction_id`.
- redsys authenticate error envelope: `reason: Some(err.error_code.clone())` (matches Direct).

> The status fix is completed by hyperswitch#PR_HS_PLACEHOLDER, which applies the error's `attempt_status` on the authenticate Err branch (mirroring the authorize gateway). `connector_transaction_id` and `reason` are fixed entirely here.

## Verification — direct gRPC A/B against prism

Real redsys sandbox, `types.PaymentMethodAuthenticationService/Authenticate` with a fabricated 3DS txn → redsys returns error envelope `SIS0434`.

**BEFORE** (clean main):
```json
{ "connectorTransactionId": "session_created",
  "error": { "connectorDetails": { "code": "SIS0434", "message": "SIS0434" } },
  "statusCode": 200 }
```
(`status` absent = UNSPECIFIED, `reason` absent)

**AFTER** (this branch):
```json
{ "status": "FAILURE",
  "error": { "connectorDetails": { "code": "SIS0434", "message": "SIS0434", "reason": "SIS0434" } },
  "statusCode": 200 }
```
→ `status=FAILURE`, `connectorTransactionId` dropped (None, = Direct null), `reason="SIS0434"` — all three now match the Direct gateway.

Grafana prod RCA (ns `validation-service`, redsys/`bu_es`) confirmed the same triple on the Authenticate failure event.

Fixes #17017, #17018, #17021, #17054, #17055.
