### PR TITLE
fix(core): add ServerAuthentication support to FRM and payout connector

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 use common_enums;
 use common_utils::{events::FlowName, lineage, metadata::MaskedMetadata, SecretSerdeValue};
-use connector_integration::types::{ConnectorData, ConnectorDataProvider};
+use connector_integration::types::{
+    ConnectorData, ConnectorDataProvider, FrmConnectorData, PayoutConnectorData,
+};
 use domain_types::payment_method_data;
 use domain_types::{
     connector_flow::{
@@ -2576,21 +2578,10 @@ impl MerchantAuthentication {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn handle_access_token<
-        T: PaymentMethodDataTypes
-            + Default
-            + Eq
-            + Debug
-            + Send
-            + serde::Serialize
-            + serde::de::DeserializeOwned
-            + Clone
-            + Sync
-            + 'static,
-    >(
+    async fn handle_access_token(
         &self,
         config: &Arc<Config>,
-        connector_data: ConnectorData<T>,
+        connector_variant: &ConnectorVariant,
         merchant_auth_flow_data: &MerchantAuthenticationFlowData,
         connector_config: ConnectorSpecificConfig,
         connector_name: &str,
@@ -2601,14 +2592,31 @@ impl MerchantAuthentication {
         ServerAuthenticationTokenRequestData:
             for<'a> ForeignTryFrom<&'a ConnectorSpecificConfig, Error = IntegrationError>,
     {
-        // Get connector integration for ServerAuthenticationToken flow
+        // Resolve connector integration for ServerAuthenticationToken flow
         let connector_integration: BoxedConnectorIntegrationV2<
             '_,
             ServerAuthenticationToken,
             MerchantAuthenticationFlowData,
             ServerAuthenticationTokenRequestData,
             ServerAuthenticationTokenResponseData,
-        > = connector_data.connector.get_connector_integration_v2();
+        > = match connector_variant {
+            ConnectorVariant::Payment(conn) => {
+                ConnectorData::<DefaultPCIHolder>::get_connector_by_name(conn)
+                    .connector
+                    .get_connector_integration_v2()
+            }
+            ConnectorVariant::Frm(conn) => FrmConnectorData::get_connector_by_name(conn)
+                .connector
+                .get_connector_integration_v2(),
+            ConnectorVariant::Payout(conn) => PayoutConnectorData::get_connector_by_name(conn)
+                .connector
+                .get_connector_integration_v2(),
+            ConnectorVariant::Surcharge(_) => {
+                return Err(tonic::Status::invalid_argument(
+                    "Surcharge connectors do not support server authentication tokens",
+                ));
+            }
+        };
 
         // Create access token request data - grant type determined by connector
         let access_token_request_data = ServerAuthenticationTokenRequestData::foreign_try_from(
@@ -2916,11 +2924,6 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         (metadata_payload.request_id, metadata_payload.lineage_ids);
                     let connector_config = &metadata_payload.connector_config;
 
-                    let connector_data: ConnectorData<DefaultPCIHolder> =
-                        ConnectorData::from_connector_variant(&metadata_payload.connector)
-                            .ok_or_else(|| {
-                                tonic::Status::invalid_argument("Invalid Connector Received")
-                            })?;
                     let access_token_create_request = request_data.payload;
                     let connectors = utils::connectors_with_connector_config_overrides(
                         connector_config,
@@ -2952,11 +2955,9 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         merchant_id: metadata_payload.merchant_id.as_str(),
                     };
 
-                    // Reuse the existing handle_access_token function which now uses
-                    // generate_access_token_response for consistent error handling
                     let server_auth_token_response = Box::pin(self.handle_access_token(
                         &config,
-                        connector_data,
+                        &metadata_payload.connector,
                         &merchant_auth_flow_data,
                         connector_config.clone(),
                         &metadata_payload.connector.get_connector_name(),

--- a/crates/integrations/connector-integration/src/payout_connectors/cybersource.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/cybersource.rs
@@ -13,9 +13,13 @@ use common_utils::{
 use domain_types::{
     connector_flow::{
         PayoutCreate, PayoutCreateLink, PayoutCreateRecipient, PayoutEnrollDisburseAccount,
-        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid,
+        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid, ServerAuthenticationToken,
     },
-    errors::{ConnectorError, IntegrationError},
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+    },
+    errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
         PayoutCreateRecipientResponse, PayoutCreateRequest, PayoutCreateResponse,
@@ -36,6 +40,7 @@ use interfaces::{
     connector_types::{
         PayoutCreateLinkV2, PayoutCreateRecipientV2, PayoutCreateV2, PayoutEnrollDisburseAccountV2,
         PayoutGetV2, PayoutServiceTrait, PayoutStageV2, PayoutTransferV2, PayoutVoidV2,
+        ServerAuthentication,
     },
 };
 use ring::{digest, hmac};
@@ -363,6 +368,36 @@ fn build_5xx_error_response(
         network_decline_code: None,
         network_error_message: None,
     })
+}
+
+// ===== SERVER AUTHENTICATION (not implemented) =====
+
+impl ServerAuthentication for CybersourcePayouts {}
+
+impl
+    ConnectorIntegrationV2<
+        ServerAuthenticationToken,
+        MerchantAuthenticationFlowData,
+        ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData,
+    > for CybersourcePayouts
+{
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::connector_flow_not_implemented(
+            ConnectorCommon::id(self),
+            "server_authentication_token",
+            IntegrationErrorContext::default(),
+        )
+        .into())
+    }
 }
 
 impl PayoutServiceTrait for CybersourcePayouts {}

--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
@@ -7,9 +7,13 @@ use common_utils::{
 use domain_types::{
     connector_flow::{
         PayoutCreate, PayoutCreateLink, PayoutCreateRecipient, PayoutEnrollDisburseAccount,
-        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid,
+        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid, ServerAuthenticationToken,
     },
-    errors::{ConnectorError, IntegrationError},
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+    },
+    errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
         PayoutCreateRecipientResponse, PayoutCreateRequest, PayoutCreateResponse,
@@ -30,6 +34,7 @@ use interfaces::{
     connector_types::{
         PayoutCreateLinkV2, PayoutCreateRecipientV2, PayoutCreateV2, PayoutEnrollDisburseAccountV2,
         PayoutGetV2, PayoutServiceTrait, PayoutStageV2, PayoutTransferV2, PayoutVoidV2,
+        ServerAuthentication,
     },
 };
 
@@ -155,6 +160,36 @@ impl ConnectorCommon for ItaubankPayouts {
                 })
             }
         }
+    }
+}
+
+// ===== SERVER AUTHENTICATION (not implemented) =====
+
+impl ServerAuthentication for ItaubankPayouts {}
+
+impl
+    ConnectorIntegrationV2<
+        ServerAuthenticationToken,
+        MerchantAuthenticationFlowData,
+        ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData,
+    > for ItaubankPayouts
+{
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::connector_flow_not_implemented(
+            ConnectorCommon::id(self),
+            "server_authentication_token",
+            IntegrationErrorContext::default(),
+        )
+        .into())
     }
 }
 

--- a/crates/integrations/connector-integration/src/payout_connectors/loonio.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/loonio.rs
@@ -5,9 +5,13 @@ use common_utils::{consts::NO_ERROR_CODE, errors::CustomResult, events, ext_trai
 use domain_types::{
     connector_flow::{
         PayoutCreate, PayoutCreateLink, PayoutCreateRecipient, PayoutEnrollDisburseAccount,
-        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid,
+        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid, ServerAuthenticationToken,
     },
-    errors::{ConnectorError, IntegrationError},
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+    },
+    errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
         PayoutCreateRecipientResponse, PayoutCreateRequest, PayoutCreateResponse,
@@ -28,6 +32,7 @@ use interfaces::{
     connector_types::{
         PayoutCreateLinkV2, PayoutCreateRecipientV2, PayoutCreateV2, PayoutEnrollDisburseAccountV2,
         PayoutGetV2, PayoutServiceTrait, PayoutStageV2, PayoutTransferV2, PayoutVoidV2,
+        ServerAuthentication,
     },
 };
 
@@ -141,6 +146,36 @@ impl ConnectorCommon for LoonioPayouts {
             network_advice_code: None,
             network_error_message: None,
         })
+    }
+}
+
+// ===== SERVER AUTHENTICATION (not implemented) =====
+
+impl ServerAuthentication for LoonioPayouts {}
+
+impl
+    ConnectorIntegrationV2<
+        ServerAuthenticationToken,
+        MerchantAuthenticationFlowData,
+        ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData,
+    > for LoonioPayouts
+{
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::connector_flow_not_implemented(
+            ConnectorCommon::id(self),
+            "server_authentication_token",
+            IntegrationErrorContext::default(),
+        )
+        .into())
     }
 }
 

