### PR TITLE
feat(observability): structured error attribution and execution_mode for UCS error alerting

### DIFF
--- a/crates/common/common_utils/src/types.rs
+++ b/crates/common/common_utils/src/types.rs
@@ -489,4 +489,12 @@ impl ExecutionMode {
             Self::Primary
         }
     }
+
+    /// Stable string form for log/span fields; matches the serde representation used in events.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Shadow => "shadow",
+        }
+    }
 }

--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -52,7 +52,10 @@ pub enum ConfigurationError {
 /// `internal` — UCS machinery failure (encoding, URL building, serialization); caller cannot fix.
 impl IntoGrpcStatus for error_stack::Report<IntegrationError> {
     fn into_grpc_status(self) -> Status {
-        logger::error!(error=?self);
+        logger::error!(
+            error = ?self,
+            error_code = %self.current_context().error_code(),
+        );
         let integration_error: grpc_api_types::payments::IntegrationError =
             ErrorSwitch::switch(self.current_context());
         let msg = integration_error.error_message.clone();
@@ -109,7 +112,11 @@ impl IntoGrpcStatus for error_stack::Report<IntegrationError> {
 /// - All UCS-side transformation failures → `internal` (UCS machinery failed).
 impl IntoGrpcStatus for error_stack::Report<ConnectorError> {
     fn into_grpc_status(self) -> Status {
-        logger::error!(error=?self);
+        logger::error!(
+            error = ?self,
+            error_code = %self.current_context().error_code(),
+            http_status_code = ?self.current_context().http_status_code(),
+        );
         let connector_error: grpc_api_types::payments::ConnectorError =
             ErrorSwitch::<grpc_api_types::payments::ConnectorError>::switch(self.current_context());
         let msg = connector_error.error_message.clone();
@@ -171,7 +178,7 @@ impl IntoGrpcStatus for error_stack::Report<KafkaClientError> {
 /// Direct gRPC status mapping for `ConnectorFlowError` (unified gRPC path wrapper).
 impl IntoGrpcStatus for error_stack::Report<ConnectorFlowError> {
     fn into_grpc_status(self) -> Status {
-        logger::error!(error=?self);
+        // inner impls log; avoid double-logging the same stack
         match self.current_context() {
             ConnectorFlowError::Request(e) => {
                 error_stack::Report::new(e.clone()).into_grpc_status()

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -34,6 +34,7 @@ pub fn record_fields_from_header<B: hyper::body::Body>(request: &Request<B>) -> 
         version = ?request.version(),
         tenant_id = tracing::field::Empty,
         request_id = tracing::field::Empty,
+        execution_mode = tracing::field::Empty,
     );
     request
         .headers()
@@ -46,6 +47,17 @@ pub fn record_fields_from_header<B: hyper::body::Body>(request: &Request<B>) -> 
         .get(consts::X_REQUEST_ID)
         .and_then(|value| value.to_str().ok())
         .map(|request_id| span.record("request_id", request_id));
+
+    // On the request span so every log line of the request carries primary/shadow.
+    let shadow = request
+        .headers()
+        .get(consts::X_SHADOW_MODE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+    span.record(
+        "execution_mode",
+        ExecutionMode::from_shadow_flag(shadow).as_str(),
+    );
 
     span
 }
@@ -288,7 +300,7 @@ where
             current_span.record("status_code", status.code().to_string());
         }
     }
-    tracing::info!("Golden Log Line (incoming)");
+    tracing::info!("Golden Log Line (response)");
 }
 
 /// Generic gRPC logging wrapper that accepts a custom parser function.

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -260,7 +260,7 @@ where
     current_span.record("merchant_id", merchant_id);
     current_span.record("tenant_id", tenant_id);
     current_span.record("request_id", request_id);
-    tracing::info!("Golden Log Line (incoming)");
+    tracing::info!("Golden Log Line (incoming - request)");
     Ok(())
 }
 
@@ -301,7 +301,7 @@ where
             current_span.record("status_code", status.code().to_string());
         }
     }
-    tracing::info!("Golden Log Line (response)");
+    tracing::info!("Golden Log Line (incoming - response)");
 }
 
 /// Generic gRPC logging wrapper that accepts a custom parser function.

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -18,6 +18,7 @@ use domain_types::{
 use error_stack::Report;
 use http::request::Request;
 use hyperswitch_masking;
+use prost::Message;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use ucs_env::{configs, error::ResultExtGrpc};
@@ -471,10 +472,41 @@ fn create_and_emit_grpc_event<R>(
 
     match grpc_response {
         Ok(response) => grpc_event.set_grpc_success_response(response.get_ref()),
-        Err(error) => grpc_event.set_grpc_error_response(error),
+        Err(error) => {
+            grpc_event.set_grpc_error_response(error);
+            // populate structured `error` (error_code/http_status_code) for event consumers
+            if let Some(detail) = decode_error_detail(error) {
+                grpc_event.set_error_response(&detail);
+            }
+        }
     }
 
     common_utils::emit_event_with_config(grpc_event, &config.events);
+}
+
+/// Recover error_code / http_status_code from a gRPC Status's proto details for the audit event.
+/// IntegrationError is decoded first: a ConnectorError's varint http_status_code (field 3) makes
+/// the IntegrationError decode fail on a wire-type mismatch, so the order is unambiguous.
+fn decode_error_detail(status: &tonic::Status) -> Option<Value> {
+    use grpc_api_types::payments::{ConnectorError, IntegrationError};
+
+    let details = status.details();
+    if details.is_empty() {
+        return None;
+    }
+    let (error_code, http_status_code, message) = IntegrationError::decode(details)
+        .map(|e| (e.error_code, None, e.error_message))
+        .or_else(|_| {
+            ConnectorError::decode(details)
+                .map(|e| (e.error_code, e.http_status_code, e.error_message))
+        })
+        .ok()?;
+    Some(serde_json::json!({
+        "grpc_code_name": format!("{:?}", status.code()),
+        "error_code": error_code,
+        "http_status_code": http_status_code,
+        "error_message": message,
+    }))
 }
 
 #[allow(clippy::result_large_err)]

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -474,39 +474,34 @@ fn create_and_emit_grpc_event<R>(
         Ok(response) => grpc_event.set_grpc_success_response(response.get_ref()),
         Err(error) => {
             grpc_event.set_grpc_error_response(error);
-            // populate structured `error` (error_code/http_status_code) for event consumers
-            if let Some(detail) = decode_error_detail(error) {
-                grpc_event.set_error_response(&detail);
-            }
+            grpc_event.set_error_response(&build_error_detail(error));
         }
     }
 
     common_utils::emit_event_with_config(grpc_event, &config.events);
 }
 
-/// Recover error_code / http_status_code from a gRPC Status's proto details for the audit event.
-/// IntegrationError is decoded first: a ConnectorError's varint http_status_code (field 3) makes
-/// the IntegrationError decode fail on a wire-type mismatch, so the order is unambiguous.
-fn decode_error_detail(status: &tonic::Status) -> Option<Value> {
+fn build_error_detail(status: &tonic::Status) -> Value {
     use grpc_api_types::payments::{ConnectorError, IntegrationError};
 
     let details = status.details();
-    if details.is_empty() {
-        return None;
-    }
-    let (error_code, http_status_code, message) = IntegrationError::decode(details)
-        .map(|e| (e.error_code, None, e.error_message))
-        .or_else(|_| {
-            ConnectorError::decode(details)
-                .map(|e| (e.error_code, e.http_status_code, e.error_message))
-        })
-        .ok()?;
-    Some(serde_json::json!({
+    let (error_code, http_status_code) = if details.is_empty() {
+        (None, None)
+    } else {
+        IntegrationError::decode(details)
+            .map(|e| (Some(e.error_code), None))
+            .or_else(|_| {
+                ConnectorError::decode(details).map(|e| (Some(e.error_code), e.http_status_code))
+            })
+            .unwrap_or((None, None))
+    };
+    serde_json::json!({
+        "grpc_code": i32::from(status.code()),
         "grpc_code_name": format!("{:?}", status.code()),
         "error_code": error_code,
         "http_status_code": http_status_code,
-        "error_message": message,
-    }))
+        "error_message": status.message(),
+    })
 }
 
 #[allow(clippy::result_large_err)]


### PR DESCRIPTION
## What

Make UCS logs and audit events self-sufficient for error alerting and connector-vs-UCS attribution, without parsing error-message text.

**Logs:**
- Record `execution_mode` (`primary`/`shadow`) on the outermost request span, so it is inherited by every child span and appears on **every log line** of the request — not just the audit event. Reuses `ExecutionMode` via a new `as_str()` helper.
- Log `error_code` (and `http_status_code` for connector responses) as structured fields on the `IntegrationError` and `ConnectorError` gRPC-status mappers.
- Stop double-logging the error stack in the `ConnectorFlowError` wrapper; each variant's inner mapper already logs it.
- Fix the response Golden Log Line label (`incoming` -> `response`).

**Audit event:**
- On a failed gRPC response, decode the `Status` proto details and populate the event's `error` field with `error_code` / `http_status_code` / message — so event consumers (ClickHouse, event-line alerts) can separate connector-attributed errors (`CONNECTOR_ERROR_RESPONSE`) from UCS-internal faults. Matches the connector-call event, which already populates `error` on failure.

## Why

`error_code != "" AND error_code != "CONNECTOR_ERROR_RESPONSE"` is a drift-proof "any UCS-side error" signal (an exclusion, not an enumeration — unknown/future error types still match). `http_status_code` separates connector 4xx from 5xx. `execution_mode` lets alerts exclude shadow traffic.

## Notes

- Errors with no proto details (transport `ApiClientError`, webhook, direct `Status::internal`) carry no `error_code`; they are inherently UCS-side and identified by a non-OK `status_code`.
- Event `error` is additive; no change to the `Event` struct shape.

## Verification

- [x] `cargo check -p common_utils -p ucs_env -p grpc-server`
- [ ] Confirm the fields land as expected on a deployed environment.
