### PR TITLE
fix(clippy): resolve rust 1.97 clippy lints across the workspace

### DIFF
--- a/crates/common/common_utils/src/ext_traits.rs
+++ b/crates/common/common_utils/src/ext_traits.rs
@@ -196,7 +196,7 @@ impl ByteSliceExt for [u8] {
     {
         serde_json::from_slice(self)
             .change_context(errors::ParsingError::StructParseFailure(type_name))
-            .attach_printable_lazy(|| format!("Unable to parse {type_name} from &[u8] {:?}", &self))
+            .attach_printable_lazy(|| format!("Unable to parse {type_name} from &[u8] {self:?}"))
     }
 }
 
@@ -305,10 +305,7 @@ impl ValueExt for serde_json::Value {
     where
         T: serde::de::DeserializeOwned,
     {
-        let debug = format!(
-            "Unable to parse {type_name} from serde_json::Value: {:?}",
-            &self
-        );
+        let debug = format!("Unable to parse {type_name} from serde_json::Value: {self:?}");
         serde_json::from_value::<T>(self)
             .change_context(errors::ParsingError::StructParseFailure(type_name))
             .attach_printable_lazy(|| debug)
@@ -566,7 +563,7 @@ impl<T> StringExt<T> for String {
         serde_json::from_str::<T>(self)
             .change_context(errors::ParsingError::StructParseFailure(type_name))
             .attach_printable_lazy(|| {
-                format!("Unable to parse {type_name} from string {:?}", &self)
+                format!("Unable to parse {type_name} from string {self:?}")
             })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/airwallex.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex.rs
@@ -281,7 +281,7 @@ macros::macro_connector_implementation!(
                 .ok_or(IntegrationError::MissingRequiredField { field_name: "connector_order_id", context: Default::default() })?;
             Ok(format!(
                 "{}/pa/payment_intents/{}/confirm",
-                &req.resource_common_data.connectors.airwallex.base_url,
+                req.resource_common_data.connectors.airwallex.base_url,
                 order_id
             ))
         }
@@ -313,7 +313,7 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<PSync, PaymentFlowData, PaymentsSyncData, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             let payment_id = req.request.get_connector_transaction_id()?;
-            Ok(format!("{}/pa/payment_intents/{}", &req.resource_common_data.connectors.airwallex.base_url, payment_id))
+            Ok(format!("{}/pa/payment_intents/{}", req.resource_common_data.connectors.airwallex.base_url, payment_id))
         }
     }
 );
@@ -347,7 +347,7 @@ macros::macro_connector_implementation!(
                 ResponseId::ConnectorTransactionId(id) => id,
                 _ => return Err(IntegrationError::MissingConnectorTransactionID { context: Default::default() }.into())
 };
-            Ok(format!("{}/pa/payment_intents/{}/capture", &req.resource_common_data.connectors.airwallex.base_url, payment_id))
+            Ok(format!("{}/pa/payment_intents/{}/capture", req.resource_common_data.connectors.airwallex.base_url, payment_id))
         }
     }
 );
@@ -377,7 +377,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<Refund, RefundFlowData, RefundsData, RefundsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/pa/refunds/create", &req.resource_common_data.connectors.airwallex.base_url))
+            Ok(format!("{}/pa/refunds/create", req.resource_common_data.connectors.airwallex.base_url))
         }
     }
 );
@@ -407,7 +407,7 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<RSync, RefundFlowData, RefundSyncData, RefundsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             let refund_id = req.request.connector_refund_id.clone();
-            Ok(format!("{}/pa/refunds/{}", &req.resource_common_data.connectors.airwallex.base_url, refund_id))
+            Ok(format!("{}/pa/refunds/{}", req.resource_common_data.connectors.airwallex.base_url, refund_id))
         }
     }
 );
@@ -450,7 +450,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<ServerAuthenticationToken, MerchantAuthenticationFlowData, ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/authentication/login", &req.resource_common_data.connectors.airwallex.base_url))
+            Ok(format!("{}/authentication/login", req.resource_common_data.connectors.airwallex.base_url))
         }
     }
 );
@@ -480,7 +480,7 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<CreateOrder, PaymentFlowData, PaymentCreateOrderData, PaymentCreateOrderResponse>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/pa/payment_intents/create", &req.resource_common_data.connectors.airwallex.base_url))
+            Ok(format!("{}/pa/payment_intents/create", req.resource_common_data.connectors.airwallex.base_url))
         }
     }
 );
