### PR TITLE
fix(jpmorgan): make merchant_purchase_description / softMerchant optional

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/requests.rs
@@ -89,7 +89,8 @@ pub struct Expiry {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganMerchant {
     pub merchant_software: JpmorganMerchantSoftware,
-    pub soft_merchant: JpmorganSoftMerchant,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub soft_merchant: Option<JpmorganSoftMerchant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -257,27 +257,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant = requests::JpmorganMerchant {
-                    merchant_software: requests::JpmorganMerchantSoftware {
-                        company_name: auth.company_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "company_name",
-                                context: Default::default(),
-                            },
-                        )?,
-                        product_name: auth.product_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "product_name",
-                                context: Default::default(),
-                            },
-                        )?,
-                    },
-                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                        requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: d,
-                        }
-                    }),
-                };
+                let merchant = requests::JpmorganMerchant::try_from(&auth)?;
 
                 let exp_month_str = card_data.card_exp_month.peek().to_string();
                 let exp_year_str = card_data.get_expiry_year_4_digit().peek().to_string();
@@ -346,27 +326,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant = requests::JpmorganMerchant {
-                    merchant_software: requests::JpmorganMerchantSoftware {
-                        company_name: auth.company_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "company_name",
-                                context: Default::default(),
-                            },
-                        )?,
-                        product_name: auth.product_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "product_name",
-                                context: Default::default(),
-                            },
-                        )?,
-                    },
-                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                        requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: d,
-                        }
-                    }),
-                };
+                let merchant = requests::JpmorganMerchant::try_from(&auth)?;
 
                 // Extract first name and last name from account holder name or billing info
                 let (first_name, last_name) =
@@ -427,27 +387,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant = requests::JpmorganMerchant {
-                    merchant_software: requests::JpmorganMerchantSoftware {
-                        company_name: auth.company_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "company_name",
-                                context: jpmorgan_missing_field_context("company_name"),
-                            },
-                        )?,
-                        product_name: auth.product_name.clone().ok_or(
-                            IntegrationError::MissingRequiredField {
-                                field_name: "product_name",
-                                context: jpmorgan_missing_field_context("product_name"),
-                            },
-                        )?,
-                    },
-                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                        requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: d,
-                        }
-                    }),
-                };
+                let merchant = requests::JpmorganMerchant::try_from(&auth)?;
 
                 // For CardToken, the token is passed in the payment_method_type
                 // instead of raw card details
@@ -497,27 +437,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                             let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                            let merchant = requests::JpmorganMerchant {
-                                merchant_software: requests::JpmorganMerchantSoftware {
-                                    company_name: auth.company_name.clone().ok_or(
-                                        IntegrationError::MissingRequiredField {
-                                            field_name: "company_name",
-                                            context: Default::default(),
-                                        },
-                                    )?,
-                                    product_name: auth.product_name.clone().ok_or(
-                                        IntegrationError::MissingRequiredField {
-                                            field_name: "product_name",
-                                            context: Default::default(),
-                                        },
-                                    )?,
-                                },
-                                soft_merchant: auth.merchant_purchase_description.clone().map(
-                                    |d| requests::JpmorganSoftMerchant {
-                                        merchant_purchase_description: d,
-                                    },
-                                ),
-                            };
+                            let merchant = requests::JpmorganMerchant::try_from(&auth)?;
 
                             let amount = JpmorganAmountConvertor::convert(
                                 router_data.request.minor_amount,
@@ -1141,13 +1061,13 @@ impl TryFrom<&JpmorganAuthType> for requests::JpmorganMerchant {
                 company_name: auth.company_name.clone().ok_or(
                     IntegrationError::MissingRequiredField {
                         field_name: "company_name",
-                        context: Default::default(),
+                        context: jpmorgan_missing_field_context("company_name"),
                     },
                 )?,
                 product_name: auth.product_name.clone().ok_or(
                     IntegrationError::MissingRequiredField {
                         field_name: "product_name",
-                        context: Default::default(),
+                        context: jpmorgan_missing_field_context("product_name"),
                     },
                 )?,
             },

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -273,15 +273,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                                 },
                             )?,
                         },
