### PR TITLE
fix(connector): [Paypal] make order status optional in PSync to handle declined captures

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2239,7 +2239,12 @@ pub enum AuthenticationStatus {
 pub struct PaypalOrdersResponse {
     id: String,
     intent: PaypalPaymentIntent,
-    status: PaypalOrderStatus,
+    // PayPal can omit the top-level order `status` in some Orders v2 responses (observed in PSync
+    // for an order whose only capture was `DECLINED`). This field is kept optional so the response
+    // still deserializes when it is absent. The attempt status is not derived from this field
+    // anyway: for orders it is taken from the capture/authorization status inside `purchase_units`
+    // (see `TryFrom<ResponseRouterData<PaypalOrdersResponse, ..>>`).
+    status: Option<PaypalOrderStatus>,
     purchase_units: Vec<PurchaseUnitItem>,
     payment_source: Option<PaymentSourceItemResponse>,
 }
@@ -2444,6 +2449,9 @@ where
             item.http_code,
             "paypal",
         ))?;
+        // Derive the attempt status from the capture/authorization status rather than the
+        // top-level order `status`, which PayPal may omit (e.g. a declined capture). For example a
+        // `DECLINED` capture maps to `AttemptStatus::Failure` and is handled by the branch below.
         let status = payment_collection_item.status.clone();
         let status = common_enums::AttemptStatus::from(status);
 


### PR DESCRIPTION
## Description
PayPal PSync failed with `HE_00 / Something went wrong` for orders whose only capture is `DECLINED`: PayPal omits the top-level order `status` in the Orders v2 response, and every variant of the untagged `PaypalSyncResponse` enum required it, so deserialization failed with:

```text
data did not match any variant of untagged enum PaypalSyncResponse
```

Made `PaypalOrdersResponse.status` an `Option<PaypalOrderStatus>`. The attempt status is not derived from this field — it comes from the capture/authorization status inside `purchase_units` (`DECLINED` capture → `AttemptStatus::Failure` via the existing `is_payment_failure` path).

Replicates hyperswitch PR: https://github.com/juspay/hyperswitch/pull/12783

## Motivation and Context


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?
- `cargo check` / `cargo clippy` clean
- Verified locally that a declined-capture Orders v2 payload without top-level `status` now deserializes into `PaypalOrdersSyncResponse`, and payloads with `status` behave exactly as before (all other untagged variants still require `status`, so variant ordering is unaffected)