### PR TITLE
fix(novalnet): preserve attempt status on PSync API failure (#17031)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -1557,10 +1557,6 @@ impl<F> TryFrom<ResponseRouterData<NovalnetPSyncResponse, Self>>
                     transaction_id,
                 ));
                 Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status: common_enums::AttemptStatus::Failure,
-                        ..item.router_data.resource_common_data
-                    },
                     response,
                     ..item.router_data
                 })


### PR DESCRIPTION
## What

Fixes the shadow-validation **router diff** `router.valueDiff:status` for **novalnet / `psync`** (issue `17031`, merchant `bu_de_getolo`, org `zurich_insurance`, prod).

```
router.valueDiff:status = { "hyperswitch": "authentication_pending", "ucs": "failure" }
```

Observed on every prod novalnet PSync event for this merchant (5/5 in the RCA window) — all on 3DS redirect-return syncs where the issuer challenge did not complete.

## Root cause

When novalnet returns an API-level failure on a PSync (`result.status = FAILURE` — e.g. a 3DS **"Authentication Failed"** (`status_code 1007`) returned over **HTTP 200**), the UCS novalnet PSync transformer **overrode** the attempt status:

```rust
NovalnetAPIStatus::Failure => {
    let response = Err(get_error_response(...));
    Ok(Self {
        resource_common_data: PaymentFlowData {
            status: common_enums::AttemptStatus::Failure,   // <-- diverges from Direct
            ..item.router_data.resource_common_data
        },
        response,
        ..item.router_data
    })
}
```

The **native (Direct)** novalnet PSync flow does *not* do this — its failure arm returns the error response and leaves the attempt status untouched (`Ok(Self { response, ..item.data })`, `crates/hyperswitch_connectors/.../novalnet/transformers.rs:1250`), so a payment still awaiting 3DS authentication remains `authentication_pending`. Because novalnet replies HTTP 200, `get_attempt_status_for_grpc` propagates the UCS-side `Failure` into the gRPC `status`, which the router reads back as `attempt_status = Failure` → the router-data snapshot diverged.

## Fix

Mirror Direct in the failure arm — drop the `status: Failure` override so the incoming status is preserved. One connector, one flow; the success arm is unchanged, and the payment still surfaces the failure via the `Err` response.

**Depends on #1624** (generic `PaymentServiceGetRequest.status` threading, redsys #16987): the caller-supplied prior attempt status is read into `PaymentFlowData.status` (it was previously hardcoded `PENDING`). Without that threading, dropping this override would yield `pending` instead of `authentication_pending`. This PR is therefore based on the #1624 branch and should merge after it. The hyperswitch-side client threading + decode guards are the **generic** machinery in **juspay/hyperswitch#12933** (no novalnet-specific change needed there).

## Verification (local shadow stack)

Direct gRPC A/B against prism `:8000` (`types.PaymentService/Get`, novalnet creds), with the upstream novalnet `transaction/details` response forced to the real 3DS `result.status=FAILURE / "Authentication Failed"` envelope and the prior status threaded as `AUTHENTICATION_PENDING` (proto field 18). The **only** variable between runs is this one-line override:

| | gRPC response `status` | `response.error` |
|---|---|---|
| **BEFORE** (override present) | `FAILURE` | connectorDetails: FAILURE / "Authentication Failed" |
| **AFTER** (this PR) | `AUTHENTICATION_PENDING` ✅ | connectorDetails: FAILURE / "Authentication Failed" |

After the fix, UCS preserves `authentication_pending` (matching Direct) while still carrying the failure in `response.Err` — the `router.valueDiff:status` that defines `17031` is gone. (The 3DS redirect-return PSync that triggers this in prod is not reproducible through the connector sandbox, so verification uses the direct gRPC A/B, as with the sibling redsys error-path fixes.)

## Re-detection: also fixes `17071` (parent `17070`)

Fixes `17071`. The validation pipeline re-detected this exact diff family as a new issue **`17071`** (parent group `17070`). Grafana RCA on its sample request-id `019ef37a-98b8-7cf0-bf81-9b85e0a0d564` confirms it is the **same merchant (`bu_de_getolo`), same mechanism, byte-for-byte the same signature** as `17031`:

```
router.valueDiff:status = { "hyperswitch": "authentication_pending", "ucs": "failure" }
```

- Direct flow `PaymentsRedirect` → PSync; novalnet returns `result.status = FAILURE` (`05 Transaction has been declined.`, tid `15403900042425343`) over **HTTP 200**.
- Direct leaves `status = authentication_pending`; UCS prism over-set `failure` — the override this PR removes.
- The re-detection is a stale-prod-build artifact: the event ran on UCS build `2026.06.17.0-dirty-aef0be919`, which predates this fix (still unmerged). No new code is required — this PR (+ dependency #1624 / hs #12933) resolves `17071` identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Re-detection: also fixes `17127` / `17128`

Fixes `17127`. Fixes `17128`. The validation pipeline re-detected this exact diff family **again** as parent tracking issue **`17127`** with child **`17128`** (`router_diff` | 11 occurrences | signature `router.valueDiff:status`). Same merchant (`bu_de_getolo`), org `zurich_insurance`, connector `novalnet`, flow `psync` — byte-for-byte the same signature as `17031` / `17071`:

```
router.valueDiff:status = { "hyperswitch": "authentication_pending", "ucs": "failure" }
```

Grafana RCA (prod Loki, datasource `loki`, app `validation-service`) confirmed the diff verbatim (VS_48, `total_value_differences:1`, x-sub-flow `PSync`, x-connector `novalnet`) across sample request-ids `019ef1b9-2ce2-79c0-9be0-fcaa1840179f`, `019ef8f3-bd4e-76f1-9835-32c325f32433`, `019ef9da-10e2-7e40-8244-ebbbba887463`, `019efa7c-b61e-7113-b915-c763efb61256`, `019efe74-1c67-7bb2-8a93-25085231f3ff` (first seen 2026-06-23, last seen 2026-06-25). Prod was on stale UCS build `2026.06.10.0-hotfix7` (commit c8b9bd9), which predates this still-unmerged fix — i.e. a stale-build re-detection, no new code required.

Mechanism re-confirmed at source: the diff is produced by the `NovalnetAPIStatus::Failure` arm of the PSync transformer (`result.status = FAILURE` over HTTP 200), which over-set `resource_common_data.status = AttemptStatus::Failure`. This PR drops that override so UCS preserves the caller-supplied `authentication_pending` (matching Direct), while still carrying the failure in `response.Err`. This PR (+ dependency #1624 / hs #12933) resolves `17127` / `17128` identically.

> Note: a separate autofix PR #1675 also references `17128` but addresses the **opposite** branch (`result.status = SUCCESS` with `transaction.status = "ERROR"`). That path does not produce the observed `ucs = failure` (a missing enum variant would fail deserialization, not yield `failure`), so it does not explain this diff — #1668 is the correct fix for `17127` / `17128`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
