### PR TITLE
fix(domain_types): populate issuer error details (network_decline_code) on setup recurring failure

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11159,7 +11159,15 @@ pub fn generate_setup_mandate_response<T: PaymentMethodDataTypes>(
                         connector_transaction_id: err.connector_transaction_id.clone(),
                         status: None,
                     }),
-                    issuer_details: None,
+                    issuer_details: Some(grpc_api_types::payments::IssuerErrorDetails {
+                        code: None, // To be filled with card network specific error code if available
+                        message: err.network_error_message.clone(),
+                        network_details: Some(grpc_api_types::payments::NetworkErrorDetails {
+                            advice_code: err.network_advice_code,
+                            decline_code: err.network_decline_code,
+                            error_message: err.network_error_message.clone(),
+                        }),
+                    }),
                 }),
                 status_code: err.status_code as u32,
                 response_headers: router_data_v2


### PR DESCRIPTION
## What

The `PaymentServiceSetupRecurringResponse` error builder in
`crates/types-traits/domain_types/src/types.rs` hard-codes `issuer_details: None`, dropping
the network error fields (`network_decline_code`, `network_advice_code`,
`network_error_message`) on the **setup_mandate / setup-recurring failure** path.

Every other failure builder in the same file populates `issuer_details` from the connector
`ErrorResponse` — e.g. the Authorize builder:

```rust
issuer_details: Some(grpc_api_types::payments::IssuerErrorDetails {
    code: None,
    message: err.network_error_message.clone(),
    network_details: Some(grpc_api_types::payments::NetworkErrorDetails {
        advice_code: err.network_advice_code,
        decline_code: err.network_decline_code,
        error_message: err.network_error_message.clone(),
    }),
}),
```

This PR makes the setup-recurring error builder do the same, so the network decline code
survives the domain → gRPC conversion.

## Why (shadow-validation diff)

Diff signature: `router.typeDiff:response.Err.network_decline_code`
(connector `cybersource`, flow `setup_mandate`, merchant `flowbird`).

For a **declined** cybersource setup_mandate, the connector returns
`processorInformation.responseCode`. The shared cybersource transformer
(`get_error_response`) maps that into `ErrorResponse.network_decline_code` on **both**
hyperswitch-native and UCS sides — so the domain value is identical.

- **HS-native path:** `network_decline_code = Some("<code>")` → emitted on `response.Err`.
- **UCS path (before this fix):** UCS builds the same domain `ErrorResponse`, but the
  `PaymentServiceSetupRecurringResponse` error builder sets `issuer_details: None`, so the
  gRPC `ErrorInfo` carries no `network_details`. When hyperswitch maps the UCS response back
  (`router/src/core/unified_connector_service/transformers.rs`, the
  `PaymentServiceSetupRecurringResponse → Result<_, ErrorResponse>` impl reads
  `issuer_details.network_details.decline_code`), it resolves to `None`.

Result: HS = `Some("<code>")`, UCS = `null` → `typeDiff` on `response.Err.network_decline_code`.

After this fix the gRPC response carries `network_details.decline_code`, the hyperswitch
mapping reconstructs `network_decline_code = Some("<code>")`, and both sides match → `no_diff`.

## Scope

- **UCS-only** (domain layer). The gRPC contract already carries the field
  (`IssuerErrorDetails.network_details.decline_code`), and the hyperswitch → UCS mapping
  already reads it back — so **no proto change and no hyperswitch change are required**.
- Minimal change: one builder block, mirroring the existing Authorize/RepeatPayment builders.

## Verification

- `cargo build --bin grpc-server` — clean (exit 0).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p domain_types --all-targets -- -D warnings`, `cargo test -p domain_types` — pass.
- Live shadow A/B against cybersource is environmentally blocked here (the sandbox host is
  unreachable through the test proxy → TLS handshake fails before any decline can be
  observed), so this is verified by **source parity**: the fixed block is byte-identical in
  network-detail handling to the proven Authorize builder, and the hyperswitch-side mapping
  that reads `decline_code` is shared across flows.

Closes #1706
