### PR TITLE
fix(connector): [Adyen] repeat_payment parity - captureDelayHours, splits, holderName

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -836,6 +836,7 @@ pub enum PaymentMethod<
     AdyenMandatePaymentMethod(Box<AdyenMandate>),
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdyenMandate {
@@ -5732,7 +5733,7 @@ fn get_additional_data_for_repeat_payment<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 >(
     item: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
-) -> Option<AdditionalData> {
+) -> Result<Option<AdditionalData>, error_stack::Report<IntegrationError>> {
     let (authorisation_type, manual_capture) = match item.request.capture_method {
         Some(common_enums::CaptureMethod::Manual)
         | Some(common_enums::CaptureMethod::ManualMultiple) => {
@@ -5762,10 +5763,74 @@ fn get_additional_data_for_repeat_payment<
         MandateReferenceId::ConnectorMandateId(_) => None,
     };
 
-    Some(AdditionalData {
+    // Mirror hyperswitch: metadata.capture_delay_hours -> additionalData.captureDelayHours.
+    let capture_delay_hours = {
+        let metadata_capture_delay =
+            get_adyen_metadata(item.request.metadata.clone().map(|m| m.expose()))
+                .capture_delay_hours;
+
+        let capture_method = item.request.capture_method.unwrap_or_default();
+        match capture_method {
+            common_enums::CaptureMethod::Manual | common_enums::CaptureMethod::ManualMultiple => {
+                // For manual capture, capture_delay_hours should be None
+                if let Some(hours) = metadata_capture_delay {
+                    return Err(IntegrationError::InvalidDataFormat {
+                        field_name: "metadata.capture_delay_hours",
+                        context: IntegrationErrorContext {
+                            additional_context: Some(format!(
+                                "Adyen does not accept capture_delay_hours for manual capture \
+                                 (capture_method = {capture_method:?}), but metadata supplied {hours}"
+                            )),
+                            suggested_action: Some(
+                                "Remove capture_delay_hours from metadata when capture_method is \
+                                 Manual/ManualMultiple, or switch to automatic capture"
+                                    .to_string(),
+                            ),
+                            doc_url: Some(
+                                "https://docs.adyen.com/online-payments/capture/".to_string(),
+                            ),
+                        },
+                    }
+                    .into());
+                }
+                None
+            }
+            // For automatic capture, only 0 (or None) is valid
+            common_enums::CaptureMethod::Automatic
+            | common_enums::CaptureMethod::Scheduled
+            | common_enums::CaptureMethod::SequentialAutomatic => match metadata_capture_delay {
+                None => None,
+                Some(0) => Some(0),
+                Some(hours) => {
+                    return Err(IntegrationError::InvalidDataFormat {
+                        field_name: "metadata.capture_delay_hours",
+                        context: IntegrationErrorContext {
+                            additional_context: Some(format!(
+                                "Adyen only accepts capture_delay_hours of 0 (or unset) for \
+                                 automatic capture (capture_method = {capture_method:?}), but \
+                                 metadata supplied {hours}"
+                            )),
+                            suggested_action: Some(
+                                "Set metadata.capture_delay_hours to 0 (or omit it) for automatic \
+                                 capture"
+                                    .to_string(),
+                            ),
+                            doc_url: Some(
+                                "https://docs.adyen.com/online-payments/capture/".to_string(),
+                            ),
+                        },
+                    }
+                    .into());
+                }
+            },
+        }
+    };
+
+    Ok(Some(AdditionalData {
         authorisation_type,
         manual_capture,
         execute_three_d,
+        capture_delay_hours,
         network_tx_reference: None,
         recurring_detail_reference: None,
         recurring_shopper_reference: None,
@@ -5778,7 +5843,7 @@ fn get_additional_data_for_repeat_payment<
         }),
         transaction_link_id,
         ..AdditionalData::default()
-    })
+    }))
 }
 
 type RecurringDetails = (Option<AdyenRecurringModel>, Option<bool>, Option<String>);
@@ -6815,7 +6880,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let (recurring_processing_model, store_payment_method, shopper_reference) =
             get_recurring_processing_model_for_repeat_payment(&item.router_data)?;
         let browser_info = None;
-        let additional_data = get_additional_data_for_repeat_payment(&item.router_data);
+        let additional_data = get_additional_data_for_repeat_payment(&item.router_data)?;
         let return_url = item.router_data.request.router_return_url.clone().ok_or(
             IntegrationError::MissingRequiredField {
                 field_name: "return_url",
@@ -6941,7 +7006,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .map(|m| m.expose()),
         );
 
-        let (store, splits) = (adyen_metadata.store.clone(), None);
+        let (store, splits) = match item.router_data.request.split_payments.as_ref() {
+            Some(SplitPaymentsDetails::AdyenSplitPayment(adyen_split_payment)) => {
+                get_adyen_split_request(adyen_split_payment, item.router_data.request.currency)
+            }
+            _ => (adyen_metadata.store.clone(), None),
+        };
         let device_fingerprint = adyen_metadata.device_fingerprint.clone();
         let platform_chargeback_logic = adyen_metadata.platform_chargeback_logic.clone();
 

--- a/data/field_probe/adyen.json
+++ b/data/field_probe/adyen.json
@@ -2551,7 +2551,7 @@
             "via": "HyperSwitch",
             "x-api-key": "probe_key"
           },
