### PR TITLE
feat(connector): [Itaubank] add merchant-authentication (access token) flow to payout connector

### DIFF
--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
@@ -12,7 +12,7 @@ use domain_types::{
     connector_types::{
         ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
     },
-    errors::{ConnectorError, IntegrationError, IntegrationErrorContext},
+    errors::{ConnectorError, IntegrationError},
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
@@ -40,7 +40,8 @@ use interfaces::{
 
 use crate::types::ResponseRouterData;
 use transformers::{
-    ItaubankAuthType, ItaubankErrorResponse, ItaubankPayoutGetResponse, ItaubankTransferRequest,
+    ItaubankAccessTokenRequest, ItaubankAccessTokenResponse, ItaubankAuthType,
+    ItaubankErrorResponse, ItaubankPayoutGetResponse, ItaubankTransferRequest,
     ItaubankTransferResponse,
 };
 
@@ -163,7 +164,7 @@ impl ConnectorCommon for ItaubankPayouts {
     }
 }
 
-// ===== SERVER AUTHENTICATION (not implemented) =====
+// ===== SERVER AUTHENTICATION (merchant-auth / access token) =====
 
 impl ServerAuthentication for ItaubankPayouts {}
 
@@ -175,7 +176,65 @@ impl
         ServerAuthenticationTokenResponseData,
     > for ItaubankPayouts
 {
+    fn get_http_method(&self) -> common_utils::request::Method {
+        common_utils::request::Method::Post
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        "application/x-www-form-urlencoded"
+    }
+
+    fn get_certificate(
+        &self,
+        req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<Option<hyperswitch_masking::Secret<String>>, IntegrationError> {
+        let auth = ItaubankAuthType::try_from(&req.connector_config)?;
+        Ok(auth.certificates)
+    }
+
+    fn get_certificate_key(
+        &self,
+        req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<Option<hyperswitch_masking::Secret<String>>, IntegrationError> {
+        let auth = ItaubankAuthType::try_from(&req.connector_config)?;
+        Ok(auth.private_key)
+    }
+
     fn get_url(
+        &self,
+        req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<String, IntegrationError> {
+        // if secondary_base_url is present, use it, else use base_url
+        if let Some(secondary_base_url) = req
+            .resource_common_data
+            .connectors
+            .itaubank
+            .secondary_base_url
+            .as_deref()
+        {
+            Ok(format!("{}/api/oauth/token", secondary_base_url))
+        } else {
+            let base_url = self.base_url(&req.resource_common_data.connectors);
+            Ok(format!("{}/api/oauth/jwt", base_url))
+        }
+    }
+
+    fn get_headers(
         &self,
         _req: &RouterDataV2<
             ServerAuthenticationToken,
@@ -183,13 +242,92 @@ impl
             ServerAuthenticationTokenRequestData,
             ServerAuthenticationTokenResponseData,
         >,
-    ) -> CustomResult<String, IntegrationError> {
-        Err(IntegrationError::connector_flow_not_implemented(
-            ConnectorCommon::id(self),
-            "server_authentication_token",
-            IntegrationErrorContext::default(),
-        )
-        .into())
+    ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+        Ok(vec![
+            (
+                headers::CONTENT_TYPE.to_string(),
+                "application/x-www-form-urlencoded".to_string().into(),
+            ),
+            (headers::ACCEPT.to_string(), "*/*".to_string().into()),
+            (
+                headers::USER_AGENT.to_string(),
+                "Hyperswitch".to_string().into(),
+            ),
+        ])
+    }
+
+    fn get_request_body(
+        &self,
+        req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> CustomResult<Option<RequestContent>, IntegrationError> {
+        let connector_req = ItaubankAccessTokenRequest::try_from(req)?;
+        Ok(Some(RequestContent::FormUrlEncoded(Box::new(
+            connector_req,
+        ))))
+    }
+
+    fn handle_response_v2(
+        &self,
+        data: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+        event_builder: Option<&mut events::Event>,
+        res: Response,
+    ) -> CustomResult<
+        RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+        ConnectorError,
+    > {
+        let response: Result<ItaubankAccessTokenResponse, _> =
+            res.response.parse_struct("ItaubankAccessTokenResponse");
+
+        match response {
+            Ok(token_res) => {
+                event_builder.map(|i| i.set_connector_response(&token_res));
+                let access_token_data = ServerAuthenticationTokenResponseData {
+                    access_token: token_res.access_token.into(),
+                    token_type: token_res.token_type,
+                    expires_in: token_res.expires_in,
+                };
+
+                Ok(RouterDataV2 {
+                    response: Ok(access_token_data),
+                    ..data.clone()
+                })
+            }
+            Err(_) => {
+                tracing::error!(
+                    "Failed to parse access token response from Itaubank. Status: {}, Raw: {:?}",
+                    res.status_code,
+                    res.response
+                );
+                Err(ConnectorError::ResponseDeserializationFailed {
+                    context: Default::default(),
+                }
+                .into())
+            }
+        }
+    }
+
+    fn get_error_response_v2(
+        &self,
+        res: Response,
+        event_builder: Option<&mut events::Event>,
+        _connector_config: &ConnectorSpecificConfig,
+    ) -> CustomResult<ErrorResponse, ConnectorError> {
+        self.build_error_response(res, event_builder, _connector_config)
     }
 }
 

--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank.rs
@@ -12,7 +12,7 @@ use domain_types::{
     connector_types::{
         ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
     },
-    errors::{ConnectorError, IntegrationError},
+    errors::{ConnectorError, IntegrationError, ResponseTransformationErrorContext},
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::payouts_types::{
         PayoutCreateLinkRequest, PayoutCreateLinkResponse, PayoutCreateRecipientRequest,
@@ -219,7 +219,8 @@ impl
             ServerAuthenticationTokenResponseData,
         >,
     ) -> CustomResult<String, IntegrationError> {
-        // if secondary_base_url is present, use it, else use base_url
+        // Itaú exposes the OAuth token endpoint on secondary_base_url for
+        // payout configs; older configs use the JWT endpoint on base_url.
         if let Some(secondary_base_url) = req
             .resource_common_data
             .connectors
@@ -249,10 +250,6 @@ impl
                 "application/x-www-form-urlencoded".to_string().into(),
             ),
             (headers::ACCEPT.to_string(), "*/*".to_string().into()),
-            (
-                headers::USER_AGENT.to_string(),
-                "Hyperswitch".to_string().into(),
-            ),
         ])
     }
 
@@ -307,14 +304,19 @@ impl
                     ..data.clone()
                 })
             }
