### PR TITLE
fix(stripe): emit moto on setup_recurring for mail/telephone order payments

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -277,6 +277,8 @@ pub struct SetupMandateRequest<
     pub expand: Option<ExpandableObjects>,
     #[serde(flatten)]
     pub browser_info: Option<StripeBrowserInformation>,
+    #[serde(rename = "payment_method_options[card][moto]")]
+    pub moto: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -4927,6 +4929,19 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .clone()
             .map(StripeBrowserInformation::from);
 
+        let is_moto = if matches!(
+            item.router_data.request.payment_method_data,
+            PaymentMethodData::Card(..)
+        ) && item.router_data.request.payment_channel
+            == Some(common_enums::PaymentChannel::MailOrder)
+            || item.router_data.request.payment_channel
+                == Some(common_enums::PaymentChannel::TelephoneOrder)
+        {
+            Some(true)
+        } else {
+            None
+        };
+
         Ok(Self {
             confirm: true,
             payment_data,
@@ -4944,6 +4959,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             payment_method_types: Some(pm_type),
             expand: Some(ExpandableObjects::LatestAttempt),
             browser_info,
+            moto: is_moto,
         })
     }
 }


### PR DESCRIPTION
## What

Stripe's `setup_recurring` (SetupMandate) request in UCS was missing the
`payment_method_options[card][moto]` field entirely, so the HS↔UCS shadow
validator flagged a diff on every setup_mandate payment carrying a MOTO
(mail order / telephone order) payment channel.

## Diff signature (shadow-validation)

```
body.keyDiff.payment_method_options[card][moto] = {"hyperswitch": true, "ucs": false}
```

A second facet was also reported on the same event:

```
body.valueDiff.payment_method_data[card][exp_month] = {"hyperswitch": "3", "ucs": "03"}
```

That second facet is a pre-existing, separate, **benign** formatting divergence
(HS's own outbound request keeps the raw un-padded month while the HS→UCS gRPC
mapping 2-digit-pads it; Stripe accepts both — same class as a previously
reviewed/closed case) and is intentionally **not** touched by this PR.

## Root cause

Hyperswitch's stripe connector (`crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs`)
sets `moto: Some(true)` on its `SetupIntentRequest` whenever the payment's
`payment_channel` is `mail_order` or `telephone_order`. The `payment_channel`
field is already carried correctly end-to-end on the UCS side (proto →
`domain_types::connector_types::SetupMandateRequestData` → HS→UCS mapping) —
but UCS's `SetupMandateRequest` struct in
`crates/integrations/connector-integration/src/connectors/stripe/transformers.rs`
never declared a `moto` field at all, so the value was silently dropped when
building the outbound Stripe request.

## Fix

Added the `moto: Option<bool>` field (serialized as
`payment_method_options[card][moto]`, matching HS's field name) to UCS's
`SetupMandateRequest`, and computed it from `payment_channel` using the same
condition HS uses (mail/telephone order → `Some(true)`, else `None`).

This is an **L3 (connector-only)** fix — no proto or domain changes were
needed, since `payment_channel` was already present on both sides.

## Verification (local shadow stack)

Reproduced against an unmodified `origin/main` build first:

```
keyDiff:   {"payment_method_options[card][moto]": {"hyperswitch": true, "ucs": false}}
valueDiff: {"payment_method_data[card][exp_month]": {"hyperswitch": "3", "ucs": "03"}}
```

Fired a `setup_mandate` payment for stripe with `payment_channel: "telephone_order"`,
card `4242424242424242`/exp `03/2030`, through the local HS→UCS shadow pipeline
(HS :8080, UCS :8001, mitmproxy, validation-service), and read the
`bodyComparison` verdict.

After applying this fix and rebuilding/restarting UCS, re-ran the identical
payment:

```
keyDiff:   {}                                                          <- moto diff gone
valueDiff: {"payment_method_data[card][exp_month]": {"hyperswitch": "3", "ucs": "03"}}  <- benign facet, unchanged
```

`moto` no longer appears in `keyDiff`; no new diffs were introduced.

## Checks run locally
- `cargo build` (workspace) — clean
- `cargo clippy -p connector-integration --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p connector-integration` — passing

Closes #1831
