### PR TITLE
fix(twoc_twop_paco): require complete billing address for airline data

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -931,16 +931,27 @@ where
         .map(PacoAirlineData::try_from)
         .transpose()?;
 
-    // PACO's airline authorization requires a billing address alongside
-    // airlineData; PACO rejects an airline payload that lacks one. Rather than
-    // fail the whole payment, drop the airline block when no billing address is
-    // present and proceed with the base authorization.
-    let airline_data = if airline_data.is_some() && paco_billing_address.is_none() {
+    // PACO's airline authorization requires a complete billing address whenever
+    // airlineData is defined; it rejects the payload otherwise ("The
+    // BillingAddress '<field>' field is required when AirlineData is defined").
+    // Verified against PACO UAT, the required set is billAddrLine1, billAddrCity,
+    // billAddrPostCode and billAddrCountry (line2/line3 are optional). A billing
+    // address object alone is not enough — all four must be populated. Rather
+    // than fail the whole payment, drop the airline block when any required
+    // field is missing and proceed with the base authorization.
+    let billing_complete_for_airline = paco_billing_address.as_ref().is_some_and(|billing| {
+        billing.bill_addr_line1.is_some()
+            && billing.bill_addr_city.is_some()
+            && billing.bill_addr_post_code.is_some()
+            && billing.bill_addr_country.is_some()
+    });
+    let airline_data = if airline_data.is_some() && !billing_complete_for_airline {
         tracing::warn!(
             target: "twoc_twop_paco",
-            "twoc_twop_paco: airlineData supplied without a billing address — \
-             dropping airlineData and proceeding with the base authorization, \
-             since PACO requires a billing address for airline data"
+            "twoc_twop_paco: airlineData supplied without a complete billing address \
+             (PACO requires billAddrLine1, billAddrCity, billAddrPostCode and \
+             billAddrCountry) — dropping airlineData and proceeding with the base \
+             authorization"
         );
         None
     } else {


### PR DESCRIPTION
## What

Follow-up correcting the airline/billing handling merged in #1810 and #1813.

PACO's airline authorization requires a **complete** billing address whenever
`airlineData` is defined. #1813 dropped the airline block only when *no billing
address object* was present, but PACO actually requires four specific fields —
`billAddrLine1`, `billAddrCity`, `billAddrPostCode`, `billAddrCountry`. A
partial billing address (e.g. present but missing city or post code) still
forwarded `airlineData` and was rejected by PACO with:

```
400 — The BillingAddress '<field>' field is required when AirlineData is defined
```

This was hit in production on a GCash transaction (`billAddrLine1` missing).

This change drops the airline block when **any** of the four required billing
fields is missing, and proceeds with the base authorization (logging a warning).
Applies to both card and GCash wallet paths. Requests with a complete billing
address are unchanged and still send `airlineData`.

## Root cause verification (A/B against PACO UAT)

Same request (airline data + a billing address missing `line1`), pre- vs
post-fix:

| Code | Result |
|------|--------|
| Pre-fix (drop only when no address object) — card & GCash | `400 — "The BillingAddress 'billAddrLine1' field is required when AirlineData is defined"` |
| Post-fix | `200` — airline dropped, base authorization succeeds |

## PACO required-field probe (UAT)

Sending `airlineData` + a progressively fuller billing address:

| Billing sent | PACO response |
|---|---|
| `line1` only | 400 — `billAddrCity` required |
| `line1 + city` | 400 — `billAddrPostCode` required |
| `line1 + city + zip` | 400 — `billAddrCountry` required |
| `line1 + city + zip + country` | **200 CHARGED** |

→ required set = `billAddrLine1`, `billAddrCity`, `billAddrPostCode`, `billAddrCountry`.

## Regression (live, HTTP composite endpoint, PACO UAT) — 10/10 pass

| Case | PM | airline | billing | airline dropped? | result |
|------|----|---------|---------|------------------|--------|
| 1 | card | no | full | — | 200 CHARGED |
| 2 | card | no | shipping-only | — | 200 CHARGED |
| 3 | card | yes | full (4 fields) | no (sent) | 200 CHARGED |
| 4 | card | yes | no line1 | yes | 200 CHARGED |
| 5 | card | yes | partial (line1+city) | yes | 200 CHARGED |
| 6 | card | yes | shipping-only | yes | 200 CHARGED |
| 7 | gcash | no | full | — | 200 PENDING (redirect) |
| 8 | gcash | yes | full (4 fields) | no (sent) | 200 PENDING (redirect) |
| 9 | gcash | yes | no line1 | yes | 200 PENDING (redirect) |
| 10 | gcash | yes | shipping-only | yes | 200 PENDING (redirect) |

Ordinary payments (no airline data) are unaffected — billing address remains
optional for them.