--- a/crates/integrations/connector-integration/src/payout_connectors/paypal.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/paypal.rs
@@ -5,12 +5,16 @@ use common_utils::{consts::NO_ERROR_CODE, errors::CustomResult, events, ext_trai
 use domain_types::{
     connector_flow::{
         PayoutCreate, PayoutCreateLink, PayoutCreateRecipient, PayoutEnrollDisburseAccount,
-        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid,
+        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid, ServerAuthenticationToken,
+    },
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
     },
     errors::{
         ConnectorError, IntegrationError, IntegrationErrorContext,
         ResponseTransformationErrorContext,
     },
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
         PayoutCreateRecipientResponse, PayoutCreateRequest, PayoutCreateResponse,
@@ -31,6 +35,7 @@ use interfaces::{
     connector_types::{
         PayoutCreateLinkV2, PayoutCreateRecipientV2, PayoutCreateV2, PayoutEnrollDisburseAccountV2,
         PayoutGetV2, PayoutServiceTrait, PayoutStageV2, PayoutTransferV2, PayoutVoidV2,
+        ServerAuthentication,
     },
 };
 
@@ -186,6 +191,36 @@ impl ConnectorCommon for PaypalPayouts {
             network_decline_code: None,
             network_error_message: None,
         })
+    }
+}
+
+// ===== SERVER AUTHENTICATION (not implemented) =====
+
+impl ServerAuthentication for PaypalPayouts {}
+
+impl
+    ConnectorIntegrationV2<
+        ServerAuthenticationToken,
+        MerchantAuthenticationFlowData,
+        ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData,
+    > for PaypalPayouts
+{
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::connector_flow_not_implemented(
+            ConnectorCommon::id(self),
+            "server_authentication_token",
+            IntegrationErrorContext::default(),
+        )
+        .into())
     }
 }
 

