### PR TITLE
fix(payload): map error reason from error_description to match Direct (#17247)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/payload.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload.rs
@@ -300,11 +300,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.error_type,
-            message: response.error_description,
-            reason: response
-                .details
-                .as_ref()
-                .map(|details_value| details_value.to_string()),
+            message: response.error_description.clone(),
+            reason: Some(response.error_description),
             attempt_status: None,
             connector_transaction_id: None,
             network_advice_code: None,
@@ -765,3 +762,54 @@ macros::macro_connector_flow_status_impls!(
         ServerAuthenticationToken,
     ],
 );
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod error_response_tests {
+    use domain_types::{
+        payment_method_data::DefaultPCIHolder, router_data::ConnectorSpecificConfig,
+        router_response_types::Response,
+    };
+    use interfaces::api::ConnectorCommon;
+
+    use super::Payload;
+
+    // Regression for issue #17247 (payload / repeat_payment router.valueDiff:response.Err.reason).
+    // Payload returns a 400 decline as an error wrapper carrying `error_type` / `error_description`
+    // plus a `details` transaction object. Direct hyperswitch maps `reason = error_description`
+    // (payload.rs build_error_response). Prism previously mapped `reason = details.to_string()`,
+    // which surfaced the whole transaction blob and diverged from Direct. This asserts prism now
+    // mirrors Direct: reason == error_description.
+    #[test]
+    fn build_error_response_maps_reason_from_error_description() {
+        let decline_msg = "The card has been declined, contact card issuer for more information.";
+        let body = serde_json::json!({
+            "error_type": "TransactionDeclined",
+            "error_description": decline_msg,
+            "object": "error",
+            "details": {
+                "amount": 827.4,
+                "status": "declined",
+                "status_code": "general_decline",
+                "status_message": decline_msg,
+                "type": "payment"
+            }
+        });
+        let res = Response {
+            headers: None,
+            response: serde_json::to_vec(&body).unwrap().into(),
+            status_code: 400,
+        };
+
+        let connector = Payload::<DefaultPCIHolder>::new();
+        let err = connector
+            .build_error_response(res, None, &ConnectorSpecificConfig::NoKey)
+            .expect("payload error body should parse");
+
+        assert_eq!(err.status_code, 400);
+        assert_eq!(err.code, "TransactionDeclined");
+        assert_eq!(err.message, decline_msg);
+        // reason must mirror Direct (error_description), NOT the stringified `details` blob.
+        assert_eq!(err.reason.as_deref(), Some(decline_msg));
+    }
+}


### PR DESCRIPTION
## What


Payload returns a 400 decline as an error wrapper that carries `error_type` / `error_description` **plus** a `details` transaction object. The Direct hyperswitch connector maps the error `reason` from `error_description` (the human-readable decline message), but prism's `build_error_response` mapped `reason = details.to_string()` — dumping the entire stringified transaction blob into the reason field. Because the proto `ConnectorErrorDetails.reason` and the router-side decode (`unified_connector_service/transformers.rs`) pass this through verbatim, the UCS leg's `response.Err.reason` diverged from Direct.

## Root cause (RCA)

| Leg | source | `response.Err.reason` |
|---|---|---|
| **Direct** (`hyperswitch payload.rs:264`) | `Some(error_description)` | `"The card has been declined, contact card issuer for more information."` |
| **UCS** (prism `payload.rs:304-307`, before) | `details.to_string()` | `"{\"amount\":827.4,...,\"status\":\"declined\",\"status_code\":\"general_decline\",...}"` |

This is the `response.Err.reason` half of the same genuine payload AMEX-decline event as #17245 (`connector_http_status_code` → hs #13041) and #17246 (`response.Err.code` → hs #13043). Both legs hit the real payload API (`api.payload.com/transactions`) and got the identical HTTP 400 decline (`error_type=TransactionDeclined`, `status_code=general_decline`) — GENUINE, not a synthetic mitm/transport artifact.

Confirmed in prod Loki VS_48 for req `019efd27-6415-7042-a8c9-8147858e2766` (sample `pay_c3H0ys3ovMdVaMVvc9GP`) and the other 3 sample req-ids.

## Fix (UCS-only)

Mirror Direct in prism's payload `build_error_response`: `reason = Some(error_description)`. No proto change and no hyperswitch change needed — the proto `ConnectorErrorDetails.reason` field already exists and is plumbed end-to-end; the router decode reads it verbatim. (Contrast #13043, which had to fix `code` because of the `CONNECTOR_ERROR_RESPONSE` discriminator — `reason` has no such issue.)

## Verification

The live decline path is not reproducible on the payload sandbox (it approves every test card; the prod diffs were real-issuer AMEX declines, and repeat_payment additionally needs an established mandate). Proof is a **deterministic regression unit test** that runs the real `build_error_response` against the prod 400 decline body shape:

**before:** `response.Err.reason = "{\"amount\":827.4,...}"` (stringified `details`)
**after:** `response.Err.reason = "The card has been declined, contact card issuer for more information."` (== Direct)

```
$ cargo test -p connector-integration --lib payload::error_response_tests
test connectors::payload::error_response_tests::build_error_response_maps_reason_from_error_description ... ok
test result: ok. 1 passed; 0 failed
```

`cargo build -p grpc-server` clean. No creds / `config/development.toml` in the diff.

Closes #1776
