### PR TITLE
fix(connector): [NMI] report Unspecified status when psync finds no transaction

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -883,14 +883,19 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
                 response.transaction.last()
             });
 
-        // Handle empty response (means AuthenticationPending) or transaction data
+        // Handle empty response (NMI has no record of the order) or transaction data
         let (status, transaction_id) = if let Some(transaction) = transaction {
             // Map condition field from XML to AttemptStatus using NmiStatus enum
             let status = AttemptStatus::from(NmiStatus::from(transaction.condition.clone()));
             (status, Some(transaction.transaction_id.clone()))
         } else {
-            // Empty XML response = AuthenticationPending (during 3DS flow)
-            (AttemptStatus::AuthenticationPending, None)
+            // Empty XML response: NMI has no record of this order, so it is telling us nothing about
+            // the attempt. Report Unspecified rather than inventing a status -- it reaches the router
+            // as PaymentStatus::UNSPECIFIED, which resolves to the attempt's existing status. Claiming
+            // AuthenticationPending here happened to suit the 3DS flow (where the attempt already is
+            // authentication-pending), but it is wrong for every other way an order goes unknown to
+            // NMI -- e.g. an attempt that never reached the connector at all.
+            (AttemptStatus::Unspecified, None)
         };
 
         Ok(Self {


### PR DESCRIPTION
## What

NMI's `query.php` returns an **empty transaction list** whenever it has no record of the order. The PSync transformer read that as `AttemptStatus::AuthenticationPending`:

```rust
} else {
    // Empty XML response = AuthenticationPending (during 3DS flow)
    (AttemptStatus::AuthenticationPending, None)
};
```

That guess only suits the 3DS flow — where the attempt is *already* authentication-pending, so it happens to be right. Every other way an order goes unknown to NMI gets the same verdict. The common one, and the one that fired in prod: **an attempt that never reached the connector at all**, so PSync falls back to `order_id = attempt_id` (NMI is the one connector that overrides `validate_psync_reference_id` to always `Ok(())`, so it still calls out with no connector txn id) and NMI has never heard of that order.

An empty response carries **no information** about the attempt, so report `Unspecified` instead of inventing a status. It reaches the router as `PaymentStatus::UNSPECIFIED`, which resolves to the attempt's existing status:

- `hyperswitch_interfaces/src/unified_connector_service/transformers.rs:589` — `PaymentStatus::Unspecified => Ok(prev_status)`
- `router/src/core/payments/gateway/psync_gateway.rs:88` passes `router_data.status` as that `prev_status`, and writes the result back at `:95`

This is exactly what hyperswitch's **direct** NMI integration does on the same branch — it leaves `RouterData` untouched (`hyperswitch_connectors/src/connectors/nmi/transformers.rs:1543`, `None => Ok(Self { ..item.data })`).

Fixes juspay/hyperswitch-cloud#19536 (parent #19534).

## Root cause (prod)

Shadow-diff `router.valueDiff:status`, merchant `merchant_1771364887457`, x-request-id `019f211d-0b72-7fd1-873a-ab4875c91ea7` (UUIDv7 → txn **2026-07-02T04:36:19Z**).

Loki confirms this is **not** the synthetic-502 class — both legs got a genuine NMI **HTTP 200** from `https://secure.nmi.com/api/query.php` (UCS `"stage":"ConnectorCall","latency_ms":2905,"status_code":200,"error":null`; Direct `[CALL_CONNECTOR_API] status_code = 200, elapsed_time = 605ms`). NMI simply returned an empty result, because the attempt (`payment_method_awaited`, no connector txn id) had never been submitted to it. Identical requests, divergent response mapping.

## Before / after

Reproduced locally on clean `main` against the real NMI sandbox: attempt in `payment_method_awaited` with no connector txn id → `GET /payments/{id}?force_sync=true&all_keys_required=true`.

**BEFORE** (`VS_48`, x-req `019f581d-ae17`) — reproduces the prod payload exactly:
```json
"differences": {
  "keyDiff": {},
  "valueDiff": {"status": {"hyperswitch": "payment_method_awaited", "ucs": "authentication_pending"}},
  "typeDiff": {"response.Ok.TransactionResponse.resource_id": {"hyperswitch": "string", "ucs": "object"}}
}
```

**AFTER** (`VS_46`, x-req `019f5823-d6e3`) — with this PR + juspay/hyperswitch#13276:
```json
"Router data comparison completed successfully - no differences found"
"summary": {"total_key_differences": 0, "total_value_differences": 0, "total_type_differences": 0},
"data_sizes": {"hyperswitch_data_keys": 56, "ucs_data_keys": 56}
```
`VS_51`: `hyperswitch_status = payment_method_awaited`, `ucs_status = payment_method_awaited`.

56/56 keys mapped on both sides, so the UCS leg really ran (not a false green).

> The `resource_id` half of the diff is a separate defect in the router's UCS client and is fixed by **juspay/hyperswitch#13276**; both are needed for the fully-green run above.

## Regression check — the non-empty branch is untouched

Real NMI authorize → approved (txn `12295063749`), then PSync so `query.php` returns an actual transaction (the `Some(transaction)` arm, which this PR does not change):

`VS_51`: `hyperswitch_status = ucs_status = charged` · `keyDiff {}` · `valueDiff {}` · `resource_id` absent from `typeDiff`.

(The two `typeDiff` keys left on that run — `amount_captured` / `minor_amount_captured` — are the pre-existing PSync bug at `psync_gateway.rs:108`/`:279`, already tracked by the open hyperswitch PR #13206. Unrelated to this issue, and absent from the #19534 repro itself.)

## Notes

- 3DS is unaffected: on that flow the attempt is already `authentication_pending`, so `Unspecified` resolves back to the same status.
- No proto change — `PaymentStatus::UNSPECIFIED` is the proto3 zero value and is already in the enum; `AttemptStatus::Unspecified` already maps to it (`domain_types/src/types.rs:6758`).

