### PR TITLE
fix(twoc_twop_paco): drop airline data when billing address is absent

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -931,30 +931,21 @@ where
         .map(PacoAirlineData::try_from)
         .transpose()?;
 
-    // PACO requires a billing address alongside airlineData; a request carrying
-    // airline data but no billing address would be rejected downstream, so fail
-    // fast with a clear message instead of forwarding an incomplete payload.
-    if airline_data.is_some() && paco_billing_address.is_none() {
-        return Err(error_stack::Report::new(
-            errors::IntegrationError::MissingRequiredField {
-                field_name: "billing_address",
-                context: errors::IntegrationErrorContext {
-                    suggested_action: Some(
-                        "PACO requires a billing address when airlineData is supplied; \
-                         provide the customer billing address."
-                            .to_string(),
-                    ),
-                    doc_url: Some(PACO_INTEGRATION_DOC_URL.to_string()),
-                    additional_context: Some(
-                        "airlineData was supplied without a billing address. PACO's airline \
-                         authorization requires the cardholder billing address, so the request \
-                         is rejected here rather than forwarded and failed by PACO."
-                            .to_string(),
-                    ),
-                },
-            },
-        ));
-    }
+    // PACO's airline authorization requires a billing address alongside
+    // airlineData; PACO rejects an airline payload that lacks one. Rather than
+    // fail the whole payment, drop the airline block when no billing address is
+    // present and proceed with the base authorization.
+    let airline_data = if airline_data.is_some() && paco_billing_address.is_none() {
+        tracing::warn!(
+            target: "twoc_twop_paco",
+            "twoc_twop_paco: airlineData supplied without a billing address — \
+             dropping airlineData and proceeding with the base authorization, \
+             since PACO requires a billing address for airline data"
+        );
+        None
+    } else {
+        airline_data
+    };
 
     match &item.request.payment_method_data {
         PaymentMethodData::Card(card) => {


### PR DESCRIPTION
## What

Follow-up correcting the behavior merged in #1810.

PACO's airline authorization requires a billing address alongside `airlineData`
— PACO rejects an airline payload that lacks one. #1810 handled this by
rejecting the payment with a `400 MISSING_REQUIRED_FIELD`. That is too strict:
the connector should not fail the payment just because airline enrichment can't
be sent.

This change makes `build_authorize_request` **drop the airline block** when
airline data is supplied without a billing address, and proceed with the base
authorization (emitting a `tracing::warn!`). The payment still succeeds; only
the airline enrichment is omitted. Applies to both the card and GCash wallet
authorize paths. Requests that include a billing address are unchanged and
still send `airlineData`.

## Testing

Verified live over the **HTTP** composite endpoint
(`POST /composite/payments/authorize`) against the PACO UAT environment
(`core.demo-paco.2c2p.com`). Connector credentials/keys are passed via the
`x-connector-config` header and are omitted below.

### Case 1 — airline data **with** billing address → airline data sent, authorized ✅

`address.billing_address` populated; `domain_data.airline_data` present.

Response — `HTTP 200` (airlineData forwarded to PACO):

```json
{
  "authorize_response": {
    "connector_transaction_id": "CEBU0000000002122",
    "status": "CHARGED",
    "status_code": 200,
    "raw_connector_response": "{... \"responseCode\":\"PC-B050000\", \"responseDescription\":\"Success\" ...}"
  },
  "composite_status": "COMPLETED"
}
```

### Case 2 — airline data **without** billing address → airline data dropped, authorized ✅

`address` carries only a `shipping_address` (no `billing_address`);
`domain_data.airline_data` present.

Server log:

```
WARN twoc_twop_paco: airlineData supplied without a billing address — dropping
airlineData and proceeding with the base authorization, since PACO requires a
billing address for airline data
```

Response — `HTTP 200` (base authorization, no airlineData sent):

```json
{
  "authorize_response": {
    "connector_transaction_id": "CEBU0000000002121",
    "status": "CHARGED",
    "status_code": 200,
    "raw_connector_response": "{... \"responseCode\":\"PC-B050000\", \"responseDescription\":\"Success\" ...}"
  },
  "composite_status": "COMPLETED"
}
```

### Regression

A plain card authorize with no airline data and no billing address is
unaffected — billing address remains optional for ordinary payments.
