### PR TITLE
refactor(tsys_transit): generic flow request building + MOTO cert fixes

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
@@ -1,3 +1,5 @@
+pub mod profile;
+pub mod rules;
 pub mod transformers;
 
 use std::fmt::Debug;

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/acceptance.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/acceptance.rs
@@ -1,0 +1,205 @@
+//! Acceptance-profile axis of `TxProfile`.
+//!
+//! Channel + recurring-or-not selects a fixed block of TSYS `terminalData`
+//! tags (operating environment, output capability, default input mode,
+//! default cardholder-present detail, etc.). This is the level the cert
+//! script's per-tab "see top requirement section for proper terminalData
+//! tags & values" callouts operate at.
+//!
+//! Each variant maps to one `TerminalDataBlock` via [`Self::terminal_data`].
+//! That block defines the "static" terminalData; per-tx rules (in `rules/`)
+//! may override individual fields based on card_family / cof_phase.
+
+use common_enums::{MitCategory, PaymentChannel};
+
+use super::super::transformers::{
+    TsysTransitCardDataInputMode, TsysTransitCardDataOutputCapability, TsysTransitCardDataSource,
+    TsysTransitCardholderAuthenticationEntity, TsysTransitCardholderAuthenticationMethod,
+    TsysTransitCardholderPresentDetail, TsysTransitMaxPinLength,
+    TsysTransitTerminalAuthenticationCapability, TsysTransitTerminalCapability,
+    TsysTransitTerminalCardCaptureCapability, TsysTransitTerminalOperatingEnvironment,
+    TsysTransitTerminalOutputCapability,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptanceProfile {
+    /// e-Commerce tab: `cardDataSource = INTERNET`.
+    EcomInternet,
+    /// Direct-Marketing / MOTO tab, phone variant.
+    MotoPhone,
+    /// Direct-Marketing / MOTO tab, mail variant.
+    MotoMail,
+    /// Recurring & Installments tab, recurring (non-installment) schedule.
+    RecurringMit,
+    /// Recurring & Installments tab, installment schedule.
+    InstallmentMit,
+}
+
+/// Block of TSYS `terminalData` tags that ride together with an
+/// acceptance profile. Selected by `AcceptanceProfile::terminal_data`.
+#[derive(Debug, Clone)]
+pub struct TerminalDataBlock {
+    pub card_data_source: TsysTransitCardDataSource,
+    pub terminal_operating_environment: TsysTransitTerminalOperatingEnvironment,
+    pub terminal_output_capability: TsysTransitTerminalOutputCapability,
+    pub terminal_capability: TsysTransitTerminalCapability,
+    pub terminal_authentication_capability: TsysTransitTerminalAuthenticationCapability,
+    pub max_pin_length: TsysTransitMaxPinLength,
+    pub terminal_card_capture_capability: TsysTransitTerminalCardCaptureCapability,
+    pub cardholder_authentication_method: TsysTransitCardholderAuthenticationMethod,
+    pub cardholder_authentication_entity: TsysTransitCardholderAuthenticationEntity,
+    pub card_data_output_capability: TsysTransitCardDataOutputCapability,
+    pub default_card_data_input_mode: TsysTransitCardDataInputMode,
+    pub default_cardholder_present_detail: TsysTransitCardholderPresentDetail,
+}
+
+impl AcceptanceProfile {
+    /// Map `(channel, mit_category)` to the acceptance profile this
+    /// transaction lives in. Recurring/installment classification dominates
+    /// channel — the cert script puts those in their own tab regardless of
+    /// how the merchant first accepted the card.
+    pub fn derive(channel: Option<PaymentChannel>, mit_category: Option<MitCategory>) -> Self {
+        match mit_category {
+            Some(MitCategory::Recurring) => return Self::RecurringMit,
+            Some(MitCategory::Installment) => return Self::InstallmentMit,
+            _ => {}
+        }
+        match channel {
+            Some(PaymentChannel::TelephoneOrder) => Self::MotoPhone,
+            Some(PaymentChannel::MailOrder) => Self::MotoMail,
+            Some(PaymentChannel::Ecommerce) | None => Self::EcomInternet,
+        }
+    }
+
+    /// Fixed terminalData block for this acceptance profile.
+    ///
+    /// The cert script's "see top requirement section for proper
+    /// terminalData tags & values" callouts come from this table.
+    /// Per-row pushback in `TSYS certification issues - MOTO.csv`
+    /// corresponds directly to entries here for MotoPhone/MotoMail.
+    pub fn terminal_data(self) -> TerminalDataBlock {
+        // Shorthand aliases (kept fully-qualified at use sites because
+        // several enums share variant names like `NotAuthenticated` and
+        // `NoCapability`).
+        type Cap = TsysTransitTerminalCapability;
+        type Env = TsysTransitTerminalOperatingEnvironment;
+        type Out = TsysTransitTerminalOutputCapability;
+        type AuthCap = TsysTransitTerminalAuthenticationCapability;
+        type Pin = TsysTransitMaxPinLength;
+        type CardCap = TsysTransitTerminalCardCaptureCapability;
+        type AuthMethod = TsysTransitCardholderAuthenticationMethod;
+        type AuthEnt = TsysTransitCardholderAuthenticationEntity;
+        type DataOut = TsysTransitCardDataOutputCapability;
+        type DataIn = TsysTransitCardDataInputMode;
+        type Present = TsysTransitCardholderPresentDetail;
+        type Source = TsysTransitCardDataSource;
+
+        match self {
+            // ── MOTO PHONE ─────────────────────────────────────────────
+            // Cert pushback rows on MOTO csv (paraphrased):
+            //   • terminalOperatingEnvironment must be
+            //     ON_MERCHANT_PREMISES_ATTENDED on all transactions
+            //   • terminalOutputCapability must be DISPLAY_ONLY
+            //   • cardholderPresentDetail must be
+            //     CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION
+            //   • cardDataSource must be PHONE
+            //   • cardDataInputMode must be KEY_ENTERED_INPUT
+            //     (overridden to MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB
+            //     when CVV is sent on AMEX/JCB; that's handled in
+            //     rules::card_input_mode, not here)
+            Self::MotoPhone => TerminalDataBlock {
+                card_data_source: Source::Phone,
+                terminal_operating_environment: Env::OnMerchantPremisesAttended,
+                terminal_output_capability: Out::DisplayOnly,
+                terminal_capability: Cap::KeyedEntryOnly,
+                terminal_authentication_capability: AuthCap::NoCapability,
+                max_pin_length: Pin::NotSupported,
+                terminal_card_capture_capability: CardCap::NoCapability,
+                cardholder_authentication_method: AuthMethod::NotAuthenticated,
+                cardholder_authentication_entity: AuthEnt::NotAuthenticated,
+                card_data_output_capability: DataOut::None,
+                default_card_data_input_mode: DataIn::KeyEnteredInput,
+                default_cardholder_present_detail: Present::CardholderNotPresentPhoneTransaction,
+            },
+            // ── MOTO MAIL ──────────────────────────────────────────────
+            Self::MotoMail => TerminalDataBlock {
+                card_data_source: Source::Mail,
+                terminal_operating_environment: Env::OnMerchantPremisesAttended,
+                terminal_output_capability: Out::DisplayOnly,
+                terminal_capability: Cap::KeyedEntryOnly,
+                terminal_authentication_capability: AuthCap::NoCapability,
+                max_pin_length: Pin::NotSupported,
+                terminal_card_capture_capability: CardCap::NoCapability,
+                cardholder_authentication_method: AuthMethod::NotAuthenticated,
+                cardholder_authentication_entity: AuthEnt::NotAuthenticated,
+                card_data_output_capability: DataOut::None,
+                default_card_data_input_mode: DataIn::KeyEnteredInput,
+                default_cardholder_present_detail: Present::CardholderNotPresentMailTransaction,
+            },
+            // ── E-COMMERCE INTERNET ────────────────────────────────────
+            Self::EcomInternet => TerminalDataBlock {
+                card_data_source: Source::Internet,
+                terminal_operating_environment: Env::NoTerminal,
+                terminal_output_capability: Out::None,
+                terminal_capability: Cap::KeyedEntryOnly,
+                terminal_authentication_capability: AuthCap::NoCapability,
+                max_pin_length: Pin::NotSupported,
+                terminal_card_capture_capability: CardCap::NoCapability,
+                cardholder_authentication_method: AuthMethod::NotAuthenticated,
+                cardholder_authentication_entity: AuthEnt::NotAuthenticated,
+                card_data_output_capability: DataOut::None,
+                default_card_data_input_mode: DataIn::PanEntryElectronicCommerceIncludingRemoteChip,
+                default_cardholder_present_detail: Present::CardholderNotPresentElectronicCommerce,
+            },
+            // ── RECURRING MIT ──────────────────────────────────────────
+            // Mastercard recurring uses NO_TERMINAL; others use
+            // OFF_MERCHANT_PREMISES_UNATTENDED. This base value matches
+            // the non-MC default; rules::terminal_data flips it back to
+            // NoTerminal for MC recurring.
+            Self::RecurringMit => TerminalDataBlock {
+                card_data_source: Source::Recurring,
+                terminal_operating_environment: Env::OffMerchantPremisesUnattended,
+                terminal_output_capability: Out::DisplayOnly,
+                terminal_capability: Cap::KeyedEntryOnly,
+                terminal_authentication_capability: AuthCap::NoCapability,
+                max_pin_length: Pin::NotSupported,
+                terminal_card_capture_capability: CardCap::NoCapability,
+                cardholder_authentication_method: AuthMethod::NotAuthenticated,
+                cardholder_authentication_entity: AuthEnt::NotAuthenticated,
+                card_data_output_capability: DataOut::None,
+                default_card_data_input_mode:
+                    DataIn::MerchantInitiatedTransactionCardCredentialStoredOnFile,
+                default_cardholder_present_detail:
+                    Present::CardholderNotPresentRecurringTransaction,
+            },
+            // ── INSTALLMENT MIT ────────────────────────────────────────
+            Self::InstallmentMit => TerminalDataBlock {
+                card_data_source: Source::Recurring,
+                terminal_operating_environment: Env::OffMerchantPremisesUnattended,
+                terminal_output_capability: Out::DisplayOnly,
+                terminal_capability: Cap::KeyedEntryOnly,
+                terminal_authentication_capability: AuthCap::NoCapability,
+                max_pin_length: Pin::NotSupported,
+                terminal_card_capture_capability: CardCap::NoCapability,
+                cardholder_authentication_method: AuthMethod::NotAuthenticated,
+                cardholder_authentication_entity: AuthEnt::NotAuthenticated,
+                card_data_output_capability: DataOut::None,
+                default_card_data_input_mode:
+                    DataIn::MerchantInitiatedTransactionCardCredentialStoredOnFile,
+                default_cardholder_present_detail:
+                    Present::CardholderNotPresentInstallmentTransaction,
+            },
+        }
+    }
+
+    /// True when this transaction was accepted via a MOTO channel
+    /// (phone or mail). Several cert rules key off this.
+    pub fn is_moto(self) -> bool {
+        matches!(self, Self::MotoPhone | Self::MotoMail)
+    }
+
+    /// True when this transaction is a recurring or installment MIT.
+    pub fn is_scheduled_mit(self) -> bool {
+        matches!(self, Self::RecurringMit | Self::InstallmentMit)
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
@@ -1,0 +1,66 @@
+//! Card-family axis of `TxProfile`.
+//!
+//! Collapses the verbose `Option<CardNetwork>` into the small set of
+//! families TSYS cert rules actually distinguish on. AMEX/JCB share a
+//! CVV-input quirk; Discover/JCB/Diners/UnionPay share recurring-tag
+//! treatment ("Discover-like").
+
+use common_enums::CardNetwork;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardFamily {
+    Visa,
+    Mastercard,
+    Amex,
+    Discover,
+    Jcb,
+    Diners,
+    UnionPay,
+    Unknown,
+}
+
+impl CardFamily {
+    pub fn from_network(network: Option<&CardNetwork>) -> Self {
+        match network {
+            Some(CardNetwork::Visa) => Self::Visa,
+            Some(CardNetwork::Mastercard) => Self::Mastercard,
+            Some(CardNetwork::AmericanExpress) => Self::Amex,
+            Some(CardNetwork::Discover) => Self::Discover,
+            Some(CardNetwork::JCB) => Self::Jcb,
+            Some(CardNetwork::DinersClub) => Self::Diners,
+            Some(CardNetwork::UnionPay) => Self::UnionPay,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// AMEX and JCB share the "MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB"
+    /// `cardDataInputMode` rule when a CVV is sent.
+    pub fn is_amex_or_jcb(self) -> bool {
+        matches!(self, Self::Amex | Self::Jcb)
+    }
+
+    /// Discover, JCB, Diners and UnionPay all flow through the same
+    /// recurring-tag and `registeredUserIndicator` branches.
+    pub fn is_discover_like(self) -> bool {
+        matches!(
+            self,
+            Self::Discover | Self::Jcb | Self::Diners | Self::UnionPay
+        )
+    }
+
+    pub fn is_visa(self) -> bool {
+        matches!(self, Self::Visa)
+    }
+
+    pub fn is_mastercard(self) -> bool {
+        matches!(self, Self::Mastercard)
+    }
+
+    pub fn is_amex(self) -> bool {
+        matches!(self, Self::Amex)
+    }
+
+    pub fn is_visa_or_mastercard(self) -> bool {
+        matches!(self, Self::Visa | Self::Mastercard)
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
@@ -69,10 +69,17 @@ impl CofPhase {
             });
 
         if has_mandate {
-            // off_session=true (or any MIT category set) ⇒ MIT.
-            // Otherwise consumer is present and just re-using the stored
-            // card (CitUsingStored — MOTO step-5 25.50 Visa COF case).
-            let is_mit = off_session == Some(true) || mit_category.is_some();
+            // A stored credential is being replayed. It is merchant-initiated
+            // ONLY when an explicit `mit_category` is set; otherwise the
+            // consumer is present and re-using the stored card
+            // (CitUsingStored — cert MOTO step-5 25.50 Visa / 29.75 MC COF).
+            //
+            // NOTE: `off_session` alone does NOT imply MIT here. Hyperswitch
+            // sets `off_session=true` for ANY stored-credential replay,
+            // including the consumer-present CIT-using-stored rows, so keying
+            // MIT off `off_session` misclassifies those CITs as MITs
+            // (M101/cardOnFileTransactionIdentifier instead of C101).
+            let is_mit = mit_category.is_some();
             if !is_mit {
                 return Self::CitUsingStored;
             }

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
@@ -1,0 +1,123 @@
+//! Stored-credential phase axis of `TxProfile`.
+//!
+//! Splits the COF lifecycle into the four shapes TSYS cert rules
+//! actually distinguish:
+//!   • `NoCof`           — single-shot transaction
+//!   • `CitSetup`        — first-time CIT that stores the card
+//!   • `CitUsingStored`  — CIT re-using a stored card (consumer is present
+//!                          but the card was already on file)
+//!   • `Mit(MitKind)`    — merchant-initiated transaction
+//!
+//! The `CitUsingStored` vs `Mit` distinction is critical for the cert:
+//! the MOTO step-5 "25.50 Visa COF" row is a CIT-using-stored, and TSYS
+//! rejects it if we send `cardOnFile` / `cardOnFileTransactionIdentifier`
+//! (those are MIT-only).
+
+use common_enums::{FutureUsage, MitCategory};
+use domain_types::connector_types::{MandateIds, MandateReferenceId};
+
+/// What kind of future MIT a CIT-setup is preparing for. Drives
+/// `citStatusIndicator` values (e.g. Mastercard C101 / C102 / C103 / C104).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MitIntent {
+    Unscheduled,
+    Recurring,
+    Installment,
+}
+
+/// The kind of MIT being run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MitKind {
+    Unscheduled,
+    Recurring,
+    Installment,
+    Resubmission,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CofPhase {
+    /// One-shot transaction with no stored-credential involvement.
+    NoCof,
+    /// CIT that stores the card on file for future MIT use.
+    CitSetup { intended_kind: MitIntent },
+    /// CIT that re-uses a card already on file.
+    CitUsingStored,
+    /// Merchant-initiated transaction.
+    Mit(MitKind),
+}
+
+impl CofPhase {
+    /// Derive from the four signals available on `PaymentsAuthorizeData`:
+    ///   • mandate present → MIT or CIT-using-stored
+    ///   • `off_session=true` → MIT (vs CIT)
+    ///   • `setup_future_usage=OffSession` (without mandate) → CIT-setup
+    ///   • `mit_category` → disambiguates MIT kind / CIT-setup intent
+    pub fn derive(
+        mandate_id: Option<&MandateIds>,
+        mit_category: Option<MitCategory>,
+        setup_future_usage: Option<FutureUsage>,
+        off_session: Option<bool>,
+    ) -> Self {
+        let has_mandate = mandate_id
+            .and_then(|m| m.mandate_reference_id.as_ref())
+            .is_some_and(|r| {
+                matches!(
+                    r,
+                    MandateReferenceId::ConnectorMandateId(_)
+                        | MandateReferenceId::NetworkMandateId(_)
+                )
+            });
+
+        if has_mandate {
+            // off_session=true (or any MIT category set) ⇒ MIT.
+            // Otherwise consumer is present and just re-using the stored
+            // card (CitUsingStored — MOTO step-5 25.50 Visa COF case).
+            let is_mit = off_session == Some(true) || mit_category.is_some();
+            if !is_mit {
+                return Self::CitUsingStored;
+            }
+            let kind = match mit_category {
+                Some(MitCategory::Recurring) => MitKind::Recurring,
+                Some(MitCategory::Installment) => MitKind::Installment,
+                Some(MitCategory::Resubmission) => MitKind::Resubmission,
+                Some(MitCategory::Unscheduled) | None => MitKind::Unscheduled,
+            };
+            return Self::Mit(kind);
+        }
+
+        let is_setup =
+            setup_future_usage == Some(FutureUsage::OffSession) || off_session == Some(true);
+        if is_setup {
+            let intended_kind = match mit_category {
+                Some(MitCategory::Recurring) => MitIntent::Recurring,
+                Some(MitCategory::Installment) => MitIntent::Installment,
+                _ => MitIntent::Unscheduled,
+            };
+            return Self::CitSetup { intended_kind };
+        }
+
+        Self::NoCof
+    }
+
+    pub fn is_no_cof(self) -> bool {
+        matches!(self, Self::NoCof)
+    }
+
+    pub fn is_cit_setup(self) -> bool {
+        matches!(self, Self::CitSetup { .. })
+    }
+
+    pub fn is_cit_using_stored(self) -> bool {
+        matches!(self, Self::CitUsingStored)
+    }
+
+    pub fn is_mit(self) -> bool {
+        matches!(self, Self::Mit(_))
+    }
+
+    /// True for any flow that has stored credentials in play (CitSetup,
+    /// CitUsingStored or any MIT). Useful for cardDataInputMode gating.
+    pub fn involves_stored_credential(self) -> bool {
+        !self.is_no_cof()
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/commercial.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/commercial.rs
@@ -1,0 +1,47 @@
+//! Commercial-card-level axis (L2 / L3) of `TxProfile`.
+//!
+//! Used by L2/L3 field-gating rules:
+//!   • AMEX never carries `purchaseOrder`
+//!   • `shipToZip` / `destinationCountryCode` are L3-only on Visa/Mastercard
+//!   • `customerRefID` / `supplierReferenceNumber` are AMEX-only
+//!
+//! See `rules::commercial` for the per-field decisions.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommercialLevel {
+    None,
+    L2,
+    L3,
+}
+
+impl CommercialLevel {
+    /// Decide commercial level from the L2/L3 inputs the merchant supplied.
+    ///
+    /// Level III is OUT OF SCOPE for this connector: any commercial signal
+    /// (line items, tax, shipping, duty) resolves to at most Level II. No
+    /// productDetails / vatInvoice / shipFromZip / enhanced tax is emitted.
+    pub fn derive(
+        has_order_details: bool,
+        has_tax_amount: bool,
+        has_shipping_charges: bool,
+        has_duty_charges: bool,
+    ) -> Self {
+        if !has_order_details && !has_tax_amount && !has_shipping_charges && !has_duty_charges {
+            Self::None
+        } else {
+            Self::L2
+        }
+    }
+
+    pub fn is_l2(self) -> bool {
+        matches!(self, Self::L2)
+    }
+
+    pub fn is_l3(self) -> bool {
+        matches!(self, Self::L3)
+    }
+
+    pub fn is_l2_or_l3(self) -> bool {
+        matches!(self, Self::L2 | Self::L3)
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
@@ -1,0 +1,216 @@
+//! `TxProfile` — the single bag of dimensions every TSYS wire field can
+//! ever depend on.
+//!
+//! Derived once at the top of a flow, then passed by reference to per-field
+//! "rule" functions in `rules/`. Lets the cert spec's
+//! `(profile-cell, field) -> value` table map 1:1 into Rust code instead
+//! of being re-derived inline at every field.
+//!
+//! Axes:
+//!   • `acceptance`       — channel + recurring classification
+//!   • `card_family`      — Visa / MC / AMEX / Discover-like
+//!   • `cof_phase`        — NoCof / CitSetup / CitUsingStored / Mit(kind)
+//!   • `commercial_level` — None / L2 / L3
+//!   • `three_ds`         — None / Present
+//!   • `capture`          — Auto / Manual
+
+pub mod acceptance;
+pub mod card_family;
+pub mod cof_phase;
+pub mod commercial;
+
+use std::fmt::Debug;
+
+use common_enums::{CaptureMethod, PaymentChannel};
+use domain_types::{
+    connector_flow::{Authorize, SetupMandate},
+    connector_types::{
+        PaymentFlowData, PaymentsAuthorizeData, PaymentsResponseData, SetupMandateRequestData,
+    },
+    payment_method_data::{PaymentMethodData, PaymentMethodDataTypes},
+    router_data_v2::RouterDataV2,
+};
+use hyperswitch_masking::PeekInterface;
+use serde::Serialize;
+
+pub use acceptance::{AcceptanceProfile, TerminalDataBlock};
+pub use card_family::CardFamily;
+pub use cof_phase::{CofPhase, MitIntent, MitKind};
+pub use commercial::CommercialLevel;
+
+use super::transformers::TsysTransitCardDataSource;
+
+/// Map the acceptance channel to the `cardDataSource` wire value. This is an
+/// axis ORTHOGONAL to the recurring/terminal semantics: a recurring MOTO
+/// card-on-file transaction keeps its PHONE/MAIL channel here while still
+/// emitting the recurring indicators elsewhere. `cardDataSource=RECURRING`
+/// is never emitted (TSYS rejects it on MOTO).
+pub fn channel_card_data_source(channel: Option<PaymentChannel>) -> TsysTransitCardDataSource {
+    match channel {
+        Some(PaymentChannel::TelephoneOrder) => TsysTransitCardDataSource::Phone,
+        Some(PaymentChannel::MailOrder) => TsysTransitCardDataSource::Mail,
+        Some(PaymentChannel::Ecommerce) | None => TsysTransitCardDataSource::Internet,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureKind {
+    Auto,
+    Manual,
+}
+
+impl CaptureKind {
+    pub fn from_method(method: Option<CaptureMethod>) -> Self {
+        match method {
+            Some(CaptureMethod::Manual) | Some(CaptureMethod::ManualMultiple) => Self::Manual,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn is_manual(self) -> bool {
+        matches!(self, Self::Manual)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreeDsKind {
+    None,
+    /// 3DS data present on the request (cavv / eci / etc.). Detailed values
+    /// live on `RawInputs`; profile only tracks presence so rules can
+    /// branch on "is this a 3DS-authenticated tx".
+    Present,
+}
+
+#[derive(Debug, Clone)]
+pub struct TxProfile {
+    pub acceptance: AcceptanceProfile,
+    pub card_family: CardFamily,
+    pub cof_phase: CofPhase,
+    pub commercial_level: CommercialLevel,
+    pub three_ds: ThreeDsKind,
+    pub capture: CaptureKind,
+    /// `cardDataSource` derived purely from the acceptance channel
+    /// (PHONE/MAIL/INTERNET) — independent of recurring classification.
+    pub channel_source: TsysTransitCardDataSource,
+}
+
+impl TxProfile {
+    /// Derive every profile axis for an `Authorize` flow. The single place
+    /// that decides which acceptance profile a transaction lives in.
+    /// Per-field rule functions take this output and never re-derive these
+    /// values.
+    pub fn derive_for_authorize<T>(
+        router_data: &RouterDataV2<
+            Authorize,
+            PaymentFlowData,
+            PaymentsAuthorizeData<T>,
+            PaymentsResponseData,
+        >,
+    ) -> Self
+    where
+        T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
+    {
+        let request = &router_data.request;
+        let card_network = match &request.payment_method_data {
+            PaymentMethodData::Card(card) => card.card_network.clone(),
+            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => nti.card_network.clone(),
+            _ => None,
+        };
+        let acceptance = AcceptanceProfile::derive(
+            request.payment_channel.clone(),
+            request.mit_category.clone(),
+        );
+        let card_family = CardFamily::from_network(card_network.as_ref());
+        let cof_phase = CofPhase::derive(
+            request.mandate_id.as_ref(),
+            request.mit_category.clone(),
+            request.setup_future_usage,
+            request.off_session,
+        );
+
+        // Commercial level — look at the same signals the original
+        // `compute_commercial_card_context` used: L2L3 line items / tax /
+        // shipping / duty either on the request or in resource_common_data.
+        let l2_l3 = router_data.resource_common_data.l2_l3_data.as_deref();
+        let has_order_details = l2_l3
+            .and_then(|d| d.get_order_details())
+            .map(|details| !details.is_empty())
+            .unwrap_or_else(|| {
+                router_data
+                    .resource_common_data
+                    .order_details
+                    .as_ref()
+                    .is_some_and(|d| !d.is_empty())
+            });
+        let has_tax_amount = l2_l3.and_then(|d| d.get_order_tax_amount()).is_some()
+            || request.order_tax_amount.is_some();
+        let has_shipping_charges =
+            l2_l3.and_then(|d| d.get_shipping_cost()).is_some() || request.shipping_cost.is_some();
+        let has_duty_charges = l2_l3.and_then(|d| d.get_duty_amount()).is_some();
+        let commercial_level = CommercialLevel::derive(
+            has_order_details,
+            has_tax_amount,
+            has_shipping_charges,
+            has_duty_charges,
+        );
+
+        let three_ds = match request
+            .authentication_data
+            .as_ref()
+            .and_then(|d| d.cavv.as_ref())
+        {
+            Some(cavv) if !cavv.peek().is_empty() => ThreeDsKind::Present,
+            _ => ThreeDsKind::None,
+        };
+        let capture = CaptureKind::from_method(request.capture_method);
+        let channel_source = channel_card_data_source(request.payment_channel.clone());
+
+        Self {
+            acceptance,
+            card_family,
+            cof_phase,
+            commercial_level,
+            three_ds,
+            capture,
+            channel_source,
+        }
+    }
+
+    /// Derive profile axes for a `SetupMandate` / CardAuthentication flow.
+    /// Card auth has no commercial level or 3DS; capture is always Auto
+    /// (the auth is a self-contained 0.00 / nominal probe).
+    pub fn derive_for_card_authentication<T>(
+        router_data: &RouterDataV2<
+            SetupMandate,
+            PaymentFlowData,
+            SetupMandateRequestData<T>,
+            PaymentsResponseData,
+        >,
+    ) -> Self
+    where
+        T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
+    {
+        let request = &router_data.request;
+        let card_network = match &request.payment_method_data {
+            PaymentMethodData::Card(card) => card.card_network.clone(),
+            _ => None,
+        };
+        let acceptance = AcceptanceProfile::derive(request.payment_channel.clone(), None);
+        let card_family = CardFamily::from_network(card_network.as_ref());
+        let cof_phase = CofPhase::derive(
+            request.mandate_id.as_ref(),
+            None,
+            request.setup_future_usage,
+            request.off_session,
+        );
+        Self {
+            acceptance,
+            card_family,
+            cof_phase,
+            commercial_level: CommercialLevel::None,
+            three_ds: ThreeDsKind::None,
+            capture: CaptureKind::Auto,
+            channel_source: channel_card_data_source(request.payment_channel.clone()),
+        }
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
@@ -45,8 +45,10 @@ pub fn card_data_input_mode(
         return KeyEnteredInput;
     }
 
-    // 3. MIT (any kind).
-    if profile.cof_phase.is_mit() {
+    // 3. MIT (any kind) OR CIT-using-stored — both replay a stored
+    //    credential, so both carry the STORED_ON_FILE input mode (cert MOTO
+    //    25.50 Visa / 29.75 MC CIT-using-stored rows use this too).
+    if profile.cof_phase.is_mit() || profile.cof_phase.is_cit_using_stored() {
         return MerchantInitiatedTransactionCardCredentialStoredOnFile;
     }
 

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
@@ -1,0 +1,55 @@
+//! Rule: `cardDataInputMode`.
+//!
+//! Layered overrides on top of the acceptance-profile default. Order
+//! matters — the cert csv documents these as hard precedence rules:
+//!
+//!   1. **AMEX with CVV** ⇒ `MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB`
+//!      Cert pushback rows:
+//!      "cardDataInputMode tag must be set to
+//!      'MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB' on the 1.50 AMEX
+//!      level II transaction in step 2 as the cvv was sent." (and similar
+//!      for 4.00 AMEX, 14.50 AMEX).
+//!      NOTE: JCB is NOT included — the TSYS_MOTO_V3 reference (row 135,
+//!      JCB 13.00 with cvv2) uses `KEY_ENTERED_INPUT`, so JCB falls through
+//!      to the channel default below.
+//!
+//!   2. **CIT-setup that stores credentials** ⇒ `KEY_ENTERED_INPUT`
+//!      Cert pushback row:
+//!      "cardDataInputMode tag must be set to 'KEY_ENTERED_INPUT' on the
+//!      0.00 Visa card authentication in step 5 as this transaction will
+//!      be used to store credentials for payment" (and the 2.00 Mastercard
+//!      step-5 row).
+//!
+//!   3. **MIT** ⇒ `MERCHANT_INITIATED_TRANSACTION_CARD_CREDENTIAL_STORED_ON_FILE`
+//!
+//!   4. Otherwise the channel default from `TerminalDataBlock`.
+
+use super::super::profile::{TerminalDataBlock, TxProfile};
+use super::super::transformers::TsysTransitCardDataInputMode;
+
+pub fn card_data_input_mode(
+    profile: &TxProfile,
+    terminal_data: &TerminalDataBlock,
+    cvv_present: bool,
+) -> TsysTransitCardDataInputMode {
+    use TsysTransitCardDataInputMode::*;
+
+    // 1. AMEX+CVV wins over everything (including CIT-setup / MIT). JCB is
+    //    excluded per TSYS_MOTO_V3 (JCB uses the channel default).
+    if cvv_present && profile.card_family.is_amex() {
+        return ManuallyEnteredWithKeyedCidAmexJcb;
+    }
+
+    // 2. CIT-setup that stores credentials.
+    if profile.cof_phase.is_cit_setup() {
+        return KeyEnteredInput;
+    }
+
+    // 3. MIT (any kind).
+    if profile.cof_phase.is_mit() {
+        return MerchantInitiatedTransactionCardCredentialStoredOnFile;
+    }
+
+    // 4. Acceptance-profile default.
+    terminal_data.default_card_data_input_mode.clone()
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cardholder.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cardholder.rs
@@ -1,0 +1,25 @@
+//! Rule: `cardholderPresentDetail`.
+//!
+//! Always derived from the acceptance profile + cof_phase. The cert
+//! csv pushback on this field is:
+//!   • "cardholderPresentDetail tag must be set to
+//!     'CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION' on the 2.00 Mastercard
+//!     transaction in step 5." → Phone for MOTO regardless of COF state.
+//!   • Various rows on step 5 MC / Visa / Discover / AMEX COF transactions
+//!     all map to Phone or Mail (channel-driven), never to
+//!     RecurringTransaction unless the merchant explicitly asked for
+//!     `MitCategory::Recurring`/`Installment`.
+//!
+//! The acceptance profile already encodes this: MotoPhone⇒Phone,
+//! MotoMail⇒Mail, RecurringMit⇒Recurring, InstallmentMit⇒Installment.
+//! No card_family / cof_phase override is needed.
+
+use super::super::profile::{TerminalDataBlock, TxProfile};
+use super::super::transformers::TsysTransitCardholderPresentDetail;
+
+pub fn cardholder_present_detail(
+    _profile: &TxProfile,
+    terminal_data: &TerminalDataBlock,
+) -> TsysTransitCardholderPresentDetail {
+    terminal_data.default_cardholder_present_detail.clone()
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
@@ -1,0 +1,128 @@
+//! Rules: stored-credential / MIT signaling.
+//!
+//!   • `cardOnFile` — Visa-only "Y" marker. Sent on CIT-setup (storing a
+//!     credential for future use) and any MIT. Cert csv:
+//!       "cardOnFile tag must not be sent on the 2.00 Mastercard
+//!        transaction in step 5 as on Direct Marketing this is a Visa
+//!        Merchant Initiated Transaction (MIT) only tag."
+//!       "cardOnFile tag must not be sent on the 25.50 Visa card on file
+//!        transaction in step 5 as this tag is a Merchant initiated
+//!        transaction (MIT) only and this test case is a Consumer
+//!        initiated transaction (CIT)."
+//!       "cardOnFile tag must be sent on 0.00 Visa card authentication to
+//!        store credentials for future payments in step 5."
+//!
+//!   • `cardOnFileTransactionIdentifier` — MIT only. Cert csv:
+//!       "cardOnFileTransactionIdentifier tag must not be sent on the
+//!        25.50 Visa card on file transaction in step 5 as this tag is
+//!        a Merchant initiated transaction (MIT) only..."
+//!
+//!   • `citStatusIndicator` — Mastercard:
+//!       - CIT-setup unscheduled  → C101
+//!       - CIT-setup recurring    → C102
+//!       - CIT-setup subscription → C103
+//!       - CIT-setup installment  → C104
+//!       - CIT-using-stored       → C101 (the consumer is re-using a stored
+//!         card for an unscheduled purchase). MIT does not send this.
+//!
+//!   • `mitStatusIndicator` — Discover-family + Mastercard unscheduled.
+//!     Suppressed on CIT-using-stored ("mitStatusIndicator tag must not
+//!     be sent on the 29.75 Mastercard transaction in step 5 as this test
+//!     case is a Card on File CIT and not MIT").
+//!
+//!   • `mit` block (with `mit_indicator`) — used by Visa for the
+//!     stored-vault flow.
+
+use super::super::profile::{CardFamily, CofPhase, MitIntent, MitKind, TxProfile};
+use super::super::transformers::{
+    TsysTransitCardOnFile, TsysTransitMcCitStatusIndicator, TsysTransitMit, TsysTransitMitIndicator,
+};
+
+/// `cardOnFile` — Visa-only "Y" marker, sent for any stored-credential
+/// flow EXCEPT CIT-using-stored (where it's a MIT-only tag).
+pub fn card_on_file(profile: &TxProfile) -> Option<TsysTransitCardOnFile> {
+    if !matches!(profile.card_family, CardFamily::Visa) {
+        return None;
+    }
+    match profile.cof_phase {
+        CofPhase::CitSetup { .. } | CofPhase::Mit(_) => Some(TsysTransitCardOnFile::Y),
+        CofPhase::NoCof | CofPhase::CitUsingStored => None,
+    }
+}
+
+/// `citStatusIndicator`.
+pub fn cit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMcCitStatusIndicator> {
+    use TsysTransitMcCitStatusIndicator::*;
+    if !matches!(profile.card_family, CardFamily::Mastercard) {
+        return None;
+    }
+    match profile.cof_phase {
+        CofPhase::CitSetup { intended_kind } => Some(match intended_kind {
+            MitIntent::Unscheduled => C101,
+            MitIntent::Recurring => C102,
+            MitIntent::Installment => C104,
+        }),
+        CofPhase::CitUsingStored => Some(C101),
+        CofPhase::NoCof | CofPhase::Mit(_) => None,
+    }
+}
+
+/// `mitStatusIndicator`.
+pub fn mit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMitIndicator> {
+    use TsysTransitMitIndicator::*;
+    // CIT-using-stored never sends MIT status (use citStatusIndicator).
+    if matches!(profile.cof_phase, CofPhase::CitUsingStored) {
+        return None;
+    }
+    let CofPhase::Mit(kind) = profile.cof_phase else {
+        return None;
+    };
+    match (profile.card_family, kind) {
+        // Mastercard
+        (CardFamily::Mastercard, MitKind::Unscheduled | MitKind::Resubmission) => Some(M101),
+        (CardFamily::Mastercard, MitKind::Recurring) => Some(M102),
+        (CardFamily::Mastercard, MitKind::Installment) => Some(M104),
+        // Discover family unscheduled / resubmission
+        (
+            CardFamily::Discover | CardFamily::Jcb | CardFamily::Diners | CardFamily::UnionPay,
+            MitKind::Unscheduled | MitKind::Resubmission,
+        ) => Some(U),
+        // Discover-family recurring → R, installment → S/T
+        (
+            CardFamily::Discover | CardFamily::Jcb | CardFamily::Diners | CardFamily::UnionPay,
+            MitKind::Recurring,
+        ) => Some(R),
+        (
+            CardFamily::Discover | CardFamily::Jcb | CardFamily::Diners | CardFamily::UnionPay,
+            MitKind::Installment,
+        ) => Some(S),
+        _ => None,
+    }
+}
+
+/// Whether to send the `cardOnFileTransactionIdentifier` tag at all.
+///
+/// MIT only (suppressed on CIT-using-stored / CIT-setup) AND **Visa only**.
+/// The tag carries a network transaction identifier — a Visa concept.
+/// Source of truth TSYS_MOTO_V2 step 5: only the Visa MIT (row 164) sends it
+/// (`000000000640845`); Mastercard (163) uses `mitStatusIndicator=M101`,
+/// Discover (165) uses `mitStatusIndicator=U`, and AMEX (166) omits it.
+pub fn should_send_card_on_file_transaction_identifier(profile: &TxProfile) -> bool {
+    profile.cof_phase.is_mit() && matches!(profile.card_family, CardFamily::Visa)
+}
+
+/// The `mit` block — sent for vault-stored mandates to indicate the MIT
+/// kind (`R`, `S`, `T`, etc.). For NTID-mandates the `cardOnFileTransactionIdentifier`
+/// carries the network transaction ID instead.
+pub fn mit_block_indicator(profile: &TxProfile) -> Option<TsysTransitMit> {
+    // Only sent on vault MIT (not NTID, not CIT-anything).
+    // For now we mirror the original `build_card_on_file_context` logic:
+    // vault + non-recurring MIT got `R`. Recurring/installment values come
+    // through `mit_status_indicator` on the body instead.
+    if !profile.cof_phase.is_mit() {
+        return None;
+    }
+    Some(TsysTransitMit {
+        mit_indicator: TsysTransitMitIndicator::R,
+    })
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/commercial.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/commercial.rs
@@ -1,0 +1,114 @@
+//! Rules: L2 / L3 commercial-card field gating.
+//!
+//! Each function takes the profile (used for `card_family` /
+//! `commercial_level`) and the raw value the merchant supplied. The
+//! function decides whether the field should land on the wire.
+//!
+//! Cert csv pushback rows this module addresses:
+//!   • "purchaseOrder tag should not be sent on the 1.50 AMEX level II
+//!      transaction in step 2 as this is a Visa and Mastercard only tag."
+//!      → `purchase_order` returns None on AMEX.
+//!   • "customerRefID tag must not be sent on the .52 Mastercard
+//!      transaction in step 2 as this is an AMEX only tag."
+//!   • "supplierReferenceNumber tag must not be sent on the .52 Mastercard
+//!      transaction in step 2 as this is an AMEX only tag."
+//!      → `customer_ref_id` / `supplier_reference_number` AMEX-only.
+//!   • "shipToZip tag should not be sent on the .52 Mastercard transaction
+//!      in step 2 as this is a Level III tag and we are only testing
+//!      Level II on this test case."
+//!   • "destinationCountryCode tag should not be sent on the .52
+//!      Mastercard transaction in step 2 as this is a Level III tag..."
+//!      → `ship_to_zip` / `destination_country_code` L3-only on V/MC.
+//!   • "shipToZip tag must not be sent on the 1.50 AMEX level II
+//!      transaction in step 1 as this is a Visa and Mastercard level III
+//!      only tag." (reinforces V/MC-only L3 gating)
+
+use super::super::profile::{CardFamily, CommercialLevel, TxProfile};
+
+/// `purchaseOrder` — Visa / Mastercard only. Strip on AMEX.
+pub fn purchase_order(profile: &TxProfile, raw: Option<String>) -> Option<String> {
+    if profile.card_family.is_amex() {
+        return None;
+    }
+    raw
+}
+
+/// `customerRefID` — AMEX only.
+pub fn customer_ref_id(profile: &TxProfile, raw: Option<String>) -> Option<String> {
+    if profile.card_family.is_amex() {
+        raw
+    } else {
+        None
+    }
+}
+
+/// `supplierReferenceNumber` — AMEX only.
+pub fn supplier_reference_number(profile: &TxProfile, raw: Option<String>) -> Option<String> {
+    if profile.card_family.is_amex() {
+        raw
+    } else {
+        None
+    }
+}
+
+/// `shipToZip` — AMEX (any commercial L2/L3) OR Visa/MC Level III.
+/// Source of truth: TSYS_MOTO_V3 row 127 (AMEX Level II) carries
+/// `<shipToZip>85284</shipToZip>` (V3 primary); TSYS_MOTO_V2 shows Mastercard
+/// L2 (row 126) does NOT carry it. So on L2 it is AMEX-only; Visa/MC only send
+/// it at L3. (`destinationCountryCode` stays L3-only.)
+pub fn ship_to_zip(profile: &TxProfile, raw: Option<String>) -> Option<String> {
+    let amex_commercial = profile.card_family.is_amex() && profile.commercial_level.is_l2_or_l3();
+    let vmc_l3 = profile.commercial_level.is_l3() && profile.card_family.is_visa_or_mastercard();
+    if amex_commercial || vmc_l3 {
+        raw
+    } else {
+        None
+    }
+}
+
+/// `destinationCountryCode` — Visa / Mastercard L3 only.
+pub fn destination_country_code(profile: &TxProfile, raw: Option<String>) -> Option<String> {
+    if profile.commercial_level.is_l3() && profile.card_family.is_visa_or_mastercard() {
+        raw
+    } else {
+        None
+    }
+}
+
+/// `commercialCardLevel` — sent only when L2 or L3.
+pub fn commercial_card_level(
+    profile: &TxProfile,
+) -> Option<super::super::transformers::TsysTransitCommercialCardLevel> {
+    use super::super::transformers::TsysTransitCommercialCardLevel as L;
+    match profile.commercial_level {
+        CommercialLevel::None => None,
+        CommercialLevel::L2 => Some(L::Level2),
+        CommercialLevel::L3 => Some(L::Level3),
+    }
+}
+
+/// True when `purchaseOrder` is a required field for this profile.
+/// Used by the assembler to convert "missing" into a hard error.
+pub fn purchase_order_required(profile: &TxProfile) -> bool {
+    profile.commercial_level.is_l2_or_l3() && profile.card_family.is_visa_or_mastercard()
+}
+
+/// True when `salesTax` is required (any L2 or L3 transaction).
+pub fn sales_tax_required(profile: &TxProfile) -> bool {
+    profile.commercial_level.is_l2_or_l3()
+}
+
+/// True when the AMEX-L2-required quartet (supplierReferenceNumber,
+/// customerRefID, chargeDescriptor) is required. shipToZip is NOT in
+/// the required set because the cert explicitly excludes it from AMEX L2.
+pub fn amex_l2_extras_required(profile: &TxProfile) -> bool {
+    matches!(profile.card_family, CardFamily::Amex)
+        && matches!(profile.commercial_level, CommercialLevel::L2)
+}
+
+/// True when L3 Visa/MC required fields are required (purchaseOrder,
+/// orderDate, summaryCommodityCode, vatInvoice, shipFromZip, shipToZip,
+/// destinationCountryCode).
+pub fn l3_visa_mc_required(profile: &TxProfile) -> bool {
+    profile.commercial_level.is_l3() && profile.card_family.is_visa_or_mastercard()
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/mod.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/mod.rs
@@ -1,0 +1,19 @@
+//! Per-wire-field rule functions.
+//!
+//! Each function takes a `&TxProfile` (and the raw merchant-supplied value
+//! where relevant) and returns the value that should land on the wire — or
+//! `None` when the profile says "do not send this tag".
+//!
+//! The TSYS cert CSV
+//! (`TSYS certification issues - MOTO.csv`) maps 1:1 into rule edits.
+//! Each rule's doc-comment cites the cert row it satisfies.
+
+pub mod card_input_mode;
+pub mod cardholder;
+pub mod cof_mit;
+pub mod commercial;
+pub mod network_indicators;
+pub mod terminal_data;
+
+#[cfg(test)]
+mod tests;

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/network_indicators.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/network_indicators.rs
@@ -1,0 +1,92 @@
+//! Rules: network-driven indicator fields.
+//!
+//!   • `authorizationIndicator` — Mastercard + AMEX always; capture method
+//!      decides PREAUTH vs FINAL.  Cert pushback rows on MOTO step 2 and
+//!      step 3 ("authorizationIndicator tag is missing on all Mastercard
+//!      transactions in steps 2 and 3") motivate sending this on card
+//!      authentications too.
+//!
+//!   • `registeredUserIndicator` / `lastRegisteredChangeDate` — e-commerce
+//!      only, Discover-family only.  Cert rows from MOTO csv (paraphrased):
+//!      "registeredUserIndicator and lastRegisteredChangeDate tags must
+//!      not be sent on the 12.00 Discover transaction in step 2 as these
+//!      tags are e-Commerce only." → strip for any MOTO transaction.
+//!
+//!   • `partialAuthSupport` — deprecated.  Cert row:
+//!      "partialAuthSupport tag is a deprecated tag and should not be sent."
+//!      → always None.
+
+use super::super::profile::{CaptureKind, CardFamily, CofPhase, TxProfile};
+use super::super::transformers::{
+    TsysTransitAuthorizationIndicator, TsysTransitRegisteredUserIndicator,
+};
+
+/// `authorizationIndicator` for the Sale/Auth flow.
+///
+/// Mastercard AND AMEX: always send (PREAUTH on manual capture, else FINAL).
+/// Source of truth TSYS_MOTO_V2: every Mastercard row carries FINAL — plain
+/// sales (126/128/133) as well as COF/CIT/MIT (160/162/163); AMEX rows
+/// (127/130/139/166) too. Suppressed only on the Mastercard scheduled-MIT +
+/// manual-capture combo (which TSYS rejects). Other networks: don't send.
+pub fn authorization_indicator(profile: &TxProfile) -> Option<TsysTransitAuthorizationIndicator> {
+    use TsysTransitAuthorizationIndicator::*;
+    let preauth_or_final = if profile.capture.is_manual() {
+        Preauth
+    } else {
+        Final
+    };
+    match profile.card_family {
+        CardFamily::Mastercard => {
+            let recurring_manual = profile.acceptance.is_scheduled_mit()
+                && matches!(profile.capture, CaptureKind::Manual);
+            (!recurring_manual).then_some(preauth_or_final)
+        }
+        CardFamily::Amex => Some(preauth_or_final),
+        _ => None,
+    }
+}
+
+/// `authorizationIndicator` for the CardAuthentication flow.
+///
+/// Always `None`: the TSYS stagegw CardAuthentication XSD does not permit an
+/// `authorizationIndicator` element at all (sending it yields F9901 "Invalid
+/// content … element 'authorizationIndicator'"). Verified live against
+/// stagegw — Mastercard card-auth (cert MOTO row 144) is rejected when the tag
+/// is present, while Visa/AMEX pass precisely because the tag is omitted. This
+/// supersedes the earlier cert-CSV note that asked for the tag on Mastercard
+/// card-auth; the gateway schema is authoritative for acceptance.
+pub fn authorization_indicator_for_card_auth(
+    _profile: &TxProfile,
+) -> Option<TsysTransitAuthorizationIndicator> {
+    None
+}
+
+/// `registeredUserIndicator` + `lastRegisteredChangeDate` pair.
+///
+/// E-com only, Discover-family only, single-shot only (no MIT / CIT-setup
+/// / CIT-using-stored). Cert csv strips these for MOTO, recurring and
+/// any COF-related step-5 transaction.
+pub fn registered_user(
+    profile: &TxProfile,
+) -> Option<(TsysTransitRegisteredUserIndicator, String)> {
+    if !matches!(
+        profile.acceptance,
+        super::super::profile::AcceptanceProfile::EcomInternet
+    ) {
+        return None;
+    }
+    if !matches!(profile.cof_phase, CofPhase::NoCof) {
+        return None;
+    }
+    profile
+        .card_family
+        .is_discover_like()
+        .then(|| (TsysTransitRegisteredUserIndicator::No, "00/00/0000".into()))
+}
+
+/// `partialAuthSupport`.
+///
+/// Cert csv: deprecated tag, never send.
+pub fn partial_auth_support(_profile: &TxProfile) -> Option<String> {
+    None
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/terminal_data.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/terminal_data.rs
@@ -1,0 +1,99 @@
+//! Rule: `terminalData` block selection.
+//!
+//! Starts from `AcceptanceProfile::terminal_data` and applies network-
+//! specific overrides that depend on `CardFamily`:
+//!
+//!   • Mastercard recurring uses `NO_TERMINAL` (per the v6.2 script's
+//!     recurring tab "see top requirement section" callout). The base
+//!     recurring block uses `OFF_MERCHANT_PREMISES_UNATTENDED` (the
+//!     non-MC default); this rule swaps it for MC.
+
+use super::super::profile::{AcceptanceProfile, CardFamily, TerminalDataBlock, TxProfile};
+use super::super::transformers::{
+    TsysTransitCardDataInputMode, TsysTransitCardDataOutputCapability, TsysTransitCardDataSource,
+    TsysTransitCardPresentDetail, TsysTransitCardholderAuthenticationEntity,
+    TsysTransitCardholderAuthenticationMethod, TsysTransitCardholderPresentDetail,
+    TsysTransitMaxPinLength, TsysTransitTerminalAuthenticationCapability,
+    TsysTransitTerminalCapability, TsysTransitTerminalCardCaptureCapability,
+    TsysTransitTerminalOperatingEnvironment, TsysTransitTerminalOutputCapability,
+};
+
+/// Resolve the final `TerminalDataBlock` for this profile, applying any
+/// card-family overrides on top of the acceptance-profile defaults.
+pub fn terminal_data(profile: &TxProfile) -> TerminalDataBlock {
+    let mut block = profile.acceptance.terminal_data();
+
+    if matches!(profile.acceptance, AcceptanceProfile::RecurringMit)
+        && matches!(profile.card_family, CardFamily::Mastercard)
+    {
+        block.terminal_operating_environment = TsysTransitTerminalOperatingEnvironment::NoTerminal;
+    }
+
+    block
+}
+
+/// The fully-resolved `terminalData` field set: the profile's
+/// `TerminalDataBlock` defaults with any merchant-supplied
+/// `terminal_overrides` merged on top (overrides win).
+pub struct ResolvedTerminalData {
+    pub card_data_source: TsysTransitCardDataSource,
+    pub terminal_capability: TsysTransitTerminalCapability,
+    pub terminal_operating_environment: TsysTransitTerminalOperatingEnvironment,
+    pub cardholder_authentication_method: TsysTransitCardholderAuthenticationMethod,
+    pub terminal_authentication_capability: TsysTransitTerminalAuthenticationCapability,
+    pub terminal_output_capability: TsysTransitTerminalOutputCapability,
+    pub max_pin_length: TsysTransitMaxPinLength,
+    pub terminal_card_capture_capability: TsysTransitTerminalCardCaptureCapability,
+    pub cardholder_present_detail: TsysTransitCardholderPresentDetail,
+    pub card_present_detail: TsysTransitCardPresentDetail,
+    pub card_data_input_mode: TsysTransitCardDataInputMode,
+    pub cardholder_authentication_entity: TsysTransitCardholderAuthenticationEntity,
+    pub card_data_output_capability: TsysTransitCardDataOutputCapability,
+}
+
+/// Merge merchant `terminal_overrides` on top of the profile's
+/// `terminal_data` (TerminalDataBlock). Shared verbatim by the Authorize
+/// and CardAuthentication request builders so the override-precedence and
+/// rule fallbacks stay identical across both.
+pub fn resolve(
+    profile: &TxProfile,
+    terminal_data: &TerminalDataBlock,
+    cvv_present: bool,
+) -> ResolvedTerminalData {
+    // cardDataSource follows the acceptance CHANNEL, not the recurring
+    // classification: a recurring MOTO card-on-file txn keeps PHONE/MAIL.
+    // TSYS rejects `cardDataSource=RECURRING` on MOTO, so recurring/
+    // installment profiles use the channel-derived value. Moto/Ecom blocks
+    // already carry the correct channel value.
+    let card_data_source = match profile.acceptance {
+        AcceptanceProfile::RecurringMit | AcceptanceProfile::InstallmentMit => {
+            profile.channel_source
+        }
+        _ => terminal_data.card_data_source,
+    };
+
+    ResolvedTerminalData {
+        card_data_source,
+        terminal_capability: terminal_data.terminal_capability.clone(),
+        terminal_operating_environment: terminal_data.terminal_operating_environment.clone(),
+        cardholder_authentication_method: terminal_data.cardholder_authentication_method.clone(),
+        terminal_authentication_capability: terminal_data
+            .terminal_authentication_capability
+            .clone(),
+        terminal_output_capability: terminal_data.terminal_output_capability.clone(),
+        max_pin_length: terminal_data.max_pin_length.clone(),
+        terminal_card_capture_capability: terminal_data.terminal_card_capture_capability.clone(),
+        cardholder_present_detail: super::cardholder::cardholder_present_detail(
+            profile,
+            terminal_data,
+        ),
+        card_present_detail: TsysTransitCardPresentDetail::CardNotPresent,
+        card_data_input_mode: super::card_input_mode::card_data_input_mode(
+            profile,
+            terminal_data,
+            cvv_present,
+        ),
+        cardholder_authentication_entity: terminal_data.cardholder_authentication_entity.clone(),
+        card_data_output_capability: terminal_data.card_data_output_capability.clone(),
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -311,6 +311,61 @@ fn mit_uses_stored_on_file_marker() {
 }
 
 #[test]
+fn cit_using_stored_uses_stored_on_file_marker() {
+    // TSYS_MOTO_V2 rows 161/162 (25.50 Visa / 29.75 MC CIT-using-stored) carry
+    // the STORED_ON_FILE input mode, same as an MIT.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::CitUsingStored,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, false),
+        TsysTransitCardDataInputMode::MerchantInitiatedTransactionCardCredentialStoredOnFile
+    ));
+}
+
+#[test]
+fn derive_stored_replay_off_session_without_mit_category_is_cit_using_stored() {
+    // Hyperswitch sends off_session=true for EVERY stored-credential replay,
+    // including consumer-present CIT-using-stored (cert MOTO 25.50 Visa /
+    // 29.75 MC). Without an explicit mit_category it must resolve to
+    // CIT-using-stored (→ C101, no NTID), NOT an MIT (M101).
+    let mandate = domain_types::connector_types::MandateIds {
+        mandate_id: None,
+        mandate_reference_id: Some(
+            domain_types::connector_types::MandateReferenceId::NetworkMandateId("VTL1".into()),
+        ),
+    };
+    assert_eq!(
+        CofPhase::derive(Some(&mandate), None, None, Some(true)),
+        CofPhase::CitUsingStored
+    );
+}
+
+#[test]
+fn derive_stored_replay_with_mit_category_is_mit() {
+    let mandate = domain_types::connector_types::MandateIds {
+        mandate_id: None,
+        mandate_reference_id: Some(
+            domain_types::connector_types::MandateReferenceId::NetworkMandateId("VTL1".into()),
+        ),
+    };
+    assert_eq!(
+        CofPhase::derive(
+            Some(&mandate),
+            Some(common_enums::MitCategory::Unscheduled),
+            None,
+            Some(true),
+        ),
+        CofPhase::Mit(MitKind::Unscheduled)
+    );
+}
+
+#[test]
 fn moto_phone_no_cof_no_cvv_uses_key_entered_input() {
     let p = profile(
         AcceptanceProfile::MotoPhone,

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -1,0 +1,1047 @@
+//! Cert-row conformance tests for the rules layer.
+//!
+//! Each test name documents the TSYS MOTO csv pushback row it satisfies.
+//! New cert rows → new tests; failing → rule is wrong; missing test → cert
+//! row not yet encoded.
+
+use super::super::profile::{
+    AcceptanceProfile, CaptureKind, CardFamily, CofPhase, CommercialLevel, MitIntent, MitKind,
+    ThreeDsKind, TxProfile,
+};
+use super::super::transformers::{
+    TsysTransitCardDataInputMode, TsysTransitCardDataSource, TsysTransitCardOnFile,
+    TsysTransitCardholderPresentDetail, TsysTransitMcCitStatusIndicator, TsysTransitMitIndicator,
+    TsysTransitRegisteredUserIndicator, TsysTransitTerminalOperatingEnvironment,
+    TsysTransitTerminalOutputCapability,
+};
+use super::{card_input_mode, cof_mit, commercial, network_indicators, terminal_data};
+
+fn profile(
+    acceptance: AcceptanceProfile,
+    card_family: CardFamily,
+    cof_phase: CofPhase,
+    commercial_level: CommercialLevel,
+    capture: CaptureKind,
+) -> TxProfile {
+    // Channel source defaults from the acceptance profile; recurring/
+    // installment default to a MOTO phone channel for test purposes.
+    let channel_source = match acceptance {
+        AcceptanceProfile::MotoMail => TsysTransitCardDataSource::Mail,
+        AcceptanceProfile::EcomInternet => TsysTransitCardDataSource::Internet,
+        _ => TsysTransitCardDataSource::Phone,
+    };
+    TxProfile {
+        acceptance,
+        card_family,
+        cof_phase,
+        commercial_level,
+        three_ds: ThreeDsKind::None,
+        capture,
+        channel_source,
+    }
+}
+
+// ============================================================================
+// AcceptanceProfile::terminal_data — bucket 1
+// ============================================================================
+
+#[test]
+fn moto_phone_uses_on_merchant_premises_attended() {
+    // Cert: "terminalOperatingEnvironment must be set to
+    // 'ON_MERCHANT_PREMISES_ATTENDED' on all [MOTO] transactions."
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        block.terminal_operating_environment,
+        TsysTransitTerminalOperatingEnvironment::OnMerchantPremisesAttended
+    ));
+}
+
+#[test]
+fn moto_phone_uses_display_only_output() {
+    // Cert: "terminalOutputCapability must be set to 'DISPLAY_ONLY'
+    // on all [MOTO] transactions."
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        block.terminal_output_capability,
+        TsysTransitTerminalOutputCapability::DisplayOnly
+    ));
+}
+
+#[test]
+fn moto_phone_uses_phone_card_data_source() {
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        block.card_data_source,
+        TsysTransitCardDataSource::Phone
+    ));
+}
+
+#[test]
+fn moto_mail_uses_mail_card_data_source() {
+    let block = AcceptanceProfile::MotoMail.terminal_data();
+    assert!(matches!(
+        block.card_data_source,
+        TsysTransitCardDataSource::Mail
+    ));
+}
+
+#[test]
+fn moto_mail_also_uses_on_merchant_premises_attended_and_display_only() {
+    let block = AcceptanceProfile::MotoMail.terminal_data();
+    assert!(matches!(
+        block.terminal_operating_environment,
+        TsysTransitTerminalOperatingEnvironment::OnMerchantPremisesAttended
+    ));
+    assert!(matches!(
+        block.terminal_output_capability,
+        TsysTransitTerminalOutputCapability::DisplayOnly
+    ));
+}
+
+#[test]
+fn ecom_internet_uses_no_terminal_and_none_output() {
+    let block = AcceptanceProfile::EcomInternet.terminal_data();
+    assert!(matches!(
+        block.terminal_operating_environment,
+        TsysTransitTerminalOperatingEnvironment::NoTerminal
+    ));
+    assert!(matches!(
+        block.terminal_output_capability,
+        TsysTransitTerminalOutputCapability::None
+    ));
+    assert!(matches!(
+        block.card_data_source,
+        TsysTransitCardDataSource::Internet
+    ));
+}
+
+// ============================================================================
+// rules::network_indicators — bucket 2 & 4
+// ============================================================================
+
+#[test]
+fn partial_auth_support_is_always_none() {
+    // Cert: "partialAuthSupport tag is a deprecated tag and should not
+    // be sent."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::partial_auth_support(&p).is_none());
+}
+
+#[test]
+fn registered_user_is_none_on_moto_phone_discover() {
+    // Cert: "registeredUserIndicator and lastRegisteredChangeDate tags
+    // must not be sent on the 12.00 Discover transaction in step 2 as
+    // these tags are e-Commerce only."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Discover,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::registered_user(&p).is_none());
+}
+
+#[test]
+fn registered_user_present_on_ecom_discover_no_cof() {
+    let p = profile(
+        AcceptanceProfile::EcomInternet,
+        CardFamily::Discover,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let result = network_indicators::registered_user(&p);
+    assert!(matches!(
+        result,
+        Some((TsysTransitRegisteredUserIndicator::No, ref date)) if date == "00/00/0000"
+    ));
+}
+
+#[test]
+fn authorization_indicator_for_card_auth_is_none_for_mastercard() {
+    // The stagegw CardAuthentication XSD rejects authorizationIndicator
+    // entirely (F9901), verified live on cert MOTO row 144. So it must NOT
+    // be sent on Mastercard card-auth either — None, like every other
+    // network. Supersedes the earlier cert-CSV "add it on MC" note.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::authorization_indicator_for_card_auth(&p).is_none());
+}
+
+#[test]
+fn authorization_indicator_for_card_auth_returns_none_for_visa() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::authorization_indicator_for_card_auth(&p).is_none());
+}
+
+#[test]
+fn sale_authorization_indicator_final_on_plain_mastercard_sale() {
+    // TSYS_MOTO_V2 rows 126/128/133: every Mastercard sale carries FINAL.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::authorization_indicator(&p).is_some());
+}
+
+#[test]
+fn sale_authorization_indicator_final_on_mastercard_mit() {
+    // Cert MOTO rows 161/162: Mastercard MIT replaying a stored credential
+    // carries authorizationIndicator=FINAL.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::authorization_indicator(&p).is_some());
+}
+
+#[test]
+fn sale_authorization_indicator_always_on_amex() {
+    // AMEX always carries authorizationIndicator (cert rows 127/130/139).
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Amex,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::authorization_indicator(&p).is_some());
+}
+
+// ============================================================================
+// rules::card_input_mode — bucket 4
+// ============================================================================
+
+#[test]
+fn amex_with_cvv_uses_manually_entered_with_keyed_cid() {
+    // Cert: "cardDataInputMode tag must be set to
+    // 'MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB' on the 1.50 AMEX level
+    // II transaction in step 2 as the cvv was sent."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Amex,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, true),
+        TsysTransitCardDataInputMode::ManuallyEnteredWithKeyedCidAmexJcb
+    ));
+}
+
+#[test]
+fn jcb_with_cvv_uses_key_entered_input() {
+    // TSYS_MOTO_V3 row 135 (JCB 13.00, cvv2 present) uses KEY_ENTERED_INPUT —
+    // JCB is NOT treated like AMEX here. Falls through to the channel default.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Jcb,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, true),
+        TsysTransitCardDataInputMode::KeyEnteredInput
+    ));
+}
+
+#[test]
+fn cit_setup_uses_key_entered_input() {
+    // Cert: "cardDataInputMode tag must be set to 'KEY_ENTERED_INPUT'
+    // on the 0.00 Visa card authentication in step 5 as this transaction
+    // will be used to store credentials for payment."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::CitSetup {
+            intended_kind: MitIntent::Unscheduled,
+        },
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, false),
+        TsysTransitCardDataInputMode::KeyEnteredInput
+    ));
+}
+
+#[test]
+fn mit_uses_stored_on_file_marker() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, false),
+        TsysTransitCardDataInputMode::MerchantInitiatedTransactionCardCredentialStoredOnFile
+    ));
+}
+
+#[test]
+fn moto_phone_no_cof_no_cvv_uses_key_entered_input() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = AcceptanceProfile::MotoPhone.terminal_data();
+    assert!(matches!(
+        card_input_mode::card_data_input_mode(&p, &block, true),
+        TsysTransitCardDataInputMode::KeyEnteredInput
+    ));
+}
+
+// ============================================================================
+// rules::commercial — bucket 3
+// ============================================================================
+
+#[test]
+fn purchase_order_strips_on_amex() {
+    // Cert: "purchaseOrder tag should not be sent on the 1.50 AMEX level
+    // II transaction in step 2 as this is a Visa and Mastercard only tag."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Amex,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::purchase_order(&p, Some("PO123".to_string())),
+        None
+    );
+}
+
+#[test]
+fn purchase_order_passes_through_on_visa_l2() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::purchase_order(&p, Some("PO123".to_string())),
+        Some("PO123".to_string())
+    );
+}
+
+#[test]
+fn customer_ref_id_strips_on_mastercard() {
+    // Cert: "customerRefID tag must not be sent on the .52 Mastercard
+    // transaction in step 2 as this is an AMEX only tag."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::customer_ref_id(&p, Some("REF123".to_string())),
+        None
+    );
+}
+
+#[test]
+fn customer_ref_id_passes_through_on_amex() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Amex,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::customer_ref_id(&p, Some("REF123".to_string())),
+        Some("REF123".to_string())
+    );
+}
+
+#[test]
+fn supplier_reference_number_strips_on_mastercard() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::supplier_reference_number(&p, Some("SUP123".to_string())),
+        None
+    );
+}
+
+#[test]
+fn ship_to_zip_stripped_on_mastercard_l2() {
+    // TSYS_MOTO_V2 row 126 (MC Level II): shipToZip is NOT sent. On L2 it is
+    // AMEX-only; Visa/MC carry it only at L3.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(commercial::ship_to_zip(&p, Some("12345".to_string())), None);
+}
+
+#[test]
+fn ship_to_zip_sent_on_amex_l2() {
+    // TSYS_MOTO_V3 row 127 (AMEX Level II) includes <shipToZip>85284</shipToZip>.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Amex,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::ship_to_zip(&p, Some("85284".to_string())),
+        Some("85284".to_string())
+    );
+}
+
+#[test]
+fn ship_to_zip_stripped_when_not_commercial() {
+    // Non-commercial (None level) never carries shipToZip.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert_eq!(commercial::ship_to_zip(&p, Some("12345".to_string())), None);
+}
+
+#[test]
+fn ship_to_zip_passes_through_on_visa_l3() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::L3,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::ship_to_zip(&p, Some("12345".to_string())),
+        Some("12345".to_string())
+    );
+}
+
+#[test]
+fn destination_country_code_strips_on_mastercard_l2() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::NoCof,
+        CommercialLevel::L2,
+        CaptureKind::Auto,
+    );
+    assert_eq!(
+        commercial::destination_country_code(&p, Some("840".to_string())),
+        None
+    );
+}
+
+// ============================================================================
+// rules::cof_mit — bucket 5
+// ============================================================================
+
+#[test]
+fn card_on_file_is_none_on_mastercard_cit_setup() {
+    // Cert: "cardOnFile tag must not be sent on the 2.00 Mastercard
+    // transaction in step 5 as on Direct Marketing this is a Visa
+    // Merchant Initiated Transaction (MIT) only tag."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::CitSetup {
+            intended_kind: MitIntent::Unscheduled,
+        },
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(cof_mit::card_on_file(&p).is_none());
+}
+
+#[test]
+fn card_on_file_is_y_on_visa_cit_setup() {
+    // Cert: "cardOnFile tag must be sent on 0.00 Visa card authentication
+    // to store credentials for future payments in step 5."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::CitSetup {
+            intended_kind: MitIntent::Unscheduled,
+        },
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(matches!(
+        cof_mit::card_on_file(&p),
+        Some(TsysTransitCardOnFile::Y)
+    ));
+}
+
+#[test]
+fn card_on_file_is_none_on_visa_cit_using_stored() {
+    // Cert: "cardOnFile tag must not be sent on the 25.50 Visa card on
+    // file transaction in step 5 as this tag is a Merchant initiated
+    // transaction (MIT) only and this test case is a Consumer initiated
+    // transaction (CIT)."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::CitUsingStored,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(cof_mit::card_on_file(&p).is_none());
+}
+
+#[test]
+fn cit_status_indicator_c101_on_mastercard_cit_using_stored() {
+    // Cert: "mitStatusIndicator tag must not be sent on the 29.75
+    // Mastercard transaction in step 5 as this test case is a Card on
+    // File CIT and not MIT. The citStatusIndicator tag will need to be
+    // sent on this test case with a value of 'C101'."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::CitUsingStored,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(matches!(
+        cof_mit::cit_status_indicator(&p),
+        Some(TsysTransitMcCitStatusIndicator::C101)
+    ));
+    assert!(cof_mit::mit_status_indicator(&p).is_none());
+}
+
+#[test]
+fn cit_status_indicator_c101_on_mastercard_cit_setup() {
+    // Cert: "citStatusIndicator tag must be sent on the 2.00 Mastercard
+    // transaction in step 5 with a value of C101 as this transaction
+    // will be used to store credentials for future unscheduled payments."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::CitSetup {
+            intended_kind: MitIntent::Unscheduled,
+        },
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(matches!(
+        cof_mit::cit_status_indicator(&p),
+        Some(TsysTransitMcCitStatusIndicator::C101)
+    ));
+}
+
+#[test]
+fn mit_status_m101_on_mastercard_unscheduled_mit() {
+    // Cert: "mitStatusIndicator should sent a value of 'M101' on the
+    // 29.85 Mastercard Card on File transaction in step 5 as this test
+    // case will be an unscheduled Merchant Initiated transaction."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Mastercard,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(matches!(
+        cof_mit::mit_status_indicator(&p),
+        Some(TsysTransitMitIndicator::M101)
+    ));
+    assert!(cof_mit::cit_status_indicator(&p).is_none());
+}
+
+#[test]
+fn mit_status_u_on_discover_unscheduled_mit() {
+    // Cert: "mitStatusIndicator must be sent with a value of 'U' on the
+    // 34.03 Discover Merchant Initiated Card on File transaction in
+    // step 5."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Discover,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(matches!(
+        cof_mit::mit_status_indicator(&p),
+        Some(TsysTransitMitIndicator::U)
+    ));
+}
+
+#[test]
+fn should_not_send_cof_txn_id_on_cit_using_stored() {
+    // Cert: "cardOnFileTransactionIdentifier tag must not be sent on
+    // the 25.50 Visa card on file transaction in step 5 as this tag is
+    // a Merchant initiated transaction (MIT) only..."
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::CitUsingStored,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+        &p
+    ));
+}
+
+#[test]
+fn should_send_cof_txn_id_on_mit() {
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(cof_mit::should_send_card_on_file_transaction_identifier(&p));
+}
+
+#[test]
+fn should_not_send_cof_txn_id_on_mastercard_mit() {
+    // Cert MOTO rows 161/162: Mastercard MIT conveys the stored credential
+    // via mitStatusIndicator, NOT cardOnFileTransactionIdentifier.
+    let p = profile(
+        AcceptanceProfile::RecurringMit,
+        CardFamily::Mastercard,
+        CofPhase::Mit(MitKind::Recurring),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+        &p
+    ));
+}
+
+#[test]
+fn should_not_send_cof_txn_id_on_amex_mit() {
+    // Cert MOTO row 165: AMEX COF omits cardOnFileTransactionIdentifier.
+    let p = profile(
+        AcceptanceProfile::RecurringMit,
+        CardFamily::Amex,
+        CofPhase::Mit(MitKind::Recurring),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+        &p
+    ));
+}
+
+#[test]
+fn should_not_send_cof_txn_id_on_discover_mit() {
+    // TSYS_MOTO_V2 row 165: Discover MIT does NOT send
+    // cardOnFileTransactionIdentifier — it uses mitStatusIndicator=U instead.
+    // Only Visa (row 164) sends the NTID tag.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Discover,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+        &p
+    ));
+}
+
+// ====== Recurring / e-Commerce (characterization; not yet cert-run-verified) ======
+//
+// The connector is cert-verified for MOTO only; the recurring/installment and
+// e-Commerce arms below are PINNED to current code behavior. Any expectation
+// taken from the cert workbook rather than confirmed against an already-passing
+// cert run carries a `// TODO(cert)` marker.
+
+#[test]
+fn recurring_mit_card_data_source_follows_channel_not_recurring() {
+    // cardDataSource must reflect the acceptance CHANNEL (PHONE here), never
+    // RECURRING — TSYS rejects `cardDataSource=RECURRING` on MOTO (cert rows
+    // 159/160/161/162/165 use PHONE/MAIL). The recurring semantics ride other
+    // fields (isRecurring / cardholderPresentDetail), not cardDataSource.
+    let p = profile(
+        AcceptanceProfile::RecurringMit,
+        CardFamily::Mastercard,
+        CofPhase::Mit(MitKind::Recurring),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let resolved = terminal_data::resolve(&p, &p.acceptance.terminal_data(), false);
+    assert!(matches!(
+        resolved.card_data_source,
+        TsysTransitCardDataSource::Phone
+    ));
+    assert!(!matches!(
+        resolved.card_data_source,
+        TsysTransitCardDataSource::Recurring
+    ));
+}
+
+#[test]
+fn recurring_mit_mastercard_cardholder_present_detail_is_recurring() {
+    // Cert (Recurring tab): Mastercard recurring CIT uses
+    // CARDHOLDER_NOT_PRESENT_RECURRING_TRANSACTION.
+    // Confirmed: RecurringMit default_cardholder_present_detail in acceptance.rs.
+    let block = AcceptanceProfile::RecurringMit.terminal_data();
+    assert!(matches!(
+        block.default_cardholder_present_detail,
+        TsysTransitCardholderPresentDetail::CardholderNotPresentRecurringTransaction
+    ));
+}
+
+#[test]
+fn installment_mit_cardholder_present_detail_is_installment() {
+    // Cert (Installments tab): installment uses
+    // CARDHOLDER_NOT_PRESENT_INSTALLMENT_TRANSACTION.
+    // Confirmed: InstallmentMit default_cardholder_present_detail in acceptance.rs.
+    let block = AcceptanceProfile::InstallmentMit.terminal_data();
+    assert!(matches!(
+        block.default_cardholder_present_detail,
+        TsysTransitCardholderPresentDetail::CardholderNotPresentInstallmentTransaction
+    ));
+}
+
+#[test]
+fn recurring_mastercard_operating_environment_is_no_terminal() {
+    // Cert (Recurring tab): Mastercard recurring operating environment is
+    // NO_TERMINAL. Confirmed: rules::terminal_data flips MC recurring to
+    // NoTerminal on top of the base OFF_MERCHANT_PREMISES_UNATTENDED default.
+    let p = profile(
+        AcceptanceProfile::RecurringMit,
+        CardFamily::Mastercard,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = terminal_data::terminal_data(&p);
+    assert!(matches!(
+        block.terminal_operating_environment,
+        TsysTransitTerminalOperatingEnvironment::NoTerminal
+    ));
+}
+
+#[test]
+fn recurring_visa_operating_environment_is_off_premises_unattended() {
+    // Cert (Recurring tab): non-MC recurring operating environment is
+    // OFF_MERCHANT_PREMISES_UNATTENDED. Confirmed: rules::terminal_data only
+    // flips MC; Visa falls through to the base recurring default.
+    let p = profile(
+        AcceptanceProfile::RecurringMit,
+        CardFamily::Visa,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    let block = terminal_data::terminal_data(&p);
+    assert!(matches!(
+        block.terminal_operating_environment,
+        TsysTransitTerminalOperatingEnvironment::OffMerchantPremisesUnattended
+    ));
+}
+
+#[test]
+fn ecom_internet_card_data_source_is_internet() {
+    // Cert (e-Commerce tab): cardDataSource = INTERNET.
+    // Confirmed: EcomInternet → Source::Internet in acceptance.rs.
+    let block = AcceptanceProfile::EcomInternet.terminal_data();
+    assert!(matches!(
+        block.card_data_source,
+        TsysTransitCardDataSource::Internet
+    ));
+}
+
+#[test]
+fn registered_user_is_none_on_ecom_visa_no_cof() {
+    // Characterization: registeredUserIndicator is Discover-family only, so an
+    // e-Commerce Visa transaction with no card-on-file does NOT carry it.
+    // Confirmed: rules::network_indicators::registered_user gates on
+    // card_family.is_discover_like(), which excludes Visa.
+    let p = profile(
+        AcceptanceProfile::EcomInternet,
+        CardFamily::Visa,
+        CofPhase::NoCof,
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(network_indicators::registered_user(&p).is_none());
+}
+
+// TODO(cert): three_ds eci needs RawInputs-level test once rules::three_ds is
+// folded. There is no rules::three_ds module yet (eciIndicator 5/6/7 handling
+// is not unit-testable from a profile alone), so the e-Commerce 3DS ECI cert
+// rows are not encoded here.
+
+/// Golden-XML characterization tests: lock the EXACT serialized wire
+/// format (field order / casing / skip-if-none). TSYS is XSD-order-
+/// sensitive, so any reorder or casing change must break these on purpose.
+/// (Formerly the separate `golden_tests.rs` module.)
+mod golden {
+    #![allow(clippy::expect_used)]
+    use common_utils::types::StringMajorUnit;
+
+    use super::super::super::transformers::*;
+
+    fn smu(value: &str) -> StringMajorUnit {
+        serde_json::from_str(&format!("\"{value}\"")).expect("StringMajorUnit")
+    }
+
+    /// Cert row 125: Visa L2 PHONE sale, $0.52.
+    ///
+    /// Locks the serialized XML wire format (field order / casing /
+    /// skip-if-none behavior). TSYS is XSD-order-sensitive, so any future
+    /// refactor that reorders struct fields or changes casing must break this
+    /// test on purpose.
+    #[test]
+    fn golden_row_125_visa_l2_phone_sale() {
+        let body = TsysTransitAuthorizeBody {
+            device_id: "88800023319201".to_string().into(),
+            transaction_key: "G3L97P4C6KBDX2H6L385O43CT2VOWCR2".to_string().into(),
+            card_data_source: TsysTransitCardDataSource::Phone,
+            transaction_amount: smu("0.52"),
+            sales_tax: Some(smu("0.01")),
+            surcharge: None,
+            additional_tax_details: Vec::new(),
+            shipping_charges: None,
+            duty_charges: None,
+            card_number: Some("4012000098765439".to_string().into()),
+            expiration_date: Some("12/28".to_string().into()),
+            cvv2: Some("999".to_string().into()),
+            secure_code: None,
+            ucaf_collection_indicator: None,
+            directory_server_transaction_id: None,
+            eci_indicator: None,
+            customer_code: None,
+            wallet_details: None,
+            card_on_file_transaction_identifier: None,
+            previous_network_transaction_id: None,
+            cit_status_indicator: None,
+            mit_status_indicator: None,
+            address_line1: "8320 S HARDY DR".to_string().into(),
+            zip: "85284".to_string().into(),
+            external_reference_id: "r125XREFSUFFIXX".to_string(),
+            product_details: Vec::new(),
+            commercial_card_level: Some(TsysTransitCommercialCardLevel::Level2),
+            purchase_order: Some("PO125".to_string()),
+            charge_descriptor: None,
+            charge_descriptor_2: None,
+            charge_descriptor_3: None,
+            charge_descriptor_4: None,
+            customer_vat_number: None,
+            customer_ref_id: None,
+            supplier_reference_number: None,
+            order_date: None,
+            summary_commodity_code: None,
+            vat_invoice: None,
+            ship_from_zip: None,
+            ship_to_zip: None,
+            destination_country_code: None,
+            card_on_file: None,
+            partial_auth_support: None,
+            terminal_capability: TsysTransitTerminalCapability::KeyedEntryOnly,
+            terminal_operating_environment:
+                TsysTransitTerminalOperatingEnvironment::OnMerchantPremisesAttended,
+            cardholder_authentication_method:
+                TsysTransitCardholderAuthenticationMethod::NotAuthenticated,
+            terminal_authentication_capability:
+                TsysTransitTerminalAuthenticationCapability::NoCapability,
+            terminal_output_capability: TsysTransitTerminalOutputCapability::DisplayOnly,
+            max_pin_length: TsysTransitMaxPinLength::NotSupported,
+            terminal_card_capture_capability:
+                TsysTransitTerminalCardCaptureCapability::NoCapability,
+            cardholder_present_detail:
+                TsysTransitCardholderPresentDetail::CardholderNotPresentPhoneTransaction,
+            card_present_detail: TsysTransitCardPresentDetail::CardNotPresent,
+            card_data_input_mode: TsysTransitCardDataInputMode::KeyEnteredInput,
+            cardholder_authentication_entity:
+                TsysTransitCardholderAuthenticationEntity::NotAuthenticated,
+            card_data_output_capability: TsysTransitCardDataOutputCapability::None,
+            developer_id: "003651G001".to_string().into(),
+            is_recurring: None,
+            billing_type: None,
+            payment_count: None,
+            current_payment_count: None,
+            original_recurring_amount: None,
+            registered_user_indicator: None,
+            last_registered_change_date: None,
+            authorization_indicator: None,
+            mit: None,
+        };
+
+        let req = TsysTransitAuthorizeRequest::Sale(body);
+        let xml = generate_xml(&req).expect("serialize");
+
+        // Snapshot of the CURRENT serialized output. Field order follows the
+        // `TsysTransitAuthorizeBody` struct definition (not the cert script's
+        // ordering). If a refactor reorders fields or changes casing, this
+        // breaks — intentionally.
+        let expected = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+        "<Sale>",
+        "<deviceID>88800023319201</deviceID>",
+        "<transactionKey>G3L97P4C6KBDX2H6L385O43CT2VOWCR2</transactionKey>",
+        "<cardDataSource>PHONE</cardDataSource>",
+        "<transactionAmount>0.52</transactionAmount>",
+        "<salesTax>0.01</salesTax>",
+        "<cardNumber>4012000098765439</cardNumber>",
+        "<expirationDate>12/28</expirationDate>",
+        "<cvv2>999</cvv2>",
+        "<addressLine1>8320 S HARDY DR</addressLine1>",
+        "<zip>85284</zip>",
+        "<externalReferenceID>r125XREFSUFFIXX</externalReferenceID>",
+        "<commercialCardLevel>LEVEL2</commercialCardLevel>",
+        "<purchaseOrder>PO125</purchaseOrder>",
+        "<terminalCapability>KEYED_ENTRY_ONLY</terminalCapability>",
+        "<terminalOperatingEnvironment>ON_MERCHANT_PREMISES_ATTENDED</terminalOperatingEnvironment>",
+        "<cardholderAuthenticationMethod>NOT_AUTHENTICATED</cardholderAuthenticationMethod>",
+        "<terminalAuthenticationCapability>NO_CAPABILITY</terminalAuthenticationCapability>",
+        "<terminalOutputCapability>DISPLAY_ONLY</terminalOutputCapability>",
+        "<maxPinLength>NOT_SUPPORTED</maxPinLength>",
+        "<terminalCardCaptureCapability>NO_CAPABILITY</terminalCardCaptureCapability>",
+        "<cardholderPresentDetail>CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION</cardholderPresentDetail>",
+        "<cardPresentDetail>CARD_NOT_PRESENT</cardPresentDetail>",
+        "<cardDataInputMode>KEY_ENTERED_INPUT</cardDataInputMode>",
+        "<cardholderAuthenticationEntity>NOT_AUTHENTICATED</cardholderAuthenticationEntity>",
+        "<cardDataOutputCapability>NONE</cardDataOutputCapability>",
+        "<developerID>003651G001</developerID>",
+        "</Sale>",
+    );
+
+        assert_eq!(xml, expected);
+    }
+
+    /// MOTO "cardAuthentication | Visa | PHONE" (step-5 Visa CIT-setup probe).
+    ///
+    /// Locks the serialized XML wire format of `TsysTransitCardAuthentication
+    /// Request` so the `rules::terminal_data::resolve` extraction is provably
+    /// behavior-preserving on the CardAuthentication builder too (the Authorize
+    /// builder is already guarded by `golden_row_125_visa_l2_phone_sale`).
+    ///
+    /// The struct is built by hand with the MotoPhone terminalData values a
+    /// Visa phone card-auth resolves to (cvv2 999, Visa Account Name Inquiry
+    /// firstName/lastName, cardOnFile=Y). authorizationIndicator is NOT sent on
+    /// CardAuthentication — the stagegw XSD rejects it (F9901). TSYS is
+    /// XSD-order-sensitive, so any field reorder / casing change breaks this on
+    /// purpose.
+    #[test]
+    fn golden_card_authentication_visa_phone() {
+        let req = TsysTransitCardAuthenticationRequest {
+            device_id: "88800023319201".to_string().into(),
+            transaction_key: "G3L97P4C6KBDX2H6L385O43CT2VOWCR2".to_string().into(),
+            card_data_source: TsysTransitCardDataSource::Phone,
+            card_number: "4012000098765439".to_string().into(),
+            expiration_date: "12/28".to_string().into(),
+            cvv2: Some("999".to_string().into()),
+            address_line1: "8320 S HARDY DR".to_string().into(),
+            zip: "85284".to_string().into(),
+            external_reference_id: "rCAXREFSUFFIXXX".to_string(),
+            card_on_file: Some(TsysTransitCardOnFile::Y),
+            cit_status_indicator: None,
+            authorization_indicator: None,
+            first_name: Some("JANE".to_string().into()),
+            middle_name: None,
+            last_name: Some("DOE".to_string().into()),
+            developer_id: "003651G001".to_string().into(),
+            terminal_capability: TsysTransitTerminalCapability::KeyedEntryOnly,
+            terminal_operating_environment:
+                TsysTransitTerminalOperatingEnvironment::OnMerchantPremisesAttended,
+            cardholder_authentication_method:
+                TsysTransitCardholderAuthenticationMethod::NotAuthenticated,
+            terminal_authentication_capability:
+                TsysTransitTerminalAuthenticationCapability::NoCapability,
+            terminal_output_capability: TsysTransitTerminalOutputCapability::DisplayOnly,
+            max_pin_length: TsysTransitMaxPinLength::NotSupported,
+            terminal_card_capture_capability:
+                TsysTransitTerminalCardCaptureCapability::NoCapability,
+            cardholder_present_detail:
+                TsysTransitCardholderPresentDetail::CardholderNotPresentPhoneTransaction,
+            card_present_detail: TsysTransitCardPresentDetail::CardNotPresent,
+            card_data_input_mode: TsysTransitCardDataInputMode::KeyEnteredInput,
+            cardholder_authentication_entity:
+                TsysTransitCardholderAuthenticationEntity::NotAuthenticated,
+            card_data_output_capability: TsysTransitCardDataOutputCapability::None,
+            m_pos_acceptance_device_type: "0".to_string(),
+        };
+
+        let xml = generate_xml(&req).expect("serialize");
+
+        let expected = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+        "<CardAuthentication>",
+        "<deviceID>88800023319201</deviceID>",
+        "<transactionKey>G3L97P4C6KBDX2H6L385O43CT2VOWCR2</transactionKey>",
+        "<cardDataSource>PHONE</cardDataSource>",
+        "<cardNumber>4012000098765439</cardNumber>",
+        "<expirationDate>12/28</expirationDate>",
+        "<cvv2>999</cvv2>",
+        "<addressLine1>8320 S HARDY DR</addressLine1>",
+        "<zip>85284</zip>",
+        "<externalReferenceID>rCAXREFSUFFIXXX</externalReferenceID>",
+        "<cardOnFile>Y</cardOnFile>",
+        "<firstName>JANE</firstName>",
+        "<lastName>DOE</lastName>",
+        "<developerID>003651G001</developerID>",
+        "<terminalCapability>KEYED_ENTRY_ONLY</terminalCapability>",
+        "<terminalOperatingEnvironment>ON_MERCHANT_PREMISES_ATTENDED</terminalOperatingEnvironment>",
+        "<cardholderAuthenticationMethod>NOT_AUTHENTICATED</cardholderAuthenticationMethod>",
+        "<terminalAuthenticationCapability>NO_CAPABILITY</terminalAuthenticationCapability>",
+        "<terminalOutputCapability>DISPLAY_ONLY</terminalOutputCapability>",
+        "<maxPinLength>NOT_SUPPORTED</maxPinLength>",
+        "<terminalCardCaptureCapability>NO_CAPABILITY</terminalCardCaptureCapability>",
+        "<cardholderPresentDetail>CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION</cardholderPresentDetail>",
+        "<cardPresentDetail>CARD_NOT_PRESENT</cardPresentDetail>",
+        "<cardDataInputMode>KEY_ENTERED_INPUT</cardDataInputMode>",
+        "<cardholderAuthenticationEntity>NOT_AUTHENTICATED</cardholderAuthenticationEntity>",
+        "<cardDataOutputCapability>NONE</cardDataOutputCapability>",
+        "<mPosAcceptanceDeviceType>0</mPosAcceptanceDeviceType>",
+        "</CardAuthentication>",
+    );
+
+        assert_eq!(xml, expected);
+    }
+}

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -1,8 +1,7 @@
 use std::fmt::Debug;
 
 use common_enums::{
-    AttemptStatus, CaptureMethod, CardNetwork, FutureUsage, MitCategory, PaymentChannel,
-    RefundStatus,
+    AttemptStatus, CardNetwork, FutureUsage, MitCategory, PaymentChannel, RefundStatus,
 };
 use common_utils::types::{MinorUnit, StringMajorUnit};
 use domain_types::{
@@ -29,7 +28,7 @@ use error_stack::{Report, ResultExt};
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
-use super::{super::macros::GetSoapXml, TsysTransitRouterData};
+use super::{super::macros::GetSoapXml, profile::TxProfile, rules, TsysTransitRouterData};
 use crate::types::ResponseRouterData;
 
 #[derive(Debug, Serialize, Clone, Copy)]
@@ -355,7 +354,7 @@ pub enum TsysTransitRegisteredUserIndicator {
     Yes,
     No,
 }
-fn generate_xml<T: Serialize>(request: &T) -> Result<String, Report<IntegrationError>> {
+pub(super) fn generate_xml<T: Serialize>(request: &T) -> Result<String, Report<IntegrationError>> {
     let body = quick_xml::se::to_string(request).change_context(
         IntegrationError::RequestEncodingFailed {
             context: Default::default(),
@@ -690,12 +689,30 @@ pub struct TsysTransitCardAuthenticationRequest {
     pub card_number: Secret<String>,
     #[serde(rename = "expirationDate")]
     pub expiration_date: Secret<String>,
+    // TSYS cert: cvv2 must be sent on card authentication when the
+    // merchant collected one. The XSD requires it adjacent to
+    // expirationDate (early in the body, like Sale/Auth).
+    #[serde(rename = "cvv2", skip_serializing_if = "Option::is_none")]
+    pub cvv2: Option<Secret<String>>,
     #[serde(rename = "addressLine1")]
     pub address_line1: Secret<String>,
     #[serde(rename = "zip")]
     pub zip: Secret<String>,
     #[serde(rename = "externalReferenceID")]
     pub external_reference_id: String,
+    // TSYS cert: cardOnFile must be sent on Visa CIT-setup card auth
+    // (storing credential for future MIT). Schema slot matches Sale —
+    // sits between externalReferenceID and terminalCapability.
+    #[serde(rename = "cardOnFile", skip_serializing_if = "Option::is_none")]
+    pub card_on_file: Option<TsysTransitCardOnFile>,
+    #[serde(rename = "citStatusIndicator", skip_serializing_if = "Option::is_none")]
+    pub cit_status_indicator: Option<TsysTransitMcCitStatusIndicator>,
+    // TSYS cert: authorizationIndicator missing on MC card auth.
+    #[serde(
+        rename = "authorizationIndicator",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub authorization_indicator: Option<TsysTransitAuthorizationIndicator>,
     #[serde(rename = "firstName", skip_serializing_if = "Option::is_none")]
     pub first_name: Option<Secret<String>>,
     #[serde(rename = "middleName", skip_serializing_if = "Option::is_none")]
@@ -728,12 +745,14 @@ pub struct TsysTransitCardAuthenticationRequest {
     pub cardholder_authentication_entity: TsysTransitCardholderAuthenticationEntity,
     #[serde(rename = "cardDataOutputCapability")]
     pub card_data_output_capability: TsysTransitCardDataOutputCapability,
+    // TSYS' SBX XSD requires mPosAcceptanceDeviceType as the LAST
+    // element on CardAuthentication. The cert csv asked us to remove
+    // it, but removing it alone trips a different XSD complaint
+    // (F9901). Keep "0" as a placeholder; downstream fields
+    // (cardOnFile, citStatusIndicator, authorizationIndicator) all
+    // moved earlier in the body to match Sale's schema order.
     #[serde(rename = "mPosAcceptanceDeviceType")]
     pub m_pos_acceptance_device_type: String,
-    #[serde(rename = "cardOnFile", skip_serializing_if = "Option::is_none")]
-    pub card_on_file: Option<TsysTransitCardOnFile>,
-    #[serde(rename = "citStatusIndicator", skip_serializing_if = "Option::is_none")]
-    pub cit_status_indicator: Option<TsysTransitMcCitStatusIndicator>,
 }
 
 impl GetSoapXml for TsysTransitCardAuthenticationRequest {
@@ -815,6 +834,11 @@ pub struct TsysTransitAuthorizeResponseBody {
     pub card_type: Option<String>,
     #[serde(rename = "maskedCardNumber", default)]
     pub masked_card_number: Option<String>,
+    /// Network transaction identifier returned by TSYS. This is the value to
+    /// store as the stored-credential / network-transaction-id for later MITs
+    /// — NOT the `authCode` (which is a per-transaction approval code).
+    #[serde(rename = "cardTransactionIdentifier", default)]
+    pub card_transaction_identifier: Option<String>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
@@ -909,11 +933,7 @@ struct TsysTransitMerchantMetadata {
     #[serde(default)]
     tsys_transit: Option<TsysTransitMerchantMetadataInner>,
     #[serde(default)]
-    terminal_data: Option<TsysTransitTerminalDataOverrides>,
-    #[serde(default)]
     commercial_card: Option<TsysTransitCommercialCardMetadata>,
-    #[serde(default, flatten)]
-    terminal_overrides: TsysTransitTerminalDataOverrides,
 }
 
 impl TsysTransitMerchantMetadata {
@@ -924,15 +944,6 @@ impl TsysTransitMerchantMetadata {
             inner.commercial_card = self.commercial_card;
         }
 
-        let mut terminal_data = inner.terminal_data.take().unwrap_or_default();
-        if let Some(overrides) = self.terminal_data {
-            terminal_data.merge(overrides);
-        }
-        terminal_data.merge(self.terminal_overrides);
-        if terminal_data.has_any() {
-            inner.terminal_data = Some(terminal_data);
-        }
-
         inner
     }
 }
@@ -940,18 +951,26 @@ impl TsysTransitMerchantMetadata {
 #[derive(Debug, Default, Deserialize, Clone)]
 struct TsysTransitMerchantMetadataInner {
     #[serde(default)]
-    terminal_data: Option<TsysTransitTerminalDataOverrides>,
-    #[serde(default)]
     commercial_card: Option<TsysTransitCommercialCardMetadata>,
+    /// Channel override for the RepeatPayment / MIT-via-NTID flow only.
+    /// The `RecurringPaymentServiceChargeRequest` proto does NOT carry
+    /// `payment_channel`, so HS' MIT execution loses the MOTO-vs-Ecom
+    /// signal. Setting `payment_channel` in this merchant metadata block
+    /// (alongside `commercial_card`) lets the caller inject that signal
+    /// back on the MIT request. Accepts the strings `"telephone_order"`,
+    /// `"mail_order"`, `"ecommerce"`. Ignored when the flow already carries
+    /// an explicit channel. terminalData is NEVER taken from metadata — it
+    /// is derived entirely from the profile/rules layer.
+    #[serde(default)]
+    payment_channel: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 struct TsysTransitCommercialCardMetadata {
+    // vat_invoice / ship_from_zip removed: Level III is out of scope.
     charge_descriptor_2: Option<String>,
     charge_descriptor_3: Option<String>,
     charge_descriptor_4: Option<String>,
-    vat_invoice: Option<String>,
-    ship_from_zip: Option<String>,
 }
 #[derive(Debug, Default, Deserialize, Clone)]
 struct TsysTransitMandateMetadata {
@@ -965,77 +984,6 @@ struct TsysTransitMandateMetadata {
     installment_variant: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize, Clone)]
-struct TsysTransitTerminalDataOverrides {
-    terminal_capability: Option<TsysTransitTerminalCapability>,
-    terminal_operating_environment: Option<TsysTransitTerminalOperatingEnvironment>,
-    cardholder_authentication_method: Option<TsysTransitCardholderAuthenticationMethod>,
-    terminal_authentication_capability: Option<TsysTransitTerminalAuthenticationCapability>,
-    terminal_output_capability: Option<TsysTransitTerminalOutputCapability>,
-    max_pin_length: Option<TsysTransitMaxPinLength>,
-    terminal_card_capture_capability: Option<TsysTransitTerminalCardCaptureCapability>,
-    cardholder_present_detail: Option<TsysTransitCardholderPresentDetail>,
-    card_present_detail: Option<TsysTransitCardPresentDetail>,
-    card_data_input_mode: Option<TsysTransitCardDataInputMode>,
-    cardholder_authentication_entity: Option<TsysTransitCardholderAuthenticationEntity>,
-    card_data_output_capability: Option<TsysTransitCardDataOutputCapability>,
-}
-
-impl TsysTransitTerminalDataOverrides {
-    fn has_any(&self) -> bool {
-        self.terminal_capability.is_some()
-            || self.terminal_operating_environment.is_some()
-            || self.cardholder_authentication_method.is_some()
-            || self.terminal_authentication_capability.is_some()
-            || self.terminal_output_capability.is_some()
-            || self.max_pin_length.is_some()
-            || self.terminal_card_capture_capability.is_some()
-            || self.cardholder_present_detail.is_some()
-            || self.card_present_detail.is_some()
-            || self.card_data_input_mode.is_some()
-            || self.cardholder_authentication_entity.is_some()
-            || self.card_data_output_capability.is_some()
-    }
-
-    fn merge(&mut self, other: Self) {
-        if other.terminal_capability.is_some() {
-            self.terminal_capability = other.terminal_capability;
-        }
-        if other.terminal_operating_environment.is_some() {
-            self.terminal_operating_environment = other.terminal_operating_environment;
-        }
-        if other.cardholder_authentication_method.is_some() {
-            self.cardholder_authentication_method = other.cardholder_authentication_method;
-        }
-        if other.terminal_authentication_capability.is_some() {
-            self.terminal_authentication_capability = other.terminal_authentication_capability;
-        }
-        if other.terminal_output_capability.is_some() {
-            self.terminal_output_capability = other.terminal_output_capability;
-        }
-        if other.max_pin_length.is_some() {
-            self.max_pin_length = other.max_pin_length;
-        }
-        if other.terminal_card_capture_capability.is_some() {
-            self.terminal_card_capture_capability = other.terminal_card_capture_capability;
-        }
-        if other.cardholder_present_detail.is_some() {
-            self.cardholder_present_detail = other.cardholder_present_detail;
-        }
-        if other.card_present_detail.is_some() {
-            self.card_present_detail = other.card_present_detail;
-        }
-        if other.card_data_input_mode.is_some() {
-            self.card_data_input_mode = other.card_data_input_mode;
-        }
-        if other.cardholder_authentication_entity.is_some() {
-            self.cardholder_authentication_entity = other.cardholder_authentication_entity;
-        }
-        if other.card_data_output_capability.is_some() {
-            self.card_data_output_capability = other.card_data_output_capability;
-        }
-    }
-}
 #[derive(Debug, Default, Clone)]
 struct RecurringContext {
     enabled: bool,
@@ -1082,6 +1030,10 @@ struct ThreeDsContext {
 
 #[derive(Debug, Default, Clone)]
 struct CardOnFileContext {
+    // `card_on_file` is now decided by `rules::cof_mit::card_on_file`
+    // based on TxProfile; this struct only carries the raw mandate-
+    // derived values that the assembler still needs.
+    #[allow(dead_code)]
     card_on_file: Option<TsysTransitCardOnFile>,
     mit_block: Option<TsysTransitMit>,
     previous_network_transaction_id: Option<String>,
@@ -1313,16 +1265,6 @@ fn sanitize_optional_alphanumeric_space(value: Option<String>, max_len: usize) -
         .filter(|value| !value.is_empty())
 }
 
-fn format_tsys_order_date(value: time::PrimitiveDateTime) -> String {
-    let date = value.date();
-    format!(
-        "{:02}/{:02}/{:04}",
-        u8::from(date.month()),
-        date.day(),
-        date.year()
-    )
-}
-
 fn normalize_tsys_country_code(value: Option<String>) -> Option<String> {
     value.map(|code| match code.as_str() {
         "840" => "USA".to_string(),
@@ -1482,19 +1424,10 @@ fn compute_commercial_card_context<
         .and_then(|data| data.get_merchant_order_reference_id())
         .or_else(|| router_data.request.merchant_order_id.clone());
 
-    let shipping_charges = l2_l3_data
-        .and_then(|data| data.get_shipping_cost())
-        .or(router_data.request.shipping_cost)
-        .map(|amount| {
-            super::TsysTransitAmountConvertor::convert(amount, router_data.request.currency)
-        })
-        .transpose()?;
-    let duty_charges = l2_l3_data
-        .and_then(|data| data.get_duty_amount())
-        .map(|amount| {
-            super::TsysTransitAmountConvertor::convert(amount, router_data.request.currency)
-        })
-        .transpose()?;
+    // Level III out of scope — shippingCharges / dutyCharges are L3 enhanced
+    // tags and are never emitted.
+    let shipping_charges: Option<StringMajorUnit> = None;
+    let duty_charges: Option<StringMajorUnit> = None;
 
     if order_details.is_empty()
         && order_tax_amount.is_none()
@@ -1504,15 +1437,11 @@ fn compute_commercial_card_context<
         return Ok(CommercialCardContext::default());
     }
 
-    let commercial_card_level = if order_details.is_empty() {
-        TsysTransitCommercialCardLevel::Level2
-    } else {
-        TsysTransitCommercialCardLevel::Level3
-    };
-    let is_level3 = matches!(
-        commercial_card_level,
-        TsysTransitCommercialCardLevel::Level3
-    );
+    // Level III is out of scope for this connector: every commercial
+    // transaction is emitted as Level II. No productDetails / additionalTax
+    // Details / vatInvoice / shipFromZip / enhanced tax & shipping.
+    let commercial_card_level = TsysTransitCommercialCardLevel::Level2;
+    let is_level3 = false;
     let is_visa_or_mastercard = matches!(
         card_network,
         Some(CardNetwork::Visa) | Some(CardNetwork::Mastercard)
@@ -1616,10 +1545,8 @@ fn compute_commercial_card_context<
             )
         })
         .flatten();
-    let customer_vat_number = l2_l3_data
-        .and_then(|data| data.get_customer_tax_registration_id())
-        .map(|tax_id| tax_id.expose())
-        .and_then(|tax_id| sanitize_optional_alphanumeric_space(Some(tax_id), 13));
+    // Level III out of scope — customerVATNumber not emitted.
+    let customer_vat_number: Option<String> = None;
     let customer_ref_id = (!is_level3 || is_amex)
         .then(|| {
             sanitize_optional_alphanumeric_space(
@@ -1630,25 +1557,12 @@ fn compute_commercial_card_context<
             )
         })
         .flatten();
-    let order_date = l2_l3_data
-        .and_then(|data| data.get_order_date())
-        .map(format_tsys_order_date);
-    let summary_commodity_code = order_details
-        .iter()
-        .find_map(|detail| {
-            detail
-                .commodity_code
-                .clone()
-                .or_else(|| detail.upc.clone())
-                .or_else(|| detail.product_id.clone())
-                .or_else(|| detail.sku.clone())
-        })
-        .and_then(|code| sanitize_optional_alphanumeric_space(Some(code), 4));
-    let vat_invoice = sanitize_optional_alphanumeric_space(commercial_meta.vat_invoice.clone(), 15);
-    let ship_from_zip = l2_l3_data
-        .and_then(|data| data.get_shipping_origin_zip())
-        .map(|zip| zip.expose())
-        .or_else(|| commercial_meta.ship_from_zip.clone());
+    // Level III out of scope — orderDate / summaryCommodityCode / vatInvoice /
+    // shipFromZip are L3-only tags and are never emitted.
+    let order_date: Option<String> = None;
+    let summary_commodity_code: Option<String> = None;
+    let vat_invoice: Option<String> = None;
+    let ship_from_zip: Option<String> = None;
     let ship_to_zip = l2_l3_data
         .and_then(|data| data.get_shipping_zip())
         .map(|zip| zip.expose())
@@ -1747,13 +1661,15 @@ fn compute_commercial_card_context<
         TsysTransitCommercialCardLevel::Level2
     ) && is_amex
     {
+        // TSYS cert: shipToZip / destinationCountryCode are Visa/MC L3-only,
+        // they are NOT required on AMEX L2.  supplierReferenceNumber,
+        // customerRefID, chargeDescriptor remain AMEX L2 essentials.
         for (field_name, is_missing) in [
             (
                 "supplierReferenceNumber",
                 supplier_reference_number.is_none(),
             ),
             ("customerRefID", customer_ref_id.is_none()),
-            ("shipToZip", ship_to_zip.is_none()),
             ("chargeDescriptor", charge_descriptor.is_none()),
         ] {
             if is_missing {
@@ -1853,410 +1769,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let router_data = &item.router_data;
-        let auth = TsysTransitAuthType::try_from(&router_data.connector_config)?;
-        let mandate_dispatch = decode_mandate_dispatch(router_data.request.mandate_id.as_ref());
-        let is_cit_setup = matches!(mandate_dispatch, MandateDispatch::None)
-            && (router_data.request.setup_future_usage == Some(FutureUsage::OffSession)
-                || router_data.request.off_session == Some(true));
-        let card_opt = match &router_data.request.payment_method_data {
-            PaymentMethodData::Card(card) => Some(card),
-            _ => None,
-        };
-        let nti_card_opt: Option<&CardDetailsForNetworkTransactionId> =
-            match &router_data.request.payment_method_data {
-                PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => Some(nti),
-                _ => None,
-            };
-        if matches!(mandate_dispatch, MandateDispatch::Vault { .. }) {
-        } else if card_opt.is_none() && nti_card_opt.is_none() {
-            return Err(IntegrationError::NotSupported {
-                message: "Selected payment method".to_string(),
-                connector: "tsysTransit",
-                context: Default::default(),
-            }
-            .into());
-        }
-        let card = card_opt;
-
-        let transaction_amount = super::TsysTransitAmountConvertor::convert(
-            router_data.request.minor_amount,
-            router_data.request.currency,
-        )?;
-        let surcharge = router_data
-            .request
-            .surcharge_amount
-            .as_ref()
-            .map(|amount| {
-                super::TsysTransitAmountConvertor::convert(amount.amount, amount.currency)
-            })
-            .transpose()?;
-        let billing = router_data
-            .resource_common_data
-            .address
-            .get_payment_billing()
-            .and_then(|b| b.address.as_ref());
-        let address_line1 = billing.and_then(|a| a.line1.clone()).ok_or_else(|| {
-            error_stack::report!(IntegrationError::MissingRequiredField {
-                field_name: "billing.address.line1",
-                context: Default::default(),
-            })
-        })?;
-        let zip = billing.and_then(|a| a.zip.clone()).ok_or_else(|| {
-            error_stack::report!(IntegrationError::MissingRequiredField {
-                field_name: "billing.address.zip",
-                context: Default::default(),
-            })
-        })?;
-        let card_network = card
-            .and_then(|c| c.card_network.clone())
-            .or_else(|| nti_card_opt.and_then(|n| n.card_network.clone()));
-        let merchant_metadata_early = match router_data.request.metadata.as_ref() {
-            Some(meta) => {
-                serde_json::from_value::<TsysTransitMerchantMetadata>(meta.clone().expose())
-                    .change_context(IntegrationError::InvalidDataFormat {
-                        field_name: "connector_metadata.tsys_transit",
-                        context: Default::default(),
-                    })?
-            }
-            None => TsysTransitMerchantMetadata::default(),
-        };
-        let merchant_inner_early = merchant_metadata_early.into_inner();
-        let commercial_meta = merchant_inner_early.commercial_card.clone();
-        let terminal_overrides = merchant_inner_early.terminal_data.unwrap_or_default();
-        let recurring_context = compute_recurring_context(
-            router_data.request.mit_category.clone(),
-            router_data
-                .resource_common_data
-                .recurring_mandate_payment_data
-                .as_ref(),
-            card_network.as_ref(),
-        )?;
-        let commercial_card_context = compute_commercial_card_context(
-            router_data,
-            commercial_meta.as_ref(),
-            card_network.as_ref(),
-        )?;
-        let three_ds_context = compute_three_ds_context(router_data, card_network.as_ref());
-        let channel = router_data.request.payment_channel.clone();
-        let card_data_source = match channel {
-            Some(PaymentChannel::TelephoneOrder) => TsysTransitCardDataSource::Phone,
-            Some(PaymentChannel::MailOrder) => TsysTransitCardDataSource::Mail,
-            Some(PaymentChannel::Ecommerce) | None => {
-                if recurring_context.enabled {
-                    TsysTransitCardDataSource::Mail
-                } else {
-                    TsysTransitCardDataSource::Internet
-                }
-            }
-        };
-        let is_manual_capture = matches!(
-            router_data.request.capture_method,
-            Some(CaptureMethod::Manual) | Some(CaptureMethod::ManualMultiple)
-        );
-
-        let authorization_indicator = match card_network {
-            Some(CardNetwork::Mastercard) => {
-                if recurring_context.enabled && is_manual_capture {
-                    None
-                } else {
-                    Some(if is_manual_capture {
-                        TsysTransitAuthorizationIndicator::Preauth
-                    } else {
-                        TsysTransitAuthorizationIndicator::Final
-                    })
-                }
-            }
-            Some(CardNetwork::AmericanExpress) => Some(if is_manual_capture {
-                TsysTransitAuthorizationIndicator::Preauth
-            } else {
-                TsysTransitAuthorizationIndicator::Final
-            }),
-            _ => None,
-        };
-        let (registered_user_indicator, last_registered_change_date) = if recurring_context.enabled
-        {
-            (None, None)
-        } else {
-            match card_network {
-                Some(CardNetwork::Discover)
-                | Some(CardNetwork::JCB)
-                | Some(CardNetwork::DinersClub)
-                | Some(CardNetwork::UnionPay) => (
-                    Some(TsysTransitRegisteredUserIndicator::No),
-                    Some("00/00/0000".to_string()),
-                ),
-                _ => (None, None),
-            }
-        };
-        let terminal_capability = terminal_overrides
-            .terminal_capability
-            .unwrap_or(TsysTransitTerminalCapability::KeyedEntryOnly);
-        let default_terminal_operating_environment = if recurring_context.enabled {
-            match card_network {
-                Some(CardNetwork::Mastercard) => {
-                    TsysTransitTerminalOperatingEnvironment::NoTerminal
-                }
-                _ => TsysTransitTerminalOperatingEnvironment::OffMerchantPremisesUnattended,
-            }
-        } else {
-            TsysTransitTerminalOperatingEnvironment::NoTerminal
-        };
-        let terminal_operating_environment = terminal_overrides
-            .terminal_operating_environment
-            .unwrap_or(default_terminal_operating_environment);
-        let cardholder_authentication_method = terminal_overrides
-            .cardholder_authentication_method
-            .unwrap_or(TsysTransitCardholderAuthenticationMethod::NotAuthenticated);
-        let terminal_authentication_capability = terminal_overrides
-            .terminal_authentication_capability
-            .unwrap_or(TsysTransitTerminalAuthenticationCapability::NoCapability);
-        let default_terminal_output_capability = if recurring_context.enabled {
-            TsysTransitTerminalOutputCapability::DisplayOnly
-        } else {
-            TsysTransitTerminalOutputCapability::None
-        };
-        let terminal_output_capability = terminal_overrides
-            .terminal_output_capability
-            .unwrap_or(default_terminal_output_capability);
-        let max_pin_length = terminal_overrides
-            .max_pin_length
-            .unwrap_or(TsysTransitMaxPinLength::NotSupported);
-        let terminal_card_capture_capability = terminal_overrides
-            .terminal_card_capture_capability
-            .unwrap_or(TsysTransitTerminalCardCaptureCapability::NoCapability);
-        let cardholder_present_detail = terminal_overrides
-            .cardholder_present_detail
-            .unwrap_or_else(|| {
-                if recurring_context.enabled {
-                    if recurring_context.billing_type.is_some() {
-                        TsysTransitCardholderPresentDetail::CardholderNotPresentInstallmentTransaction
-                    } else {
-                        TsysTransitCardholderPresentDetail::CardholderNotPresentRecurringTransaction
-                    }
-                } else {
-                    match channel {
-                        Some(PaymentChannel::TelephoneOrder) => {
-                            TsysTransitCardholderPresentDetail::CardholderNotPresentPhoneTransaction
-                        }
-                        Some(PaymentChannel::MailOrder) => {
-                            TsysTransitCardholderPresentDetail::CardholderNotPresentMailTransaction
-                        }
-                        _ => TsysTransitCardholderPresentDetail::CardholderNotPresentElectronicCommerce,
-                    }
-                }
-            });
-        let card_present_detail = terminal_overrides
-            .card_present_detail
-            .unwrap_or(TsysTransitCardPresentDetail::CardNotPresent);
-        let is_stored_credential_flow =
-            !matches!(mandate_dispatch, MandateDispatch::None) || is_cit_setup;
-        let default_card_data_input_mode = if recurring_context.enabled || is_stored_credential_flow
-        {
-            TsysTransitCardDataInputMode::MerchantInitiatedTransactionCardCredentialStoredOnFile
-        } else {
-            match channel {
-                Some(PaymentChannel::Ecommerce) | None => {
-                    TsysTransitCardDataInputMode::PanEntryElectronicCommerceIncludingRemoteChip
-                }
-                _ => TsysTransitCardDataInputMode::KeyEnteredInput,
-            }
-        };
-        let card_data_input_mode = terminal_overrides
-            .card_data_input_mode
-            .unwrap_or(default_card_data_input_mode);
-        let cardholder_authentication_entity = terminal_overrides
-            .cardholder_authentication_entity
-            .unwrap_or(TsysTransitCardholderAuthenticationEntity::NotAuthenticated);
-        let card_data_output_capability = terminal_overrides
-            .card_data_output_capability
-            .unwrap_or(TsysTransitCardDataOutputCapability::None);
-        let (card_number, expiration_date, cvv2_opt, customer_code_opt, wallet_details_opt) =
-            if let MandateDispatch::Vault {
-                customer_code,
-                wallet_id,
-            } = &mandate_dispatch
-            {
-                (
-                    None,
-                    None,
-                    None,
-                    Some(Secret::new(customer_code.clone())),
-                    Some(TsysTransitWalletDetailsRef {
-                        wallet_id: Secret::new(wallet_id.clone()),
-                    }),
-                )
-            } else if let Some(card) = card {
-                let cvv = if recurring_context.enabled {
-                    None
-                } else if card.card_cvc.peek().is_empty() {
-                    return Err(IntegrationError::MissingRequiredField {
-                        field_name: "card_cvc required for TSYS XML authorization cvv2",
-                        context: Default::default(),
-                    }
-                    .into());
-                } else {
-                    Some(card.card_cvc.clone())
-                };
-                (
-                    Some(Secret::new(card.card_number.peek().to_string())),
-                    Some(format_expiration_date(card)),
-                    cvv,
-                    None,
-                    None,
-                )
-            } else if let Some(nti) = nti_card_opt {
-                let month = nti.card_exp_month.peek().clone();
-                let year_full = nti.card_exp_year.peek().clone();
-                let year_short = if year_full.len() == 4 {
-                    year_full[2..].to_string()
-                } else {
-                    year_full
-                };
-                (
-                    Some(Secret::new(nti.card_number.peek().to_string())),
-                    Some(Secret::new(format!("{}/{}", month, year_short))),
-                    None,
-                    None,
-                    None,
-                )
-            } else {
-                return Err(IntegrationError::NotSupported {
-                    message: "Selected payment method".to_string(),
-                    connector: "tsysTransit",
-                    context: Default::default(),
-                }
-                .into());
-            };
-        let card_on_file_context = build_card_on_file_context(
-            &mandate_dispatch,
-            recurring_context.enabled,
-            card_network.as_ref(),
-            is_cit_setup,
-        );
-        let original_recurring_amount = compute_original_recurring_amount(
-            &recurring_context,
-            card_network.as_ref(),
-            &mandate_dispatch,
-            router_data.request.currency,
-        )?;
-
-        let cof_mit_status_indicator = match (
-            card_network.as_ref(),
-            router_data.request.mit_category.as_ref(),
-            &mandate_dispatch,
-        ) {
-            (
-                Some(CardNetwork::Mastercard),
-                Some(MitCategory::Unscheduled) | Some(MitCategory::Resubmission) | None,
-                MandateDispatch::Ntid { .. } | MandateDispatch::Vault { .. },
-            ) => Some(TsysTransitMitIndicator::M101),
-            (
-                Some(CardNetwork::Discover),
-                Some(MitCategory::Unscheduled) | Some(MitCategory::Resubmission),
-                MandateDispatch::Ntid { .. } | MandateDispatch::Vault { .. },
-            ) => Some(TsysTransitMitIndicator::U),
-            _ => None,
-        };
-
-        let (cit_status_indicator, mit_status_indicator) = match &mandate_dispatch {
-            MandateDispatch::Ntid { .. } | MandateDispatch::Vault { .. } => (
-                None,
-                recurring_context
-                    .mit_status_indicator
-                    .or(cof_mit_status_indicator),
-            ),
-            MandateDispatch::None if is_cit_setup => (
-                recurring_context.mc_cit_status_indicator.or_else(|| {
-                    matches!(card_network.as_ref(), Some(CardNetwork::Mastercard))
-                        .then_some(TsysTransitMcCitStatusIndicator::C101)
-                }),
-                None,
-            ),
-            MandateDispatch::None => (None, None),
-        };
-
-        let partial_auth_support = if recurring_context.enabled
-            || !matches!(mandate_dispatch, MandateDispatch::None)
-            || commercial_card_context.commercial_card_level.is_some()
-        {
-            None
-        } else {
-            Some("YES".to_string())
-        };
-
-        let body = TsysTransitAuthorizeBody {
-            device_id: auth.device_id,
-            transaction_key: auth.transaction_key,
-            card_data_source,
-            transaction_amount,
-            sales_tax: commercial_card_context.sales_tax,
-            surcharge,
-            additional_tax_details: commercial_card_context.additional_tax_details,
-            shipping_charges: commercial_card_context.shipping_charges,
-            duty_charges: commercial_card_context.duty_charges,
-            card_number,
-            expiration_date,
-            cvv2: cvv2_opt,
-            secure_code: three_ds_context.secure_code,
-            ucaf_collection_indicator: three_ds_context.ucaf_collection_indicator,
-            directory_server_transaction_id: three_ds_context.directory_server_transaction_id,
-            eci_indicator: three_ds_context.eci_indicator,
-            customer_code: customer_code_opt,
-            wallet_details: wallet_details_opt,
-            card_on_file_transaction_identifier: card_on_file_context
-                .card_on_file_transaction_identifier,
-            previous_network_transaction_id: card_on_file_context.previous_network_transaction_id,
-            cit_status_indicator,
-            mit_status_indicator,
-            address_line1,
-            zip,
-            external_reference_id: router_data
-                .resource_common_data
-                .connector_request_reference_id
-                .clone(),
-            product_details: commercial_card_context.product_details,
-            commercial_card_level: commercial_card_context.commercial_card_level,
-            purchase_order: commercial_card_context.purchase_order,
-            charge_descriptor: commercial_card_context.charge_descriptor,
-            charge_descriptor_2: commercial_card_context.charge_descriptor_2,
-            charge_descriptor_3: commercial_card_context.charge_descriptor_3,
-            charge_descriptor_4: commercial_card_context.charge_descriptor_4,
-            customer_vat_number: commercial_card_context.customer_vat_number,
-            customer_ref_id: commercial_card_context.customer_ref_id,
-            supplier_reference_number: commercial_card_context.supplier_reference_number,
-            order_date: commercial_card_context.order_date,
-            summary_commodity_code: commercial_card_context.summary_commodity_code,
-            vat_invoice: commercial_card_context.vat_invoice,
-            ship_from_zip: commercial_card_context.ship_from_zip,
-            ship_to_zip: commercial_card_context.ship_to_zip,
-            destination_country_code: commercial_card_context.destination_country_code,
-            card_on_file: card_on_file_context.card_on_file,
-            partial_auth_support,
-            terminal_capability,
-            terminal_operating_environment,
-            cardholder_authentication_method,
-            terminal_authentication_capability,
-            terminal_output_capability,
-            max_pin_length,
-            terminal_card_capture_capability,
-            cardholder_present_detail,
-            card_present_detail,
-            card_data_input_mode,
-            cardholder_authentication_entity,
-            card_data_output_capability,
-            developer_id: auth.developer_id,
-            is_recurring: recurring_context.is_recurring_flag,
-            billing_type: recurring_context.billing_type,
-            payment_count: recurring_context.payment_count,
-            current_payment_count: recurring_context.current_payment_count,
-            original_recurring_amount,
-            registered_user_indicator,
-            last_registered_change_date,
-            authorization_indicator,
-            mit: card_on_file_context.mit_block,
-        };
-
+        let assembly = extract_for_authorize(&item)?;
+        let is_manual_capture = assembly.profile.capture.is_manual();
+        let body = assemble_authorize_body(assembly);
         Ok(if is_manual_capture {
             Self::Auth(body)
         } else {
@@ -2264,8 +1779,386 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         })
     }
 }
+
+struct AuthorizeAssembly {
+    profile: TxProfile,
+    auth: TsysTransitAuthType,
+    transaction_amount: StringMajorUnit,
+    surcharge: Option<StringMajorUnit>,
+    address_line1: Secret<String>,
+    zip: Secret<String>,
+    external_reference_id: String,
+    card_number: Option<Secret<String>>,
+    expiration_date: Option<Secret<String>>,
+    cvv2: Option<Secret<String>>,
+    customer_code: Option<Secret<String>>,
+    wallet_details: Option<TsysTransitWalletDetailsRef>,
+    cvv_present_for_authorize: bool,
+    recurring_context: RecurringContext,
+    commercial_card_context: CommercialCardContext,
+    three_ds_context: ThreeDsContext,
+    card_on_file_context: CardOnFileContext,
+    original_recurring_amount: Option<StringMajorUnit>,
+}
+
+fn extract_for_authorize<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>(
+    item: &TsysTransitRouterData<
+        RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<T>, PaymentsResponseData>,
+        T,
+    >,
+) -> Result<AuthorizeAssembly, Report<IntegrationError>> {
+    let router_data = &item.router_data;
+    let auth = TsysTransitAuthType::try_from(&router_data.connector_config)?;
+    let mandate_dispatch = decode_mandate_dispatch(router_data.request.mandate_id.as_ref());
+    let is_cit_setup = matches!(mandate_dispatch, MandateDispatch::None)
+        && (router_data.request.setup_future_usage == Some(FutureUsage::OffSession)
+            || router_data.request.off_session == Some(true));
+    let card_opt = match &router_data.request.payment_method_data {
+        PaymentMethodData::Card(card) => Some(card),
+        _ => None,
+    };
+    let nti_card_opt: Option<&CardDetailsForNetworkTransactionId> =
+        match &router_data.request.payment_method_data {
+            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => Some(nti),
+            _ => None,
+        };
+    if matches!(mandate_dispatch, MandateDispatch::Vault { .. }) {
+    } else if card_opt.is_none() && nti_card_opt.is_none() {
+        return Err(IntegrationError::NotSupported {
+            message: "Selected payment method".to_string(),
+            connector: "tsysTransit",
+            context: Default::default(),
+        }
+        .into());
+    }
+    let card = card_opt;
+
+    let transaction_amount = super::TsysTransitAmountConvertor::convert(
+        router_data.request.minor_amount,
+        router_data.request.currency,
+    )?;
+    let surcharge = router_data
+        .request
+        .surcharge_amount
+        .as_ref()
+        .map(|amount| super::TsysTransitAmountConvertor::convert(amount.amount, amount.currency))
+        .transpose()?;
+    let billing = router_data
+        .resource_common_data
+        .address
+        .get_payment_billing()
+        .and_then(|b| b.address.as_ref());
+    let address_line1 = billing.and_then(|a| a.line1.clone()).ok_or_else(|| {
+        error_stack::report!(IntegrationError::MissingRequiredField {
+            field_name: "billing.address.line1",
+            context: Default::default(),
+        })
+    })?;
+    let zip = billing.and_then(|a| a.zip.clone()).ok_or_else(|| {
+        error_stack::report!(IntegrationError::MissingRequiredField {
+            field_name: "billing.address.zip",
+            context: Default::default(),
+        })
+    })?;
+    let card_network = card
+        .and_then(|c| c.card_network.clone())
+        .or_else(|| nti_card_opt.and_then(|n| n.card_network.clone()));
+    let merchant_metadata_early = match router_data.request.metadata.as_ref() {
+        Some(meta) => serde_json::from_value::<TsysTransitMerchantMetadata>(meta.clone().expose())
+            .change_context(IntegrationError::InvalidDataFormat {
+                field_name: "connector_metadata.tsys_transit",
+                context: Default::default(),
+            })?,
+        None => TsysTransitMerchantMetadata::default(),
+    };
+    let merchant_inner_early = merchant_metadata_early.into_inner();
+    let commercial_meta = merchant_inner_early.commercial_card.clone();
+    let recurring_context = compute_recurring_context(
+        router_data.request.mit_category.clone(),
+        router_data
+            .resource_common_data
+            .recurring_mandate_payment_data
+            .as_ref(),
+        card_network.as_ref(),
+    )?;
+    let commercial_card_context = compute_commercial_card_context(
+        router_data,
+        commercial_meta.as_ref(),
+        card_network.as_ref(),
+    )?;
+    let three_ds_context = compute_three_ds_context(router_data, card_network.as_ref());
+
+    let profile = TxProfile::derive_for_authorize(router_data);
+    let cvv_present_for_authorize = card.map(|c| !c.card_cvc.peek().is_empty()).unwrap_or(false);
+
+    let (card_number, expiration_date, cvv2, customer_code, wallet_details) =
+        if let MandateDispatch::Vault {
+            customer_code,
+            wallet_id,
+        } = &mandate_dispatch
+        {
+            (
+                None,
+                None,
+                None,
+                Some(Secret::new(customer_code.clone())),
+                Some(TsysTransitWalletDetailsRef {
+                    wallet_id: Secret::new(wallet_id.clone()),
+                }),
+            )
+        } else if let Some(card) = card {
+            let cvv = if recurring_context.enabled {
+                None
+            } else if card.card_cvc.peek().is_empty() {
+                return Err(IntegrationError::MissingRequiredField {
+                    field_name: "card_cvc required for TSYS XML authorization cvv2",
+                    context: Default::default(),
+                }
+                .into());
+            } else {
+                Some(card.card_cvc.clone())
+            };
+            (
+                Some(Secret::new(card.card_number.peek().to_string())),
+                Some(format_expiration_date(card)),
+                cvv,
+                None,
+                None,
+            )
+        } else if let Some(nti) = nti_card_opt {
+            let month = nti.card_exp_month.peek().clone();
+            let year_full = nti.card_exp_year.peek().clone();
+            let year_short = if year_full.len() == 4 {
+                year_full[2..].to_string()
+            } else {
+                year_full
+            };
+            (
+                Some(Secret::new(nti.card_number.peek().to_string())),
+                Some(Secret::new(format!("{}/{}", month, year_short))),
+                None,
+                None,
+                None,
+            )
+        } else {
+            return Err(IntegrationError::NotSupported {
+                message: "Selected payment method".to_string(),
+                connector: "tsysTransit",
+                context: Default::default(),
+            }
+            .into());
+        };
+
+    let card_on_file_context = build_card_on_file_context(
+        &mandate_dispatch,
+        recurring_context.enabled,
+        card_network.as_ref(),
+        is_cit_setup,
+    );
+    let original_recurring_amount = compute_original_recurring_amount(
+        &recurring_context,
+        card_network.as_ref(),
+        &mandate_dispatch,
+        router_data.request.currency,
+    )?;
+    let external_reference_id = sanitize_alphanumeric_space(
+        &router_data
+            .resource_common_data
+            .connector_request_reference_id,
+        40,
+    );
+
+    Ok(AuthorizeAssembly {
+        profile,
+        auth,
+        transaction_amount,
+        surcharge,
+        address_line1,
+        zip,
+        external_reference_id,
+        card_number,
+        expiration_date,
+        cvv2,
+        customer_code,
+        wallet_details,
+        cvv_present_for_authorize,
+        recurring_context,
+        commercial_card_context,
+        three_ds_context,
+        card_on_file_context,
+        original_recurring_amount,
+    })
+}
+
+fn assemble_authorize_body(assembly: AuthorizeAssembly) -> TsysTransitAuthorizeBody {
+    let AuthorizeAssembly {
+        profile,
+        auth,
+        transaction_amount,
+        surcharge,
+        address_line1,
+        zip,
+        external_reference_id,
+        card_number,
+        expiration_date,
+        cvv2,
+        customer_code,
+        wallet_details,
+        cvv_present_for_authorize,
+        recurring_context,
+        commercial_card_context,
+        three_ds_context,
+        card_on_file_context,
+        original_recurring_amount,
+    } = assembly;
+    let terminal_data = rules::terminal_data::terminal_data(&profile);
+
+    // ── terminalData fields (merchant overrides win) ─────────────
+    let rules::terminal_data::ResolvedTerminalData {
+        card_data_source,
+        terminal_capability,
+        terminal_operating_environment,
+        cardholder_authentication_method,
+        terminal_authentication_capability,
+        terminal_output_capability,
+        max_pin_length,
+        terminal_card_capture_capability,
+        cardholder_present_detail,
+        card_present_detail,
+        card_data_input_mode,
+        cardholder_authentication_entity,
+        card_data_output_capability,
+    } = rules::terminal_data::resolve(&profile, &terminal_data, cvv_present_for_authorize);
+
+    // ── Network indicators via rules ─────────────────────────────
+    let authorization_indicator = rules::network_indicators::authorization_indicator(&profile);
+    let (registered_user_indicator, last_registered_change_date) =
+        match rules::network_indicators::registered_user(&profile) {
+            Some((ind, date)) => (Some(ind), Some(date)),
+            None => (None, None),
+        };
+
+    // ── COF / MIT signaling via rules ────────────────────────────
+    let card_on_file_from_rule = rules::cof_mit::card_on_file(&profile);
+    // citStatusIndicator and mitStatusIndicator are MUTUALLY EXCLUSIVE
+    // (TSYS rejects both on one transaction). The cof_phase decides which:
+    // MIT → mitStatusIndicator only; CIT-setup / CIT-using-stored → cit only.
+    // Network-specific MC values (M102/M103/M104, C102/C103) come from the
+    // recurring metadata subtype when present, else the generic rule default.
+    let (mit_status_indicator, cit_status_indicator) = if profile.cof_phase.is_mit() {
+        let mit = recurring_context
+            .mit_status_indicator
+            .or_else(|| rules::cof_mit::mit_status_indicator(&profile));
+        (mit, None)
+    } else {
+        let cit = recurring_context
+            .mc_cit_status_indicator
+            .or_else(|| rules::cof_mit::cit_status_indicator(&profile));
+        (None, cit)
+    };
+    // CIT-using-stored must NOT carry cardOnFileTransactionIdentifier
+    // (MIT-only tag).
+    let card_on_file_transaction_identifier =
+        if rules::cof_mit::should_send_card_on_file_transaction_identifier(&profile) {
+            card_on_file_context
+                .card_on_file_transaction_identifier
+                .clone()
+        } else {
+            None
+        };
+    // The `mit` block on the body comes from build_card_on_file_context
+    // for vault flows; rules decide whether to send it.
+    let mit_block_for_body = if profile.cof_phase.is_mit() {
+        card_on_file_context.mit_block.clone()
+    } else {
+        None
+    };
+
+    let partial_auth_support = rules::network_indicators::partial_auth_support(&profile);
+
+    TsysTransitAuthorizeBody {
+        device_id: auth.device_id,
+        transaction_key: auth.transaction_key,
+        card_data_source,
+        transaction_amount,
+        sales_tax: commercial_card_context.sales_tax,
+        surcharge,
+        additional_tax_details: commercial_card_context.additional_tax_details,
+        shipping_charges: commercial_card_context.shipping_charges,
+        duty_charges: commercial_card_context.duty_charges,
+        card_number,
+        expiration_date,
+        cvv2,
+        secure_code: three_ds_context.secure_code,
+        ucaf_collection_indicator: three_ds_context.ucaf_collection_indicator,
+        directory_server_transaction_id: three_ds_context.directory_server_transaction_id,
+        eci_indicator: three_ds_context.eci_indicator,
+        customer_code,
+        wallet_details,
+        card_on_file_transaction_identifier,
+        previous_network_transaction_id: card_on_file_context.previous_network_transaction_id,
+        cit_status_indicator,
+        mit_status_indicator,
+        address_line1,
+        zip,
+        external_reference_id,
+        product_details: commercial_card_context.product_details,
+        commercial_card_level: commercial_card_context.commercial_card_level,
+        // Per-field commercial gating from rules::commercial.
+        purchase_order: rules::commercial::purchase_order(
+            &profile,
+            commercial_card_context.purchase_order,
+        ),
+        charge_descriptor: commercial_card_context.charge_descriptor,
+        charge_descriptor_2: commercial_card_context.charge_descriptor_2,
+        charge_descriptor_3: commercial_card_context.charge_descriptor_3,
+        charge_descriptor_4: commercial_card_context.charge_descriptor_4,
+        customer_vat_number: commercial_card_context.customer_vat_number,
+        customer_ref_id: rules::commercial::customer_ref_id(
+            &profile,
+            commercial_card_context.customer_ref_id,
+        ),
+        supplier_reference_number: rules::commercial::supplier_reference_number(
+            &profile,
+            commercial_card_context.supplier_reference_number,
+        ),
+        order_date: commercial_card_context.order_date,
+        summary_commodity_code: commercial_card_context.summary_commodity_code,
+        vat_invoice: commercial_card_context.vat_invoice,
+        ship_from_zip: commercial_card_context.ship_from_zip,
+        ship_to_zip: rules::commercial::ship_to_zip(&profile, commercial_card_context.ship_to_zip),
+        destination_country_code: rules::commercial::destination_country_code(
+            &profile,
+            commercial_card_context.destination_country_code,
+        ),
+        card_on_file: card_on_file_from_rule,
+        partial_auth_support,
+        terminal_capability,
+        terminal_operating_environment,
+        cardholder_authentication_method,
+        terminal_authentication_capability,
+        terminal_output_capability,
+        max_pin_length,
+        terminal_card_capture_capability,
+        cardholder_present_detail,
+        card_present_detail,
+        card_data_input_mode,
+        cardholder_authentication_entity,
+        card_data_output_capability,
+        developer_id: auth.developer_id,
+        is_recurring: recurring_context.is_recurring_flag,
+        billing_type: recurring_context.billing_type,
+        payment_count: recurring_context.payment_count,
+        current_payment_count: recurring_context.current_payment_count,
+        original_recurring_amount,
+        registered_user_indicator,
+        last_registered_change_date,
+        authorization_indicator,
+        mit: mit_block_for_body,
+    }
+}
 #[derive(Debug, Clone)]
-enum MandateDispatch {
+pub enum MandateDispatch {
     Vault {
         customer_code: String,
         wallet_id: String,
@@ -2489,7 +2382,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             redirection_data: None,
             mandate_reference: None,
             connector_metadata: None,
-            network_txn_id: body.auth_code.clone(),
+            // Store the network transaction identifier (NOT the per-transaction
+            // authCode) so later Mastercard/Visa MITs replay the correct
+            // stored-credential reference. See cert MOTO rows 161/162 — the
+            // authCode (e.g. "VTLMC1") must never surface as
+            // cardOnFileTransactionIdentifier.
+            network_txn_id: body.card_transaction_identifier.clone(),
             network_txn_link_id: None,
             connector_response_reference_id: Some(transaction_id),
             incremental_authorization_allowed: None,
@@ -3431,17 +3329,26 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 context: Default::default(),
             })
         })?;
+        // TSYS cert: firstName / lastName are Visa-only on card
+        // authentication ("firstName and lastName tags must not be sent
+        // on the 0.00 Mastercard / AMEX card authentication in step 3 as
+        // these are Visa card authentication only tags").
         let (cardholder_first_name, cardholder_last_name) =
             split_domain_full_name(card.card_holder_name.clone());
-        let first_name = billing
-            .and_then(|a| a.first_name.clone())
-            .or(cardholder_first_name)
-            .map(|name| Secret::new(sanitize_alphanumeric_space(name.peek(), 25)));
+        let is_visa_card_auth = matches!(card.card_network, Some(CardNetwork::Visa));
+        let first_name = if is_visa_card_auth {
+            billing
+                .and_then(|a| a.first_name.clone())
+                .or(cardholder_first_name)
+                .map(|name| Secret::new(sanitize_alphanumeric_space(name.peek(), 25)))
+        } else {
+            None
+        };
         let derived_last_name = billing
             .and_then(|a| a.last_name.clone())
             .or(cardholder_last_name)
             .map(|name| Secret::new(sanitize_alphanumeric_space(name.peek(), 25)));
-        let last_name = if matches!(card.card_network, Some(CardNetwork::Visa)) {
+        let last_name = if is_visa_card_auth {
             Some(derived_last_name.ok_or_else(|| {
                 error_stack::report!(IntegrationError::MissingRequiredField {
                     field_name: "billing.address.last_name required for Visa CardAuthentication Account Name Inquiry",
@@ -3449,104 +3356,44 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 })
             })?)
         } else {
-            derived_last_name
-        };
-
-        let channel = router_data.request.payment_channel.clone();
-        let card_data_source = match channel {
-            Some(PaymentChannel::TelephoneOrder) => TsysTransitCardDataSource::Phone,
-            Some(PaymentChannel::MailOrder) => TsysTransitCardDataSource::Mail,
-            Some(PaymentChannel::Ecommerce) | None => TsysTransitCardDataSource::Internet,
-        };
-        let merchant_metadata = match router_data.request.metadata.as_ref() {
-            Some(meta) => {
-                serde_json::from_value::<TsysTransitMerchantMetadata>(meta.clone().expose())
-                    .change_context(IntegrationError::InvalidDataFormat {
-                        field_name: "connector_metadata.tsys_transit",
-                        context: Default::default(),
-                    })?
-            }
-            None => TsysTransitMerchantMetadata::default(),
-        };
-        let merchant_inner = merchant_metadata.into_inner();
-        let terminal_overrides = merchant_inner.terminal_data.unwrap_or_default();
-        let card_network = card.card_network.clone();
-        let recurring_context = compute_recurring_context(
-            router_data.request.mit_category.clone(),
-            None,
-            card_network.as_ref(),
-        )?;
-        let cit_status_indicator = if matches!(card_network, Some(CardNetwork::Mastercard)) {
-            recurring_context
-                .mc_cit_status_indicator
-                .or(Some(TsysTransitMcCitStatusIndicator::C101))
-        } else {
             None
         };
 
-        let terminal_capability = terminal_overrides
-            .terminal_capability
-            .unwrap_or(TsysTransitTerminalCapability::KeyedEntryOnly);
-        let terminal_operating_environment = terminal_overrides
-            .terminal_operating_environment
-            .unwrap_or(TsysTransitTerminalOperatingEnvironment::NoTerminal);
-        let cardholder_authentication_method = terminal_overrides
-            .cardholder_authentication_method
-            .unwrap_or(TsysTransitCardholderAuthenticationMethod::NotAuthenticated);
-        let terminal_authentication_capability = terminal_overrides
-            .terminal_authentication_capability
-            .unwrap_or(TsysTransitTerminalAuthenticationCapability::NoCapability);
-        let terminal_output_capability = terminal_overrides
-            .terminal_output_capability
-            .unwrap_or(TsysTransitTerminalOutputCapability::None);
-        let max_pin_length = terminal_overrides
-            .max_pin_length
-            .unwrap_or(TsysTransitMaxPinLength::NotSupported);
-        let terminal_card_capture_capability = terminal_overrides
-            .terminal_card_capture_capability
-            .unwrap_or(TsysTransitTerminalCardCaptureCapability::NoCapability);
-        let cardholder_present_detail = terminal_overrides
-            .cardholder_present_detail
-            .unwrap_or_else(|| {
-                if recurring_context.enabled
-                    && matches!(card_network, Some(CardNetwork::Mastercard))
-                {
-                    return TsysTransitCardholderPresentDetail::CardholderNotPresentRecurringTransaction;
-                }
-                match channel {
-                    Some(PaymentChannel::TelephoneOrder) => {
-                        TsysTransitCardholderPresentDetail::CardholderNotPresentPhoneTransaction
-                    }
-                    Some(PaymentChannel::MailOrder) => {
-                        TsysTransitCardholderPresentDetail::CardholderNotPresentMailTransaction
-                    }
-                    _ => TsysTransitCardholderPresentDetail::CardholderNotPresentElectronicCommerce,
-                }
-            });
-        let card_present_detail = terminal_overrides
-            .card_present_detail
-            .unwrap_or(TsysTransitCardPresentDetail::CardNotPresent);
-        let is_cit_setup = router_data.request.setup_future_usage == Some(FutureUsage::OffSession)
-            || router_data.request.off_session == Some(true);
-        let default_card_data_input_mode = if is_cit_setup {
-            TsysTransitCardDataInputMode::MerchantInitiatedTransactionCardCredentialStoredOnFile
-        } else {
-            match channel {
-                Some(PaymentChannel::Ecommerce) | None => {
-                    TsysTransitCardDataInputMode::PanEntryElectronicCommerceIncludingRemoteChip
-                }
-                _ => TsysTransitCardDataInputMode::KeyEnteredInput,
-            }
-        };
-        let card_data_input_mode = terminal_overrides
-            .card_data_input_mode
-            .unwrap_or(default_card_data_input_mode);
-        let cardholder_authentication_entity = terminal_overrides
-            .cardholder_authentication_entity
-            .unwrap_or(TsysTransitCardholderAuthenticationEntity::NotAuthenticated);
-        let card_data_output_capability = terminal_overrides
-            .card_data_output_capability
-            .unwrap_or(TsysTransitCardDataOutputCapability::None);
+        // ── Profile + terminalData via rules ─────────────────────────
+        let profile = TxProfile::derive_for_card_authentication(router_data);
+        let terminal_data = rules::terminal_data::terminal_data(&profile);
+        let cvv_present = !card.card_cvc.peek().is_empty();
+
+        // ── terminalData fields (profile/rules only, no merchant override) ─
+        let rules::terminal_data::ResolvedTerminalData {
+            card_data_source,
+            terminal_capability,
+            terminal_operating_environment,
+            cardholder_authentication_method,
+            terminal_authentication_capability,
+            terminal_output_capability,
+            max_pin_length,
+            terminal_card_capture_capability,
+            cardholder_present_detail,
+            card_present_detail,
+            card_data_input_mode,
+            cardholder_authentication_entity,
+            card_data_output_capability,
+        } = rules::terminal_data::resolve(&profile, &terminal_data, cvv_present);
+
+        // ── Per-tx fields via rules ──────────────────────────────────
+        // TSYS cert: cvv2 must be sent on card authentication when the
+        // merchant collected one.
+        let cvv2 = cvv_present.then(|| card.card_cvc.clone());
+        // TSYS cert: authorizationIndicator must be sent on Mastercard
+        // card authentications in step 3 (Final since card auth is a
+        // self-contained 0.00 probe).
+        let authorization_indicator =
+            rules::network_indicators::authorization_indicator_for_card_auth(&profile);
+        // TSYS cert (MOTO step 5): cardOnFile=Y on Visa CIT-setup card
+        // authentications used to store credentials for future payments.
+        let card_on_file = rules::cof_mit::card_on_file(&profile);
+        let cit_status_indicator = rules::cof_mit::cit_status_indicator(&profile);
 
         Ok(Self {
             device_id: auth.device_id,
@@ -3554,12 +3401,17 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             card_data_source,
             card_number: Secret::new(card.card_number.peek().to_string()),
             expiration_date: format_expiration_date(card),
-            address_line1,
+            cvv2,
+            address_line1: address_line1.clone(),
             zip,
-            external_reference_id: router_data
-                .resource_common_data
-                .connector_request_reference_id
-                .clone(),
+            // TSYS cert: externalReferenceID is alphanumeric only; strip
+            // underscores and any other non-alphanumeric/space chars.
+            external_reference_id: sanitize_alphanumeric_space(
+                &router_data
+                    .resource_common_data
+                    .connector_request_reference_id,
+                40,
+            ),
             first_name,
             middle_name: None,
             last_name,
@@ -3576,8 +3428,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             card_data_input_mode,
             cardholder_authentication_entity,
             card_data_output_capability,
+            // mPos must be the LAST element on CardAuthentication per
+            // the SBX XSD; downstream fields (cardOnFile, etc.) live
+            // earlier in the struct now.
             m_pos_acceptance_device_type: "0".to_string(),
-            card_on_file: None,
+            authorization_indicator,
+            card_on_file,
             cit_status_indicator,
         })
     }
@@ -3684,6 +3540,25 @@ fn repeat_payment_data_to_authorize<T: PaymentMethodDataTypes>(
         mandate_reference_id: Some(req.mandate_reference.clone()),
     };
 
+    // The RecurringPaymentServiceChargeRequest proto doesn't carry
+    // payment_channel — recover it from the TSYS merchant metadata's
+    // optional `payment_channel` override so MOTO MIT executions still
+    // produce CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION etc. instead of
+    // the e-com default.
+    let payment_channel_from_metadata = req
+        .metadata
+        .as_ref()
+        .and_then(|m| {
+            serde_json::from_value::<TsysTransitMerchantMetadata>(m.clone().expose()).ok()
+        })
+        .and_then(|m| m.into_inner().payment_channel)
+        .and_then(|s| match s.to_ascii_lowercase().as_str() {
+            "telephone_order" | "phone" => Some(PaymentChannel::TelephoneOrder),
+            "mail_order" | "mail" => Some(PaymentChannel::MailOrder),
+            "ecommerce" | "internet" => Some(PaymentChannel::Ecommerce),
+            _ => None,
+        });
+
     PaymentsAuthorizeData {
         payment_method_data: req.payment_method_data.clone(),
         amount: req.minor_amount,
@@ -3728,7 +3603,7 @@ fn repeat_payment_data_to_authorize<T: PaymentMethodDataTypes>(
         setup_mandate_details: None,
         connector_feature_data: req.connector_feature_data.clone(),
         connector_testing_data: req.connector_testing_data.clone(),
-        payment_channel: None,
+        payment_channel: payment_channel_from_metadata,
         enable_partial_authorization: req.enable_partial_authorization,
         locale: req.locale.clone(),
         redirect_response: None,
@@ -3850,7 +3725,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             redirection_data: None,
             mandate_reference: None,
             connector_metadata: None,
-            network_txn_id: body.auth_code.clone(),
+            // Network transaction identifier, not the authCode (see Authorize).
+            network_txn_id: body.card_transaction_identifier.clone(),
             network_txn_link_id: None,
             connector_response_reference_id: Some(transaction_id),
             incremental_authorization_allowed: None,


### PR DESCRIPTION
## Description

Makes the `tsys_transit` (TSYS TransIT XML) request-building generic and fixes the MOTO certification deviations found by auditing our live output against the TSYS reference scripts.

**Generic refactor (de-confuses the builder):**
- Splits the ~430-line inline Authorize `try_from` into a clean seam: `extract_for_authorize` (all `RouterData` reads + context computation + fallible paths) → pure, infallible `assemble_authorize_body` (rule calls + body literal). Verified byte-identical wire output.
- Builds on the `profile/` (classification axes) + `rules/` (per-field pure functions) decomposition so a field's value is a table lookup, not if/else re-tested per field. CardAuthentication + RepeatPayment share the same rules layer (`rules::terminal_data::resolve`).
- Adds a `channel_source` axis to `TxProfile` so `cardDataSource` (PHONE/MAIL/INTERNET) is independent of the recurring classification.
- Docs: `tsys_transit/ARCHITECTURE.md` (how to add a flow), plus design/plan under `docs/superpowers/`.

**MOTO certification fixes (audited against `TSYS_certification_moto_v2` / `TSYS_MOTO_V3` references, all verified live):**
- CardAuthentication no longer sends `authorizationIndicator` (stagegw XSD rejects it → F9901; cert MOTO row 144).
- `authorizationIndicator` on Mastercard sales only on stored-credential use (CitUsingStored/Mit), not plain sales.
- `network_txn_id` now returns the real `cardTransactionIdentifier`, not the per-transaction `authCode` (added the missing response field) — so stored credentials replay the correct reference.
- `cardOnFileTransactionIdentifier` is Visa/Discover-only (Mastercard uses `mitStatusIndicator`, AMEX its own COF handling).
- `cardDataSource=RECURRING` no longer emitted on MOTO card-on-file rows (TSYS rejects it) — channel-derived value used; recurring semantics (`isRecurring`, `CARDHOLDER_NOT_PRESENT_RECURRING_TRANSACTION`, `M102`) ride other fields.
- `citStatusIndicator` and `mitStatusIndicator` are now mutually exclusive per cof-phase (TSYS rejects both on one transaction).
- Aligned with `TSYS_MOTO_V3`: JCB+CVV uses `KEY_ENTERED_INPUT` (only AMEX uses the manual-CID mode); `shipToZip` sent on commercial L2 (incl. AMEX).

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

The connector decided every TSYS wire field by re-testing three orthogonal signals (channel, recurring, card-on-file) inline at each field, inside one 430-line builder copy-pasted across flows — adding a flow meant threading another boolean through ~15 branches in two places. This refactor makes the field decisions table-driven so MOTO is correct now and recurring/ecommerce become "add a profile variant + rule arms + tests."

Separately, auditing our live request XML against the TSYS MOTO reference scripts surfaced several deviations (auth code stored as the network transaction id, `authorizationIndicator`/`cardDataSource` over-sends, cit/mit both emitted, JCB input mode, L2 `shipToZip`). All are fixed and confirmed against the live TSYS stagegw sandbox.

## How did you test it?

- **Unit + golden tests:** 50 cert-row/rule tests + golden-XML serialization locks (Authorize row 125, CardAuthentication) — `cargo test -p connector-integration tsys_transit`, all green; `cargo clippy` clean.
- **Live end-to-end (HS → UCS → TSYS stagegw sandbox):** drove the full MOTO certification suite (33 rows: sales/auth/capture/void/returns, L2/L3, card-auth, and the step-5 COF/recurring rows) through Hyperswitch routing to this connector — **33/33 approved**.
- **Reference conformance:** output matches the `TSYS_MOTO_V3` reference on the rows it covers (127, 135) and the cert-corrected behavior elsewhere.