-                        soft_merchant: requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: auth
-                                .merchant_purchase_description
-                                .clone()
-                                .ok_or(IntegrationError::MissingRequiredField {
-                                    field_name: "merchant_purchase_description",
-                                    context: Default::default(),
-                                })?,
-                        },
+                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                            requests::JpmorganSoftMerchant {
+                                merchant_purchase_description: d,
+                            }
+                        }),
                     };
 
                 let exp_month_str = card_data.card_exp_month.peek().to_string();
@@ -367,15 +363,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                                 },
                             )?,
                         },
-                        soft_merchant: requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: auth
-                                .merchant_purchase_description
-                                .clone()
-                                .ok_or(IntegrationError::MissingRequiredField {
-                                    field_name: "merchant_purchase_description",
-                                    context: Default::default(),
-                                })?,
-                        },
+                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                            requests::JpmorganSoftMerchant {
+                                merchant_purchase_description: d,
+                            }
+                        }),
                     };
 
                 // Extract first name and last name from account holder name or billing info
@@ -453,17 +445,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                                 },
                             )?,
                         },
-                        soft_merchant: requests::JpmorganSoftMerchant {
-                            merchant_purchase_description: auth
-                                .merchant_purchase_description
-                                .clone()
-                                .ok_or(IntegrationError::MissingRequiredField {
-                                    field_name: "merchant_purchase_description",
-                                    context: jpmorgan_missing_field_context(
-                                        "merchant_purchase_description",
-                                    ),
-                                })?,
-                        },
+                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                            requests::JpmorganSoftMerchant {
+                                merchant_purchase_description: d,
+                            }
+                        }),
                     };
 
                 // For CardToken, the token is passed in the payment_method_type
@@ -529,15 +515,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                                         },
                                     )?,
                                 },
-                                soft_merchant: requests::JpmorganSoftMerchant {
-                                    merchant_purchase_description: auth
-                                        .merchant_purchase_description
-                                        .clone()
-                                        .ok_or(IntegrationError::MissingRequiredField {
-                                            field_name: "merchant_purchase_description",
-                                            context: Default::default(),
-                                        })?,
-                                },
+                                soft_merchant: auth.merchant_purchase_description.clone().map(
+                                    |d| requests::JpmorganSoftMerchant {
+                                        merchant_purchase_description: d,
+                                    },
+                                ),
                             };
 
                             let amount = JpmorganAmountConvertor::convert(
@@ -1172,14 +1154,11 @@ impl TryFrom<&JpmorganAuthType> for requests::JpmorganMerchant {
                     },
                 )?,
             },
-            soft_merchant: requests::JpmorganSoftMerchant {
-                merchant_purchase_description: auth.merchant_purchase_description.clone().ok_or(
-                    IntegrationError::MissingRequiredField {
-                        field_name: "merchant_purchase_description",
-                        context: Default::default(),
-                    },
-                )?,
-            },
+            soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                requests::JpmorganSoftMerchant {
+                    merchant_purchase_description: d,
+                }
+            }),
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -257,28 +257,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant =
-                    requests::JpmorganMerchant {
-                        merchant_software: requests::JpmorganMerchantSoftware {
-                            company_name: auth.company_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "company_name",
-                                    context: Default::default(),
-                                },
-                            )?,
-                            product_name: auth.product_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "product_name",
-                                    context: Default::default(),
-                                },
-                            )?,
-                        },
-                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                            requests::JpmorganSoftMerchant {
-                                merchant_purchase_description: d,
-                            }
-                        }),
-                    };
+                let merchant = requests::JpmorganMerchant {
+                    merchant_software: requests::JpmorganMerchantSoftware {
+                        company_name: auth.company_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "company_name",
+                                context: Default::default(),
+                            },
+                        )?,
+                        product_name: auth.product_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "product_name",
+                                context: Default::default(),
+                            },
+                        )?,
+                    },
+                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                        requests::JpmorganSoftMerchant {
+                            merchant_purchase_description: d,
+                        }
+                    }),
+                };
 
                 let exp_month_str = card_data.card_exp_month.peek().to_string();
                 let exp_year_str = card_data.get_expiry_year_4_digit().peek().to_string();
