### PR TITLE
fix(cybersource): sort merchantDefinedInformation & use merchant_order_reference_id label

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5601,9 +5601,13 @@ fn convert_metadata_to_merchant_defined_info(
 ) -> Option<Vec<utils::MerchantDefinedInformation>> {
     let mut iter = 1;
 
+    // Deserialize into a BTreeMap so metadata keys are emitted in sorted order,
+    // matching Hyperswitch's merchantDefinedInformation output (which is built
+    // from a BTreeMap) regardless of the incoming JSON's insertion order.
     let mut result: Vec<utils::MerchantDefinedInformation> = metadata
-        .and_then(|value| value.as_object().cloned())
-        .map(|map| {
+        .map(|value| {
+            let map: std::collections::BTreeMap<String, serde_json::Value> =
+                serde_json::from_value(value).unwrap_or_default();
             map.into_iter()
                 .map(|(key, value)| {
                     let mdi = utils::MerchantDefinedInformation {
@@ -5620,7 +5624,7 @@ fn convert_metadata_to_merchant_defined_info(
     if let Some(merchant_ref_id) = merchant_order_id {
         result.push(utils::MerchantDefinedInformation {
             key: iter,
-            value: format!("merchant_order_id={merchant_ref_id}"),
+            value: format!("merchant_order_reference_id={merchant_ref_id}"),
         });
     }
 
@@ -5846,5 +5850,36 @@ mod tests {
         let issuer = domain_types::utils::get_card_issuer("4242424242424242")
             .expect("Visa BIN should be recognized");
         assert_eq!(card_issuer_to_string(issuer), "001");
+    }
+
+    // Regression for shadow-validation diff (cybersource/capture): UCS previously
+    // preserved the JSON insertion order of metadata keys and labelled the trailing
+    // entry `merchant_order_id=`, whereas Hyperswitch sorts the keys (BTreeMap) and
+    // labels it `merchant_order_reference_id=`. Both sides must now agree.
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn merchant_defined_info_is_sorted_and_uses_reference_id_label() {
+        // Insertion order here is `kind` before `brand` (as seen in prod).
+        let metadata = serde_json::json!({ "kind": "hourly", "brand": "flowbird" });
+        let result = convert_metadata_to_merchant_defined_info(
+            Some(metadata),
+            Some("376164644".to_string()),
+        )
+        .expect("non-empty merchantDefinedInformation");
+
+        let values: Vec<&str> = result.iter().map(|mdi| mdi.value.as_str()).collect();
+        assert_eq!(
+            values,
+            vec![
+                "brand=\"flowbird\"",
+                "kind=\"hourly\"",
+                "merchant_order_reference_id=376164644",
+            ]
+        );
+        // keys are sequential 1-based positions
+        assert_eq!(
+            result.iter().map(|mdi| mdi.key).collect::<Vec<u8>>(),
+            vec![1u8, 2, 3]
+        );
     }
 }


### PR DESCRIPTION
### What

`cybersource`'s `convert_metadata_to_merchant_defined_info` built the
`merchantDefinedInformation` array in two ways that diverged from Hyperswitch:

1. **Ordering** — it iterated the metadata `serde_json` object in JSON insertion
   order, while Hyperswitch deserializes the metadata into a `BTreeMap` and emits
   the entries in **sorted key order**. So the same metadata produced the entries
   in a different sequence on each side.
2. **Label** — the trailing merchant-order entry was labelled `merchant_order_id=`,
   whereas Hyperswitch uses `merchant_order_reference_id=`.

### Diff signature (shadow-validation, cybersource / capture)

```
merchantDefinedInformation[0].value  hyperswitch: brand="flowbird"   ucs: kind="hourly"
merchantDefinedInformation[1].value  hyperswitch: kind="hourly"      ucs: brand="flowbird"
merchantDefinedInformation[3].value  hyperswitch: merchant_order_reference_id=376164644
                                     ucs: merchant_order_id=376164644
```

### Fix

Deserialize the metadata into a `BTreeMap<String, Value>` (mirroring Hyperswitch's
implementation) so keys are emitted in sorted order, and rename the trailing entry's
label to `merchant_order_reference_id=`. This is a connector-layer (L3) change only —
the field already flows through the gRPC contract and domain types. Hyperswitch's
connector transformer is the reference and is left unchanged.

### Verification

- Added a unit test (`merchant_defined_info_is_sorted_and_uses_reference_id_label`)
  that feeds `{kind, brand}` in insertion order and asserts the output is
  `brand=…`, `kind=…`, `merchant_order_reference_id=…` — i.e. the diffed fields
  now match Hyperswitch byte-for-byte.
- Local: `cargo build`, `cargo test -p connector-integration`,
  `cargo clippy -p connector-integration --all-targets -- -D warnings`,
  `cargo fmt --all -- --check` all pass.
- Before → after shadow verdict: the three `merchantDefinedInformation` valueDiffs → no_diff.

### Layer
L3 — connector transformer only (cybersource).

Closes #1711



Also covers internal tracking issue (re-detection, req 019ef9ca / hyperswitch-cloud#17160 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019ef9cc / hyperswitch-cloud#17161 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).


Also covers internal tracking issue (re-detection, req 019ef9d2 / hyperswitch-cloud#17162 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).


Also covers internal tracking issue (re-detection, req 019ef9f0 / hyperswitch-cloud#17163 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019ef9f3 / hyperswitch-cloud#17164 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).


Also covers internal tracking issue (re-detection, req 019ef9f8 / hyperswitch-cloud#17165 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019ef9fe / hyperswitch-cloud#17166 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019ef9fe-b1d4-7c70-a738-c67d5ab2c69b / hyperswitch-cloud#17167 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019efa50-6654-79b0-b6c9-d3a3da166791 / hyperswitch-cloud#17170 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers internal tracking issue (re-detection, req 019efa54-f740-7c53-9d82-40f8f9a09ae6 / hyperswitch-cloud#17171 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872).



Also covers re-detection req 019efa56-0767-7a12-b597-a8d33c7c18bc / hyperswitch-cloud#17172 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. (stale prod build 2026.06.17.0)



Also covers re-detection req 019efa56-5b33-7991-ae20-5d889f6647fd / hyperswitch-cloud#17174 (parent #17173) — `merchantDefinedInformation` ordering/label (MDI) half, now on the **repeat_payment** flow (same flow-agnostic `convert_metadata_to_merchant_defined_info` fix). The MIT half of #17174 (authorizationOptions.initiator + merchantInitiatedTransaction.originalAuthorizedAmount) is handled separately by prism #1735 + juspay/hyperswitch#13040. (stale prod build 2026.06.17.0)



Also covers re-detection req 019efa57-811c-7730-a849-9d36e09b96ea / hyperswitch-cloud#17175 — `merchantDefinedInformation` ordering/label (MDI) half of the flowbird/cybersource/authorize union (brand/kind swap + merchant_order_reference_id→merchant_order_id); 3DS half = connector-service#1594 + juspay/hyperswitch#12872. (stale prod build 2026.06.17.0)


- Re-detected as #17176 (flowbird, prod, req 019efa5c-579d-77a3-ba36-b36bf0fde96c, 2026-06-24T16:00:20Z, cybersource Authorize THREE_DS AUTHORIZED). Byte-identical signature; prod UCS build stale 2026.06.17.0 predates this fix. No new PR.


- Re-detected as #17177 (flowbird, prod, req 019efa63-f91f-7542-9891-8e8f4515539d, 2026-06-24T16:08:40Z, cybersource Authorize THREE_DS AUTHORIZED, amount 2500 EUR). Byte-identical signature; prod UCS build stale 2026.06.17.0 (aef0be919) predates this fix. No new PR.


- Re-detected as #17179 (parent #17178) — flowbird, prod, req 019efa6a-7f43-7671-9bd0-3552b9a87c69, first/last seen 2026-06-24T21:16–21:46Z, cybersource **capture** flow. Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This PR's branch (`autofix/cybersource-capture-17179`) was authored for exactly this capture signature; the fix lives in the shared `convert_metadata_to_merchant_defined_info` helper which the capture request builder (`CybersourcePaymentsCaptureRequest`) calls, so capture is fully covered. prod UCS build stale 2026.06.17.0 predates this fix. No new PR.



- Re-detected as #17183 (flowbird, prod, req 019efa6d-12e1-76a2-b954-b7755842eced, sample pay_vs4g8lvqfXPQPflEzhy6, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki; prod UCS build stale 2026.06.17.0 (aef0be919) predates this fix. No new PR.


- Re-detected as #17184 (flowbird, prod, req 019efa72-5f6c-72f3-a7c0-669d48977c5d, sample pay_Q8lNV8Ci3pdVCJayDT0w, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (event 2026-06-24T16:24:23Z, pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.



- Re-detected as #17189 (flowbird, prod, req 019efa7a-7f2f-7c80-933f-f5189934f6a4, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki; prod UCS build stale 2026.06.10.0-hotfix7 predates this fix. No new PR.


- Re-detected as #17190 (flowbird, prod, req 019efa7f-1ea7-7be3-b16b-bfbbb8f324f6, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki (window logs exist → retention, not indexing); prod UCS build stale 2026.06.10.0-hotfix7 predates this fix. No new PR.


- Re-detected as #17191 (flowbird, prod, req 019efa86-1986-73d2-b977-70d4b92a6877, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki (window has live cybersource/flowbird ShadowUCS traffic → retention drop, not indexing); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.



- Re-detected as #17192 (flowbird, prod, req 019efa86-4a20-7a91-8952-cc1bdf5f4538, first/last seen 2026-06-24T21:46–22:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki (window has live cybersource/flowbird ShadowUCS traffic → retention drop, not indexing); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.


- Re-detected as #17206 (flowbird, prod, req 019efa99-dd7e-7b22-ad86-ad99845ea616, first/last seen 2026-06-24T22:16–22:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req not retained in prod Loki (window has live cybersource/flowbird ShadowUCS traffic → retention drop, not indexing); prod UCS build stale 2026.06.10.0-hotfix7 predates this fix. No new PR.



- Re-detected as #17210 (flowbird, prod, req 019efab2-5923-7ae1-84c9-92bc300acd01, sample pay_jW6yZZ4S2HMxdmmmbfoL, first/last seen 2026-06-24T22:46–23:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS event 2026-06-24T17:34:16Z, pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.



- Re-detected as #17211 (flowbird, prod, req 019efab5-44d5-79d3-9e0e-e5914174d24b, sample pay_YFIbnjfdqxbWjEcqvRVz, first/last seen 2026-06-24T22:46–23:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS event 2026-06-24T17:37:28Z, pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.



- Re-detected as #17216 (flowbird, prod, req 019efac5-bd3b-7ba0-8f91-5681d72bef32, sample pay_XxLnjCW3j5IRXi4HLzuD, first/last seen 2026-06-24T23:16–23:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req NOT retained in prod Loki (retention/stale build); prod UCS build predates this fix. No new PR.

- Re-detected as #17226 (flowbird, prod, req 019efafc-bda2-7fa1-bcf0-030c272695f2, sample pay_oO7IopcoTGN1aWdDStXK, first/last seen 2026-06-25T00:16–00:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req NOT in prod Loki (event not shipped/sampled; window has live flowbird/cybersource ShadowUCS traffic on stale build 2026.06.10.0-hotfix7-c8b9bd9 which predates this fix). No new PR.

- Re-detected as #17227 (flowbird, prod, req 019efb08-7fb9-7842-9ed7-4cb59af9b769, sample pay_83b8DaVTfIUXAhE3aZob, first/last seen 2026-06-25T00:16–00:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS/validation event 2026-06-24T19:08:23Z, v-c-merchant-id fbappfr7020Gap, pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.



- Re-detected as #17228 (flowbird, prod, req 019efb8b-894b-7ad3-8804-79c72ba7e5f4, first/last seen 2026-06-25T02:46–03:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS event 2026-06-24T21:31:30Z, namespace connector-service, profile pro_hCHAtJFCW6hH1V19vvSB, auth_type THREE_DS, status authorized; pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.

- Re-detected as #17229 (flowbird, prod, req 019efb8d-f969-7352-bf2f-a9dc315fa973, first/last seen 2026-06-25T02:46–03:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS event 2026-06-24T21:34:10Z, profile pro_AjjPLbCiveiV2xVna2vR, auth_type THREE_DS, status CHARGED/AUTHORIZED; pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.



- Re-detected as #17255 (flowbird, prod, req 019efc57-a6f3-72f0-9544-85e1d03d98b4, sample pay_VkSSMrxAQiNCy6W6OZrh, first/last seen 2026-06-25T06:16–06:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: req FOUND in prod Loki (UCS authorize event 2026-06-25T01:14:23Z, v-c-merchant-id fbappfr11Besancon, auth_type THREE_DS, real signed request to api.cybersource.com, router-data comparison clean; pod connector-service-grpc-2026o06o17o0); prod UCS build stale 2026.06.17.0 predates this fix. No new PR.

- Re-detected as #17272 (flowbird, prod, req 019efd65-c123-7960-8ebd-de1c0c44046b, sample pay_IP0uW2LrlgWMkFhV7IWI, first/last seen 2026-06-25T11:16–11:46Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: exact req aged out (Occurrences:1) but identical RP_05 request-phase diff fired continuously for flowbird/cybersource/authorize across the window (e.g. req 019efe7f-24cc @ 2026-06-25T11:16:51Z), BOTH legs real signed POSTs to api.cybersource.com (no mitm/502/timeout), auth_type THREE_DS; pod connector-service-grpc-2026o06o17o0, prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.


- Re-detected as #17281 (flowbird, prod, req 019efd70-f0af-7cc0-b900-896372bf68e3, sample pay_Ms1U2FBKRNJaBPIoaSy5, first/last seen 2026-06-25T11:46–12:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: exact req aged out (Occurrences:1) but identical request-phase diff fired continuously across the window (representative req 019efe98-0cf0-7330-a7e8-cd63379d169b @ 2026-06-25T11:44:01Z), BOTH legs real signed POSTs to api.cybersource.com (Signature / v-c-merchant-id present, no mitm/502/timeout), auth_type THREE_DS; pod connector-service-grpc-2026o06o17o0, prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.


- Re-detected as #17282 (flowbird, prod, req 019efd71-8a78-7d12-9bb3-902ba94304c5, sample pay_SQQ2kgq4CUmCx0w9fg3t, first/last seen 2026-06-25T11:46–12:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: exact req aged out (Occurrences:1) but a head-to-head representative req 019efe70-1ae4-7f70-8aee-9be620bd6946 @ 2026-06-25T11:00:24Z captured BOTH legs — Direct emits MDI [brand="flowbird", kind="fps", order_id, merchant_order_reference_id=376310499] while UCS emits [kind="fps", brand="flowbird", order_id, merchant_order_id=376310499] (brand/kind swapped + key-4 renamed); BOTH legs real signed POSTs to api.cybersource.com (201 AUTHORIZED, no mitm/502/timeout), auth_type THREE_DS; pod connector-service-grpc-2026o06o17o0, prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.



- Re-detected as #17283 (flowbird, prod, req 019efd76-83c9-7850-9d69-51ed22493db0, sample pay_MUrnvCdMWVPJuQPvwhjv, first/last seen 2026-06-25T11:46–12:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: exact req aged out (Occurrences:1) but head-to-head representative req 019efe70-1ae4-7f70-8aee-9be620bd6946 @ 2026-06-25T11:00:24Z captured BOTH legs — Direct emits MDI [brand="flowbird", kind="fps", order_id, merchant_order_reference_id=376310499] while UCS emits [kind="fps", brand="flowbird", order_id, merchant_order_id=376310499] (brand/kind swapped + key-4 renamed); BOTH legs real signed POSTs to api.cybersource.com (201 AUTHORIZED, no mitm/502/timeout), auth_type THREE_DS; pod connector-service-grpc-2026o06o17o0, prod UCS build stale 2026.06.17.0-dirty-aef0be919 predates this fix. No new PR.


- Re-detected as #17284 (flowbird, prod, req 019efd7a-4c5e-7b71-bb41-a13640e6893d, sample pay_Pw4Uqj7V7ygqcpbqSWuq, first/last seen 2026-06-25T11:46–12:16Z, cybersource **authorize** flow). Byte-identical MDI signature: merchantDefinedInformation[0]/[1] brand/kind swap + [3] merchant_order_reference_id→merchant_order_id. This is the MDI half of the flowbird/cybersource/authorize union; 3DS half = connector-service#1594 + juspay/hyperswitch#12872. Grafana RCA: exact req aged out (Occurrences:1) but head-to-head representative req 019efe70-1ae4-7f70-8aee-9be620bd6946 @ 2026-06-25T11:00:24Z captured BOTH legs — Direct emits MDI [brand="flowbird", kind="fps", order_id, merchant_order_reference_id] while UCS emits [kind="fps", brand="flowbird", order_id, merchant_order_id] (brand/kind swapped + key-4 renamed); BOTH legs real signed POSTs to api.cybersource.com (201 AUTHORIZED, no mitm/502/timeout), auth_type THREE_DS; pod connector-service-grpc-2026o06o17o0, prod UCS build stale 2026.06.17.0 predates this fix. No new PR.