### PR TITLE
fix(finix): return Err + set connector_response on failed Authorize (#17036)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -508,81 +508,100 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             convert_to_additional_payment_method_connector_response(&item.response)
                 .map(ConnectorResponseData::with_additional_payment_method_data);
 
-        // Handle error vs success responses
-        match &response.failure_message {
-            Some(_failure_message) => Ok(Self {
-                response: Ok(PaymentsResponseData::TransactionResponse {
-                    resource_id: ResponseId::ConnectorTransactionId(response.id.clone()),
-                    redirection_data: None,
-                    mandate_reference: None,
-                    connector_metadata: None,
-                    network_txn_id: None,
-                    network_txn_link_id: None,
-                    connector_response_reference_id: None,
-                    incremental_authorization_allowed: None,
-                    status_code: item.http_code,
-                    splits: None,
-                }),
-                resource_common_data: PaymentFlowData {
-                    status: AttemptStatus::Failure,
-                    ..item.router_data.resource_common_data.clone()
-                },
-                ..item.router_data
-            }),
-            None => {
-                // Determine status based on ID type (following Hyperswitch pattern):
-                // - Transfer (TR*): Succeeded -> Charged
-                // - Authorization (AU*): Succeeded -> Authorized
-                let finix_id = FinixId::from(response.id.clone());
-                let status = match (&finix_id, &response.state) {
-                    (FinixId::Transfer(_), FinixPaymentStatus::Succeeded) => AttemptStatus::Charged,
-                    (FinixId::Transfer(_), FinixPaymentStatus::Pending) => AttemptStatus::Pending,
-                    (FinixId::Auth(_), FinixPaymentStatus::Succeeded) => AttemptStatus::Authorized,
-                    (FinixId::Auth(_), FinixPaymentStatus::Pending) => {
-                        AttemptStatus::AuthenticationPending
-                    }
-                    (_, FinixPaymentStatus::Failed) => AttemptStatus::Failure,
-                    (_, FinixPaymentStatus::Canceled) => AttemptStatus::Voided,
-                    (_, FinixPaymentStatus::Unknown) => AttemptStatus::Pending,
-                };
+        // Determine failure from the connector state, mirroring Hyperswitch's
+        // `FinixState::is_failure` (FAILED | CANCELED | UNKNOWN). Hyperswitch routes
+        // every failed Finix payment through `get_finix_response`, which returns
+        // `response: Err(ErrorResponse)` on failure. UCS must do the same instead of
+        // wrapping a decline in `Ok(.., status = Failure)`, otherwise HS↔UCS shadow
+        // validation reports `response.Ok`/`response.Err` keyDiffs and a
+        // `connector_response` typeDiff (HS object vs UCS null) on every failed Finix
+        // authorize.
+        let is_failure = matches!(
+            response.state,
+            FinixPaymentStatus::Failed | FinixPaymentStatus::Canceled | FinixPaymentStatus::Unknown
+        );
 
-                // Determine connector_transaction_id:
-                // - Transfer (TR*): Use the response ID directly (it's already a transfer ID)
-                // - Authorization (AU*): Use transfer field if present (for refunds), else use ID
-                let connector_transaction_id = match &finix_id {
-                    FinixId::Transfer(_) => response.id.clone(),
-                    FinixId::Auth(_) => response
-                        .transfer
-                        .clone()
-                        .unwrap_or_else(|| response.id.clone()),
-                };
-
-                Ok(Self {
-                    response: Ok(PaymentsResponseData::TransactionResponse {
-                        resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
-                        redirection_data: None,
-                        mandate_reference: Some(Box::new(MandateReference {
-                            connector_mandate_id: response.source.clone().map(|id| id.expose()),
-                            payment_method_id: None,
-                            connector_mandate_request_reference_id: None,
-                        })),
-                        connector_metadata: None,
-                        network_txn_id: None,
-                        network_txn_link_id: None,
-                        connector_response_reference_id: Some(response.id.clone()),
-                        incremental_authorization_allowed: None,
-                        status_code: item.http_code,
-                        splits: None,
-                    }),
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        connector_response: connector_response_data,
-                        ..item.router_data.resource_common_data.clone()
-                    },
-                    ..item.router_data
-                })
+        // Determine status based on ID type (following Hyperswitch pattern):
+        // - Transfer (TR*): Succeeded -> Charged
+        // - Authorization (AU*): Succeeded -> Authorized
+        let finix_id = FinixId::from(response.id.clone());
+        let status = if is_failure {
+            AttemptStatus::Failure
+        } else {
+            match (&finix_id, &response.state) {
+                (FinixId::Transfer(_), FinixPaymentStatus::Succeeded) => AttemptStatus::Charged,
+                (FinixId::Transfer(_), FinixPaymentStatus::Pending) => AttemptStatus::Pending,
+                (FinixId::Auth(_), FinixPaymentStatus::Succeeded) => AttemptStatus::Authorized,
+                (FinixId::Auth(_), FinixPaymentStatus::Pending) => {
+                    AttemptStatus::AuthenticationPending
+                }
+                // FAILED / CANCELED / UNKNOWN are handled by `is_failure` above.
+                (_, FinixPaymentStatus::Failed)
+                | (_, FinixPaymentStatus::Canceled)
+                | (_, FinixPaymentStatus::Unknown) => AttemptStatus::Failure,
             }
-        }
+        };
+
+        let flow_response = if is_failure {
+            Err(ErrorResponse {
+                code: response
+                    .failure_code
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+                message: response
+                    .failure_message
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+                reason: None,
+                status_code: item.http_code,
+                attempt_status: Some(FlowStatus::Payment(status)),
+                connector_transaction_id: Some(response.id.clone()),
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            })
+        } else {
+            // Determine connector_transaction_id:
+            // - Transfer (TR*): Use the response ID directly (it's already a transfer ID)
+            // - Authorization (AU*): Use transfer field if present (for refunds), else use ID
+            let connector_transaction_id = match &finix_id {
+                FinixId::Transfer(_) => response.id.clone(),
+                FinixId::Auth(_) => response
+                    .transfer
+                    .clone()
+                    .unwrap_or_else(|| response.id.clone()),
+            };
+
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
+                redirection_data: None,
+                mandate_reference: Some(Box::new(MandateReference {
+                    connector_mandate_id: response.source.clone().map(|id| id.expose()),
+                    payment_method_id: None,
+                    connector_mandate_request_reference_id: None,
+                })),
+                connector_metadata: None,
+                network_txn_id: None,
+                network_txn_link_id: None,
+                connector_response_reference_id: Some(response.id.clone()),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+                splits: None,
+            })
+        };
+
+        // `connector_response` (AVS / network details) is set on both success and
+        // failure paths, mirroring Hyperswitch's `get_finix_response`, which builds it
+        // before the Ok/Err split.
+        Ok(Self {
+            response: flow_response,
+            resource_common_data: PaymentFlowData {
+                status,
+                connector_response: connector_response_data,
+                ..item.router_data.resource_common_data.clone()
+            },
+            ..item.router_data
+        })
     }
 }
 


