### PR TITLE
fix(novalnet): keep attempt status on SetupMandate API FAILURE to match Hyperswitch

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -932,10 +932,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     transaction_id,
                 ));
                 Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status: common_enums::AttemptStatus::Failure,
-                        ..item.router_data.resource_common_data
-                    },
                     response,
                     ..item.router_data
                 })


### PR DESCRIPTION
## Summary
On an API-level `FAILURE` response from Novalnet, the UCS `SetupMandate` connector
transformer was **overwriting the attempt status to `Failure`** at the router-data level.
Hyperswitch (the ground truth both sides are compared against) does **not** set a status
on this path — it returns `Err(ErrorResponse)` (with `attempt_status: None`) and leaves the
incoming (`pending`) status untouched, letting the error drive the final attempt status
downstream.

This produced a shadow-validation `router.valueDiff:status`:

```
"valueDiff":{"status":{"hyperswitch":"pending","ucs":"failure"}}
```

(connector `novalnet`, flow `setup_mandate`, merchant `bu_de_getolo`)

## Root cause
Same "force `Failure` on the error arm" anti-pattern already fixed for the `Authorize`
sub-flow in #1680 (issue `21051`), which explicitly flagged `SetupMandate` / `RepeatPayment`
/ `Capture` / `Void` / `PSync` as follow-ups to align if/when they surface. This is the
`SetupMandate` one surfacing.

HS `novalnet/transformers.rs` (ground truth), `SetupMandate` `Failure` arm:
```rust
NovalnetAPIStatus::Failure => {
    let response = Err(get_error_response(item.response.result, item.http_code, transaction_id));
    Ok(Self { response, ..item.data })   // status UNCHANGED
}
```

UCS `novalnet/transformers.rs`, `SetupMandate` `Failure` arm (before this fix) forced:
```rust
resource_common_data: PaymentFlowData {
    status: common_enums::AttemptStatus::Failure,
    ..item.router_data.resource_common_data
},
```

## Fix (L3 — UCS connector transformer only)
In the novalnet `SetupMandate` `Failure` arm, stop overwriting the status — mirror HS by
returning the `Err` and leaving `resource_common_data` (and thus the attempt status)
unchanged via `..item.router_data`. No proto / domain / HS-mapping change.

## Verify
Reproduced locally with a novalnet test-decline card (`4000000000000002`, no_three_ds) on a
zero-amount `setup_mandate` request:
- **Before fix**: router-data comparison verdict —
  `valueDiff: {"status": {"hyperswitch": "pending", "ucs": "failure"}}`
- **After fix**: same repro — `valueDiff: {}` (status no longer diverges; verdict flips
  diff → no_diff). Remaining `typeDiff` entries on that request
  (`response.Err.connector_response_reference_id`) are a separate, already-tracked issue.
- `cargo build -p connector-integration` / `--bin grpc-server` — clean.
- `cargo clippy -p connector-integration --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

The other sibling flows (`RepeatPayment` / `Capture` / `Void` / `PSync`) still carry the
same pattern; left untouched here since only `SetupMandate` is observed diverging for this
issue — same follow-up policy as #1680.

Fixes `21419`.
