### PR TITLE
fix(stripe): send payment_method_options[card][moto] for MOTO payments

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -230,6 +230,8 @@ pub struct PaymentIntentRequest<
     pub browser_info: Option<StripeBrowserInformation>,
     #[serde(flatten)]
     pub charges: Option<IntentCharges>,
+    #[serde(rename = "payment_method_options[card][moto]")]
+    pub moto: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -2137,6 +2139,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             (None, None) => None,
         };
 
+        let is_moto = if matches!(item.request.payment_method_data, PaymentMethodData::Card(_))
+            && item.request.payment_channel == Some(common_enums::PaymentChannel::MailOrder)
+            || item.request.payment_channel == Some(common_enums::PaymentChannel::TelephoneOrder)
+        {
+            Some(true)
+        } else {
+            None
+        };
+
         Ok(Self {
             amount,                                      //hopefully we don't loose some cents here
             currency: item.request.currency.to_string(), //we need to copy the value and not transfer ownership
@@ -2175,8 +2186,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 item.request.split_payments.as_ref(),
                 item.request.setup_future_usage,
                 item.request.customer_acceptance.as_ref(),
+                is_moto,
             ) {
-                (Some(_), Some(usage), Some(_)) => Some(usage),
+                (_, Some(common_enums::FutureUsage::OnSession), _, Some(true)) => None,
+                (Some(_), Some(usage), Some(_), _) => Some(usage),
                 _ => setup_future_usage,
             },
 
@@ -2184,6 +2197,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             expand: Some(ExpandableObjects::LatestCharge),
             browser_info,
             charges: charges_in,
+            moto: is_moto,
         })
     }
 }
@@ -5615,6 +5629,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             expand: Some(ExpandableObjects::LatestCharge),
             browser_info,
             charges: charges_in,
+            moto: None,
         })
     }
 }


### PR DESCRIPTION
## Summary
for Stripe `authorize` (card) payments carrying `payment_channel = mail_order` or
`telephone_order` (MOTO — mail order / telephone order transactions).

Hyperswitch always derives and sends `payment_method_options[card][moto]=true` on the outbound
Stripe request in that case (`stripe/transformers.rs`, `is_moto` in the `PaymentIntentRequest`
builder). UCS's `PaymentIntentRequest` struct had no `moto` field at all, so the flag was silently
dropped from the shadow request. Two different request bodies reaching Stripe's `/payment_intents`
endpoint can lead Stripe to process (and potentially decline) the transaction differently,
producing a different error `code`/`connector_transaction_id`/`http_status` between the two paths.

## Root cause
- `payment_channel` is already plumbed end-to-end through the gRPC proto / `domain_types`
  (`PaymentsAuthorizeData.payment_channel`) — only the Stripe connector transformer was missing
  the derivation + field.
- Verified from production shadow-validation logs (Loki): for a real `abo_factory` production
  request, `bodyComparison.keyDiff` showed `payment_method_options[card][moto]: {hyperswitch:
  true, ucs: false}` on the outbound Stripe request, with the downstream router-data comparison
  showing `response.Err.code` (`card_declined` vs `CONNECTOR_ERROR_RESPONSE`) plus
  `connector_transaction_id`/`connector_http_status_code` diverging as a consequence.

## Fix
Add `moto: Option<bool>` to `PaymentIntentRequest` (serde-renamed to
`payment_method_options[card][moto]`, matching Hyperswitch's wire field exactly) and derive it
the same way Hyperswitch does: `true` when the payment method is a card and
`payment_channel` is `MailOrder` or `TelephoneOrder`. Also mirrors Hyperswitch's
`setup_future_usage` interaction (MOTO + `OnSession` future usage clears `setup_future_usage`).
The sibling `RepeatPayment` builder for the same struct sets `moto: None` — Hyperswitch does not
send `moto` for that flow either (only `Authorize`/`SetupMandate` do).

## Verification
Local live shadow-diff replay wasn't usable for this pass — an unrelated stack issue is
currently preventing UCS shadow calls from firing for card authorize on this dev merchant (config
key set correctly, but the request never reaches UCS/MITM). Verified instead via:
- A `serde_urlencoded` proof (temporary local test, not part of this diff) confirming the request
  now serializes to the exact wire key Hyperswitch sends:
  `payment_method_options%5Bcard%5D%5Bmoto%5D=true` when `payment_channel=MailOrder` and the field
  is absent when unset — parity with Hyperswitch's own rename/derivation.
- Direct gRPC `PaymentService.Authorize` calls against a real Stripe test account, both with and
  without `payment_channel=MAIL_ORDER`: both authorize successfully with no regression.
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --all -- --check` all
  pass on the touched crate.

## Category
L3 — connector transformer only (`connector-integration` crate), no proto/domain_types changes
needed since `payment_channel` was already available on `PaymentsAuthorizeData`.

Closes #1825