-          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"paypal\",\"storedPaymentMethodId\":\"probe-mandate-123\",\"holderName\":null},\"reference\":\"\",\"returnUrl\":\"https://example.com/recurring-return\",\"shopperInteraction\":\"ContAuth\",\"recurringProcessingModel\":\"UnscheduledCardOnFile\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperReference\":\"cust_probe_123\"}"
+          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"paypal\",\"storedPaymentMethodId\":\"probe-mandate-123\"},\"reference\":\"\",\"returnUrl\":\"https://example.com/recurring-return\",\"shopperInteraction\":\"ContAuth\",\"recurringProcessingModel\":\"UnscheduledCardOnFile\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperReference\":\"cust_probe_123\"}"
         }
       }
     },
@@ -2694,7 +2694,7 @@
             "via": "HyperSwitch",
             "x-api-key": "probe_key"
           },
-          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"scheme\",\"storedPaymentMethodId\":\"pm_1AbcXyzStripeTestToken\",\"holderName\":null},\"reference\":\"probe_tokenized_txn_001\",\"returnUrl\":\"https://example.com/return\",\"shopperInteraction\":\"Ecommerce\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperName\":{}}"
+          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"scheme\",\"storedPaymentMethodId\":\"pm_1AbcXyzStripeTestToken\"},\"reference\":\"probe_tokenized_txn_001\",\"returnUrl\":\"https://example.com/return\",\"shopperInteraction\":\"Ecommerce\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperName\":{}}"
         }
       }
     },


### PR DESCRIPTION
## What

Adyen's `RepeatPayment` (recurring / merchant-initiated) request builder in
`connector-integration` diverged from hyperswitch's outbound request in three
independent ways, all traced to the same builder
(`TryFrom<AdyenRouterData<RouterDataV2<RepeatPayment, ...>>> for AdyenRepeatPaymentRequest`):

1. **`additionalData.captureDelayHours`** — `get_additional_data_for_repeat_payment`
   never derived `capture_delay_hours` from `metadata.capture_delay_hours` at all
   (the `Authorize` builder, `get_additional_data`, already does this). Field was
   always omitted for repeat payments.
2. **`splits`** — hardcoded to `(metadata.store, None)`, ignoring
   `request.split_payments` entirely. The `Authorize`/`Refund` builders already
   read `request.split_payments`/`request.split_refunds` via
   `get_adyen_split_request`; `RepeatPayment` skipped it.
3. **`paymentMethod.holderName`** — `AdyenMandate` was missing
   `#[serde_with::skip_serializing_none]`. hyperswitch's own `AdyenMandate` has
   this attribute, so a `None` `holder_name` is omitted entirely; without it,
   `connector-service` serialized an explicit `"holderName": null`, causing a
   key-presence (not value) mismatch.

## Fix

- `get_additional_data_for_repeat_payment` now mirrors `get_additional_data`'s
  `capture_delay_hours` derivation (same manual/automatic-capture validation).
- The `splits`/`store` tuple is now built via `request.split_payments.as_ref()`
  matched against `SplitPaymentsDetails::AdyenSplitPayment`, same as the other
  Adyen flows.
- Added `#[serde_with::skip_serializing_none]` to `AdyenMandate`.

All three changes are confined to
`crates/integrations/connector-integration/src/connectors/adyen/transformers.rs`.
No proto/domain changes were needed — `RepeatPaymentData.split_payments` and
`metadata` were already available on the domain type; the `RepeatPayment`
builder just wasn't using them.

## Verification

Reproduced locally against the shadow-validation harness (hyperswitch → shadow
gRPC → connector-service, both legs proxied and diffed):

1. Adyen card payment with `setup_future_usage=off_session` + mandate data
   (mandate setup, automatic capture).
2. A subsequent repeat/MIT payment via `recurring_details` (mandate reuse),
   with `metadata.capture_delay_hours=0` and an Adyen `split_payments` payload.

Before the fix, the shadow-validation body comparison for the repeat-payment
request showed:
```
keyDiff.additionalData.captureDelayHours = {hyperswitch: true, ucs: false}
keyDiff.paymentMethod.holderName        = {hyperswitch: false, ucs: true}
keyDiff.splits                          = {hyperswitch: true, ucs: false}
```

After the fix, re-running the identical repro produced a full match — both
`keyDiff`/`valueDiff`/`typeDiff` empty, and the two raw outbound request bodies
byte-identical.

## Layer

L3 (connector transformer only, `adyen/transformers.rs`) — no proto/domain/HS
mapping changes required.

## Checks run locally

- `cargo build --bin grpc-server` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p connector-integration adyen` — 2 passed

Closes #1838
