### PR TITLE
fix(checkout): build metadata.udf5 from partner_merchant_identifier_details

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -7,10 +7,10 @@ use common_utils::{
 use domain_types::{
     connector_flow::{Authorize, Capture, RepeatPayment, SetupMandate, Void},
     connector_types::{
-        MandateReference, MandateReferenceId, PaymentFlowData, PaymentVoidData,
-        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        ResponseId, SetupMandateRequestData,
+        MandateReference, MandateReferenceId, PartnerMerchantIdentifierDetails, PaymentFlowData,
+        PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
+        PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
+        RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{
@@ -392,6 +392,27 @@ fn split_account_holder_name(
     }
 }
 
+// checkout's `udf5` field carries the partner/integrator name so checkout can attribute the
+// payment; mirrors `hyperswitch_connectors::connectors::checkout::transformers::build_metadata`.
+fn add_udf5(
+    mut metadata_json: serde_json::Value,
+    partner_merchant_identifier_details: Option<&PartnerMerchantIdentifierDetails>,
+) -> serde_json::Value {
+    let udf5 = partner_merchant_identifier_details
+        .and_then(|p| p.partner_details.as_ref())
+        .and_then(|e| e.name.clone().or_else(|| e.integrator.clone()));
+
+    if let Some(v) = udf5 {
+        if let Some(obj) = metadata_json.as_object_mut() {
+            obj.insert("udf5".to_string(), json!(v));
+        } else {
+            metadata_json = json!({ "udf5": v });
+        }
+    }
+
+    metadata_json
+}
+
 fn build_metadata<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 >(
@@ -408,6 +429,14 @@ fn build_metadata<
         .clone()
         .expose_option()
         .unwrap_or_else(|| json!({}));
+
+    let metadata_json = add_udf5(
+        metadata_json,
+        item.router_data
+            .request
+            .partner_merchant_identifier_details
+            .as_ref(),
+    );
 
     Some(Secret::new(metadata_json))
 }
@@ -1027,7 +1056,20 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let auth_type: CheckoutAuthType = connector_auth.try_into()?;
         let processing_channel_id = auth_type.processing_channel_id;
 
-        let metadata = item.router_data.request.metadata.clone();
+        let metadata_json = item
+            .router_data
+            .request
+            .metadata
+            .clone()
+            .expose_option()
+            .unwrap_or_else(|| json!({}));
+        let metadata = Some(Secret::new(add_udf5(
+            metadata_json,
+            item.router_data
+                .request
+                .partner_merchant_identifier_details
+                .as_ref(),
+        )));
 
         let (customer, processing, shipping, items) = if let Some(l2l3_data) =
             &item.router_data.resource_common_data.l2_l3_data

--- a/data/field_probe/checkout.json
+++ b/data/field_probe/checkout.json
@@ -839,7 +839,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"source\":{\"type\":\"id\",\"id\":\"probe-mandate-123\",\"billing_address\":{}},\"amount\":1000,\"currency\":\"USD\",\"processing_channel_id\":\"probe_id\",\"3ds\":{\"enabled\":false,\"force_3ds\":false,\"eci\":null,\"cryptogram\":null,\"xid\":null,\"version\":null,\"challenge_indicator\":\"no_preference\"},\"success_url\":\"https://example.com/recurring-return?status=success\",\"failure_url\":\"https://example.com/recurring-return?status=failure\",\"capture\":true,\"reference\":\"\",\"payment_type\":\"Unscheduled\",\"merchant_initiated\":true}"
+          "body": "{\"source\":{\"type\":\"id\",\"id\":\"probe-mandate-123\",\"billing_address\":{}},\"amount\":1000,\"currency\":\"USD\",\"processing_channel_id\":\"probe_id\",\"3ds\":{\"enabled\":false,\"force_3ds\":false,\"eci\":null,\"cryptogram\":null,\"xid\":null,\"version\":null,\"challenge_indicator\":\"no_preference\"},\"success_url\":\"https://example.com/recurring-return?status=success\",\"failure_url\":\"https://example.com/recurring-return?status=failure\",\"capture\":true,\"reference\":\"\",\"metadata\":{},\"payment_type\":\"Unscheduled\",\"merchant_initiated\":true}"
         }
       }
     },


### PR DESCRIPTION
## What

`checkout`'s Authorize and RepeatPayment (MIT) transformers built the outbound `metadata`
object but never populated `udf5` from `partner_merchant_identifier_details`, unlike
`hyperswitch_connectors::connectors::checkout::transformers::build_metadata` on the HS side,
which sets `udf5` to `partner_details.name` (falling back to `partner_details.integrator`).

## Diff signature

Shadow-validation diff on `checkout` / `repeat_payment`:

```
body.keyDiff.metadata.udf5 = {"hyperswitch": true, "ucs": false}
```

HS's outbound checkout request body carried `metadata.udf5`; UCS's did not.

## Root cause

`partner_merchant_identifier_details` is already carried end-to-end through the UCS gRPC
proto and domain types (added for the Adyen `applicationInfo` fix) and is available on both
`PaymentsAuthorizeData` and `RepeatPaymentData`. checkout's UCS transformer simply never
read it when building `metadata` for either flow.

## Fix

Added a small `add_udf5` helper (mirroring HS's logic: prefer `partner_details.name`, else
`partner_details.integrator`) and call it from both the `Authorize` `build_metadata` and the
`RepeatPayment` request builder in
`crates/integrations/connector-integration/src/connectors/checkout/transformers.rs`.

## Verification (local shadow-validation stack)

Reproduced with a CIT (off_session, `partner_merchant_identifier_details` set) followed by
an MIT repeat payment carrying the same field, against a local HS+UCS+MITM+validation-service
stack on latest `main`:

- **Before fix**: `bodyComparison.keyDiff` → `{"metadata": {"hyperswitch": true, "ucs": false}}`
  (reproducing the reported diff).
- **After fix**: `bodyComparison.keyDiff` → `{}`, `bodyComparison.valueDiff` → `{}` (`no_diff`),
  with no new diffs introduced.

Ran as an A/B on the same UCS build (stash/restore the fix, rebuild, re-run the identical
repro) to confirm the diff reproduces only without the fix and disappears only with it.

Local checks run clean on this diff: `cargo build --bin grpc-server`,
`cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `typos` on the
changed file.

## Category

L3 — connector-only fix (`connector-service/.../connectors/checkout/transformers.rs`); the
field already flows through the proto + domain types, so no proto/HS-mapping change needed.

Closes #1828
