### PR TITLE
feat(flywire): redirect payer on failed checkout_session event

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
@@ -78,6 +78,9 @@ const FLYWIRE_EVENT_LISTENER_TEMPLATE: &str = r#"window.addEventListener("messag
   if (d.source !== 'checkout_session') return;
   if (d.success === true && d.confirm_url) {
     window.location.href = __RETURN_URL__;
+  } else if (d.success === false) {
+    // Decline / error / payer-closed: redirect back so euler /pay/response can PSync and finalize the failed txn.
+    window.location.href = __RETURN_URL__;
   }
 });"#;
 


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
The injected iframe postMessage listener only redirected on success===true. Flywire also emits a checkout_session message with success===false on decline / error / payer-closing the element; that message was dropped, leaving the payer stuck in the iframe with no return to the merchant. Redirect on success===false as well so euler /pay/response can PSync and finalize the failed txn.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
