### PR TITLE
fix(nmi): drop request-email fallback for repeat_payment shipping_email/email

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1970,12 +1970,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             zip: common_data.get_optional_billing_zip(),
             country: common_data.get_optional_billing_country(),
             phone: common_data.get_optional_billing_phone_number(),
-            // Prefer the billing-address email (mirrors the hyperswitch reference
-            // NMI MIT path), falling back to the top-level `RepeatPaymentData.email`
-            // so the customer email is still sent when no billing email is present.
-            email: common_data
-                .get_optional_billing_email()
-                .or_else(|| router_data.request.email.clone()),
+            // Mirrors the hyperswitch reference NMI MIT path (get_billing_details()):
+            // billing-address email only, no fallback to the top-level request email.
+            email: common_data.get_optional_billing_email(),
             shipping_details: Some(NmiShippingDetails {
                 shipping_firstname: common_data.get_optional_shipping_first_name(),
                 shipping_lastname: common_data.get_optional_shipping_last_name(),
@@ -1985,11 +1982,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 shipping_state: common_data.get_optional_shipping_state(),
                 shipping_zip: common_data.get_optional_shipping_zip(),
                 shipping_country: common_data.get_optional_shipping_country(),
-                // Same precedence for the shipping email: shipping-address email
-                // first, then the top-level `RepeatPaymentData.email` fallback.
-                shipping_email: common_data
-                    .get_optional_shipping_email()
-                    .or_else(|| router_data.request.email.clone()),
+                // Mirrors the hyperswitch reference (get_shipping_details()): shipping-
+                // address email only, no fallback to the top-level request email.
+                shipping_email: common_data.get_optional_shipping_email(),
             }),
         })
     }


### PR DESCRIPTION
## What

Fixes a shadow-validation diff on nmi `repeat_payment` (MIT via `ConnectorMandateId`):

```
body.keyDiff.shipping_email = {"hyperswitch": false, "ucs": true}
```

(the plain `email` key had the identical diff for the same reason, and is fixed by
the same change.)

## Root cause

`NmiRepeatPaymentRequest`'s builder (`connectors/nmi/transformers.rs`, added by #1682)
fell back both `email` and `shipping_details.shipping_email` to the top-level
`RepeatPaymentData.email` whenever the billing/shipping address itself had no email:

```rust
email: common_data.get_optional_billing_email().or_else(|| router_data.request.email.clone()),
...
shipping_email: common_data.get_optional_shipping_email().or_else(|| router_data.request.email.clone()),
```

The hyperswitch reference implementation has no such fallback — `get_billing_details()`
and `get_shipping_details()` (`hyperswitch_connectors/src/connectors/nmi/transformers.rs`)
only ever read the billing/shipping address's own email field, for both the Authorize and
the `ConnectorMandateId` repeat-payment path. So whenever a merchant sends a top-level
customer `email` but no address-level email, HS omits `email`/`shipping_email` from the
outbound NMI request while UCS incorrectly includes them.

## Fix

Drop the `.or_else(|| router_data.request.email.clone())` fallback for both fields —
`email` now mirrors `get_optional_billing_email()` only, `shipping_email` mirrors
`get_optional_shipping_email()` only, matching the hyperswitch reference exactly. Pure
L3 connector-transformer fix; no proto/domain/HS-side change needed (the fields already
flow to UCS unchanged).

## Verification

Reproduced and verified locally against a live NMI sandbox call through the HS↔UCS shadow
validation stack (HS `:8080` shadow-calls UCS `:8001`, both outbound requests mirrored
through a MITM proxy and diffed):

1. Authorize with `setup_future_usage: off_session` + `mandate_data` (mandate setup),
   card details, billing address **with no email field**, top-level `email` set to a
   customer email.
2. Repeat payment (MIT) via `recurring_details: {type: mandate_id, data: <mandate_id>}`,
   again a top-level customer `email` and a billing address with no email, no shipping
   address at all.
3. Compared the resulting `bodyComparison.keyDiff` for the RepeatPayment shadow call.

**Before fix:**
```json
{"email": {"hyperswitch": false, "ucs": true}, "shipping_email": {"hyperswitch": false, "ucs": true}}
```

**After fix:** `{}` (`no_diff` on both fields, no new diffs introduced).