--- a/crates/integrations/connector-integration/src/payout_connectors/worldpayxml.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/worldpayxml.rs
@@ -11,9 +11,13 @@ use common_utils::{
 use domain_types::{
     connector_flow::{
         PayoutCreate, PayoutCreateLink, PayoutCreateRecipient, PayoutEnrollDisburseAccount,
-        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid,
+        PayoutGet, PayoutStage, PayoutTransfer, PayoutVoid, ServerAuthenticationToken,
     },
-    errors::{ConnectorError, IntegrationError},
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+    },
+    errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
         PayoutCreateRecipientResponse, PayoutCreateRequest, PayoutCreateResponse,
@@ -34,6 +38,7 @@ use interfaces::{
     connector_types::{
         PayoutCreateLinkV2, PayoutCreateRecipientV2, PayoutCreateV2, PayoutEnrollDisburseAccountV2,
         PayoutGetV2, PayoutServiceTrait, PayoutStageV2, PayoutTransferV2, PayoutVoidV2,
+        ServerAuthentication,
     },
 };
 
@@ -191,6 +196,36 @@ impl ConnectorCommon for WorldpayxmlPayouts {
                 })
             }
         }
+    }
+}
+
+// ===== SERVER AUTHENTICATION (not implemented) =====
+
+impl ServerAuthentication for WorldpayxmlPayouts {}
+
+impl
+    ConnectorIntegrationV2<
+        ServerAuthenticationToken,
+        MerchantAuthenticationFlowData,
+        ServerAuthenticationTokenRequestData,
+        ServerAuthenticationTokenResponseData,
+    > for WorldpayxmlPayouts
+{
+    fn get_url(
+        &self,
+        _req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        Err(IntegrationError::connector_flow_not_implemented(
+            ConnectorCommon::id(self),
+            "server_authentication_token",
+            IntegrationErrorContext::default(),
+        )
+        .into())
     }
 }
 

--- a/crates/types-traits/interfaces/src/connector_types.rs
+++ b/crates/types-traits/interfaces/src/connector_types.rs
@@ -137,6 +137,7 @@ pub trait SurchargeServiceTrait:
 pub trait FrmServiceTrait:
     ConnectorCommon
     + ValidationTrait
+    + ServerAuthentication
     + PreRiskCheckV2
     + PostRiskCheckV2
     + FrmPaymentOutcomeV2
@@ -147,6 +148,7 @@ pub trait FrmServiceTrait:
 
 pub trait PayoutServiceTrait:
     ConnectorCommon