@@ -347,28 +346,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant =
-                    requests::JpmorganMerchant {
-                        merchant_software: requests::JpmorganMerchantSoftware {
-                            company_name: auth.company_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "company_name",
-                                    context: Default::default(),
-                                },
-                            )?,
-                            product_name: auth.product_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "product_name",
-                                    context: Default::default(),
-                                },
-                            )?,
-                        },
-                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                            requests::JpmorganSoftMerchant {
-                                merchant_purchase_description: d,
-                            }
-                        }),
-                    };
+                let merchant = requests::JpmorganMerchant {
+                    merchant_software: requests::JpmorganMerchantSoftware {
+                        company_name: auth.company_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "company_name",
+                                context: Default::default(),
+                            },
+                        )?,
+                        product_name: auth.product_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "product_name",
+                                context: Default::default(),
+                            },
+                        )?,
+                    },
+                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                        requests::JpmorganSoftMerchant {
+                            merchant_purchase_description: d,
+                        }
+                    }),
+                };
 
                 // Extract first name and last name from account holder name or billing info
                 let (first_name, last_name) =
@@ -429,28 +427,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 let auth = JpmorganAuthType::try_from(&router_data.connector_config)?;
 
-                let merchant =
-                    requests::JpmorganMerchant {
-                        merchant_software: requests::JpmorganMerchantSoftware {
-                            company_name: auth.company_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "company_name",
-                                    context: jpmorgan_missing_field_context("company_name"),
-                                },
-                            )?,
-                            product_name: auth.product_name.clone().ok_or(
-                                IntegrationError::MissingRequiredField {
-                                    field_name: "product_name",
-                                    context: jpmorgan_missing_field_context("product_name"),
-                                },
-                            )?,
-                        },
-                        soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
-                            requests::JpmorganSoftMerchant {
-                                merchant_purchase_description: d,
-                            }
-                        }),
-                    };
+                let merchant = requests::JpmorganMerchant {
+                    merchant_software: requests::JpmorganMerchantSoftware {
+                        company_name: auth.company_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "company_name",
+                                context: jpmorgan_missing_field_context("company_name"),
+                            },
+                        )?,
+                        product_name: auth.product_name.clone().ok_or(
+                            IntegrationError::MissingRequiredField {
+                                field_name: "product_name",
+                                context: jpmorgan_missing_field_context("product_name"),
+                            },
+                        )?,
+                    },
+                    soft_merchant: auth.merchant_purchase_description.clone().map(|d| {
+                        requests::JpmorganSoftMerchant {
+                            merchant_purchase_description: d,
+                        }
+                    }),
+                };
 
                 // For CardToken, the token is passed in the payment_method_type
                 // instead of raw card details

--- a/docs-generated/connectors/flywire.md
+++ b/docs-generated/connectors/flywire.md
@@ -131,19 +131,19 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L194)
+**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L196)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L210)
+**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L212)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L233)
+**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L235)
 
 ## API Reference
 

--- a/docs-generated/connectors/flywire.md
+++ b/docs-generated/connectors/flywire.md
@@ -131,19 +131,19 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L196)
+**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L194)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L212)
+**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L210)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L235)
+**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L233)
 
 ## API Reference
 

--- a/examples/flywire/flywire.rs
+++ b/examples/flywire/flywire.rs
@@ -98,14 +98,15 @@ pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetReq
     }
 }
 
