### PR TITLE
feat(connector): implement Finix incoming webhooks in UCS

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/finix.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix.rs
@@ -5,7 +5,13 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_enums::{PaymentMethod, PaymentMethodType};
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{
+    crypto::{self, SignMessage},
+    errors::CustomResult,
+    events,
+    ext_traits::ByteSliceExt,
+    types::MinorUnit,
+};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, CreateConnectorCustomer, PSync, PaymentMethodToken, RSync, Refund,
@@ -37,6 +43,7 @@ use transformers::{
 use crate::{types::ResponseRouterData, with_error_response_body};
 use domain_types::errors::ConnectorError;
 use domain_types::errors::IntegrationError;
+use domain_types::errors::WebhookError;
 
 pub(crate) mod headers {
     pub(crate) const CONTENT_TYPE: &str = "Content-Type";
@@ -159,9 +166,124 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 {
 }
 
+// Ported 1:1 from hyperswitch `impl webhooks::IncomingWebhook for Finix`
+// (crates/hyperswitch_connectors/src/connectors/finix.rs). Hyperswitch (Direct
+// gateway) is the source of truth: HMAC-SHA256 over `"{timestamp}:{raw body}"`
+// with the hex-encoded signature carried in the comma-separated
+// `Finix-Signature: timestamp=...,sig=...` header.
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::IncomingWebhook for Finix<T>
 {
+    fn verify_webhook_source(
+        &self,
+        request: RequestDetails,
+        connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+    ) -> Result<bool, error_stack::Report<WebhookError>> {
+        let connector_webhook_secrets = connector_webhook_secret.ok_or_else(|| {
+            tracing::warn!(
+                target: "finix_webhook",
+                "no webhook secret configured for Finix source verification"
+            );
+            error_stack::report!(WebhookError::WebhookVerificationSecretNotFound)
+        })?;
+
+        let signature_header = finix::decode_finix_signature(&request.headers)?;
+
+        // HS hex-decodes the `sig` value before comparing
+        // (get_webhook_source_verification_signature).
+        let signature = hex::decode(&signature_header.sig)
+            .change_context(WebhookError::WebhookSignatureNotFound)
+            .attach_printable("Finix-Signature `sig` value is not valid hex")?;
+
+        // HS signs `"{timestamp}:{raw body}"` — the RAW request bytes, never a
+        // re-serialization (get_webhook_source_verification_message).
+        let message = format!(
+            "{}:{}",
+            signature_header.timestamp,
+            String::from_utf8_lossy(&request.body)
+        )
+        .into_bytes();
+
+        let signed_message = crypto::HmacSha256
+            .sign_message(&connector_webhook_secrets.secret, &message)
+            .change_context(WebhookError::WebhookSourceVerificationFailed)
+            .attach_printable("failed to compute the HMAC-SHA256 over the Finix webhook message")?;
+
+        Ok(signed_message.eq(&signature))
+    }
+
+    fn get_event_type(
+        &self,
+        request: RequestDetails,
+    ) -> Result<EventType, error_stack::Report<WebhookError>> {
+        // HS: an empty body or a body that trims to `{}` is Finix's
+        // endpoint-verification probe (get_webhook_event_type).
+        if finix::is_endpoint_verification_body(&request.body) {
+            return Ok(EventType::EndpointVerification);
+        }
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        finix::get_finix_webhook_event_type(&webhook_body)
+    }
+
+    fn get_webhook_event_reference(
+        &self,
+        request: RequestDetails,
+    ) -> Result<Option<WebhookResourceReference>, error_stack::Report<WebhookError>> {
+        // Endpoint-verification probes carry no resource; HS's Direct gateway
+        // also resolves no reference for them (`get_webhook_object_reference_id`
+        // fails to parse `{}` and the router `.ok()`s it away).
+        if finix::is_endpoint_verification_body(&request.body) {
+            return Ok(None);
+        }
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        finix::get_finix_webhook_reference(&webhook_body)
+    }
+
+    fn process_payment_webhook(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+        _event_context: Option<EventContext>,
+    ) -> Result<WebhookDetailsResponse, error_stack::Report<WebhookError>> {
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        finix::build_finix_payment_webhook_response(&webhook_body, &request.body)
+    }
+
+    fn process_refund_webhook(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+    ) -> Result<RefundWebhookDetailsResponse, error_stack::Report<WebhookError>> {
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        finix::build_finix_refund_webhook_response(&webhook_body, &request.body)
+    }
+
+    fn process_dispute_webhook(
+        &self,
+        request: RequestDetails,
+        _connector_webhook_secret: Option<ConnectorWebhookSecrets>,
+        _connector_account_details: Option<ConnectorSpecificConfig>,
+    ) -> Result<DisputeWebhookDetailsResponse, error_stack::Report<WebhookError>> {
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        finix::build_finix_dispute_webhook_response(&webhook_body, &request.body)
+    }
+
+    fn get_webhook_resource_object(
+        &self,
+        request: RequestDetails,
+    ) -> Result<Box<dyn hyperswitch_masking::ErasedMaskSerialize>, error_stack::Report<WebhookError>>
+    {
+        let webhook_body = finix::parse_finix_webhook_body(&request.body)?;
+        Ok(Box::new(webhook_body))
+    }
+
+    /// A minimal, structurally valid Finix transfer webhook (field-probe input).
+    fn sample_webhook_body(&self) -> &'static [u8] {
+        br#"{"type":"updated","entity":"transfer","_embedded":{"transfers":[{"id":"TRsample000000000000000","amount":1000,"currency":"USD","state":"SUCCEEDED","tags":{},"type":"DEBIT"}]}}"#
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -1761,3 +1761,514 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         })
     }
 }
