### PR TITLE
fix(connector): [Noon] preserve current_status for Locked payment status

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -561,7 +561,7 @@ pub enum NoonPaymentStatus {
     Locked,
 }
 
-fn get_payment_status(item: NoonPaymentStatus) -> AttemptStatus {
+fn get_payment_status(item: NoonPaymentStatus, current_status: AttemptStatus) -> AttemptStatus {
     match item {
         NoonPaymentStatus::Authorized => AttemptStatus::Authorized,
         NoonPaymentStatus::Captured
@@ -581,7 +581,9 @@ fn get_payment_status(item: NoonPaymentStatus) -> AttemptStatus {
         NoonPaymentStatus::Initiated
         | NoonPaymentStatus::PaymentInfoAdded
         | NoonPaymentStatus::Authenticated => AttemptStatus::Started,
-        NoonPaymentStatus::Locked => AttemptStatus::Unspecified,
+        // Preserve the current attempt status when Noon locks the order (e.g. pending fraud review),
+        // matching HS behaviour which returns current_status for Locked.
+        NoonPaymentStatus::Locked => current_status,
     }
 }
 
@@ -625,7 +627,7 @@ impl<F, T> TryFrom<ResponseRouterData<NoonPaymentsResponse, Self>>
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<NoonPaymentsResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status(order.status, item.router_data.resource_common_data.status);
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1435,7 +1437,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<SetupMandateResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status(order.status, item.router_data.resource_common_data.status);
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1652,7 +1654,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         } = item;
 
         let order = payments_response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status(order.status, router_data.resource_common_data.status);
         let redirection_data = payments_response
             .result
             .checkout_data


### PR DESCRIPTION
## Summary

When Noon returns `LOCKED` order status, UCS was mapping it to `AttemptStatus::Unspecified`
while HS correctly preserves the current attempt status (`current_status`). This caused a
`router.valueDiff:status` shadow-validation diff in the `repeat_payment` flow.

**Root cause**: `get_payment_status` in `noon/transformers.rs` accepted only the connector
status, so it had no way to preserve the prior status for `Locked`. HS passes
`(order.status, current_status)` as a tuple and returns `current_status` for `Locked`;
UCS returned `AttemptStatus::Unspecified`.

**Fix**: add `current_status: AttemptStatus` parameter to `get_payment_status` and return
it for `NoonPaymentStatus::Locked`, updating all three callers:
- Generic `TryFrom<ResponseRouterData<NoonPaymentsResponse, …>>`
- `TryFrom<ResponseRouterData<SetupMandateResponse, …>>`
- `TryFrom<ResponseRouterData<NoonRepeatPaymentResponse, …>>`

## Diff signature

`router.valueDiff:status` — connector=noon, flow=repeat_payment

## Before → After (source-parity)

**Before**: Noon `LOCKED` → `AttemptStatus::Unspecified` (diverges from HS)  
**After**: Noon `LOCKED` → `current_status` (matches HS behaviour)

Verified locally: build clean, `cargo clippy --all-targets -- -D warnings` 0 errors,
`cargo fmt --check` clean.  UCS restarted on the fixed binary; noon live credentials
not available locally so diff→no_diff was confirmed via source-parity (code now
mirrors HS's `get_payment_status` logic exactly).

## Layer category

**L3 — connector transformer** (UCS-only PR; no proto change required — `status` is
already in the gRPC response contract).

Closes #1768
