### PR TITLE
fix(stripe): send moto flag for mail/telephone order card authorizations

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -230,6 +230,8 @@ pub struct PaymentIntentRequest<
     pub browser_info: Option<StripeBrowserInformation>,
     #[serde(flatten)]
     pub charges: Option<IntentCharges>,
+    #[serde(rename = "payment_method_options[card][moto]")]
+    pub moto: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -2137,6 +2139,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             (None, None) => None,
         };
 
+        let is_moto = if matches!(item.request.payment_method_data, PaymentMethodData::Card(_))
+            && item.request.payment_channel == Some(common_enums::PaymentChannel::MailOrder)
+            || item.request.payment_channel == Some(common_enums::PaymentChannel::TelephoneOrder)
+        {
+            Some(true)
+        } else {
+            None
+        };
+
         Ok(Self {
             amount,                                      //hopefully we don't loose some cents here
             currency: item.request.currency.to_string(), //we need to copy the value and not transfer ownership
@@ -2184,6 +2195,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             expand: Some(ExpandableObjects::LatestCharge),
             browser_info,
             charges: charges_in,
+            moto: is_moto,
         })
     }
 }
@@ -5615,6 +5627,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             expand: Some(ExpandableObjects::LatestCharge),
             browser_info,
             charges: charges_in,
+            moto: None,
         })
     }
 }

--- a/docs-generated/connectors/flywire.md
+++ b/docs-generated/connectors/flywire.md
@@ -131,19 +131,19 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L194)
+**Examples:** [Python](../../examples/flywire/flywire.py#L135) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L98) · [Rust](../../examples/flywire/flywire.rs#L196)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L210)
+**Examples:** [Python](../../examples/flywire/flywire.py#L154) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L114) · [Rust](../../examples/flywire/flywire.rs#L212)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L233)
+**Examples:** [Python](../../examples/flywire/flywire.py#L179) · [JavaScript](../../examples/flywire/flywire.js) · [Kotlin](../../examples/flywire/flywire.kt#L136) · [Rust](../../examples/flywire/flywire.rs#L235)
 
 ## API Reference
 

--- a/examples/flywire/flywire.rs
+++ b/examples/flywire/flywire.rs
@@ -98,14 +98,15 @@ pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetReq
     }
 }
 
+#[allow(dead_code)]
 pub fn build_handle_event_request() -> EventServiceHandleRequest {
     EventServiceHandleRequest {
         merchant_event_id: Some("probe_event_001".to_string()),  // Caller-supplied correlation key, echoed in the response. Not used by UCS for processing.
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
         ..Default::default()
@@ -115,10 +116,10 @@ pub fn build_handle_event_request() -> EventServiceHandleRequest {
 pub fn build_parse_event_request() -> EventServiceParseRequest {
     EventServiceParseRequest {
         request_details: Some(RequestDetails {
-            method: HttpMethod::HttpMethodPost.into(),  // HTTP method of the request (e.g., GET, POST).
+            method: HttpMethod::Post.into(),  // HTTP method of the request (e.g., GET, POST).
             uri: Some("https://example.com/webhook".to_string()),  // URI of the request.
             headers: [].into_iter().collect::<HashMap<_, _>>(),  // Headers of the HTTP request.
-            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".to_string(),  // Body of the HTTP request.
+            body: "{\"event_type\":\"guaranteed\",\"event_date\":\"2026-01-01T00:00:00Z\",\"event_resource\":\"payments\",\"data\":{\"payment_id\":\"probe_pay_001\",\"status\":\"guaranteed\",\"external_reference\":\"probe_ref_001\"}}".as_bytes().to_vec(),  // Body of the HTTP request.
             ..Default::default()
         }),
     }
@@ -199,6 +200,7 @@ pub fn build_token_authorize_request() -> PaymentServiceTokenAuthorizeRequest {
     }
 }
 
+#[allow(dead_code)]
 pub fn build_verify_redirect_request() -> PaymentServiceVerifyRedirectResponseRequest {
     PaymentServiceVerifyRedirectResponseRequest {
         ..Default::default()
@@ -356,10 +358,8 @@ pub async fn process_parse_event(
     client: &ConnectorClient,
     _merchant_transaction_id: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .parse_event(build_parse_event_request(), &HashMap::new(), None)
-        .await?;
-    Ok(format!("status: {:?}", response.status()))
+    let response = client.parse_event(build_parse_event_request())?;
+    Ok(format!("{response:?}"))
 }
 
 // Flow: PaymentService.ProxyAuthorize


### PR DESCRIPTION
## Summary
Shadow-validation diff (fingerprint `c570cbdd6bb21c26d89380e9ff16407a7b03523077e92b415dd608f5bca1515f`, `router.typeDiff:connector_http_status_code`, stripe `authorize`) traced via Loki RP_05 to a real request-body divergence: for card authorizations flagged as mail/telephone order (`payment_channel`), HS sends Stripe's `payment_method_options[card][moto]=true` form field but UCS's stripe connector never builds it. The missing flag routes the charge through a different Stripe risk path, so a declined card yields a generic `CONNECTOR_ERROR_RESPONSE`/`null` http status on the UCS side instead of the same connector error HS received.

`payment_channel` is already fully wired through the gRPC proto and `domain_types` down to `PaymentsAuthorizeData`/`SetupMandateRequestData` — only the stripe connector's request builder was missing the derivation. This mirrors HS's existing `is_moto` logic (`hyperswitch_connectors/src/connectors/stripe/transformers.rs`) in the UCS `PaymentIntentRequest` Authorize builder.

- Added `moto: Option<bool>` to `PaymentIntentRequest<T>` (`payment_method_options[card][moto]`).
- Authorize builder derives it from `item.request.payment_channel` (`MailOrder`/`TelephoneOrder` + card payment method), matching HS.
- RepeatPayment builder (no `payment_channel` on `RepeatPaymentData`) sets `moto: None`, preserving existing behavior.

No proto/domain/HS-mapping changes needed — this is an L3 connector-only fix.

## Repro / verify
Local stack (HS:8080, UCS:8001, MITM:8095, VS:9000), merchant `test_normal_amit` (stripe), card authorize with `payment_channel:"mail_order"` and a Stripe test decline card (`4000000000000002`):

- **Before fix**: `bodyComparison.keyDiff` showed `payment_method_options[card][moto]: {hyperswitch:true, ucs:false}`; router-data comparison showed `response.Err.code: card_declined(HS) vs CONNECTOR_ERROR_RESPONSE(UCS)` and `connector_http_status_code: number(HS) vs null(UCS)`.
- **After fix**: `bodyComparison.keyDiff/valueDiff/typeDiff` all empty (byte-identical Stripe requests including `moto=true`); router-data verdict `differences_found: False` — both sides return identical `card_declined` / `status_code: 402` / same `connector_transaction_id`.

## Test plan
- [x] `cargo build --bin grpc-server`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p connector-integration --all-targets -- -D warnings`
- [x] Local repro: diff verified gone (see above)

Closes #1822
