### PR TITLE
fix(cybersource): map 3DS consumerAuthenticationInformation fields in UCS authorize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -584,41 +584,63 @@ pub struct CybersourceConsumerAuthInformation {
     cavv_algorithm: Option<String>,
 }
 
-impl From<router_request_types::AuthenticationData> for CybersourceConsumerAuthInformation {
-    fn from(value: router_request_types::AuthenticationData) -> Self {
+impl From<(router_request_types::AuthenticationData, Option<common_enums::CardNetwork>)>
+    for CybersourceConsumerAuthInformation
+{
+    fn from(
+        (value, card_network): (
+            router_request_types::AuthenticationData,
+            Option<common_enums::CardNetwork>,
+        ),
+    ) -> Self {
         let router_request_types::AuthenticationData {
-            eci: _,
+            eci,
             cavv,
             threeds_server_transaction_id: _,
             message_version,
             ds_trans_id,
             trans_status: _,
-            acs_transaction_id: _,
-            transaction_id,
-            ucaf_collection_indicator,
+            acs_transaction_id,
+            transaction_id: _,
+            ucaf_collection_indicator: _,
             exemption_indicator: _,
             network_params: _,
         } = value;
 
+        // Mirror the hyperswitch Direct cybersource mapping: for Mastercard the CAVV is carried in
+        // `ucafAuthenticationData` (with `ucafCollectionIndicator = 2`), otherwise it is sent in `cavv`.
+        let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
+            if card_network == Some(common_enums::CardNetwork::Mastercard) {
+                (cavv, None, Some("2".to_string()))
+            } else {
+                (None, cavv, None)
+            };
+
         Self {
-            pares_status: None,
+            // For all card payments hyperswitch explicitly sends `AuthenticationSuccessful`,
+            // regardless of the actual ACS response.
+            pares_status: Some(CybersourceParesStatus::AuthenticationSuccessful),
             ucaf_collection_indicator,
-            ucaf_authentication_data: cavv.clone(),
-            xid: transaction_id,
+            ucaf_authentication_data,
+            // hyperswitch Direct always sends `xid: None`.
+            xid: None,
             cavv,
             directory_server_transaction_id: ds_trans_id.map(Secret::new),
-            specification_version: None,
+            specification_version: message_version.clone(),
             pa_specification_version: message_version,
-            veres_enrolled: None,
-            eci_raw: None,
+            veres_enrolled: Some("Y".to_string()),
+            eci_raw: eci,
+            // The following fields have no source in the proto `AuthenticationData` message
+            // (authenticationDate/created_at, challengeCode, effectiveAuthenticationType,
+            // signedParesStatusReason, challengeCancelCode, networkScore) and remain a proto gap.
             authentication_date: None,
             effective_authentication_type: None,
             challenge_code: None,
             signed_pares_status_reason: None,
             challenge_cancel_code: None,
             network_score: None,
-            acs_transaction_id: None,
-            cavv_algorithm: None,
+            acs_transaction_id,
+            cavv_algorithm: Some("2".to_string()),
         }
     }
 }
@@ -1424,7 +1446,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let processing_information = ProcessingInformation::try_from((
             item,
             None,
-            raw_card_type.map(|network| network.to_string()),
+            raw_card_type.clone().map(|network| network.to_string()),
         ))?;
         let client_reference_information = ClientReferenceInformation::from(item);
         let merchant_defined_information = convert_metadata_to_merchant_defined_info(
@@ -1441,7 +1463,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .request
             .authentication_data
             .clone()
-            .map(From::from);
+            .map(|authn_data| From::from((authn_data, raw_card_type.clone())));
         Ok(Self {
             processing_information,
             payment_information,
@@ -5177,7 +5199,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .request
             .authentication_data
             .clone()
-            .map(From::from);
+            .map(|authn_data| From::from((authn_data, ccard.card_network.clone())));
 
         Ok(Self {
             processing_information,
@@ -5265,7 +5287,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .request
             .authentication_data
             .clone()
-            .map(From::from);
+            .map(|authn_data| From::from((authn_data, token_data.card_network.clone())));
 
         Ok(Self {
             processing_information,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -584,8 +584,11 @@ pub struct CybersourceConsumerAuthInformation {
     cavv_algorithm: Option<String>,
 }
 
-impl From<(router_request_types::AuthenticationData, Option<common_enums::CardNetwork>)>
-    for CybersourceConsumerAuthInformation
+impl
+    From<(
+        router_request_types::AuthenticationData,
+        Option<common_enums::CardNetwork>,
+    )> for CybersourceConsumerAuthInformation
 {
     fn from(
         (value, card_network): (


### PR DESCRIPTION
## What


The UCS cybersource transformer's `From<AuthenticationData>` impl dropped or nulled several 3DS fields that the hyperswitch **Direct** gateway populates, so the shadow-mode outbound body diverged from Direct on `consumerAuthenticationInformation`.

## Root cause (RCA)

Issue #17889, connector `cybersource`, flow `authorize`, merchant `flowbird`, prod.
Sample `x-request-id` `019f1929-123d-7800-aa16-d13cf954c0a4` (UUIDv7 → real txn **2026-06-30T15:32:29.885Z**). Prod build `aef0be919` (2026-06-17), which predates the merged MDI fix (#1740).

The reported diff had two parts:

1. **`merchantDefinedInformation` [0]/[1]/[3]** brand/kind swap + `merchant_order_reference_id` key — **already fixed** by the merged MDI change (`convert_metadata_to_merchant_defined_info`); reproduces byte-identical on current `main` (validation service `request_diff` = `data: []`). Not touched here.

2. **`consumerAuthenticationInformation` type-diffs** (HS sends a string, UCS sends `null`) on ~11 fields. This PR fixes the transformer-mappable subset.

The proto `AuthenticationData` message **already carries** `eci`, `cavv`, `acs_transaction_id` and `message_version` — the HS→UCS client sets them (`router/.../unified_connector_service/transformers.rs` `foreign_try_from`). But the prism `From<AuthenticationData>` impl:

- destructured `eci: _` and `acs_transaction_id: _` (discarded), leaving `eci_raw = None`, `acs_transaction_id = None`
- mapped `message_version` only to `pa_specification_version`, leaving `specification_version = None`
- omitted the constants HS always sends (`pares_status`, `veres_enrolled`, `cavv_algorithm`)
- filled `ucaf_authentication_data`/`cavv` unconditionally instead of applying HS's Mastercard branch (→ inverted `ucafAuthenticationData`)
- set `xid = transaction_id` where HS always sends `xid = None`

## Fix

Mirror the hyperswitch Direct cybersource mapping exactly (`crates/hyperswitch_connectors/.../cybersource/transformers.rs`), threading the card network into the conversion at all three call sites (authorize + the two repeat-payment builders):

| field | before (UCS) | after (matches HS Direct) |
|---|---|---|
| `eciRaw` | `None` | `eci` |
| `acsTransactionId` | `None` | `acs_transaction_id` |
| `specificationVersion` | `None` | `message_version` |
| `paresStatus` | `None` | `AuthenticationSuccessful` (const) |
| `veresEnrolled` | `None` | `"Y"` (const) |
| `cavvAlgorithm` | `None` | `"2"` (const) |
| `xid` | `transaction_id` | `None` |
| `cavv` / `ucafAuthenticationData` | both = `cavv` | Mastercard → CAVV in `ucafAuthenticationData` (+`ucafCollectionIndicator="2"`); else CAVV in `cavv` |

### Remaining proto gap (out of scope)
`authenticationDate` (←`created_at`), `challengeCode`, `effectiveAuthenticationType` (and `signedParesStatusReason`, `challengeCancelCode`, `networkScore`) have **no source field** in the proto `AuthenticationData` message, so they stay `None`. Closing these requires a proto + client change (follow-up).

## Verification

- `cargo build -p grpc-server` ✅
- **MDI part** verified live: fresh flowbird cybersource/authorize fired through the shadow-validation stack → `request_diff` results `code: VS_25, data: []` (UCS outbound byte-identical to Direct).
- **No regression**: re-fired after the change with the patched grpc-server → still `data: []` (the `consumerAuthenticationInformation` block is gated on `authentication_data.is_some()`, so the non-3DS path is unchanged).
- The 3DS mapping is field-for-field identical to the hyperswitch Direct reference; a full 3DS-challenge repro through an external authentication provider is not reproducible in the local sandbox, so the 3DS output parity is established by source-parity + compile rather than a live `keyDiff`. Please review the mapping table against the Direct transformer.


Closes #1844
