### PR TITLE
fix(nexixpay): echo connector_metadata on PSync response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -625,7 +625,15 @@ impl TryFrom<ResponseRouterData<NexixpaySyncResponse, Self>>
                 resource_id: ResponseId::ConnectorTransactionId(item.response.operation_id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
+                // Echo back the connector metadata carried in the sync request
+                // (stored at authorize time), mirroring HS which sets
+                // connector_metadata = request.connector_meta on PSync.
+                connector_metadata: item
+                    .router_data
+                    .request
+                    .connector_feature_data
+                    .as_ref()
+                    .map(|meta| meta.peek().clone()),
                 network_txn_id: None,
                 network_txn_link_id: None,
                 connector_response_reference_id: Some(item.response.order_id.clone()),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -7105,7 +7105,7 @@ pub fn generate_payment_sync_response(
             PaymentsResponseData::TransactionResponse {
                 resource_id,
                 redirection_data,
-                connector_metadata: _,
+                connector_metadata,
                 network_txn_id,
                 network_txn_link_id,
                 connector_response_reference_id,
@@ -7173,7 +7173,10 @@ pub fn generate_payment_sync_response(
                         .connector_customer
                         .clone(),
                     merchant_order_id: None,
-                    metadata: None,
+                    // Round-trip connector_metadata back to HS via the response
+                    // `metadata` field (mirrors authorize's connector_feature_data),
+                    // so PSync echoes the stored connector metadata for parity.
+                    metadata: convert_connector_metadata_to_secret_string(connector_metadata),
                     status_code: status_code as u32,
                     raw_connector_response,
                     response_headers: router_data_v2


### PR DESCRIPTION
## What

Fix the shadow-validation router diff for **nexixpay / psync**:

```
router.typeDiff:response.Ok.TransactionResponse.connector_metadata
```

On PSync, HS-native carries the connector metadata stored at authorize time into the
response (`connector_metadata = request.connector_meta`), but the UCS path returned
`connector_metadata = null`. Two gaps on the UCS side:

1. The nexixpay PSync response transformer hard-coded `connector_metadata: None` instead of
   echoing the metadata that HS sends in the sync request (`connector_feature_data`).
2. The generic `generate_payment_sync_response` discarded the domain `connector_metadata`
   and hard-coded the proto `metadata` field to `None`, so even a populated value would not
   round-trip back to HS.

This mirrors how **authorize** already round-trips connector metadata (domain
`connector_metadata` → proto field → HS parse).

## Changes (L3 connector + L2 domain→proto, no proto contract change)

- `crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs`
  — PSync response now sets `connector_metadata` from `request.connector_feature_data`
  (the stored metadata HS forwards on sync), mirroring HS's `request.connector_meta`.
- `crates/types-traits/domain_types/src/types.rs` — `generate_payment_sync_response` now
  captures the domain `connector_metadata` and serializes it into the existing proto
  `metadata` field (#21) via `convert_connector_metadata_to_secret_string` (same helper the
  authorize response uses). No `.proto` change — the field already exists.

## Request-side chain (already present, unchanged)

HS sends the stored metadata to UCS on the sync call:
`attempt.connector_metadata` → `PaymentsSyncData.connector_meta` →
`PaymentServiceGetRequest.connector_feature_data` (field 10) → UCS
`PaymentsSyncData.connector_feature_data`. This PR makes UCS echo it back.

## Verification

- `cargo build` / `cargo fmt --all -- --check` / `cargo clippy` clean.
- Live nexixpay PSync shadow is not locally reproducible (a sync needs a completed
  3DS authorize + a real sandbox order; nexixpay sandbox is reachable but the shadow
  MITM path can't be driven end-to-end for this 3DS flow here).
- **Source-parity verified:** after this change the UCS PSync response yields
  `connector_metadata` = the same stored value HS-native returns
  (`request.connector_meta` == round-tripped `request.connector_feature_data`), so the
  `router.typeDiff` on `connector_metadata` (object vs null) is resolved.

Paired HS PR (parses the proto `metadata` field back into `connector_metadata` on the
PSync response mapping): see cross-link below.

---
Paired HS PR: juspay/hyperswitch#12957

Closes #1707