-            Err(_) => {
-                tracing::error!(
-                    "Failed to parse access token response from Itaubank. Status: {}, Raw: {:?}",
-                    res.status_code,
-                    res.response
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    status_code = res.status_code,
+                    "Failed to parse access token response from Itaubank"
                 );
                 Err(ConnectorError::ResponseDeserializationFailed {
-                    context: Default::default(),
+                    context: ResponseTransformationErrorContext {
+                        http_status_code: Some(res.status_code),
+                        additional_context: Some(
+                            "Itaubank access token - failed to deserialize response".to_string(),
+                        ),
+                    },
                 }
                 .into())
             }

--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
@@ -2,7 +2,9 @@ use crate::types::ResponseRouterData;
 use common_utils::types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector};
 use domain_types::{
     connector_flow::{PayoutGet, PayoutTransfer, ServerAuthenticationToken},
-    connector_types::{ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData},
+    connector_types::{
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+    },
     errors::{ConnectorError, IntegrationError},
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::{

--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
@@ -121,6 +121,7 @@ impl
 pub struct ItaubankAccessTokenResponse {
     pub access_token: String,
     pub token_type: Option<String>,
+    // Token lifetime in seconds, as returned by Itaú OAuth.
     pub expires_in: Option<i64>,
 }
 

--- a/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/itaubank/transformers.rs
@@ -1,8 +1,10 @@
 use crate::types::ResponseRouterData;
 use common_utils::types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector};
 use domain_types::{
-    connector_flow::{PayoutGet, PayoutTransfer},
+    connector_flow::{PayoutGet, PayoutTransfer, ServerAuthenticationToken},
+    connector_types::{ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData},
     errors::{ConnectorError, IntegrationError},
+    merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payouts::{
         payout_method_data::{
             Bank, PayoutMethodData, PixBankTransfer, PixEmvBankTransfer, PixKeyBankTransfer,
@@ -71,6 +73,53 @@ pub struct ItauErrorFields {
     pub campo: String,
     // mensagem = message (validation error message for the field)
     pub mensagem: String,
+}
+
+// ===== ACCESS TOKEN REQUEST/RESPONSE =====
+
+const CLIENT_CREDENTIALS_GRANT_TYPE: &str = "client_credentials";
+
+#[derive(Debug, Serialize)]
+pub struct ItaubankAccessTokenRequest {
+    pub grant_type: String,
+    pub client_id: Secret<String>,
+    pub client_secret: Secret<String>,
+}
+
+impl
+    TryFrom<
+        &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    > for ItaubankAccessTokenRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        req: &RouterDataV2<
+            ServerAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ServerAuthenticationTokenRequestData,
+            ServerAuthenticationTokenResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let auth = ItaubankAuthType::try_from(&req.connector_config)?;
+        Ok(Self {
+            grant_type: CLIENT_CREDENTIALS_GRANT_TYPE.to_string(),
+            client_id: auth.client_id,
+            client_secret: auth.client_secret,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ItaubankAccessTokenResponse {
+    pub access_token: String,
+    pub token_type: Option<String>,
+    pub expires_in: Option<i64>,
 }
 
 // ===== PAYOUT TRANSFER REQUEST/RESPONSE =====


### PR DESCRIPTION
## Summary

The Itaú (itaubank) **payout** connector did not implement the merchant-authentication (`ServerAuthenticationToken`) flow — its `ConnectorIntegrationV2<ServerAuthenticationToken, …>` was a stub returning `connector_flow_not_implemented`. As a result, payout access-token (merchant-auth) calls could not run the payout connector's own OAuth token flow.

## What this does

Implements `ConnectorIntegrationV2<ServerAuthenticationToken, MerchantAuthenticationFlowData, ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData>` for `ItaubankPayouts`, mirroring the payment connector's OAuth token flow:

- `get_url` → `{secondary_base_url}/api/oauth/token` when a secondary base URL is configured, else `{base_url}/api/oauth/jwt`
- `get_http_method` → `POST`, `get_content_type` → `application/x-www-form-urlencoded`
- `get_certificate` / `get_certificate_key` from `ItaubankAuthType`
- `get_request_body` → form-url-encoded `ItaubankAccessTokenRequest` (`client_credentials` grant)
- `handle_response_v2` → parses `ItaubankAccessTokenResponse` into `ServerAuthenticationTokenResponseData`
- `get_error_response_v2` → `build_error_response`

New transformer types `ItaubankAccessTokenRequest` / `ItaubankAccessTokenResponse` are added alongside the existing payout transformers.

No connector registration change is needed — `PayoutConnectorEnum::Itaubank` already maps to `ItaubankPayouts`.

## Companion change

Requires the paired hyperswitch (app) change that routes payout merchant-auth calls through the payout connector: juspay/hyperswitch#<HS_PR>