+
+// =============================================================================
+// INCOMING WEBHOOKS
+// Ported 1:1 from hyperswitch `crates/hyperswitch_connectors/src/connectors/finix.rs`
+// (`impl IncomingWebhook for Finix`) and `finix/transformers/response.rs`
+// (`FinixWebhookBody::{get_webhook_object_reference_id, get_webhook_event_type,
+// get_dispute_details}`). Hyperswitch (Direct gateway) is the source of truth.
+// =============================================================================
+
+use domain_types::connector_types::{
+    DisputeWebhookDetailsResponse, DisputeWebhookReference, EventType, PaymentWebhookReference,
+    RefundWebhookDetailsResponse, RefundWebhookReference, WebhookDetailsResponse,
+    WebhookResourceReference,
+};
+use domain_types::errors::WebhookError;
+use time::PrimitiveDateTime;
+
+/// Webhook transaction state. Mirrors HS `FinixState` (transformers/request.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FinixState {
+    Pending,
+    Succeeded,
+    Failed,
+    Canceled,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Webhook transfer type. Mirrors HS `FinixPaymentType` (transformers/request.rs).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FinixPaymentType {
+    Debit,
+    Credit,
+    Reversal,
+    Fee,
+    Adjustment,
+    Dispute,
+    Reserve,
+    Settlement,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Mirrors HS `FinixThreeDSecure` (transformers/request.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FinixThreeDSecure {
+    pub cardholder_authentication: Secret<String>,
+    pub electronic_commerce_indicator: String,
+    pub transaction_id: Option<String>,
+}
+
+/// Webhook payment resource (authorization or transfer). Mirrors HS
+/// `FinixPaymentsResponse` (transformers/response.rs) field-for-field so that
+/// (de)serialization succeeds/fails on exactly the same payloads.
+/// Named `FinixWebhookPaymentsResponse` because prism already has a different
+/// `FinixPaymentsResponse` for the sync/authorize API responses.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FinixWebhookPaymentsResponse {
+    pub id: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub application: Option<Secret<String>>,
+    pub amount: MinorUnit,
+    pub captured_amount: Option<MinorUnit>,
+    pub currency: Currency,
+    pub is_void: Option<bool>,
+    pub source: Option<Secret<String>>,
+    pub state: FinixState,
+    pub failure_code: Option<String>,
+    pub messages: Option<Vec<String>>,
+    pub failure_message: Option<String>,
+    pub transfer: Option<String>,
+    pub tags: FinixTags,
+    #[serde(rename = "type")]
+    pub payment_type: Option<FinixPaymentType>,
+    pub three_d_secure: Option<FinixThreeDSecure>,
+    pub address_verification: Option<String>,
+    pub network_details: Option<FinixNetworkDetails>,
+}
+
+/// Mirrors HS `FinixDisputeState` (transformers/response.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FinixDisputeState {
+    Inquiry,
+    Pending,
+    Lost,
+    Won,
+}
+
+/// Mirrors HS `FinixDisputes` (transformers/response.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FinixDisputes {
+    pub transfer: String,
+    pub reason: Option<String>,
+    pub amount: MinorUnit,
+    pub state: FinixDisputeState,
+    pub currency: Currency,
+    pub id: String,
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub created_at: Option<PrimitiveDateTime>,
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub updated_at: Option<PrimitiveDateTime>,
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub respond_by: Option<PrimitiveDateTime>,
+}
+
+/// Mirrors HS `SingleEventType` (transformers/response.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SingleEventType<T>(Vec<T>);
+
+impl<T: Clone> SingleEventType<T> {
+    pub fn get_first_event(&self) -> Result<T, error_stack::Report<WebhookError>> {
+        self.0
+            .first()
+            .cloned()
+            .ok_or_else(|| error_stack::report!(WebhookError::WebhookBodyDecodingFailed))
+    }
+}
+
+/// Mirrors HS `FinixEmbedded` (transformers/response.rs). Untagged: variant order
+/// (Authorizations, Transfers, Disputes) matches HS so ambiguous payloads resolve
+/// identically.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FinixEmbedded {
+    Authorizations {
+        authorizations: SingleEventType<FinixWebhookPaymentsResponse>,
+    },
+    Transfers {
+        transfers: SingleEventType<FinixWebhookPaymentsResponse>,
+    },
+    Disputes {
+        disputes: SingleEventType<FinixDisputes>,
+    },
+}
+
+/// Mirrors HS `FinixWebhookBody` (transformers/response.rs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FinixWebhookBody {
+    #[serde(rename = "type")]
+    pub webhook_type: String,
+    pub entity: String,
+    #[serde(rename = "_embedded")]
+    pub webhook_embedded: FinixEmbedded,
+}
+
+/// Parsed `Finix-Signature` header. Mirrors HS `FinixWebhookSignature`
+/// (`sig` kept as the hex string; hex-decoded at the verification site).
+#[derive(Debug)]
+pub struct FinixWebhookSignature {
+    pub timestamp: String,
+    pub sig: String,
+}
+
+/// HS treats an empty body or a body that trims to `{}` as Finix's
+/// endpoint-verification probe (finix.rs `get_webhook_event_type`). HS's
+/// `SetupWebhook` arm is unreachable there (`is_test_webhook` only matches an
+/// exact `"{}"` body, which this check already catches), so it is not ported.
+pub(super) fn is_endpoint_verification_body(body: &[u8]) -> bool {
+    let trimmed_body = std::str::from_utf8(body)
+        .map(|string| string.trim())
+        .unwrap_or("");
+    body.is_empty() || trimmed_body == "{}"
+}
+
+pub(super) fn parse_finix_webhook_body(
+    body: &[u8],
+) -> Result<FinixWebhookBody, error_stack::Report<WebhookError>> {
+    serde_json::from_slice::<FinixWebhookBody>(body)
+        .change_context(WebhookError::WebhookBodyDecodingFailed)
+        .attach_printable("failed to deserialize the Finix webhook body (FinixWebhookBody)")
+}
+
+/// Parses the comma-separated `key=value` pairs of the `Finix-Signature` header.
+/// Ports HS `decode_finix_signature` (finix.rs); header lookup is
+/// case-insensitive because the gRPC surface transports headers as a plain map.
+pub(super) fn decode_finix_signature(
+    headers: &HashMap<String, String>,
+) -> Result<FinixWebhookSignature, error_stack::Report<WebhookError>> {
+    let security_header = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("finix-signature"))
+        .map(|(_, value)| value.as_str())
+        .ok_or_else(|| error_stack::report!(WebhookError::WebhookSignatureNotFound))?;
+
+    let map: HashMap<&str, &str> = security_header
+        .split(',')
+        .map(|kv| {
+            let mut parts = kv.trim().splitn(2, '=');
+            let key = parts
+                .next()
+                .ok_or_else(|| error_stack::report!(WebhookError::WebhookSignatureNotFound))?;
+            let value = parts
+                .next()
+                .ok_or_else(|| error_stack::report!(WebhookError::WebhookSignatureNotFound))?;
+            Ok((key, value))
+        })
+        .collect::<Result<_, error_stack::Report<WebhookError>>>()?;
+
+    let timestamp = map
+        .get("timestamp")
+        .ok_or_else(|| error_stack::report!(WebhookError::WebhookSignatureNotFound))?
+        .to_string();
+
+    let sig = map
+        .get("sig")
+        .ok_or_else(|| error_stack::report!(WebhookError::WebhookSignatureNotFound))?
+        .to_string();
+
+    Ok(FinixWebhookSignature { timestamp, sig })
+}
+
+/// Ports HS `FinixWebhookBody::get_webhook_event_type` arm-for-arm.
+/// HS maps a PENDING reversal to `IncomingWebhookEvent::EventNotSupported`;
+/// the equivalent here is `EventType::IncomingWebhookEventUnspecified`
+/// (proto `WEBHOOK_EVENT_TYPE_UNSPECIFIED` = 0, which the HS UCS client maps
+/// back to `EventNotSupported` in `from_ucs_event_type`).
+pub(super) fn get_finix_webhook_event_type(
+    body: &FinixWebhookBody,
+) -> Result<EventType, error_stack::Report<WebhookError>> {
+    match &body.webhook_embedded {
+        FinixEmbedded::Authorizations { authorizations } => {
+            let authorization = authorizations.get_first_event()?;
+
+            if authorization.is_void == Some(true) {
+                match authorization.state {
+                    FinixState::Failed | FinixState::Canceled | FinixState::Unknown => {
+                        Ok(EventType::PaymentIntentCancelFailure)
+                    }
+                    FinixState::Pending => Ok(EventType::PaymentIntentProcessing),
+                    FinixState::Succeeded => Ok(EventType::PaymentIntentCancelled),
+                }
+            } else {
+                match authorization.state {
+                    FinixState::Pending => Ok(EventType::PaymentIntentProcessing),
+                    FinixState::Succeeded => Ok(EventType::PaymentIntentAuthorizationSuccess),
+                    FinixState::Failed | FinixState::Canceled | FinixState::Unknown => {
+                        Ok(EventType::PaymentIntentAuthorizationFailure)
+                    }
+                }
+            }
+        }
+        FinixEmbedded::Transfers { transfers } => {
+            let transfer = transfers.get_first_event()?;
+
+            if transfer.payment_type == Some(FinixPaymentType::Reversal) {
+                match transfer.state {
+                    FinixState::Succeeded => Ok(EventType::RefundSuccess),
+                    // HS: `EventNotSupported` (see doc comment above).
+                    FinixState::Pending => Ok(EventType::IncomingWebhookEventUnspecified),
+                    FinixState::Failed | FinixState::Canceled | FinixState::Unknown => {
+                        Ok(EventType::RefundFailure)
+                    }
+                }
+            } else {
+                match transfer.state {
+                    FinixState::Pending => Ok(EventType::PaymentIntentProcessing),
+                    FinixState::Succeeded => Ok(EventType::PaymentIntentSuccess),
+                    FinixState::Failed | FinixState::Canceled | FinixState::Unknown => {
+                        Ok(EventType::PaymentIntentFailure)
+                    }
+                }
+            }
+        }
+        FinixEmbedded::Disputes { disputes } => {
+            let dispute = disputes.get_first_event()?;
+
+            match dispute.state {
+                FinixDisputeState::Pending => Ok(EventType::DisputeOpened),
+                FinixDisputeState::Inquiry => Ok(EventType::DisputeChallenged),
+                FinixDisputeState::Lost => Ok(EventType::DisputeLost),
+                FinixDisputeState::Won => Ok(EventType::DisputeWon),
+            }
+        }
+    }
+}
+
+/// Ports HS `FinixWebhookBody::get_webhook_object_reference_id`:
+/// - Authorizations -> `PaymentId(ConnectorTransactionId(authorization.id))`
+/// - Transfers (REVERSAL) -> `RefundId(ConnectorRefundId(transfer.id))`
+/// - Transfers (FEE) -> error (HS: `WebhookEventTypeNotFound`, platform fee ignored)
+/// - Transfers (other) -> `PaymentId(ConnectorTransactionId(transfer.id))`
+/// - Disputes -> HS emits `PaymentId(ConnectorTransactionId(dispute.transfer))`; the
+///   HS reference normaliser maps a prism Dispute reference via
+///   `connector_dispute_id.or(connector_transaction_id)` into exactly that, so
+///   `connector_dispute_id` MUST stay `None` for byte-parity with the Direct gateway.
+pub(super) fn get_finix_webhook_reference(
+    body: &FinixWebhookBody,
+) -> Result<Option<WebhookResourceReference>, error_stack::Report<WebhookError>> {
+    match &body.webhook_embedded {
+        FinixEmbedded::Authorizations { authorizations } => {
+            let authorization = authorizations.get_first_event()?;
+
+            Ok(Some(WebhookResourceReference::Payment(
+                PaymentWebhookReference {
+                    connector_transaction_id: Some(authorization.id),
+                    merchant_transaction_id: None,
+                },
+            )))
+        }
+        FinixEmbedded::Transfers { transfers } => {
+            let transfer = transfers.get_first_event()?;
+
+            match transfer.payment_type {
+                Some(FinixPaymentType::Reversal) => Ok(Some(WebhookResourceReference::Refund(
+                    RefundWebhookReference {
+                        connector_refund_id: Some(transfer.id),
+                        merchant_refund_id: None,
+                        connector_transaction_id: None,
+                    },
+                ))),
+                // finix platform fee ignored (HS: Err(WebhookEventTypeNotFound))
+                Some(FinixPaymentType::Fee) => Err(error_stack::report!(
+                    WebhookError::WebhookReferenceIdNotFound
+                )),
+                _ => Ok(Some(WebhookResourceReference::Payment(
+                    PaymentWebhookReference {
+                        connector_transaction_id: Some(transfer.id),
+                        merchant_transaction_id: None,
+                    },
+                ))),
+            }
+        }
+        FinixEmbedded::Disputes { disputes } => {
+            let dispute = disputes.get_first_event()?;
+
+            Ok(Some(WebhookResourceReference::Dispute(
+                DisputeWebhookReference {
+                    connector_dispute_id: None,
+                    connector_transaction_id: Some(dispute.transfer),
+                },
+            )))
+        }
+    }
+}
+
+/// Which HS flow a webhook payment resource belongs to (`FinixFlow` in HS).
+/// Webhooks only ever carry authorizations or transfers, so HS's `Capture` arm
+/// is unreachable from the webhook path and is not ported.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum FinixWebhookFlow {
+    Auth,
+    Transfer,
+}
+
+/// Ports HS `get_attempt_status` (finix/transformers.rs) for the webhook path.
+fn get_finix_webhook_attempt_status(
+    state: &FinixState,
+    flow: FinixWebhookFlow,
+    is_void: Option<bool>,
+) -> AttemptStatus {
+    if is_void == Some(true) {
+        return match state {
+            FinixState::Failed | FinixState::Canceled | FinixState::Unknown => {
+                AttemptStatus::VoidFailed
+            }
+            FinixState::Pending => AttemptStatus::Voided,
+            FinixState::Succeeded => AttemptStatus::Voided,
+        };
+    }
+    match (flow, state) {
+        (FinixWebhookFlow::Auth, FinixState::Pending) => AttemptStatus::AuthenticationPending,
+        (FinixWebhookFlow::Auth, FinixState::Succeeded) => AttemptStatus::Authorized,
+        (
+            FinixWebhookFlow::Auth,
+            FinixState::Failed | FinixState::Canceled | FinixState::Unknown,
+        ) => AttemptStatus::AuthorizationFailed,
+        (FinixWebhookFlow::Transfer, FinixState::Pending) => AttemptStatus::Pending,
+        (FinixWebhookFlow::Transfer, FinixState::Succeeded) => AttemptStatus::Charged,
+        (
+            FinixWebhookFlow::Transfer,
+            FinixState::Failed | FinixState::Canceled | FinixState::Unknown,
+        ) => AttemptStatus::Failure,
+    }
+}
+
+/// Ports HS `impl From<FinixState> for RefundStatus` (finix/transformers.rs).
+fn get_finix_webhook_refund_status(state: &FinixState) -> RefundStatus {
+    match state {
+        FinixState::Pending => RefundStatus::Pending,
+        FinixState::Succeeded => RefundStatus::Success,
+        FinixState::Failed | FinixState::Canceled | FinixState::Unknown => RefundStatus::Failure,
+    }
+}
+
+/// Dispute status per the HS webhook event mapping (PENDING -> DisputeOpened,
+/// INQUIRY -> DisputeChallenged, LOST -> DisputeLost, WON -> DisputeWon).
+fn get_finix_webhook_dispute_status(state: &FinixDisputeState) -> common_enums::DisputeStatus {
+    match state {
+        FinixDisputeState::Pending => common_enums::DisputeStatus::DisputeOpened,
+        FinixDisputeState::Inquiry => common_enums::DisputeStatus::DisputeChallenged,
+        FinixDisputeState::Lost => common_enums::DisputeStatus::DisputeLost,
+        FinixDisputeState::Won => common_enums::DisputeStatus::DisputeWon,
+    }
+}
+
+/// Builds the payment webhook content for authorizations and (non-reversal)
+/// transfers. Status mapping ports HS `get_attempt_status` with
+/// `FinixFlow::Auth` / `FinixFlow::Transfer` respectively.
+pub(super) fn build_finix_payment_webhook_response(
+    body: &FinixWebhookBody,
+    raw_body: &[u8],
+) -> Result<WebhookDetailsResponse, error_stack::Report<WebhookError>> {
+    let (resource, flow) = match &body.webhook_embedded {
+        FinixEmbedded::Authorizations { authorizations } => {
+            (authorizations.get_first_event()?, FinixWebhookFlow::Auth)
+        }
+        FinixEmbedded::Transfers { transfers } => {
+            (transfers.get_first_event()?, FinixWebhookFlow::Transfer)
+        }
+        FinixEmbedded::Disputes { .. } => {
+            return Err(error_stack::report!(
+                WebhookError::WebhookResourceObjectNotFound
+            ))
+            .attach_printable("expected a payment webhook, but found a dispute webhook");
+        }
+    };
+
+    let status = get_finix_webhook_attempt_status(&resource.state, flow, resource.is_void);
+
+    Ok(WebhookDetailsResponse {
+        resource_id: Some(ResponseId::ConnectorTransactionId(resource.id.clone())),
+        status,
+        connector_response_reference_id: Some(resource.id),
+        mandate_reference: None,
+        error_code: resource.failure_code,
+        error_message: resource.failure_message.clone(),
+        error_reason: resource.failure_message,
+        raw_connector_response: Some(String::from_utf8_lossy(raw_body).to_string()),
+        status_code: 200,
+        response_headers: None,
+        amount_captured: resource
+            .captured_amount
+            .map(|amount| amount.get_amount_as_i64()),
+        minor_amount_captured: resource.captured_amount,
+        network_txn_id: None,
+        payment_method_update: None,
+        sender_payment_instrument_id: None,
+    })
+}
+
+/// Builds the refund webhook content for REVERSAL transfers. Status mapping
+/// ports HS `impl From<FinixState> for RefundStatus`.
+pub(super) fn build_finix_refund_webhook_response(
+    body: &FinixWebhookBody,
+    raw_body: &[u8],
+) -> Result<RefundWebhookDetailsResponse, error_stack::Report<WebhookError>> {
+    let transfer = match &body.webhook_embedded {
+        FinixEmbedded::Transfers { transfers } => transfers.get_first_event()?,
+        FinixEmbedded::Authorizations { .. } | FinixEmbedded::Disputes { .. } => {
+            return Err(error_stack::report!(
+                WebhookError::WebhookResourceObjectNotFound
+            ))
+            .attach_printable("expected a refund (reversal transfer) webhook");
+        }
+    };
+
+    Ok(RefundWebhookDetailsResponse {
+        connector_refund_id: Some(transfer.id),
+        // Finix REVERSAL webhooks only carry connector-side ids — no merchant
+        // reference for the original payment.
+        merchant_transaction_id: None,
+        status: get_finix_webhook_refund_status(&transfer.state),
+        connector_response_reference_id: None,
+        error_code: transfer.failure_code,
+        error_message: transfer.failure_message,
+        raw_connector_response: Some(String::from_utf8_lossy(raw_body).to_string()),
+        status_code: 200,
+        response_headers: None,
+    })
+}
+
+/// Builds the dispute webhook content. Ports HS
+/// `FinixWebhookBody::get_dispute_details`: amount converted with the HS
+/// webhook amount converter (`StringMinorUnitForConnector`), stage is always
+/// `Dispute`, reason surfaced as the dispute message.
+pub(super) fn build_finix_dispute_webhook_response(
+    body: &FinixWebhookBody,
+    raw_body: &[u8],
+) -> Result<DisputeWebhookDetailsResponse, error_stack::Report<WebhookError>> {
+    let dispute = match &body.webhook_embedded {
+        FinixEmbedded::Disputes { disputes } => disputes.get_first_event()?,
+        FinixEmbedded::Authorizations { .. } | FinixEmbedded::Transfers { .. } => {
+            return Err(error_stack::report!(
+                WebhookError::WebhookResourceObjectNotFound
+            ))
+            .attach_printable("expected a dispute webhook, but found other webhooks");
+        }
+    };
+
+    Ok(DisputeWebhookDetailsResponse {
+        amount: domain_types::utils::convert_amount_for_webhook(
+            &common_utils::types::StringMinorUnitForConnector,
+            dispute.amount,
+            dispute.currency,
+        )?,
+        currency: dispute.currency,
+        dispute_id: dispute.id,
+        status: get_finix_webhook_dispute_status(&dispute.state),
+        stage: common_enums::DisputeStage::Dispute,
+        connector_response_reference_id: None,
+        dispute_message: dispute.reason,
+        connector_reason_code: None,
+        raw_connector_response: Some(String::from_utf8_lossy(raw_body).to_string()),
+        status_code: 200,
+        response_headers: None,
+    })
+}

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -571,7 +571,22 @@
     },
     "handle_event": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "merchant_event_id": "probe_event_001",