@@ -516,7 +516,7 @@ macros::macro_connector_implementation!(
                 .ok_or(IntegrationError::MissingRequiredField { field_name: "connector_order_id", context: Default::default() })?;
             Ok(format!(
                 "{}/pa/payment_intents/{}/confirm",
-                &req.resource_common_data.connectors.airwallex.base_url,
+                req.resource_common_data.connectors.airwallex.base_url,
                 order_id
             ))
         }
@@ -570,7 +570,7 @@ macros::macro_connector_implementation!(
                 })?;
             Ok(format!(
                 "{}/pa/payment_intents/{}/confirm",
-                &req.resource_common_data.connectors.airwallex.base_url,
+                req.resource_common_data.connectors.airwallex.base_url,
                 order_id
             ))
         }
@@ -606,7 +606,7 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
             let payment_id = req.request.connector_transaction_id.clone();
-            Ok(format!("{}/pa/payment_intents/{}/cancel", &req.resource_common_data.connectors.airwallex.base_url, payment_id))
+            Ok(format!("{}/pa/payment_intents/{}/cancel", req.resource_common_data.connectors.airwallex.base_url, payment_id))
         }
     }
 );
@@ -698,7 +698,7 @@ macros::macro_connector_implementation!(
         ) -> CustomResult<String, IntegrationError> {
             Ok(format!(
                 "{}/pa/customers/create",
-                &req.resource_common_data.connectors.airwallex.base_url
+                req.resource_common_data.connectors.airwallex.base_url
             ))
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -930,9 +930,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             imerchantsolutions_metadata,
             item.router_data.request.is_auto_capture(),
         )?;
