### PR TITLE
fix(nmi): preserve resource_id and status on empty PSync response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -882,20 +882,29 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
                 response.transaction.last()
             });
 
-        // Handle empty response (means AuthenticationPending) or transaction data
-        // On the empty-response branch, keep resource_id anchored to the transaction_id
-        // that was actually requested (Hyperswitch's PSync leaves the prior resource_id
-        // untouched via `..item.data` in this case, so it never regresses to NoResponseId).
-        let (status, transaction_id) = if let Some(transaction) = transaction {
-            // Map condition field from XML to AttemptStatus using NmiStatus enum
-            let status = AttemptStatus::from(NmiStatus::from(transaction.condition.clone()));
-            (status, transaction.transaction_id.clone())
-        } else {
-            // Empty XML response = AuthenticationPending (during 3DS flow)
-            (
-                AttemptStatus::AuthenticationPending,
-                requested_transaction_id,
-            )
+        // Handle empty response (connector hasn't indexed the transaction yet, e.g.
+        // AuthenticationPending) or transaction data. Hyperswitch's own PSync transformer
+        // leaves the ENTIRE prior response untouched in the empty-response branch
+        // (`None => Ok(Self { ..item.data })`) — both resource_id and status. Match that:
+        // anchor resource_id to the requested transaction_id, and leave status as whatever
+        // it already was instead of forcing AttemptStatus::AuthenticationPending.
+        let (status, transaction_id) = match transaction {
+            Some(transaction) => (
+                // Map condition field from XML to AttemptStatus using NmiStatus enum
+                Some(AttemptStatus::from(NmiStatus::from(
+                    transaction.condition.clone(),
+                ))),
+                transaction.transaction_id.clone(),
+            ),
+            None => (None, requested_transaction_id),
+        };
+
+        let resource_common_data = match status {
+            Some(status) => PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            None => item.router_data.resource_common_data,
         };
 
         Ok(Self {
@@ -911,10 +920,7 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
                 status_code: item.http_code,
                 splits: None,
             }),
-            resource_common_data: PaymentFlowData {
-                status,
-                ..item.router_data.resource_common_data
-            },
+            resource_common_data,
             ..item.router_data
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -883,20 +883,24 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
             });
 
         // Handle empty response (means AuthenticationPending) or transaction data
+        // On the empty-response branch, keep resource_id anchored to the transaction_id
+        // that was actually requested (Hyperswitch's PSync leaves the prior resource_id
+        // untouched via `..item.data` in this case, so it never regresses to NoResponseId).
         let (status, transaction_id) = if let Some(transaction) = transaction {
             // Map condition field from XML to AttemptStatus using NmiStatus enum
             let status = AttemptStatus::from(NmiStatus::from(transaction.condition.clone()));
-            (status, Some(transaction.transaction_id.clone()))
+            (status, transaction.transaction_id.clone())
         } else {
             // Empty XML response = AuthenticationPending (during 3DS flow)
-            (AttemptStatus::AuthenticationPending, None)
+            (
+                AttemptStatus::AuthenticationPending,
+                requested_transaction_id,
+            )
         };
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: transaction_id
-                    .map(ResponseId::ConnectorTransactionId)
-                    .unwrap_or(ResponseId::NoResponseId),
+                resource_id: ResponseId::ConnectorTransactionId(transaction_id),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,


### PR DESCRIPTION
## What

Two shadow-validation diffs on NMI PSync for the same underlying event (both HS and UCS
racing NMI's `query.php` before the connector has indexed the transaction under the
queried order id):

- `router.typeDiff:response.Ok.TransactionResponse.resource_id`
- `router.valueDiff:status`

## Root cause

NMI's `query.php` returns an empty `<nm_response></nm_response>` (no `<transaction>` node)
when it hasn't indexed the transaction yet under the queried order id — this is the
connector's signal for an in-flight/`AuthenticationPending` payment. Confirmed directly
against NMI:

```
$ curl -s https://secure.nmi.com/api/query.php -d "security_key=...&order_id=nonexistent_order_id_xyz123"
<?xml version="1.0" encoding="UTF-8"?>
<nm_response>
</nm_response>
```

Hyperswitch's own PSync transformer (`hyperswitch_connectors/src/connectors/nmi/transformers.rs`,
`TryFrom<ResponseRouterData<F, SyncResponse, T, PaymentsResponseData>>`) handles this by leaving
the **entire previous `response`** untouched in that branch — `None => Ok(Self { ..item.data })`.
That's not just `resource_id`; it's the whole `RouterData`, including `status`. It never
regresses to an id-less state, and it never overwrites the attempt's existing status.

UCS's PSync transformer instead explicitly:
1. reset `resource_id` to `ResponseId::NoResponseId`, and
2. hardcoded `status` to `AttemptStatus::AuthenticationPending`,

in the same empty-response branch — producing, for the same event, a `typeDiff` on
`response.Ok.TransactionResponse.resource_id` (different enum variant than HS) **and** a
`valueDiff` on `status` (HS reports whatever status the attempt already had; UCS reports
`AuthenticationPending`).

## Fix (UCS-only, L3, connector transformer)

`crates/integrations/connector-integration/src/connectors/nmi/transformers.rs`, PSync
`TryFrom<ResponseRouterData<SyncResponse, Self>>`: on the empty-response branch,
- fall back `resource_id` to `ResponseId::ConnectorTransactionId(requested_transaction_id)` —
  the id UCS already extracts earlier in the same function to look up the transaction —
  instead of `ResponseId::NoResponseId`; and
- leave `status` as whatever `item.router_data.resource_common_data.status` already was,
  instead of overwriting it with `AttemptStatus::AuthenticationPending`.

This matches Hyperswitch's effective behavior (leaving the prior response's id and status
untouched) without touching Hyperswitch itself. No proto or HS-mapping change needed — both
fields already flow correctly; only the UCS connector's own fallback values were wrong.

## Verification

- `cargo build --bin grpc-server`, `cargo clippy -p connector-integration --all-targets -- -D warnings`,
  `cargo fmt --all -- --check` all clean on this diff.
- Restarted the local UCS instance with the fix; re-ran the normal (non-empty-response) NMI PSync
  path end-to-end through the local HS→UCS shadow harness — no regression, `resource_id` and
  `status` still correctly set from the matched transaction.
- The specific empty-response branch (AuthenticationPending / transaction-not-yet-indexed) needs a
  genuinely pending/in-flight NMI transaction to exercise live, which isn't reliably forceable in
  the NMI test sandbox (same limitation as prior NMI/nexixpay PSync shadow-validation fixes — the
  sandbox settles transactions before a force_sync can race the indexing window). Root cause and
  fix for both diffs were verified by direct comparison of both connectors' PSync source, and by
  hitting NMI's real `query.php` with an unmatched order id to confirm it returns exactly the
  empty-response shape this code path handles.

Closes #1791
