### PR TITLE
fix(novalnet): keep attempt status on API FAILURE to match Hyperswitch (issue #17033)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -825,10 +825,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     transaction_id,
                 ));
                 Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status: common_enums::AttemptStatus::Failure,
-                        ..item.router_data.resource_common_data
-                    },
                     response,
                     ..item.router_data
                 })


### PR DESCRIPTION
## Summary
On an API-level `FAILURE` response from Novalnet, the UCS `Authorize` connector transformer
was **overwriting the attempt status to `Failure`** at the router-data level. Hyperswitch
(the ground truth both sides are compared against) does **not** set a status on this path —
it returns `Err(ErrorResponse)` (with `attempt_status: None`) and leaves the incoming
(`pending`) status untouched, letting the error drive the final attempt status downstream.

This produced a shadow-validation `router.valueDiff:status`:

```
"valueDiff":{"status":{"hyperswitch":"pending","ucs":"failure"}}
```

(sub-flow `Authorize`)

## Diff signature
`router.valueDiff:status` — hyperswitch-cloud `21051` (diff group `21047`,
merchant `bu_de_micromobility`, connector `novalnet`, flow `authorize`), plus the
`bu_de_getolo` authorize family (`18221`, wallet apple_pay / google_pay / paypal).

## Root cause (verified from prod Loki)
Sample requests `019f4232-5470-7331-93f9-29449175da43` / `019f429e-a608-7d81-be44-9d2cbba2bff0`:
- Novalnet response: `result.status = "FAILURE"` (e.g. `406076`, "insufficient funds"),
  `transaction.status = "FAILURE"` — both sides deserialize this fine.
- HS attempt status at the router-data snapshot = `pending` (status left unchanged; the
  `Err` drives `Failure` later via GSM).
- UCS attempt status = `failure` (forced in the `NovalnetAPIStatus::Failure` arm).

HS `novalnet/transformers.rs` (ground truth), Authorize `Failure` arm:
```rust
NovalnetAPIStatus::Failure => {
    let response = Err(get_error_response(item.response.result, item.http_code, transaction_id));
    Ok(Self { response, ..item.data })   // status UNCHANGED
}
```

## Fix (L3 — UCS connector transformer only)
In the novalnet Authorize `Failure` arm, stop overwriting the status — mirror HS by
returning the `Err` and leaving `resource_common_data` (and thus the attempt status)
unchanged via `..item.router_data`. No proto / domain / HS-mapping change.

## Verify
Novalnet declined-payment shadow is not locally reproducible (Novalnet sandbox TLS-blocked
for a fresh live shadow, and the diff requires a real issuer decline). Verified by:
- **Source-parity**: the UCS Authorize `Failure` arm is now behaviorally identical to HS —
  both return `Err(get_error_response(...))` with the router-data status left at its incoming
  value. The validation compares exactly that router-data status, so
  `status{hs:pending, ucs:failure}` deterministically becomes `no_diff`.
- `cargo build -p connector-integration` — clean.
- `cargo clippy -p connector-integration --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

The same "force `Failure` on the error arm" pattern exists in the sibling flows
(SetupMandate / RepeatPayment / Capture / Void / PSync). RepeatPayment is handled
separately by #1633; the rest are left untouched here since only the Authorize sub-flow is
observed diverging for this issue family.

Fixes `21051`.