-        let shopper_reference = match item.router_data.resource_common_data.get_customer_id() {
-            Ok(customer_id) => Some(customer_id.get_string_repr().to_string()),
-            Err(err) => return Err(err),
+        let shopper_reference = {
+            let customer_id = item.router_data.resource_common_data.get_customer_id()?;
+            Some(customer_id.get_string_repr().to_string())
         };
         let stored_payment_method_id =
             item.router_data

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
@@ -305,7 +305,7 @@ macros::create_all_prerequisites!(
                 headers::AUTHORIZATION.to_string(),
                 format!(
                     "Bearer {}",
-                    &req.resource_common_data
+                    req.resource_common_data
                         .access_token()
                         .ok_or(IntegrationError::FailedToObtainAuthType { context: Default::default() })?
                         .access_token.peek()

--- a/crates/integrations/connector-integration/src/connectors/multisafepay.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay.rs
@@ -325,7 +325,7 @@ macros::macro_connector_implementation!(
             let connector_refund_id = req.request.connector_refund_id.clone();
 
             if connector_refund_id.is_empty() {
-                return Err(IntegrationError::MissingConnectorRefundID { context: Default::default() })?;
+                Err(IntegrationError::MissingConnectorRefundID { context: Default::default() })?;
             }
 
             let auth = multisafepay::MultisafepayAuthType::try_from(&req.connector_config)

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -1246,7 +1246,7 @@ fn get_payment_source<
     bank_redirection_data: &BankRedirectData,
 ) -> Result<PaymentSourceItem<T>, Report<IntegrationError>> {
     match bank_redirection_data {
-        BankRedirectData::Eps { bank_name: _, .. } => Ok(PaymentSourceItem::Eps(RedirectRequest {
+        BankRedirectData::Eps { .. } => Ok(PaymentSourceItem::Eps(RedirectRequest {
             name: item.resource_common_data.get_billing_full_name()?,
             country_code: item.resource_common_data.get_billing_country()?,
             experience_context: ContextStruct {
@@ -1282,7 +1282,7 @@ fn get_payment_source<
                 user_action: Some(UserAction::PayNow),
             },
         })),
-        BankRedirectData::Ideal { bank_name: _, .. } => {
+        BankRedirectData::Ideal { .. } => {
             Ok(PaymentSourceItem::IDeal(RedirectRequest {
                 name: item.resource_common_data.get_billing_full_name()?,
                 country_code: item.resource_common_data.get_billing_country()?,
@@ -1303,7 +1303,6 @@ fn get_payment_source<
             }))
         }
         BankRedirectData::Sofort {
-            preferred_language: _,
             ..
         } => Ok(PaymentSourceItem::Sofort(RedirectRequest {
             name: item.resource_common_data.get_billing_full_name()?,

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
@@ -474,7 +474,7 @@ where
                         "Cancel Redeem reads the original Redeem's `TransactionId` from \
                          `connector_transaction_id`; expected a numeric `i64`, got \
                          `{}`.",
-                        &req.connector_transaction_id
+                        req.connector_transaction_id
                     ),
                     "Pass the `connector_transaction_id` from the original Redeem response \
                      verbatim (it's just the Pine Labs txn id as a numeric string).",

--- a/crates/integrations/connector-integration/src/payout_connectors/loonio.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/loonio.rs
@@ -214,7 +214,7 @@ impl
     ) -> CustomResult<String, IntegrationError> {
         Ok(format!(
             "{}api/v1/transactions/outgoing/send_to_interac",
-            &req.resource_common_data.connectors.loonio.base_url
+            req.resource_common_data.connectors.loonio.base_url
         ))
     }
 
@@ -312,7 +312,7 @@ impl ConnectorIntegrationV2<PayoutGet, PayoutFlowData, PayoutGetRequest, PayoutG
         )?;
         Ok(format!(
             "{}api/v1/transactions/{}/details",
-            &req.resource_common_data.connectors.loonio.base_url, connector_payout_id
+            req.resource_common_data.connectors.loonio.base_url, connector_payout_id
         ))
     }
 

--- a/crates/internal/field-probe/build.rs
+++ b/crates/internal/field-probe/build.rs
@@ -103,10 +103,9 @@ fn parse_flow_info(transformer_fn: &str, request_type: &str) -> Option<FlowInfo>
         }
     } else if let Some(pos) = base.find("MethodService") {
         pos + "MethodService".len()
-    } else if let Some(pos) = base.rfind("Service") {
-        pos + 7
     } else {
-        return None;
+        let pos = base.rfind("Service")?;
+        pos + 7
     };
 
     let service = &base[..service_end];

--- a/crates/types-traits/cards/src/validate.rs
+++ b/crates/types-traits/cards/src/validate.rs
@@ -83,7 +83,7 @@ impl CardNumber {
         let mut no_of_supported_card_networks = 0;
 
         let card_number_str = self.get_card_no();
-        for (_, regex) in CARD_NETWORK_REGEX.iter() {
+        for regex in CARD_NETWORK_REGEX.values() {
             let card_regex = match regex.as_ref() {
                 Ok(regex) => Ok(regex),
                 Err(_) => Err(report!(ValidationError::InvalidValue {

--- a/crates/types-traits/domain_types/src/utils.rs
+++ b/crates/types-traits/domain_types/src/utils.rs
@@ -50,10 +50,7 @@ impl ValueExt for Value {
     where
         T: serde::de::DeserializeOwned,
     {
-        let debug = format!(
-            "Unable to parse {type_name} from serde_json::Value: {:?}",
-            &self
-        );
+        let debug = format!("Unable to parse {type_name} from serde_json::Value: {self:?}");
         serde_json::from_value::<T>(self)
             .change_context(ParsingError::StructParseFailure(type_name))
             .attach_printable_lazy(|| debug)

--- a/sdk/rust/smoke-test/src/main.rs
+++ b/sdk/rust/smoke-test/src/main.rs
@@ -201,7 +201,7 @@ async fn test_connector_scenarios(
                     ));
                 } else if detail.contains("Rust panic:") || detail.starts_with("thread '") {
                     // Rust panic (real SDK crash)
-                    println!("{} — {}", red("FAILED"), &detail);
+                    println!("{} — {}", red("FAILED"), detail);
                     scenarios.push((
                         scenario_key,
                         ScenarioResult {


### PR DESCRIPTION
## What

CI's `dtolnay/rust-toolchain@stable` picked up the new **Rust 1.97** stable release, whose clippy introduced/extended several lints. With `RUSTFLAGS=-D warnings` these are fatal, so the Clippy check currently fails for **every PR** in the repo (first seen on #1594, but unrelated to it — all flagged code predates that PR).

## Changes

All fixes are clippy's own machine-applicable suggestions — **no functional change**:

| Lint | Sites |
|---|---|
| `question_mark` | `field-probe/build.rs` service-boundary parsing; `imerchantsolutions` shopper_reference |
| `useless_borrows_in_formatting` | redundant `&x` in `format!`/`println!` args: `common_utils/ext_traits.rs` (3), `domain_types/utils.rs`, `airwallex.rs` (12), `jpmorgan.rs`, `qwikcilver`, `loonio` (2), rust sdk smoke-test |
| `for_kv_map` | `cards/validate.rs` — `CARD_NETWORK_REGEX.values()` |
| `unneeded_wildcard_pattern` | `paypal` BankRedirectData patterns (3) |
| `needless_return_with_question_mark` | `multisafepay` refund-id guard |

## Verification

`RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --all-features --all-targets` exits **clean** on the full workspace (iterated per dependency layer — each fix unblocked the next crate — until a zero-error pass).