### PR TITLE
fix(nexixpay): anchor PSync resource_id to order_id (juspay/hyperswitch-cloud#16986)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -622,7 +622,12 @@ impl TryFrom<ResponseRouterData<NexixpaySyncResponse, Self>>
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.operation_id.clone()),
+                // Anchor the synced attempt to the connector `order_id`, mirroring HS
+                // (`resource_id = ConnectorTransactionId(order_id)` in its PSync transformer).
+                // The `operation_id` is the per-operation id and is surfaced separately;
+                // using it here produced a value mismatch on
+                // response.Ok.TransactionResponse.resource_id.ConnectorTransactionId.
+                resource_id: ResponseId::ConnectorTransactionId(item.response.order_id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,


### PR DESCRIPTION
## What

Fix the nexixpay **PSync** response transformer to anchor `resource_id` to the
connector **`order_id`** instead of the per-operation `operation_id`, matching
Hyperswitch (the validation ground truth).

## Why — shadow-validation diff

Issue: `[prod] Validation router diff: bu_it_zie / nexixpay / psync`

```
Diff signature: router.valueDiff:response.Ok.TransactionResponse.resource_id.ConnectorTransactionId
Connector: nexixpay   Flow: psync   Merchant: bu_it_zie   Occurrences: 16
```

`valueDiff` = both HS and UCS emit a `ConnectorTransactionId`, but with **different
values**:

- **HS** (`hyperswitch_connectors/.../nexixpay/transformers.rs`, PSync
  `TryFrom<PaymentsSyncResponseRouterData<NexixpayTransactionResponse>>`):
  `resource_id = ResponseId::ConnectorTransactionId(item.response.order_id)`
- **UCS** (before this change): `resource_id =
  ResponseId::ConnectorTransactionId(item.response.operation_id)` ← wrong source

The nexixpay sync response carries both `orderId` and `operationId`; HS anchors the
attempt to `orderId`, UCS was returning `operationId`, so the synced attempt's
`connector_transaction_id` diverged.

This was also **internally inconsistent in UCS itself**: the nexixpay *authorize*
transformer already sets `resource_id = ConnectorTransactionId(order_id)` (see the
"Hyperswitch anchors the attempt to the orderId returned by /init" comment), and
stores `operation_id` separately in `preprocessing_id`. PSync overwriting that with
`operation_id` broke the anchor on every sync.

## Fix (L3 — connector transformer only)

`crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs`,
PSync `TryFrom<ResponseRouterData<NexixpaySyncResponse, …>>`:

```rust
-resource_id: ResponseId::ConnectorTransactionId(item.response.operation_id.clone()),
+resource_id: ResponseId::ConnectorTransactionId(item.response.order_id.clone()),
```

`order_id` is already a field of `NexixpaySyncResponse`; no proto, domain, or HS-mapping
change is required (HS is already correct). This is a UCS-only fix.

## Verify

- **Source parity**: UCS PSync `resource_id` now derives from `order_id`, byte-identical
  to HS's PSync transformer (`order_id`) and to UCS's own authorize transformer
  (`order_id`).
- nexixpay live shadow is not locally reproducible (psync requires a completed real-3DS
  authorize + live sandbox order), consistent with the sibling fix #16984.
- Local checks: `cargo build` · `cargo clippy --all-targets -- -D warnings` ·
  `cargo fmt --all -- --check` green.

Closes #1697