+          "request_details": {
+            "method": "HTTP_METHOD_POST",
+            "uri": "https://example.com/webhook",
+            "headers": {},
+            "body": "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}"
+          }
+        },
+        "sample": {
+          "url": "",
+          "method": "Post",
+          "headers": {},
+          "body": "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}"
+        }
       }
     },
     "incremental_authorization": {
@@ -582,7 +597,21 @@
     },
     "parse_event": {
       "default": {
-        "status": "not_implemented"
+        "status": "supported",
+        "proto_request": {
+          "request_details": {
+            "method": "HTTP_METHOD_POST",
+            "uri": "https://example.com/webhook",
+            "headers": {},
+            "body": "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}"
+          }
+        },
+        "sample": {
+          "url": "",
+          "method": "Post",
+          "headers": {},
+          "body": "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}"
+        }
       }
     },
     "payment_method_eligibility": {

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -155,7 +155,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [dLocal](connectors/dlocal.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ? | ? | ? | ? | ? | ? | ⚠ | ✓ | x | x | ⚠ | x | x | x | x | x | x | ⚠ | x | x | x | ⚠ | ⚠ | ⚠ | x | ✓ | ✓ | x |
 | [Easebuzz](connectors/easebuzz.md) | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Elavon](connectors/elavon.md) | ✓ | ⚠ | ⚠ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | x | ⚠ | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
-| [Finix](connectors/finix.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | x | ⚠ | ? | ✓ | ? | x | ? | ✓ | x | ✓ | x | ✓ | ? | x | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
+| [Finix](connectors/finix.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | x | ⚠ | ? | ✓ | ? | x | ? | ✓ | x | ✓ | x | ✓ | ? | x | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
 | [Fiserv](connectors/fiserv.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | x | ✓ | x | x | x | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Fiservcommercehub](connectors/fiservcommercehub.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ? | ⚠ | ⚠ | ? | ? | ✓ | x | ✓ | x | x | x | x | x | x | x | ✓ | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Fiservemea](connectors/fiservemea.md) | ✓ | ✓ | ✓ | ✓ | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | x | ⚠ | x | x | x | x | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |

--- a/docs-generated/connectors/finix.md
+++ b/docs-generated/connectors/finix.md
@@ -126,6 +126,8 @@ let config = ConnectorConfig {
 | [PaymentService.Capture](#paymentservicecapture) | Payments | `PaymentServiceCaptureRequest` |
 | [CustomerService.Create](#customerservicecreate) | Customers | `CustomerServiceCreateRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
+| [EventService.HandleEvent](#eventservicehandleevent) | Events | `EventServiceHandleRequest` |
+| [EventService.ParseEvent](#eventserviceparseevent) | Events | `EventServiceParseRequest` |
 | [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
@@ -143,7 +145,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L127) · [Kotlin](../../examples/finix/finix.kt#L88) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L152) · [Kotlin](../../examples/finix/finix.kt#L90) · [Rust](../../examples/finix/finix.rs)
 
 #### PaymentService.Get
 
@@ -154,7 +156,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L145) · [Kotlin](../../examples/finix/finix.kt#L111) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L170) · [Kotlin](../../examples/finix/finix.kt#L113) · [Rust](../../examples/finix/finix.rs)
 
 #### PaymentService.Refund
 
@@ -165,7 +167,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L163) · [Kotlin](../../examples/finix/finix.kt#L150) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L206) · [Kotlin](../../examples/finix/finix.kt#L183) · [Rust](../../examples/finix/finix.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -176,7 +178,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L181) · [Kotlin](../../examples/finix/finix.kt#L172) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L224) · [Kotlin](../../examples/finix/finix.kt#L205) · [Rust](../../examples/finix/finix.rs)
 
 #### PaymentService.Void
 
@@ -187,7 +189,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts) · [Kotlin](../../examples/finix/finix.kt#L193) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts) · [Kotlin](../../examples/finix/finix.kt#L226) · [Rust](../../examples/finix/finix.rs)
 
 ### Refunds
 
@@ -200,7 +202,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L172) · [Kotlin](../../examples/finix/finix.kt#L160) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L215) · [Kotlin](../../examples/finix/finix.kt#L193) · [Rust](../../examples/finix/finix.rs)
 
 ### Mandates
 
@@ -213,7 +215,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L154) · [Kotlin](../../examples/finix/finix.kt#L119) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L197) · [Kotlin](../../examples/finix/finix.kt#L152) · [Rust](../../examples/finix/finix.rs)
 
 ### Customers
 
@@ -226,4 +228,4 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L136) · [Kotlin](../../examples/finix/finix.kt#L98) · [Rust](../../examples/finix/finix.rs)
+**Examples:** [Python](../../examples/finix/finix.py) · [TypeScript](../../examples/finix/finix.ts#L161) · [Kotlin](../../examples/finix/finix.kt#L100) · [Rust](../../examples/finix/finix.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -235,7 +235,7 @@ connector_id: finix
 doc: docs/connectors/finix.md
 scenarios: none
 payment_methods: none
-flows: capture, customer_create, get, recurring_charge, refund, refund_get, token_authorize, void
+flows: capture, customer_create, get, handle_event, parse_event, recurring_charge, refund, refund_get, token_authorize, void
 examples_python: none
 
 ## Fiserv

--- a/examples/finix/finix.kt
+++ b/examples/finix/finix.kt
@@ -11,10 +11,12 @@ import types.Payment.*
 import types.PaymentMethods.*
 import payments.PaymentClient
 import payments.CustomerClient
+import payments.EventClient
 import payments.RecurringPaymentClient
 import payments.RefundClient
 import payments.CaptureMethod
 import payments.Currency
+import payments.HttpMethod
 import payments.PaymentMethodType
 import payments.ConnectorConfig
 import payments.SdkOptions
@@ -23,7 +25,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.FinixConfig
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("capture", "customer_create", "get", "recurring_charge", "refund", "refund_get", "token_authorize", "void")
+val SUPPORTED_FLOWS = listOf<String>("capture", "customer_create", "get", "parse_event", "recurring_charge", "refund", "refund_get", "token_authorize", "void")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -113,6 +115,37 @@ fun get(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val request = buildGetRequest("probe_connector_txn_001")
     val response = client.get(request)
     println("Status: ${response.status.name}")
+}
+
+// Flow: EventService.HandleEvent
+fun handleEvent(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = EventClient(config)
+    val request = EventServiceHandleRequest.newBuilder().apply {
+        merchantEventId = "probe_event_001"  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
+        requestDetailsBuilder.apply {
+            method = HttpMethod.HTTP_METHOD_POST  // HTTP method of the request (e.g., GET, POST).
+            uri = "https://example.com/webhook"  // URI of the request.
+            putAllHeaders(mapOf())  // Headers of the HTTP request.
+            body = com.google.protobuf.ByteString.copyFromUtf8("{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}")  // Body of the HTTP request.
+        }
+    }.build()
+    val response = client.handle_event(request)
+    println("Webhook: type=${response.eventType.name} verified=${response.sourceVerified}")
+}
+
+// Flow: EventService.ParseEvent
+fun parseEvent(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = EventClient(config)
+    val request = EventServiceParseRequest.newBuilder().apply {
+        requestDetailsBuilder.apply {
+            method = HttpMethod.HTTP_METHOD_POST  // HTTP method of the request (e.g., GET, POST).
+            uri = "https://example.com/webhook"  // URI of the request.
+            putAllHeaders(mapOf())  // Headers of the HTTP request.
+            body = com.google.protobuf.ByteString.copyFromUtf8("{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}")  // Body of the HTTP request.
+        }
+    }.build()
+    val response = client.parse_event(request)
+    println("Webhook parsed: type=${response.eventType.name}")
 }
 
 // Flow: RecurringPaymentService.Charge
@@ -207,11 +240,13 @@ fun main(args: Array<String>) {
         "capture" -> capture(txnId)
         "customerCreate" -> customerCreate(txnId)
         "get" -> get(txnId)
+        "handleEvent" -> handleEvent(txnId)
+        "parseEvent" -> parseEvent(txnId)
         "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: capture, customerCreate, get, recurringCharge, refund, refundGet, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: capture, customerCreate, get, handleEvent, parseEvent, recurringCharge, refund, refundGet, tokenAuthorize, void")
     }
 }

--- a/examples/finix/finix.py
+++ b/examples/finix/finix.py
@@ -9,11 +9,12 @@ import asyncio
 import sys
 from payments import PaymentClient
 from payments import CustomerClient
+from payments import EventClient
 from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["capture", "customer_create", "get", "recurring_charge", "refund", "refund_get", "token_authorize", "void"]
+SUPPORTED_FLOWS = ["capture", "customer_create", "get", "parse_event", "recurring_charge", "refund", "refund_get", "token_authorize", "void"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -56,6 +57,16 @@ def _build_get_request(connector_transaction_id: str):
         amount=payment_pb2.Money(  # Amount Information.
             minor_amount=1000,  # Amount in minor units (e.g., 1000 = $10.00).
             currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+        ),
+    )
+
+def _build_parse_event_request():
+    return payment_pb2.EventServiceParseRequest(
+        request_details=payment_pb2.RequestDetails(
+            method=payment_pb2.HttpMethod.Value("HTTP_METHOD_POST"),  # HTTP method of the request (e.g., GET, POST).
+            uri="https://example.com/webhook",  # URI of the request.
+            headers={},  # Headers of the HTTP request.
+            body="{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}".encode(),  # Body of the HTTP request.
         ),
     )
 
@@ -145,6 +156,15 @@ async def process_get(merchant_transaction_id: str, config: sdk_config_pb2.Conne
     get_response = await payment_client.get(_build_get_request("probe_connector_txn_001"))
 
     return {"status": get_response.status}
+
+
+async def process_parse_event(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: EventService.ParseEvent"""
+    event_client = EventClient(config)
+
+    parse_response = event_client.parse_event(_build_parse_event_request())
+
+    return {"event_type": parse_response.event_type}
 
 
 async def process_recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/finix/finix.rs
+++ b/examples/finix/finix.rs
@@ -16,6 +16,7 @@ pub const SUPPORTED_FLOWS: &[&str] = &[
     "capture",
     "customer_create",
     "get",
+    "parse_event",
     "recurring_charge",
     "refund",
     "refund_get",
@@ -85,6 +86,33 @@ pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetReq
             currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
         }),
         ..Default::default()
+    }
+}
+
+#[allow(dead_code)]
+pub fn build_handle_event_request() -> EventServiceHandleRequest {
+    EventServiceHandleRequest {
+        merchant_event_id: Some("probe_event_001".to_string()),  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
+        request_details: Some(RequestDetails {
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
+            uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
+            headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
+            body: "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}".as_bytes().to_vec(),  // Body of the HTTP request.
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+pub fn build_parse_event_request() -> EventServiceParseRequest {
+    EventServiceParseRequest {
+        request_details: Some(RequestDetails {
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
+            uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
+            headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
+            body: "{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}".as_bytes().to_vec(),  // Body of the HTTP request.
+            ..Default::default()
+        }),
     }
 }
 
@@ -212,6 +240,16 @@ pub async fn process_get(
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: EventService.ParseEvent
+#[allow(dead_code)]
+pub async fn process_parse_event(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client.parse_event(build_parse_event_request())?;
+    Ok(format!("{response:?}"))
+}
+
 // Flow: RecurringPaymentService.Charge
 #[allow(dead_code)]
 pub async fn process_recurring_charge(
@@ -291,13 +329,14 @@ async fn main() {
         "process_capture" => process_capture(&client, "txn_001").await,
         "process_customer_create" => process_customer_create(&client, "txn_001").await,
         "process_get" => process_get(&client, "txn_001").await,
+        "process_parse_event" => process_parse_event(&client, "txn_001").await,
         "process_recurring_charge" => process_recurring_charge(&client, "txn_001").await,
         "process_refund" => process_refund(&client, "txn_001").await,
         "process_refund_get" => process_refund_get(&client, "txn_001").await,
         "process_token_authorize" => process_token_authorize(&client, "txn_001").await,
         "process_void" => process_void(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_capture, process_customer_create, process_get, process_recurring_charge, process_refund, process_refund_get, process_token_authorize, process_void", flow);
+            eprintln!("Unknown flow: {}. Available: process_capture, process_customer_create, process_get, process_parse_event, process_recurring_charge, process_refund, process_refund_get, process_token_authorize, process_void", flow);
             return;
         }
     };

--- a/examples/finix/finix.ts
+++ b/examples/finix/finix.ts
@@ -5,9 +5,9 @@
 // Finix — all integration scenarios and flows in one file.
 // Run a scenario:  npx tsx finix.ts checkout_autocapture
 
-import { PaymentClient, CustomerClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
-const { Environment, CaptureMethod, Currency, PaymentMethodType } = types;
-export const SUPPORTED_FLOWS = ["capture", "customer_create", "get", "recurring_charge", "refund", "refund_get", "token_authorize", "void"];
+import { PaymentClient, CustomerClient, EventClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
+const { Environment, CaptureMethod, Currency, HttpMethod, PaymentMethodType } = types;
+export const SUPPORTED_FLOWS = ["capture", "customer_create", "get", "parse_event", "recurring_charge", "refund", "refund_get", "token_authorize", "void"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -52,6 +52,31 @@ function _buildGetRequest(connectorTransactionId: string): types.IPaymentService
         "amount": {  // Amount Information.
             "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
             "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+    };
+}
+
+function _buildHandleEventRequest(): types.IEventServiceHandleRequest {
+    return {
+        "merchantEventId": "probe_event_001",  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
+        "requestDetails": {
+            "method": HttpMethod.HTTP_METHOD_POST,  // HTTP method of the request (e.g., GET, POST).
+            "uri": "https://example.com/webhook",  // URI of the request.
+            "headers": {  // Headers of the HTTP request.
+            },
+            "body": new Uint8Array(Buffer.from("{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}", "utf-8"))  // Body of the HTTP request.
+        }
+    };
+}
+
+function _buildParseEventRequest(): types.IEventServiceParseRequest {
+    return {
+        "requestDetails": {
+            "method": HttpMethod.HTTP_METHOD_POST,  // HTTP method of the request (e.g., GET, POST).
+            "uri": "https://example.com/webhook",  // URI of the request.
+            "headers": {  // Headers of the HTTP request.
+            },
+            "body": new Uint8Array(Buffer.from("{\"type\":\"updated\",\"entity\":\"transfer\",\"_embedded\":{\"transfers\":[{\"id\":\"TRsample000000000000000\",\"amount\":1000,\"currency\":\"USD\",\"state\":\"SUCCEEDED\",\"tags\":{},\"type\":\"DEBIT\"}]}}", "utf-8"))  // Body of the HTTP request.
         }
     };
 }
@@ -150,6 +175,24 @@ async function get(merchantTransactionId: string, config: types.IConnectorConfig
     return getResponse;
 }
 
+// Flow: EventService.HandleEvent
+async function handleEvent(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const eventClient = new EventClient(config);
+
+    const handleResponse = await eventClient.handleEvent(_buildHandleEventRequest());
+
+    return handleResponse;
+}
+
+// Flow: EventService.ParseEvent
+async function parseEvent(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const eventClient = new EventClient(config);
+
+    const parseResponse = await eventClient.parseEvent(_buildParseEventRequest());
+
+    return parseResponse;
+}
+
 // Flow: RecurringPaymentService.Charge
 async function recurringCharge(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const recurringPaymentClient = new RecurringPaymentClient(config);
@@ -198,7 +241,7 @@ async function voidPayment(merchantTransactionId: string, config: types.IConnect
 
 // Export all process* functions for the smoke test
 export {
-    capture, customerCreate, get, recurringCharge, refund, refundGet, tokenAuthorize, voidPayment, _buildCaptureRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    capture, customerCreate, get, handleEvent, parseEvent, recurringCharge, refund, refundGet, tokenAuthorize, voidPayment, _buildCaptureRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildHandleEventRequest, _buildParseEventRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## What

Implements `IncomingWebhook` for **Finix** in UCS, ported 1:1 from the hyperswitch Direct-gateway implementation (`crates/hyperswitch_connectors/src/connectors/finix.rs` + `finix/transformers/response.rs`).

Resolves https://github.com/juspay/hyperswitch-cloud/issues/19598 (ParseEvent) and https://github.com/juspay/hyperswitch-cloud/issues/19599 (HandleEvent).

**hyperswitch Direct gateway used as source of truth; validated in shadow (diff empty) then primary (UCS served the webhook live).**

### Behaviour ported
- **Source verification**: HMAC-SHA256 over `"{timestamp}:{raw body}"`; signature and timestamp come from the comma-separated `Finix-Signature: timestamp=...,sig=...` header (case-insensitive lookup); `sig` is hex-decoded before comparison. Raw body bytes are never re-serialized before signing.
- **Event map** (every arm from HS `FinixWebhookBody::get_webhook_event_type`):
  - authorizations (`is_void=true`): SUCCEEDED→`PAYMENT_INTENT_CANCELLED`, PENDING→`PAYMENT_INTENT_PROCESSING`, FAILED/CANCELED/UNKNOWN→`PAYMENT_INTENT_CANCEL_FAILURE`
  - authorizations: SUCCEEDED→`PAYMENT_INTENT_AUTHORIZATION_SUCCESS`, PENDING→`PAYMENT_INTENT_PROCESSING`, FAILED/CANCELED/UNKNOWN→`PAYMENT_INTENT_AUTHORIZATION_FAILURE`
  - transfers (REVERSAL): SUCCEEDED→`WEBHOOK_REFUND_SUCCESS`, FAILED/CANCELED/UNKNOWN→`WEBHOOK_REFUND_FAILURE`, PENDING→`WEBHOOK_EVENT_TYPE_UNSPECIFIED` (HS: `EventNotSupported`; `from_ucs_event_type(0)` maps it back to `EventNotSupported` on the HS side)
  - transfers: SUCCEEDED→`PAYMENT_INTENT_SUCCESS`, PENDING→`PAYMENT_INTENT_PROCESSING`, FAILED/CANCELED/UNKNOWN→`PAYMENT_INTENT_FAILURE`
  - disputes: PENDING→`WEBHOOK_DISPUTE_OPENED`, INQUIRY→`WEBHOOK_DISPUTE_CHALLENGED`, LOST→`WEBHOOK_DISPUTE_LOST`, WON→`WEBHOOK_DISPUTE_WON`
  - empty body / `{}` → `ENDPOINT_VERIFICATION` (HS's `SetupWebhook` arm is unreachable dead code and is not ported)
- **References**: authorizations/transfers→`Payment(connector_transaction_id)`; REVERSAL transfers→`Refund(connector_refund_id)`; platform `FEE` transfers→error (ignored, as HS); disputes→`Dispute{connector_dispute_id: None, connector_transaction_id: parent transfer}` so the HS normaliser (`connector_dispute_id.or(connector_transaction_id)`) reproduces HS's `PaymentId(ConnectorTransactionId(dispute.transfer))` byte-for-byte.
- **Content**: payment status via HS `get_attempt_status` (Auth/Transfer flows + `is_void`); refund status via HS `From<FinixState> for RefundStatus`; dispute payload via HS `get_dispute_details` (amount through `StringMinorUnitForConnector`, stage=`Dispute`).

Only `crates/integrations/connector-integration/src/connectors/finix.rs` and `finix/transformers.rs` are touched (in-band Family-1 verification: no `default_implementations.rs` or proto changes needed).

## PRIMARY_EVIDENCE (grpcurl against `types.EventService`, secrets redacted)

ParseEvent (headers: `x-connector: finix`, `x-auth: NoKey`; body base64 of the raw webhook JSON):

| vector | eventType | reference |
|---|---|---|
| authorization SUCCEEDED | `PAYMENT_INTENT_AUTHORIZATION_SUCCESS` | `payment.connectorTransactionId=AUtestauth0000000000001` |
| authorization FAILED | `PAYMENT_INTENT_AUTHORIZATION_FAILURE` | `payment.connectorTransactionId=AUtestauth0000000000002` |
| authorization is_void SUCCEEDED | `PAYMENT_INTENT_CANCELLED` | `payment.connectorTransactionId=AUtestauth0000000000003` |
| transfer SUCCEEDED | `PAYMENT_INTENT_SUCCESS` | `payment.connectorTransactionId=TRtesttransfer000000001` |
| transfer FAILED | `PAYMENT_INTENT_FAILURE` | `payment.connectorTransactionId=TRtesttransfer000000002` |
| REVERSAL SUCCEEDED | `WEBHOOK_REFUND_SUCCESS` | `refund.connectorRefundId=TRtestreversal000000001` |
| REVERSAL FAILED | `WEBHOOK_REFUND_FAILURE` | `refund.connectorRefundId=TRtestreversal000000002` |
| REVERSAL PENDING | `WEBHOOK_EVENT_TYPE_UNSPECIFIED` (HS: EventNotSupported) | `refund.connectorRefundId=TRtestreversal000000003` |
| dispute PENDING | `WEBHOOK_DISPUTE_OPENED` | `dispute.connectorTransactionId=TRtesttransfer000000001` |
| dispute WON | `WEBHOOK_DISPUTE_WON` | `dispute.connectorTransactionId=TRtesttransfer000000001` |
| `{}` body | `ENDPOINT_VERIFICATION` | (none) |

HandleEvent (valid `Finix-Signature: timestamp=<ts>,sig=<hmac-sha256-hex>` + `webhook_secrets.secret=<redacted>`): `sourceVerified: true` on every family with the HS status mapping, e.g.

```
transfer SUCCEEDED  -> paymentsResponse { status: CHARGED,  connectorTransactionId: TR..., capturedAmount: 10000 }, sourceVerified: true
auth SUCCEEDED      -> paymentsResponse { status: AUTHORIZED }, sourceVerified: true
auth FAILED         -> paymentsResponse { status: AUTHORIZATION_FAILED, error: {code: CARD_DECLINED, message: "The card was declined"} }
is_void SUCCEEDED   -> paymentsResponse { status: VOIDED }
REVERSAL SUCCEEDED  -> refundsResponse  { status: REFUND_SUCCESS, connectorRefundId: TR... }
REVERSAL FAILED     -> refundsResponse  { status: REFUND_FAILURE, error: {code: REFUND_DECLINED} }
dispute PENDING     -> disputesResponse { disputeStatus: DISPUTE_OPENED, disputeStage: ACTIVE_DISPUTE, connectorDisputeId: DI... }
dispute WON         -> disputesResponse { disputeStatus: DISPUTE_WON }
```

**Negative tests (all pass):**
```
wrong secret            -> sourceVerified: false (no error)
tampered body (1 byte)  -> sourceVerified: false (no error)
missing Finix-Signature -> sourceVerified: false (graceful, no panic)
```

## SHADOW_EVIDENCE (real webhooks through the hyperswitch router, Direct + shadow UCS on the same request)

Setup: merchant `finix_ucs_wh_1` + finix MCA (sandbox creds + `connector_webhook_details.merchant_secret` configured), real sandbox payment `TR4nB5DhEgVBurimk4Xm2rET` (succeeded) + real refund `TRo6TBL7tqPWJmSD8YsKBqfv`, rollout `ucs_rollout_config_finix_ucs_wh_1_finix_Webhooks` with `execution_mode=shadow` and `webhook_flows=[Payment,Refund,Dispute,ReturnResponse]`.

Router `"Webhook shadow diff"` log lines (`execution_path=ShadowUnifiedConnectorService`):

```
payment success  (x-request-id 019f2254-d256-7330-bed4-71ecbe8cdd65): primary_event_type: Some(PaymentIntentSuccess), shadow_event_type: Some(PaymentIntentSuccess), event_type_match: true, primary_source_verified: Some(true), shadow_source_verified: Some(true)
payment failure  (x-request-id 019f2256-cf2c-7071-b366-e30d26e7f6ee): primary/shadow: Some(PaymentIntentFailure), event_type_match: true, source_verified: Some(true)/Some(true)
refund success   (x-request-id 019f2255-baa1-74a0-a806-49992cf9551b): primary/shadow: Some(RefundSuccess),        event_type_match: true, source_verified: Some(true)/Some(true)
dispute opened   (x-request-id 019f2256-1389-71a3-898f-49839b2a792f): primary/shadow: Some(DisputeOpened),        event_type_match: true, source_verified: Some(true)/Some(true)
endpoint verify  (x-request-id 019f2256-43b8-7ec1-82d5-114b1252fb2d): primary/shadow: Some(EndpointVerification), event_type_match: true, source_verified: None/None (skipped/ReturnResponse on both sides)
```

Validation service (`:9000` router-data comparison, code VS_48/VS_46) for each of the above:

```
"differences": { "keyDiff": {}, "valueDiff": { "content_kind": { "hyperswitch": "direct", "ucs": "unified_connector_service" } }, "typeDiff": {} }
endpoint verification: "no differences found" (VS_46, zero key/value/type differences)
```

`bodyComparison.keyDiff == {}` on every family; the single `content_kind` valueDiff is the structural Direct-vs-UCS content encoding marker (raw connector object vs proto EventContent) that exists for every connector in shadow and is benign.

## PRIMARY mode through the router (UCS live)

Flipped the same rollout key to `execution_mode=primary`, restarted the router, re-fired the webhooks:

```
Webhook gateway decision: gateway=UnifiedConnectorService, execution_path=UnifiedConnectorService - merchant_id=finix_ucs_wh_1, connector=finix, flow=Webhooks
UCS webhook gRPC request/response: EventServiceParseEvent + EventServiceHandleEvent (external_latency: 2ms)
payment webhook  -> HTTP 200 (x-request-id 019f2257-6713-73e2-9239-02e96ee39ad5)
refund webhook   -> HTTP 200 (x-request-id 019f2257-a31e-7470-855d-9c4379314ae1)
endpoint verify  -> HTTP 200 (x-request-id 019f2257-a363-71a2-b6fe-14e62a0dcb00)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
