### PR TITLE
fix(payload): map error reason to error_description to match hyperswitch

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/payload.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload.rs
@@ -300,11 +300,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.error_type,
-            message: response.error_description,
-            reason: response
-                .details
-                .as_ref()
-                .map(|details_value| details_value.to_string()),
+            message: response.error_description.clone(),
+            reason: Some(response.error_description),
             attempt_status: None,
             connector_transaction_id: None,
             network_advice_code: None,


### PR DESCRIPTION
## What

For the `payload` connector, `build_error_response` derived the `ErrorResponse.reason`
from the connector's arbitrary `details` JSON (stringified):

```rust
message: response.error_description,
reason: response.details.as_ref().map(|d| d.to_string()),
```

hyperswitch's native payload connector instead sets:

```rust
message: response.error_description.clone(),
reason: Some(response.error_description),
```

So on any payload 4xx decline the two produced a **different `reason`**:
- hyperswitch (reference): the clean `error_description` string, e.g.
  `"There was an issue processing the payment, please try again later."`
- UCS/prism: the entire `details` transaction object serialized to a string,
  e.g. `"{\"amount\":0.01,...,\"status\":\"declined\",\"status_code\":\"processing_issue\",...}"`.

This surfaced in shadow validation as `response.Err.reason` value diffs on real
payload declines (zero-amount-auth on a card). `code` and `message` already matched
across the two paths — only `reason` diverged.

## Fix

Map `reason` from `error_description` (matching hyperswitch's native connector), so
the two error paths are byte-identical.

## Verification

- **Root cause** confirmed from production logs: both the Direct and shadow-UCS paths
  reached the real payload API and received the same HTTP 400 `TransactionDeclined`
  body; the only divergence was `reason` (clean message vs stringified `details`).
- **Source trace** on current `main` of both repos: after this change prism's
  `build_error_response` sets `reason` identically to hyperswitch's native payload
  connector; the value threads unchanged through the gRPC `ConnectorErrorDetails.reason`
  field and back into hyperswitch's `ErrorResponse.reason`.
- **No regression**: a happy-path payload `authorize` shadow run against the rebuilt
  `grpc-server` produced a fully green diff (keyDiff / typeDiff / valueDiff all `{}`).

## Before → After (reason facet)

| | Direct (reference) | UCS before | UCS after |
|---|---|---|---|
| `response.Err.reason` | clean `error_description` | stringified `details` JSON | clean `error_description` ✅ matches |
