### PR TITLE
docs(medusa): update connector support matrix (Mollie, Authorize.Net)

### DIFF
--- a/plugins/medusa/README.md
+++ b/plugins/medusa/README.md
@@ -19,8 +19,8 @@ Hyperswitch Prism payment integration for Medusa v2. This monorepo contains two 
 > | [![GlobalPay](https://img.shields.io/badge/GlobalPay-E4002B?style=for-the-badge&logoColor=white)](https://developer.globalpay.com) | ✅ | ✅ |
 > | [![Braintree](https://img.shields.io/badge/Braintree-1B3FA0?style=for-the-badge&logoColor=white)](https://developer.paypal.com/braintree/docs) | ✅ | — |
 > | [![Cybersource](https://img.shields.io/badge/Cybersource-FF6600?style=for-the-badge&logoColor=white)](https://developer.cybersource.com) | ✅ | ✅ |
-> | [![Mollie](https://img.shields.io/badge/Mollie-000000?style=for-the-badge&logo=mollie&logoColor=white)](https://mollie.com) | ✅ | — |
-> | [![Authorize.net](https://img.shields.io/badge/Authorize.Net-EE3124?style=for-the-badge&logoColor=white)](https://developer.authorize.net) | ✅ | ✅ |
+> | [![Mollie](https://img.shields.io/badge/Mollie-000000?style=for-the-badge&logo=mollie&logoColor=white)](https://mollie.com) | ✅ | ✅ |
+> | [![Authorize.net](https://img.shields.io/badge/Authorize.Net-EE3124?style=for-the-badge&logoColor=white)](https://developer.authorize.net) | [🚧][auth-issue] | [🚧][auth-issue] |
 > | [![PayU](https://img.shields.io/badge/PayU-A6CE39?style=for-the-badge&logoColor=white)](https://payu.com) | [🚧][payu-issue] | [🚧][payu-issue] |
 > | [![Razorpay](https://img.shields.io/badge/Razorpay-3395FF?style=for-the-badge&logo=razorpay&logoColor=white)](https://razorpay.com) | [🚧][razorpay-issue] | [🚧][razorpay-issue] |
 > | [![Square](https://img.shields.io/badge/Square-3E4348?style=for-the-badge&logo=square&logoColor=white)](https://developer.squareup.com) | [🚧][square-issue] | [🚧][square-issue] |

--- a/plugins/medusa/medusa-custom-payments/README.md
+++ b/plugins/medusa/medusa-custom-payments/README.md
@@ -214,7 +214,7 @@ Each credential value is provided as `{ value: string }` to support secret manag
 | `braintree` | ✅ | ✅ | ✅ | ✅ | ○ |
 | `cybersource` | ✅ | ✅ | ✅ | ✅ | ○ |
 | `mollie` | — | ✅ | ✅ | ✅ | ○ |
-| `authorizedotnet` | — | ✅ | ✅ | ✅ | ○ |
+| `authorizedotnet` | — | ○ | ○ | ○ | ○ |
 
 **Legend**
 


### PR DESCRIPTION
## What

Two corrections to the connector support matrix in `plugins/medusa/README.md`:

```diff
- | Mollie       | ✅ | — |
+ | Mollie       | ✅ | ✅ |
- | Authorize.net | ✅ | ✅ |
+ | Authorize.net | [🚧][auth-issue] | [🚧][auth-issue] |
```

- **Mollie** → marked supported (`✅`) in the `medusa-custom-payments-react` column. It is implemented and exported there (`MollieWrapper`, `MolliePaymentButton`, `MollieKlarnaForm`, `isHyperswitchPrismMollie`), and the React package's own matrix already shows it as supported.
- **Authorize.Net** → moved from supported (`✅`) to in-progress (`🚧`) in both columns, linked to the existing `auth-issue` tracker reference already defined in the file.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)