### PR TITLE
fix(novalnet): map ERROR transaction status to Failure (issue #17128)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -640,6 +640,7 @@ pub enum NovalnetTransactionStatus {
     Pending,
     Deactivated,
     Progress,
+    Error,
 }
 
 #[derive(Debug, Copy, Display, Clone, Serialize, Deserialize, PartialEq)]
@@ -660,7 +661,7 @@ impl From<NovalnetTransactionStatus> for common_enums::AttemptStatus {
             NovalnetTransactionStatus::Pending => Self::Pending,
             NovalnetTransactionStatus::Progress => Self::AuthenticationPending,
             NovalnetTransactionStatus::Deactivated => Self::Voided,
-            NovalnetTransactionStatus::Failure => Self::Failure,
+            NovalnetTransactionStatus::Failure | NovalnetTransactionStatus::Error => Self::Failure,
         }
     }
 }
@@ -1296,6 +1297,7 @@ impl From<NovalnetTransactionStatus> for common_enums::RefundStatus {
             }
             NovalnetTransactionStatus::Pending => Self::Pending,
             NovalnetTransactionStatus::Failure
+            | NovalnetTransactionStatus::Error
             | NovalnetTransactionStatus::OnHold
             | NovalnetTransactionStatus::Deactivated
             | NovalnetTransactionStatus::Progress => Self::Failure,
@@ -2756,6 +2758,7 @@ impl TryFrom<ResponseRouterData<NovalnetIncrementalAuthResponse, Self>>
                         common_enums::AuthorizationStatus::Processing
                     }
                     Some(NovalnetTransactionStatus::Failure)
+                    | Some(NovalnetTransactionStatus::Error)
                     | Some(NovalnetTransactionStatus::Deactivated) => {
                         common_enums::AuthorizationStatus::Failure
                     }
@@ -2802,5 +2805,30 @@ impl TryFrom<ResponseRouterData<NovalnetIncrementalAuthResponse, Self>>
                 })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Novalnet can return a transaction-level status of "ERROR" (e.g. on a PSync of a
+    // transaction the connector could not process). Hyperswitch deserializes this into
+    // `NovalnetTransactionStatus::Error` and maps it to a terminal failure. UCS must do
+    // the same, otherwise the "ERROR" payload fails to deserialize and the synced
+    // `AttemptStatus` diverges from Hyperswitch (shadow diff router.valueDiff:status,
+    // cloud issue #17128).
+    #[test]
+    fn error_status_deserializes_and_maps_to_failure() {
+        let status = serde_json::from_str::<NovalnetTransactionStatus>("\"ERROR\"").ok();
+        assert_eq!(status, Some(NovalnetTransactionStatus::Error));
+        assert_eq!(
+            common_enums::AttemptStatus::from(NovalnetTransactionStatus::Error),
+            common_enums::AttemptStatus::Failure
+        );
+        assert_eq!(
+            common_enums::RefundStatus::from(NovalnetTransactionStatus::Error),
+            common_enums::RefundStatus::Failure
+        );
     }
 }


### PR DESCRIPTION
## Summary

Novalnet's transaction-level status field can be `"ERROR"` (e.g. when a `PSync` /
`transaction/details` call resolves a transaction the connector could not process).
Hyperswitch's `novalnet` connector models this with a `NovalnetTransactionStatus::Error`
variant and maps it to a terminal failure. UCS's `NovalnetTransactionStatus` enum was
**missing the `Error` variant**, so an `"ERROR"` payload failed to deserialize and the
synced `AttemptStatus` diverged from Hyperswitch.

This closes the shadow-validation diff `router.valueDiff:status` for
**novalnet / psync** (merchant `bu_de_getolo`).

## Diff signature

```
connector = novalnet
flow      = psync
diff      = router.valueDiff:status
```

When Novalnet returns `result.status = "SUCCESS"` with `transaction.status = "ERROR"`:
- **Hyperswitch** (ground truth): `"ERROR"` → `NovalnetTransactionStatus::Error` → `AttemptStatus::Failure`.
- **UCS (before)**: `"ERROR"` is not a known enum variant → `NovalnetPSyncResponse` fails to
  deserialize → the synced attempt status does not advance to `Failure` → status diverges.

## Root cause / category

**L3 — connector transformer only** (UCS-side). The `status` field already flows over the
existing gRPC contract as the domain `AttemptStatus` enum (both sides already support
`Failure`), and the Hyperswitch mapping is already correct — the only gap is the missing
enum variant on the UCS side. No proto change, no HS change.

## Fix

In `crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs`,
mirror Hyperswitch's `novalnet/transformers.rs` exactly:
- add `Error` to `NovalnetTransactionStatus` (deserializes from `"ERROR"` via the existing
  `SCREAMING_SNAKE_CASE` rename);
- map `Error => Failure` in `From<NovalnetTransactionStatus> for AttemptStatus`;
- map `Error => Failure` in `From<NovalnetTransactionStatus> for RefundStatus`;
- include `Error` in the failure arm of the incremental-authorization status match.

## Verification

Novalnet PSync is not reproducible against the live sandbox (it requires a real transaction
that Novalnet itself resolved to `ERROR`), so this was verified by **source parity** with the
Hyperswitch connector plus a focused unit test:

```
cargo test -p connector-integration error_status_deserializes_and_maps_to_failure
# test result: ok. 1 passed
```

The test asserts `"ERROR"` deserializes into `NovalnetTransactionStatus::Error` and maps to
`AttemptStatus::Failure` / `RefundStatus::Failure` — byte-identical to Hyperswitch.

Local checks (all green): `cargo build -p connector-integration`,
`cargo clippy -p connector-integration --all-targets -- -D warnings`,
`cargo fmt --all -- --check`.

Closes #1699
