### PR TITLE
fix(adyen): map payment_channel to shopperInteraction MOTO on authorize

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -889,7 +889,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ) -> Self {
         match item.request.off_session {
             Some(true) => Self::ContinuedAuthentication,
-            _ => Self::Ecommerce,
+            _ => match item.request.payment_channel {
+                Some(common_enums::PaymentChannel::MailOrder)
+                | Some(common_enums::PaymentChannel::TelephoneOrder) => Self::Moto,
+                Some(common_enums::PaymentChannel::Ecommerce) | None => Self::Ecommerce,
+            },
         }
     }
 }


### PR DESCRIPTION
## Summary
Adyen `authorize` requests carrying `payment_channel = mail_order` / `telephone_order` are sent to Adyen with `shopperInteraction = "Moto"` by Hyperswitch, but the UCS (connector-service) shadow request sent `shopperInteraction = "Ecommerce"` — a functional divergence, since Adyen treats MOTO transactions differently for authentication/liability purposes.

Diff signature observed via shadow validation:
```
body.valueDiff.shopperInteraction = {"hyperswitch":"Moto","ucs":"Ecommerce"}
```

## Root cause
`AdyenShopperInteraction::from(&RouterDataV2<Authorize, ...>)` in
`crates/integrations/connector-integration/src/connectors/adyen/transformers.rs` only checked
`request.off_session`, ignoring `request.payment_channel` entirely — so it always fell back to
`Ecommerce` unless `off_session == Some(true)`. Hyperswitch's own Adyen transformer additionally
maps `payment_channel == MailOrder | TelephoneOrder` to `Moto`.

`payment_channel` already exists end-to-end in the UCS gRPC contract and domain types
(`PaymentsAuthorizeData::payment_channel: Option<common_enums::PaymentChannel>`) — it just wasn't
read in this one connector transformer. This is an **L3-only** fix (no proto/domain change needed).

## Fix
Mirror Hyperswitch's logic in the UCS Adyen `Authorize` transformer:
```rust
match item.request.off_session {
    Some(true) => Self::ContinuedAuthentication,
    _ => match item.request.payment_channel {
        Some(common_enums::PaymentChannel::MailOrder)
        | Some(common_enums::PaymentChannel::TelephoneOrder) => Self::Moto,
        Some(common_enums::PaymentChannel::Ecommerce) | None => Self::Ecommerce,
    },
}
```

## Verification (local shadow-validation stack, HS:8080 + UCS:8001 + MITM + validation-service)
Repro: create a merchant + Adyen MCA, enroll `ucs_rollout_config_{mid}_adyen_card_Authorize` in
the shadow rollout, fire `POST /payments` with `"payment_channel": "mail_order"`, `confirm: true`.

- **Before fix**: `bodyComparison.valueDiff = {"shopperInteraction": {"hyperswitch":"Moto","ucs":"Ecommerce"}}`
- **After fix** (rebuilt + restarted UCS on this branch, same repro re-run): `bodyComparison.valueDiff = {}`, `keyDiff = {}` — both HS and UCS requests now serialize `"shopperInteraction":"Moto"`. Verdict: `no_diff`.

Local checks run on the touched crate: `cargo build --bin grpc-server`, `cargo fmt --all -- --check`, `cargo clippy -p connector-integration --all-targets -- -D warnings` — all clean.

Closes #1850