+    + ServerAuthentication
     + PayoutCreateV2
     + PayoutTransferV2
     + PayoutGetV2


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
                                                                                                                                                                                                                                                  
  - Add `ServerAuthentication` support for x-frm-connector and x-payout-connector
  - Added `ServerAuthentication` as a supertrait bound on `FrmServiceTrait` and `PayoutServiceTrait` in `connector_types.rs`, enabling access token flows for FRM and payout connectors                                                             
                                                                                                                                                                                                                                                    ## Additional Changes                                                                                                                                                                                                                                      

  - Implemented the `ServerAuthentication` trait (as not-implemented stubs) for all existing payout connectors: Cybersource, Itaubank, Loonio, PayPal, and Worldpayxml
  - `crates/integrations/connector-integration/src/payout_connectors/{cybersource,itaubank,loonio,paypal,worldpayxml}.rs`: Implemented `ServerAuthentication` marker trait and `ConnectorIntegrationV2<ServerAuthenticationToken, ...>` stub
  (returns `connector_flow_not_implemented` error) for each payout connector                                                                                                                                                                        


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Composite preRiskCheck request with Access Token (using x-frm-connector)
```
curl --location 'http://localhost:8000/composite/frm/pre_risk_check' \
--header 'Content-Type: application/json' \
--header 'x-frm-connector: kount' \
--header 'x-connector-config: {"config":{"Kount":{"api_key":"MG9hMXg5N2lsdmtpUmQ3OHEzNTg6WUpYY3YyUGlOeHdkMG14Nlo2ck5JaDVfMVRMOFdGUlFRMFBCLXRPY2thdHVBVWY5SE1ZTzdfVVB0RzBBTHJyNw=="}}}' \
--data-raw '{
  "amount": { "minor_amount": 1000, "currency": "USD" },
  "merchant_transaction_id": "kount-postman-1",
  "customer_info": { "customer_name": "John Doe", "customer_email": "jdoe@example.com", "customer_phone_number": "+15555550123" },
  "payment_method": { "payment_method": { "card": { "card_number": "4111111111111111", "card_exp_month": "12", "card_exp_year": "30", "card_cvc": "123", "card_holder_name": "John Doe", "card_type": "credit" } } },
  "order_details": [ { "product_name": "Widget", "quantity": 1, "amount": 1000, "category": "goods", "sku": "SKU1", "description": "Test widget", "requires_shipping": true } ],
  "address": { "first_name": "John", "last_name": "Doe", "line1": "123 Test St", "city": "San Jose", "state": "CA", "zip_code": "95131", "country_alpha2_code": "US", "email": "jdoe@example.com", "phone_number": "5555550123" },
  "browser_info": { "ip_address": "203.0.113.55", "user_agent": "Mozilla/5.0 Chrome/120" },
  "test_mode": true
}'
```
Response
```
{"pre_risk_check_response":{"frm_decision":"APPROVE","risk_score":53,"frm_transaction_id":"0F5BFNGDZ7HLLBBX","status_code":200,"raw_connector_response":"{\"order\":{\"orderId\":\"0F5BFNGDZ7HLLBBX\",\"riskInquiry\":{\"decision\":\"APPROVE\",\"omniscore\":52.7,\"reason\":null}}}","response_headers":{}},"access_token_response":{"access_token":"eyJraWQiOiJKVk4zUml4cUZ0bUtaWTlzOVAyV0RUT2JHVEJHcEM3WjRtbU5aczI2OXRjIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnl3R25LVmVfSXYtd0tlSzZ2MTd5aktJQmR0RkFRV0wwbklaVWtXU1ZNTnciLCJpc3MiOiJodHRwczovL2xvZ2luLmtvdW50LmNvbS9vYXV0aDIvYXVzZHBwa3VqekNQUXVJclkzNTciLCJhdWQiOiJrMV9zYW5kYm94MTNfaW50ZWdyYXRpb25fYXBpX2F1dGhfc2VydmVyIiwic3ViIjoiMG9hMXg5N2lsdmtpUmQ3OHEzNTgiLCJpYXQiOjE3ODI4MTU5NTcsImV4cCI6MTc4MjgyMzE1NywiY2lkIjoiMG9hMXg5N2lsdmtpUmQ3OHEzNTgiLCJzY3AiOlsiazFfaW50ZWdyYXRpb25fYXBpIl0sImVudGl0bGVtZW50cyI6WyIwMUo4VFEzUzA0WkpLRkFLUkIzNEFaTUpXUiIsIjAxSjhUUTNTMDVTTVhCOTM5U1dBVFdZWlNTIiwiMDFKOFRRM1MwNVE1NzJNSFZURkdSOUgyTjAiLCIwMUo4VFEzUzA1RTg2MDZSMUtXNzFZQ1c5UCJdLCJvcmdfaWQiOiJkNzIyNm5pcmtxbGM3M2M2NTlxMCIsImNsaWVudF9pZCI6IjQwOTA2NzQzOTM4NjQwNiJ9.i5HZhyuyFhr55UQgDM6Ckj8NqO9RYqMB1vorJ_fXHT_7VUbn75tqCkhE51HXEY-zArxL7PvaiaPhhA33RynZ6oprf1eSZvuQlDpxFS7QtzbeX31pXa8XC5kD-EQUldZg4KeB2LxddMcMz-zRL78XsBpf2_-Dr0Mxtmi2HG2QeaL2TRhiOrqfi0T1h92VnXmzHWh2jlkb2PZs0fijiKSrkTYC-s_FvqN3qq71sMUan0vhsStxnfggrN0CuL0_18WYDdMeAR3HGYEzGvqUebUH2MfPlckAjMI7KVZbub56zgGieHrinw_Tfeug1bMn12U4ZzsypzUuNyxsEkdSYiG8-A","token_type":"Bearer","expires_in_seconds":7200,"status":"OPERATION_STATUS_SUCCESS","status_code":200}}
```