### PR DESCRIPTION
### Summary
On a **failed** Finix **Authorize**, align the UCS connector response mapping with Hyperswitch (HS):
- return `response: Err(ErrorResponse)` instead of wrapping the decline in `Ok(.., status = Failure)`, and
- populate `connector_response` (AVS / network details) on the failure path too.

### Diff signatures (HS ↔ UCS shadow validation, `golfdistrict` / `finix` / authorize)
This one change resolves the whole failed-authorize divergence bundle (parent
internal tracking issue):

| Cloud issue | Signature | HS (ground truth) | UCS before | UCS after |
|---|---|---|---|---|
| internal tracking issue | `router.typeDiff:connector_response` | object (`Card{avs,network}`) | `null` | object ✅ |
| internal tracking issue | `router.keyDiff:response.Ok` | absent (`Err`) | `Ok` present | absent ✅ |
| internal tracking issue | `router.keyDiff:response.Err` | `Err` present | absent | `Err` present ✅ |

### Root cause
HS routes every Finix payment success **and failure** through the flow-generic
`get_finix_response` (`crates/hyperswitch_connectors/src/connectors/finix/transformers.rs`):
it builds `connector_response` from the AVS / network details **before** the Ok/Err split,
and on `FinixState::is_failure()` (`FAILED | CANCELED | UNKNOWN`) it sets
`response: Err(ErrorResponse)`.

The UCS Finix **Authorize** response transformer
(`TryFrom<ResponseRouterData<FinixAuthorizeResponse, …>>`) instead:
1. matched on `failure_message` and returned `response: Ok(TransactionResponse { .. })` with
   `status = Failure` on a decline — so HS has `response.Err` while UCS has `response.Ok`
   (`#17034` / `#17035`), and
2. set `connector_response` **only on the success branch**, leaving it `None` on the failure
   branch — so HS has an object and UCS `null` (`#17036`).

Finix returns AVS / `network_details` (auth code, brand) on declines too, so HS emits a
non-null `connector_response` on failed authorizes; UCS dropped it. Both sample request_ids
(`019ef782-…`, `019ef1e5-…`, payment_status `failed`) hit exactly this path.

### Fix
`crates/integrations/connector-integration/src/connectors/finix/transformers.rs` — rewrite the
Authorize response branch to mirror HS `get_finix_response` (and the sibling UCS
`FinixPaymentsResponse` transformer used for PSync/Capture/Void, which already does this):
- compute `is_failure` from `response.state` (`Failed | Canceled | Unknown`), matching
  `FinixState::is_failure`;
- on failure → `Err(ErrorResponse { code, message, status_code, attempt_status, connector_transaction_id, .. })`;
- set `connector_response` on **both** the success and failure paths.

The success path (status mapping, `connector_transaction_id`, mandate reference) is unchanged.

### Verification
Finix sandbox currently serves leaf-only TLS chains through the shadow MITM, so a fresh live
HS↔UCS shadow verdict for Finix is not reproducible locally (same TLS block noted on
internal tracking issue /
internal tracking issue). Verified instead by:
- `cargo build -p connector-integration` — clean;
- `cargo clippy -p connector-integration --all-targets -- -D warnings` — clean;
- `cargo fmt --all -- --check` — clean;
- `cargo test -p connector-integration --lib` — 79 passed, 0 failed;
- **source parity**: the failure path now byte-for-byte mirrors HS `get_finix_response`'s
  `Err` + always-set `connector_response`, so all three diff fields converge to HS.

### Note on overlap with #1625
[#1625](https://github.com/juspay/connector-service/pull/1625) (`#17011`) edits the same
Authorize **success** branch (`connector_response_reference_id` → `None`); this PR rewrites that
block, so the two will need a trivial rebase whichever merges first. They are independent fixes
(failure-path Ok→Err + `connector_response` here vs success-path
`connector_response_reference_id` there).

Closes #1696
