### PR TITLE
fix(stripe): carry request auth_type through into setup_recurring PaymentFlowData

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4869,6 +4869,7 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
     fn foreign_try_from(
         (value, connectors, metadata): (SetupRecurringRequest, Connectors, &MaskedMetadata),
     ) -> Result<Self, error_stack::Report<Self::Error>> {
+        let auth_type = common_enums::AuthenticationType::foreign_try_from(value.auth_type)?;
         let address = match &value.address {
             Some(address_value) => PaymentAddress::foreign_try_from((*address_value).clone())?,
             None => {
@@ -4909,7 +4910,7 @@ impl ForeignTryFrom<(SetupRecurringRequest, Connectors, &MaskedMetadata)> for Pa
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            auth_type,
             connector_request_reference_id: extract_connector_request_reference_id(&Some(
                 value.merchant_recurring_payment_id.clone(),
             )),
@@ -10336,6 +10337,7 @@ impl
             &MaskedMetadata,
         ),
     ) -> Result<Self, error_stack::Report<Self::Error>> {
+        let auth_type = common_enums::AuthenticationType::foreign_try_from(value.auth_type())?;
         let address = match value.address {
             Some(address) => PaymentAddress::foreign_try_from(address)?,
             None => {
@@ -10378,7 +10380,7 @@ impl
             status: common_enums::AttemptStatus::Pending,
             payment_method: PaymentMethod::Card,
             address,
-            auth_type: common_enums::AuthenticationType::default(),
+            auth_type,
             connector_request_reference_id: value.merchant_recurring_payment_id,
             customer_id: Option::<CustomerId>::foreign_try_from(value.customer.clone())?,
             connector_customer: value


### PR DESCRIPTION
## What
`PaymentFlowData::foreign_try_from` for the setup-recurring (SetupMandate) flow hardcoded
`auth_type: common_enums::AuthenticationType::default()` (i.e. always `NoThreeDs`) instead of
using the `auth_type` already parsed from the incoming `SetupRecurringRequest` /
`PaymentServiceSetupRecurringRequest`. This affected both the primary gRPC path (built through
the `SetupRecurringRequest` intermediate type) and the FFI/SDK path (built directly from the
proto request), so `resource_common_data.auth_type` was silently reset to `NoThreeDs` for every
SetupMandate call regardless of what the caller actually requested.

For Stripe specifically, the connector transformer maps
`AuthenticationType::ThreeDs -> Auth3ds::Any` and `NoThreeDs -> Auth3ds::Automatic`, which get
serialized as `payment_method_options[card][request_three_d_secure]`. With the bug, a merchant
requesting `authentication_type: "three_ds"` always got `request_three_d_secure=automatic` sent
to Stripe instead of the correct `any`.

## Why (shadow-validation diff)
Caught via HS<->UCS shadow-validation diffing on a live Stripe `setup_mandate` request:

```
body.valueDiff.payment_method_options[card][request_three_d_secure] = {"hyperswitch":"any","ucs":"automatic"}
```

(A co-reported `payment_method_data[card][exp_month]` diff in the same event is an unrelated,
pre-existing, benign format difference — HS's own outbound request keeps a single-digit month
as-is while the shared HS->UCS mapping always 2-digit-pads it; Stripe accepts both forms. Not
addressed by this PR.)

## Fix
Use the already-parsed `auth_type` from the request instead of `AuthenticationType::default()`
in both `PaymentFlowData` conversions for setup-recurring.

## Verification
Reproduced locally on a fresh `origin/main` build with the full HS<->UCS<->MITM<->validation-service
shadow stack: fired a Stripe `setup_mandate` (`payment_type: "setup_mandate"`, `amount: 0`,
`authentication_type: "three_ds"`, `setup_future_usage: "off_session"`) request.

- **Before fix:** `bodyComparison.valueDiff` on the setup_mandate request showed
  `payment_method_options[card][request_three_d_secure] = {hyperswitch:"any", ucs:"automatic"}`
  (plus the unrelated exp_month padding facet).
- **After fix (rebuilt + restarted grpc-server, same repro):** the `request_three_d_secure`
  facet disappeared entirely (`valueDiff` for that request only contains the unrelated exp_month
  facet).

Local checks run and green: `cargo build`, `cargo clippy -p domain_types --all-targets -- -D warnings`,
`cargo fmt --all -- --check`, `cargo test -p domain_types`.

Closes #1829
