### PR TITLE
feat(proto): migrate MandateAmountData.amount to Money type

### DIFF
--- a/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
+++ b/crates/grpc-server/grpc-server/tests/payload_payment_flows_test.rs
@@ -365,9 +365,11 @@ fn create_register_request_with_prefix(_prefix: &str) -> PaymentServiceSetupRecu
             update_mandate_id: None,
             customer_acceptance: None,
             mandate_type: Some(MandateType {
+                #[allow(deprecated)]
                 mandate_type: Some(MandateTypeInner::MultiUse(MandateAmountData {
                     amount: 0,
                     currency: i32::from(Currency::Usd),
+                    amount_money: None,
                     start_date: None,
                     end_date: None,
                     amount_type: Some("max".to_string()),

--- a/crates/internal/field-probe/src/requests.rs
+++ b/crates/internal/field-probe/src/requests.rs
@@ -406,6 +406,7 @@ pub(crate) fn base_tokenized_setup_recurring_request() -> PaymentServiceTokenSet
                     proto::MandateAmountData {
                         amount: 0,
                         currency: proto::Currency::Usd as i32,
+                        amount_money: Some(usd_money(0)),
                         ..Default::default()
                     },
                 )),

--- a/crates/internal/field-probe/src/requests.rs
+++ b/crates/internal/field-probe/src/requests.rs
@@ -402,6 +402,7 @@ pub(crate) fn base_tokenized_setup_recurring_request() -> PaymentServiceTokenSet
         setup_mandate_details: Some(proto::SetupMandateDetails {
             mandate_type: Some(proto::MandateType {
                 mandate_type: Some(proto::mandate_type::MandateType::MultiUse(
+                    #[allow(deprecated)]
                     proto::MandateAmountData {
                         amount: 0,
                         currency: proto::Currency::Usd as i32,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -10827,9 +10827,18 @@ impl ForeignTryFrom<grpc_api_types::payments::SetupMandateDetails> for MandateDa
                     amount_data,
                 )) => Some(mandates::MandateDataType::SingleUse(
                     mandates::MandateAmountData {
-                        amount: common_utils::types::MinorUnit::new(amount_data.amount_money.map(|m| m.minor_amount).unwrap_or(amount_data.amount)),
+                        amount: common_utils::types::MinorUnit::new(
+                            amount_data
+                                .amount_money
+                                .map(|m| m.minor_amount)
+                                .unwrap_or(amount_data.amount),
+                        ),
                         currency: grpc_api_types::payments::Currency::try_from(
-                            amount_data.amount_money.as_ref().map(|m| m.currency).unwrap_or(amount_data.currency),
+                            amount_data
+                                .amount_money
+                                .as_ref()
+                                .map(|m| m.currency)
+                                .unwrap_or(amount_data.currency),
                         )
                         .ok()
                         .and_then(|grpc_currency| {
@@ -10859,9 +10868,18 @@ impl ForeignTryFrom<grpc_api_types::payments::SetupMandateDetails> for MandateDa
                     amount_data,
                 )) => Some(mandates::MandateDataType::MultiUse(Some(
                     mandates::MandateAmountData {
-                        amount: common_utils::types::MinorUnit::new(amount_data.amount_money.map(|m| m.minor_amount).unwrap_or(amount_data.amount)),
+                        amount: common_utils::types::MinorUnit::new(
+                            amount_data
+                                .amount_money
+                                .map(|m| m.minor_amount)
+                                .unwrap_or(amount_data.amount),
+                        ),
                         currency: grpc_api_types::payments::Currency::try_from(
-                            amount_data.amount_money.as_ref().map(|m| m.currency).unwrap_or(amount_data.currency),
+                            amount_data
+                                .amount_money
+                                .as_ref()
+                                .map(|m| m.currency)
+                                .unwrap_or(amount_data.currency),
                         )
                         .ok()
                         .and_then(|grpc_currency| {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -10819,6 +10819,7 @@ impl ForeignTryFrom<grpc_api_types::payments::SetupMandateDetails> for MandateDa
         value: grpc_api_types::payments::SetupMandateDetails,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         // Map the mandate_type from grpc type to domain type
+        #[allow(deprecated)]
         let mandate_type = value
             .mandate_type
             .and_then(|grpc_mandate_type| match grpc_mandate_type.mandate_type {
@@ -10826,9 +10827,9 @@ impl ForeignTryFrom<grpc_api_types::payments::SetupMandateDetails> for MandateDa
                     amount_data,
                 )) => Some(mandates::MandateDataType::SingleUse(
                     mandates::MandateAmountData {
-                        amount: common_utils::types::MinorUnit::new(amount_data.amount),
+                        amount: common_utils::types::MinorUnit::new(amount_data.amount_money.map(|m| m.minor_amount).unwrap_or(amount_data.amount)),
                         currency: grpc_api_types::payments::Currency::try_from(
-                            amount_data.currency,
+                            amount_data.amount_money.as_ref().map(|m| m.currency).unwrap_or(amount_data.currency),
                         )
                         .ok()
                         .and_then(|grpc_currency| {
@@ -10858,9 +10859,9 @@ impl ForeignTryFrom<grpc_api_types::payments::SetupMandateDetails> for MandateDa
                     amount_data,
                 )) => Some(mandates::MandateDataType::MultiUse(Some(
                     mandates::MandateAmountData {
-                        amount: common_utils::types::MinorUnit::new(amount_data.amount),
+                        amount: common_utils::types::MinorUnit::new(amount_data.amount_money.map(|m| m.minor_amount).unwrap_or(amount_data.amount)),
                         currency: grpc_api_types::payments::Currency::try_from(
-                            amount_data.currency,
+                            amount_data.amount_money.as_ref().map(|m| m.currency).unwrap_or(amount_data.currency),
                         )
                         .ok()
                         .and_then(|grpc_currency| {

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -1136,14 +1136,15 @@ message OnlineMandate {
 
 // Amount data for mandate
 message MandateAmountData {
-  int64 amount = 1;              // Amount
-  Currency currency = 2;         // Currency code (ISO 4217)
-  optional int64 start_date = 3; // Unix timestamp for start date
-  optional int64 end_date = 4;   // Unix timestamp for end date
+  int64 amount = 1 [deprecated = true]; // Use amount_money instead (will be removed in a future release)
+  Currency currency = 2 [deprecated = true]; // Use amount_money.currency instead (will be removed in a future release)
+  optional int64 start_date = 3;        // Unix timestamp for start date
+  optional int64 end_date = 4;          // Unix timestamp for end date
   optional string amount_type =
       5; // Amount type for variable mandates ("exact", "max", "variable")
   optional string frequency =
       6; // Frequency for recurring mandates ("daily", "weekly", "monthly")
+  optional Money amount_money = 7; // Amount in Money type
 }
 
 // Mandate type with amount details

--- a/data/field_probe/billwerk.json
+++ b/data/field_probe/billwerk.json
@@ -753,7 +753,11 @@
             "mandate_type": {
               "multi_use": {
                 "amount": 0,
-                "currency": "USD"
+                "currency": "USD",
+                "amount_money": {
+                  "minor_amount": 0,
+                  "currency": "USD"
+                }
               }
             }
           },

--- a/data/field_probe/shift4.json
+++ b/data/field_probe/shift4.json
@@ -991,7 +991,11 @@
             "mandate_type": {
               "multi_use": {
                 "amount": 0,
-                "currency": "USD"
+                "currency": "USD",
+                "amount_money": {
+                  "minor_amount": 0,
+                  "currency": "USD"
+                }
               }
             }
           },

--- a/data/field_probe/stax.json
+++ b/data/field_probe/stax.json
@@ -765,7 +765,11 @@
             "mandate_type": {
               "multi_use": {
                 "amount": 0,
-                "currency": "USD"
+                "currency": "USD",
+                "amount_money": {
+                  "minor_amount": 0,
+                  "currency": "USD"
+                }
               }
             }
           },

--- a/docs-generated/connectors/billwerk.md
+++ b/docs-generated/connectors/billwerk.md
@@ -140,7 +140,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L172) · [Kotlin](../../examples/billwerk/billwerk.kt#L90) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L176) · [Kotlin](../../examples/billwerk/billwerk.kt#L90) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentService.Get
 
@@ -151,7 +151,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L181) · [Kotlin](../../examples/billwerk/billwerk.kt#L100) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L185) · [Kotlin](../../examples/billwerk/billwerk.kt#L100) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentService.Refund
 
@@ -162,7 +162,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L199) · [Kotlin](../../examples/billwerk/billwerk.kt#L139) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L203) · [Kotlin](../../examples/billwerk/billwerk.kt#L139) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -173,7 +173,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L217) · [Kotlin](../../examples/billwerk/billwerk.kt#L161) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L221) · [Kotlin](../../examples/billwerk/billwerk.kt#L161) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentService.TokenSetupRecurring
 
@@ -184,7 +184,7 @@ Setup a recurring mandate using a connector token.
 | **Request** | `PaymentServiceTokenSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L226) · [Kotlin](../../examples/billwerk/billwerk.kt#L182) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L230) · [Kotlin](../../examples/billwerk/billwerk.kt#L182) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentMethodService.Tokenize
 
@@ -195,7 +195,7 @@ Tokenize payment method for secure storage. Replaces raw card details with secur
 | **Request** | `PaymentMethodServiceTokenizeRequest` |
 | **Response** | `PaymentMethodServiceTokenizeResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L235) · [Kotlin](../../examples/billwerk/billwerk.kt#L218) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L239) · [Kotlin](../../examples/billwerk/billwerk.kt#L222) · [Rust](../../examples/billwerk/billwerk.rs)
 
 #### PaymentService.Void
 
@@ -206,7 +206,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts) · [Kotlin](../../examples/billwerk/billwerk.kt#L244) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts) · [Kotlin](../../examples/billwerk/billwerk.kt#L248) · [Rust](../../examples/billwerk/billwerk.rs)
 
 ### Refunds
 
@@ -219,7 +219,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L208) · [Kotlin](../../examples/billwerk/billwerk.kt#L149) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L212) · [Kotlin](../../examples/billwerk/billwerk.kt#L149) · [Rust](../../examples/billwerk/billwerk.rs)
 
 ### Mandates
 
@@ -232,4 +232,4 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L190) · [Kotlin](../../examples/billwerk/billwerk.kt#L108) · [Rust](../../examples/billwerk/billwerk.rs)
+**Examples:** [Python](../../examples/billwerk/billwerk.py) · [TypeScript](../../examples/billwerk/billwerk.ts#L194) · [Kotlin](../../examples/billwerk/billwerk.kt#L108) · [Rust](../../examples/billwerk/billwerk.rs)

--- a/docs-generated/connectors/shift4.md
+++ b/docs-generated/connectors/shift4.md
@@ -123,7 +123,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L278) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L111) · [Rust](../../examples/shift4/shift4.rs#L336)
+**Examples:** [Python](../../examples/shift4/shift4.py#L282) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L111) · [Rust](../../examples/shift4/shift4.rs#L340)
 
 ### Card Payment (Authorize + Capture)
 
@@ -137,19 +137,19 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L297) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L127) · [Rust](../../examples/shift4/shift4.rs#L352)
+**Examples:** [Python](../../examples/shift4/shift4.py#L301) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L127) · [Rust](../../examples/shift4/shift4.rs#L356)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L322) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L149) · [Rust](../../examples/shift4/shift4.rs#L375)
+**Examples:** [Python](../../examples/shift4/shift4.py#L326) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L149) · [Rust](../../examples/shift4/shift4.rs#L379)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L347) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L171) · [Rust](../../examples/shift4/shift4.rs#L398)
+**Examples:** [Python](../../examples/shift4/shift4.py#L351) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L171) · [Rust](../../examples/shift4/shift4.rs#L402)
 
 ## API Reference
 
@@ -310,7 +310,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L381) · [Kotlin](../../examples/shift4/shift4.kt#L189) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L385) · [Kotlin](../../examples/shift4/shift4.kt#L189) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Capture
 
@@ -321,7 +321,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L390) · [Kotlin](../../examples/shift4/shift4.kt#L201) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L394) · [Kotlin](../../examples/shift4/shift4.kt#L201) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Get
 
@@ -332,7 +332,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L417) · [Kotlin](../../examples/shift4/shift4.kt#L240) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L421) · [Kotlin](../../examples/shift4/shift4.kt#L240) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.IncrementalAuthorization
 
@@ -343,7 +343,7 @@ Increase the authorized amount for an existing payment. Enables you to capture a
 | **Request** | `PaymentServiceIncrementalAuthorizationRequest` |
 | **Response** | `PaymentServiceIncrementalAuthorizationResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L426) · [Kotlin](../../examples/shift4/shift4.kt#L248) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L430) · [Kotlin](../../examples/shift4/shift4.kt#L248) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -354,7 +354,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L435) · [Kotlin](../../examples/shift4/shift4.kt#L264) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L439) · [Kotlin](../../examples/shift4/shift4.kt#L264) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.ProxySetupRecurring
 
@@ -365,7 +365,7 @@ Setup recurring mandate using vault-aliased card data.
 | **Request** | `PaymentServiceProxySetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L444) · [Kotlin](../../examples/shift4/shift4.kt#L294) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L448) · [Kotlin](../../examples/shift4/shift4.kt#L294) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Refund
 
@@ -376,7 +376,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L462) · [Kotlin](../../examples/shift4/shift4.kt#L358) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L466) · [Kotlin](../../examples/shift4/shift4.kt#L358) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.SetupRecurring
 
@@ -387,7 +387,7 @@ Configure a payment method for recurring billing. Sets up the mandate and paymen
 | **Request** | `PaymentServiceSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L480) · [Kotlin](../../examples/shift4/shift4.kt#L380) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L484) · [Kotlin](../../examples/shift4/shift4.kt#L380) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -398,7 +398,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L489) · [Kotlin](../../examples/shift4/shift4.kt#L420) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L493) · [Kotlin](../../examples/shift4/shift4.kt#L420) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenSetupRecurring
 
@@ -409,7 +409,7 @@ Setup a recurring mandate using a connector token.
 | **Request** | `PaymentServiceTokenSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L498) · [Kotlin](../../examples/shift4/shift4.kt#L441) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L502) · [Kotlin](../../examples/shift4/shift4.kt#L441) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Refunds
 
@@ -422,7 +422,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L471) · [Kotlin](../../examples/shift4/shift4.kt#L368) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L475) · [Kotlin](../../examples/shift4/shift4.kt#L368) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Mandates
 
@@ -435,7 +435,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L453) · [Kotlin](../../examples/shift4/shift4.kt#L327) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L457) · [Kotlin](../../examples/shift4/shift4.kt#L327) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Customers
 
@@ -448,7 +448,7 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L408) · [Kotlin](../../examples/shift4/shift4.kt#L227) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L412) · [Kotlin](../../examples/shift4/shift4.kt#L227) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Authentication
 
@@ -461,4 +461,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L399) · [Kotlin](../../examples/shift4/shift4.kt#L211) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L403) · [Kotlin](../../examples/shift4/shift4.kt#L211) · [Rust](../../examples/shift4/shift4.rs)

--- a/docs-generated/connectors/stax.md
+++ b/docs-generated/connectors/stax.md
@@ -132,7 +132,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L156) · [Kotlin](../../examples/stax/stax.kt#L87) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L160) · [Kotlin](../../examples/stax/stax.kt#L87) · [Rust](../../examples/stax/stax.rs)
 
 #### PaymentService.Get
 
@@ -143,7 +143,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L174) · [Kotlin](../../examples/stax/stax.kt#L110) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L178) · [Kotlin](../../examples/stax/stax.kt#L110) · [Rust](../../examples/stax/stax.rs)
 
 #### PaymentService.Refund
 
@@ -154,7 +154,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L192) · [Kotlin](../../examples/stax/stax.kt#L149) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L196) · [Kotlin](../../examples/stax/stax.kt#L149) · [Rust](../../examples/stax/stax.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -165,7 +165,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L210) · [Kotlin](../../examples/stax/stax.kt#L171) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L214) · [Kotlin](../../examples/stax/stax.kt#L171) · [Rust](../../examples/stax/stax.rs)
 
 #### PaymentService.TokenSetupRecurring
 
@@ -176,7 +176,7 @@ Setup a recurring mandate using a connector token.
 | **Request** | `PaymentServiceTokenSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L219) · [Kotlin](../../examples/stax/stax.kt#L192) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L223) · [Kotlin](../../examples/stax/stax.kt#L192) · [Rust](../../examples/stax/stax.rs)
 
 #### PaymentService.Void
 
@@ -187,7 +187,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts) · [Kotlin](../../examples/stax/stax.kt#L228) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts) · [Kotlin](../../examples/stax/stax.kt#L232) · [Rust](../../examples/stax/stax.rs)
 
 ### Refunds
 
@@ -200,7 +200,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L201) · [Kotlin](../../examples/stax/stax.kt#L159) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L205) · [Kotlin](../../examples/stax/stax.kt#L159) · [Rust](../../examples/stax/stax.rs)
 
 ### Mandates
 
@@ -213,7 +213,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L183) · [Kotlin](../../examples/stax/stax.kt#L118) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L187) · [Kotlin](../../examples/stax/stax.kt#L118) · [Rust](../../examples/stax/stax.rs)
 
 ### Customers
 
@@ -226,4 +226,4 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L165) · [Kotlin](../../examples/stax/stax.kt#L97) · [Rust](../../examples/stax/stax.rs)
+**Examples:** [Python](../../examples/stax/stax.py) · [TypeScript](../../examples/stax/stax.ts#L169) · [Kotlin](../../examples/stax/stax.kt#L97) · [Rust](../../examples/stax/stax.rs)

--- a/examples/billwerk/billwerk.kt
+++ b/examples/billwerk/billwerk.kt
@@ -203,8 +203,8 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
         setupMandateDetailsBuilder.apply {
             mandateTypeBuilder.apply {  // Type of mandate (single_use or multi_use) with amount details.
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
-                    amount = 0L  // Amount.
-                    currency = Currency.USD  // Currency code (ISO 4217).
+                    amount = 0L  // Use amount_money instead (will be removed in a future release).
+                    currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         }

--- a/examples/billwerk/billwerk.kt
+++ b/examples/billwerk/billwerk.kt
@@ -205,6 +205,10 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
                     amount = 0L  // Use amount_money instead (will be removed in a future release).
                     currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    amountMoneyBuilder.apply {  // Amount in Money type.
+                        minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+                        currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         }

--- a/examples/billwerk/billwerk.py
+++ b/examples/billwerk/billwerk.py
@@ -131,6 +131,10 @@ def _build_token_setup_recurring_request():
                 multi_use=payment_pb2.MandateAmountData(
                     amount=0,  # Use amount_money instead (will be removed in a future release).
                     currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
+                    amount_money=payment_pb2.Money(  # Amount in Money type.
+                        minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
+                        currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+                    ),
                 ),
             ),
         ),

--- a/examples/billwerk/billwerk.py
+++ b/examples/billwerk/billwerk.py
@@ -129,8 +129,8 @@ def _build_token_setup_recurring_request():
         setup_mandate_details=payment_pb2.SetupMandateDetails(
             mandate_type=payment_pb2.MandateType(  # Type of mandate (single_use or multi_use) with amount details.
                 multi_use=payment_pb2.MandateAmountData(
-                    amount=0,  # Amount.
-                    currency=payment_pb2.Currency.Value("USD"),  # Currency code (ISO 4217).
+                    amount=0,  # Use amount_money instead (will be removed in a future release).
+                    currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
                 ),
             ),
         ),

--- a/examples/billwerk/billwerk.rs
+++ b/examples/billwerk/billwerk.rs
@@ -176,8 +176,8 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
-                    amount: 0,                      // Amount.
-                    currency: Currency::Usd.into(), // Currency code (ISO 4217).
+                    amount: 0, // Use amount_money instead (will be removed in a future release).
+                    currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/billwerk/billwerk.rs
+++ b/examples/billwerk/billwerk.rs
@@ -178,6 +178,11 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
+                    amount_money: Some(Money {
+                        // Amount in Money type.
+                        minor_amount: 0, // Amount in minor units (e.g., 1000 = $10.00).
+                        currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }),
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/billwerk/billwerk.rs
+++ b/examples/billwerk/billwerk.rs
@@ -175,7 +175,6 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
-                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/billwerk/billwerk.rs
+++ b/examples/billwerk/billwerk.rs
@@ -175,6 +175,7 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
+                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/billwerk/billwerk.ts
+++ b/examples/billwerk/billwerk.ts
@@ -128,8 +128,8 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
         "setupMandateDetails": {
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
-                    "amount": 0,  // Amount.
-                    "currency": Currency.USD  // Currency code (ISO 4217).
+                    "amount": 0,  // Use amount_money instead (will be removed in a future release).
+                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         },

--- a/examples/billwerk/billwerk.ts
+++ b/examples/billwerk/billwerk.ts
@@ -129,7 +129,11 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
                     "amount": 0,  // Use amount_money instead (will be removed in a future release).
-                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    "currency": Currency.USD,  // Use amount_money.currency instead (will be removed in a future release).
+                    "amountMoney": {  // Amount in Money type.
+                        "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+                        "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         },

--- a/examples/shift4/shift4.kt
+++ b/examples/shift4/shift4.kt
@@ -462,8 +462,8 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
         setupMandateDetailsBuilder.apply {
             mandateTypeBuilder.apply {  // Type of mandate (single_use or multi_use) with amount details.
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
-                    amount = 0L  // Amount.
-                    currency = Currency.USD  // Currency code (ISO 4217).
+                    amount = 0L  // Use amount_money instead (will be removed in a future release).
+                    currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         }

--- a/examples/shift4/shift4.kt
+++ b/examples/shift4/shift4.kt
@@ -464,6 +464,10 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
                     amount = 0L  // Use amount_money instead (will be removed in a future release).
                     currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    amountMoneyBuilder.apply {  // Amount in Money type.
+                        minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+                        currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         }

--- a/examples/shift4/shift4.py
+++ b/examples/shift4/shift4.py
@@ -270,6 +270,10 @@ def _build_token_setup_recurring_request():
                 multi_use=payment_pb2.MandateAmountData(
                     amount=0,  # Use amount_money instead (will be removed in a future release).
                     currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
+                    amount_money=payment_pb2.Money(  # Amount in Money type.
+                        minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
+                        currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+                    ),
                 ),
             ),
         ),

--- a/examples/shift4/shift4.py
+++ b/examples/shift4/shift4.py
@@ -268,8 +268,8 @@ def _build_token_setup_recurring_request():
         setup_mandate_details=payment_pb2.SetupMandateDetails(
             mandate_type=payment_pb2.MandateType(  # Type of mandate (single_use or multi_use) with amount details.
                 multi_use=payment_pb2.MandateAmountData(
-                    amount=0,  # Amount.
-                    currency=payment_pb2.Currency.Value("USD"),  # Currency code (ISO 4217).
+                    amount=0,  # Use amount_money instead (will be removed in a future release).
+                    currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
                 ),
             ),
         ),

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -353,6 +353,7 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
+                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -354,8 +354,8 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
-                    amount: 0,                      // Amount.
-                    currency: Currency::Usd.into(), // Currency code (ISO 4217).
+                    amount: 0, // Use amount_money instead (will be removed in a future release).
+                    currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -356,6 +356,11 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
+                    amount_money: Some(Money {
+                        // Amount in Money type.
+                        minor_amount: 0, // Amount in minor units (e.g., 1000 = $10.00).
+                        currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }),
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -353,7 +353,6 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
-                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/shift4/shift4.ts
+++ b/examples/shift4/shift4.ts
@@ -274,7 +274,11 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
                     "amount": 0,  // Use amount_money instead (will be removed in a future release).
-                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    "currency": Currency.USD,  // Use amount_money.currency instead (will be removed in a future release).
+                    "amountMoney": {  // Amount in Money type.
+                        "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+                        "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         },

--- a/examples/shift4/shift4.ts
+++ b/examples/shift4/shift4.ts
@@ -273,8 +273,8 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
         "setupMandateDetails": {
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
-                    "amount": 0,  // Amount.
-                    "currency": Currency.USD  // Currency code (ISO 4217).
+                    "amount": 0,  // Use amount_money instead (will be removed in a future release).
+                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         },

--- a/examples/stax/stax.kt
+++ b/examples/stax/stax.kt
@@ -213,8 +213,8 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
         setupMandateDetailsBuilder.apply {
             mandateTypeBuilder.apply {  // Type of mandate (single_use or multi_use) with amount details.
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
-                    amount = 0L  // Amount.
-                    currency = Currency.USD  // Currency code (ISO 4217).
+                    amount = 0L  // Use amount_money instead (will be removed in a future release).
+                    currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         }

--- a/examples/stax/stax.kt
+++ b/examples/stax/stax.kt
@@ -215,6 +215,10 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
                 multiUseBuilder.apply {  // Multi use mandate with amount details (for recurring payments).
                     amount = 0L  // Use amount_money instead (will be removed in a future release).
                     currency = Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    amountMoneyBuilder.apply {  // Amount in Money type.
+                        minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+                        currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         }

--- a/examples/stax/stax.py
+++ b/examples/stax/stax.py
@@ -136,6 +136,10 @@ def _build_token_setup_recurring_request():
                 multi_use=payment_pb2.MandateAmountData(
                     amount=0,  # Use amount_money instead (will be removed in a future release).
                     currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
+                    amount_money=payment_pb2.Money(  # Amount in Money type.
+                        minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
+                        currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+                    ),
                 ),
             ),
         ),

--- a/examples/stax/stax.py
+++ b/examples/stax/stax.py
@@ -134,8 +134,8 @@ def _build_token_setup_recurring_request():
         setup_mandate_details=payment_pb2.SetupMandateDetails(
             mandate_type=payment_pb2.MandateType(  # Type of mandate (single_use or multi_use) with amount details.
                 multi_use=payment_pb2.MandateAmountData(
-                    amount=0,  # Amount.
-                    currency=payment_pb2.Currency.Value("USD"),  # Currency code (ISO 4217).
+                    amount=0,  # Use amount_money instead (will be removed in a future release).
+                    currency=payment_pb2.Currency.Value("USD"),  # Use amount_money.currency instead (will be removed in a future release).
                 ),
             ),
         ),

--- a/examples/stax/stax.rs
+++ b/examples/stax/stax.rs
@@ -176,7 +176,6 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
-                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/stax/stax.rs
+++ b/examples/stax/stax.rs
@@ -177,8 +177,8 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
-                    amount: 0,                      // Amount.
-                    currency: Currency::Usd.into(), // Currency code (ISO 4217).
+                    amount: 0, // Use amount_money instead (will be removed in a future release).
+                    currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/stax/stax.rs
+++ b/examples/stax/stax.rs
@@ -176,6 +176,7 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
         setup_mandate_details: Some(SetupMandateDetails {
             mandate_type: Some(MandateType {
                 // Type of mandate (single_use or multi_use) with amount details.
+                #[allow(deprecated)]
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).

--- a/examples/stax/stax.rs
+++ b/examples/stax/stax.rs
@@ -179,6 +179,11 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
                 mandate_type: Some(mandate_type::MandateType::MultiUse(MandateAmountData {
                     amount: 0, // Use amount_money instead (will be removed in a future release).
                     currency: Currency::Usd.into(), // Use amount_money.currency instead (will be removed in a future release).
+                    amount_money: Some(Money {
+                        // Amount in Money type.
+                        minor_amount: 0, // Amount in minor units (e.g., 1000 = $10.00).
+                        currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }),
                     ..Default::default()
                 })),
                 ..Default::default()

--- a/examples/stax/stax.ts
+++ b/examples/stax/stax.ts
@@ -134,8 +134,8 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
         "setupMandateDetails": {
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
-                    "amount": 0,  // Amount.
-                    "currency": Currency.USD  // Currency code (ISO 4217).
+                    "amount": 0,  // Use amount_money instead (will be removed in a future release).
+                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
                 }
             }
         },

--- a/examples/stax/stax.ts
+++ b/examples/stax/stax.ts
@@ -135,7 +135,11 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
             "mandateType": {  // Type of mandate (single_use or multi_use) with amount details.
                 "multiUse": {  // Multi use mandate with amount details (for recurring payments).
                     "amount": 0,  // Use amount_money instead (will be removed in a future release).
-                    "currency": Currency.USD  // Use amount_money.currency instead (will be removed in a future release).
+                    "currency": Currency.USD,  // Use amount_money.currency instead (will be removed in a future release).
+                    "amountMoney": {  // Amount in Money type.
+                        "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+                        "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+                    }
                 }
             }
         },

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -352,6 +352,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   NetworkParams: { "cartesBancaires": "CartesBancairesParams" },
   AuthenticationData: { "networkParams": "NetworkParams" },
   CustomerAcceptance: { "onlineMandateDetails": "OnlineMandate" },
+  MandateAmountData: { "amountMoney": "Money" },
   MandateType: { "singleUse": "MandateAmountData", "multiUse": "MandateAmountData" },
   SetupMandateDetails: { "customerAcceptance": "CustomerAcceptance", "mandateType": "MandateType" },
   MandateReference: { "connectorMandateId": "ConnectorMandateReferenceId", "networkTokenWithNti": "NetworkTokenWithNTI" },


### PR DESCRIPTION
## Description

Migrate `MandateAmountData` fields from `int64`/`Currency` to `Money` type for type safety and consistency with the rest of the proto.

Deprecates `amount` (field 1) and `currency` (field 2) in favor of `optional Money amount_money = 7` (field 7).

## Motivation and Context

The int64-to-Money migration aligns monetary fields across the entire proto surface. `MandateAmountData` was identified as a candidate because it contains both an amount value (`amount`) and a `Currency` field in the same message — making it a natural fit for the `Money` type (`{int64 minor_amount, Currency currency}`).

## Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

- `cargo check` (full workspace) ✅
- `cargo clippy` (full workspace) ✅
- `cargo fmt --check` ✅
- `make generate` (JS SDK regeneration) ✅