### PR TITLE
fix(cybersource): set MIT initiator for repeat_payment ConnectorMandateId (shadow diff #17471)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5509,7 +5509,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     None,
                     None,
                     Some(CybersourceAuthorizationOptions {
-                        initiator: None,
+                        // Match the Direct (hyperswitch) gateway, which sets the initiator
+                        // block for the ConnectorMandateId (stored-credential MIT) flow.
+                        // Without this UCS emits authorizationOptions.initiator = null while
+                        // Direct emits the merchant-initiated stored-credential object.
+                        initiator: Some(CybersourcePaymentInitiator {
+                            initiator_type: Some(CybersourcePaymentInitiatorTypes::Merchant),
+                            credential_stored_on_file: None,
+                            stored_credential_used: Some(true),
+                        }),
                         merchant_initiated_transaction: Some(MerchantInitiatedTransaction {
                             reason: None,
                             original_authorized_amount,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5509,10 +5509,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     None,
                     None,
                     Some(CybersourceAuthorizationOptions {
-                        // Match the Direct (hyperswitch) gateway, which sets the initiator
-                        // block for the ConnectorMandateId (stored-credential MIT) flow.
-                        // Without this UCS emits authorizationOptions.initiator = null while
-                        // Direct emits the merchant-initiated stored-credential object.
                         initiator: Some(CybersourcePaymentInitiator {
                             initiator_type: Some(CybersourcePaymentInitiatorTypes::Merchant),
                             credential_stored_on_file: None,

--- a/data/field_probe/cybersource.json
+++ b/data/field_probe/cybersource.json
@@ -1132,7 +1132,7 @@
             "v-c-merchant-id": "probe_merchant",
             "via": "HyperSwitch"
           },
-          "body": "{\"processingInformation\":{\"actionList\":null,\"actionTokenTypes\":null,\"authorizationOptions\":{\"initiator\":null,\"merchantInitiatedTransaction\":{\"reason\":null,\"previousTransactionId\":null,\"originalAuthorizedAmount\":null},\"ignoreAvsResult\":null,\"ignoreCvResult\":null},\"commerceIndicator\":\"internet\",\"capture\":true,\"captureOptions\":null,\"paymentSolution\":null},\"paymentInformation\":{\"paymentInstrument\":{\"id\":\"probe-mandate-123\"},\"card\":null},\"orderInformation\":{\"amountDetails\":{\"totalAmount\":\"10.00\",\"currency\":\"USD\"},\"billTo\":null},\"clientReferenceInformation\":{\"code\":\"\"}}"
+          "body": "{\"processingInformation\":{\"actionList\":null,\"actionTokenTypes\":null,\"authorizationOptions\":{\"initiator\":{\"type\":\"merchant\",\"credentialStoredOnFile\":null,\"storedCredentialUsed\":true},\"merchantInitiatedTransaction\":{\"reason\":null,\"previousTransactionId\":null,\"originalAuthorizedAmount\":null},\"ignoreAvsResult\":null,\"ignoreCvResult\":null},\"commerceIndicator\":\"internet\",\"capture\":true,\"captureOptions\":null,\"paymentSolution\":null},\"paymentInformation\":{\"paymentInstrument\":{\"id\":\"probe-mandate-123\"},\"card\":null},\"orderInformation\":{\"amountDetails\":{\"totalAmount\":\"10.00\",\"currency\":\"USD\"},\"billTo\":null},\"clientReferenceInformation\":{\"code\":\"\"}}"
         }
       }
     },


### PR DESCRIPTION
## What

Fixes shadow-validation request_diff **#17471** (`prod` / flowbird / **cybersource** / **repeat_payment**).

For the repeat_payment stored-credential MIT flow (`MandateReferenceId::ConnectorMandateId`), the
Cybersource transformer built `CybersourceAuthorizationOptions` with `initiator: None`, so the UCS
leg emitted `processingInformation.authorizationOptions.initiator = null` while the Direct
(hyperswitch) gateway emits the merchant-initiated stored-credential object.

This sets the `initiator` block to match Direct — exactly as the sibling `NetworkMandateId` arm in
the same function already does:

```rust
initiator: Some(CybersourcePaymentInitiator {
    initiator_type: Some(CybersourcePaymentInitiatorTypes::Merchant),
    credential_stored_on_file: None,
    stored_credential_used: Some(true),
}),
```

No proto change — `initiator` is derived in the transformer from the mandate type.

## Root cause (RCA)

- Live prod request `019f17b7-a5d0-76e1-b2e1-cbc78384f95b` (event 2026-06-30T08:48:59Z), 2.60 EUR,
  flowbird, `pay_SNJf2ptr0y2HCCcAZY47`, off-session recurring MIT.
- validation-service RP_05 (2026-06-30T08:49:02.162056Z) captured **both** outbound Cybersource
  requests via mitm-proxy: HS/router leg **1109 bytes** vs UCS leg **1024 bytes** — the byte gap is
  the omitted MIT `authorizationOptions` fields.

### Before (issue diff signature)
```
body.typeDiff.processingInformation.authorizationOptions.initiator = {"hyperswitch":"object","ucs":"null"}
body.valueDiff.merchantDefinedInformation[0].value = {"hyperswitch":"brand=\"flowbird\"","ucs":"kind=\"hourly\""}
body.valueDiff.merchantDefinedInformation[1].value = {"hyperswitch":"kind=\"hourly\"","ucs":"brand=\"flowbird\""}
body.valueDiff.merchantDefinedInformation[3].value = {"hyperswitch":"merchant_order_reference_id=377239532","ucs":"merchant_order_id=377239532"}
```

### After
- `authorizationOptions.initiator` now emitted as the merchant-initiated stored-credential object,
  byte-matching Direct.
- The `merchantDefinedInformation[0]/[1]` ordering swap and `[3]` key naming are already resolved on
  `main` by merged PR #1740 (shared `convert_metadata_to_merchant_defined_info`, which repeat_payment
  reuses) — the prod diff was captured on a pre-#1740 build.
- The companion `authorizationOptions.merchantInitiatedTransaction.originalAuthorizedAmount = null`
  facet is fixed on the hyperswitch side (the UCS client was not populating the proto field); see the
  paired hyperswitch PR.

## Verification
- `cargo build -p grpc-server` → exit 0.
- Code parity: the ConnectorMandateId `initiator` block is now byte-identical to the Direct gateway
  (`hyperswitch_connectors/.../cybersource/transformers.rs`) and the sibling NetworkMandateId arm.

No creds; `config/development.toml` excluded.