+#[allow(dead_code)]
 pub fn build_handle_event_request() -> EventServiceHandleRequest {
     EventServiceHandleRequest {
         merchant_event_id: Some("probe_event_001".to_string()),  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
         ..Default::default()
@@ -115,10 +116,10 @@ pub fn build_handle_event_request() -> EventServiceHandleRequest {
 pub fn build_parse_event_request() -> EventServiceParseRequest {
     EventServiceParseRequest {
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
     }
@@ -199,6 +200,7 @@ pub fn build_token_authorize_request() -> PaymentServiceTokenAuthorizeRequest {
     }
 }
 
+#[allow(dead_code)]
 pub fn build_verify_redirect_request() -> PaymentServiceVerifyRedirectResponseRequest {
     PaymentServiceVerifyRedirectResponseRequest {
         ..Default::default()
@@ -356,10 +358,8 @@ pub async fn process_parse_event(
     client: &ConnectorClient,
     _merchant_transaction_id: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .parse_event(build_parse_event_request(), &HashMap::new(), None)
-        .await?;
-    Ok(format!("status: {:?}", response.status()))
+    let response = client.parse_event(build_parse_event_request())?;
+    Ok(format!("{response:?}"))
 }
 
 // Flow: PaymentService.ProxyAuthorize

--- a/examples/flywire/flywire.rs
+++ b/examples/flywire/flywire.rs
@@ -98,15 +98,14 @@ pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetReq
     }
 }
 
-#[allow(dead_code)]
 pub fn build_handle_event_request() -> EventServiceHandleRequest {
     EventServiceHandleRequest {
         merchant_event_id: Some("probe_event_001".to_string()),  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
         request_details: Some(RequestDetails {
-            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
             ..Default::default()
         }),
         ..Default::default()
@@ -116,10 +115,10 @@ pub fn build_handle_event_request() -> EventServiceHandleRequest {
 pub fn build_parse_event_request() -> EventServiceParseRequest {
     EventServiceParseRequest {
         request_details: Some(RequestDetails {
-            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
             ..Default::default()
         }),
     }
@@ -200,7 +199,6 @@ pub fn build_token_authorize_request() -> PaymentServiceTokenAuthorizeRequest {
     }
 }
 
-#[allow(dead_code)]
 pub fn build_verify_redirect_request() -> PaymentServiceVerifyRedirectResponseRequest {
     PaymentServiceVerifyRedirectResponseRequest {
         ..Default::default()
@@ -358,8 +356,10 @@ pub async fn process_parse_event(
     client: &ConnectorClient,
     _merchant_transaction_id: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client.parse_event(build_parse_event_request())?;
-    Ok(format!("{response:?}"))
+    let response = client
+        .parse_event(build_parse_event_request(), &HashMap::new(), None)
+        .await?;
+    Ok(format!("status: {:?}", response.status()))
 }
 
 // Flow: PaymentService.ProxyAuthorize


### PR DESCRIPTION
## Description

The JPMorgan `Authorize` / `SetupMandate` / `RepeatPayment` transformers required `merchant_purchase_description` (the `softMerchant.merchantPurchaseDescription` field) and errored with `MissingRequiredField` when it was absent.

The **upstream hyperswitch** JPMorgan connector has **no `softMerchant` field at all** — it sends only `merchant.merchantSoftware.{companyName, productName}` (see `hyperswitch/crates/hyperswitch_connectors/src/connectors/jpmorgan/transformers.rs` — `JpmorganMerchant` has a single `merchant_software` field). HS collects only `company_name` / `product_name` via the MCA metadata, so it can never supply `merchant_purchase_description`. This made the field an over-strict requirement that blocked every HS→UCS JPMorgan authorize with:

```
Missing required field: merchant_purchase_description
```

### Changes
- `requests.rs`: `JpmorganMerchant.soft_merchant` → `Option<JpmorganSoftMerchant>` with `skip_serializing_if = "Option::is_none"`.
- `transformers.rs`: build `soft_merchant` via `.map(...)` — present only when `merchant_purchase_description` is supplied — at all **5** construction sites (Authorize card, ACH, card-token, SetupMandate/Repeat, and the `JpmorganMerchant` `TryFrom`), instead of `.ok_or(MissingRequiredField)?`.

`company_name` / `product_name` remain **required**. When `merchant_purchase_description` is absent, the `softMerchant` object is now omitted entirely — byte-for-byte parity with the upstream connector's request shape.

### Companion PR
- hyperswitch (forward `company_name`/`product_name` from MCA metadata over the UCS bridge): juspay/hyperswitch#13178

## How did you test it?
- `cargo check -p connector-integration` passes.
- End-to-end via the UCS shadow-validation harness: JPMorgan `Authorize` returns `status: Charged` (JPMorgan `responseCode: APPROVED`); outbound request carries `merchant.merchantSoftware.companyName` / `.productName` and omits `softMerchant` (no `merchant_purchase_description` supplied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)