### PR TITLE
feat(connector): [datatrans] Card 3DS + Recurring (SetupMandate + MIT) to HS Direct parity

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/datatrans.rs
+++ b/crates/integrations/connector-integration/src/connectors/datatrans.rs
@@ -6,13 +6,14 @@ use common_enums::CurrencyUnit;
 use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, ClientAuthenticationToken, PSync, RSync, Refund, Void, VoidPC,
+        Authorize, Capture, ClientAuthenticationToken, PSync, RSync, Refund, RepeatPayment,
+        SetupMandate, Void, VoidPC,
     },
     connector_types::{
         ClientAuthenticationTokenRequestData, PaymentFlowData, PaymentVoidData,
         PaymentsAuthorizeData, PaymentsCancelPostCaptureData, PaymentsCaptureData,
         PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
-        RefundsResponseData,
+        RefundsResponseData, RepeatPaymentData, SetupMandateRequestData,
     },
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payment_method_data::PaymentMethodDataTypes,
@@ -32,8 +33,9 @@ use transformers::{
     self as datatrans, DatatransCaptureRequest, DatatransCaptureResponse,
     DatatransClientAuthRequest, DatatransClientAuthResponse, DatatransPaymentsRequest,
     DatatransPaymentsResponse, DatatransRefundRequest, DatatransRefundResponse,
-    DatatransRefundSyncResponse, DatatransSyncResponse, DatatransVoidPCRequest,
-    DatatransVoidPCResponse, DatatransVoidRequest, DatatransVoidResponse,
+    DatatransRefundSyncResponse, DatatransRepeatPaymentRequest, DatatransRepeatPaymentResponse,
+    DatatransSetupMandateRequest, DatatransSetupMandateResponse, DatatransSyncResponse,
+    DatatransVoidPCRequest, DatatransVoidPCResponse, DatatransVoidRequest, DatatransVoidResponse,
 };
 
 use super::macros;
@@ -76,6 +78,16 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::PaymentCapture for Datatrans<T>
+{
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::SetupMandateV2<T> for Datatrans<T>
+{
+}
+
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::RepeatPaymentV2<T> for Datatrans<T>
 {
 }
 
@@ -177,6 +189,18 @@ macros::create_all_prerequisites!(
             request_body: DatatransClientAuthRequest,
             response_body: DatatransClientAuthResponse,
             router_data: RouterDataV2<ClientAuthenticationToken, MerchantAuthenticationFlowData, ClientAuthenticationTokenRequestData, PaymentsResponseData>,
+        ),
+        (
+            flow: SetupMandate,
+            request_body: DatatransSetupMandateRequest<T>,
+            response_body: DatatransSetupMandateResponse,
+            router_data: RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ),
+        (
+            flow: RepeatPayment,
+            request_body: DatatransRepeatPaymentRequest<T>,
+            response_body: DatatransRepeatPaymentResponse,
+            router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
     amount_converters: [],
@@ -286,8 +310,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         "application/json"
     }
 
-    fn base_url<'a>(&self, _connectors: &'a Connectors) -> &'a str {
-        "https://api.sandbox.datatrans.com"
+    fn base_url<'a>(&self, connectors: &'a Connectors) -> &'a str {
+        // Return the configured base_url (prod vs sandbox per environment), like HS Direct,
+        // instead of a hardcoded sandbox literal. Flow URLs are built via
+        // `connector_base_url_payments/refunds/merchant_auth`, which read the same config value.
+        &connectors.datatrans.base_url
     }
 
     fn get_auth_header(
@@ -314,13 +341,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         let response: datatrans::DatatransErrorResponse = if res.response.is_empty() {
             datatrans::DatatransErrorResponse::default()
         } else {
+            // Datatrans normally returns `{"error":{"code","message"}}`, but some gateway errors
+            // come back as a non-JSON (HTML) page. Fall back to surfacing the raw body text
+            // instead of failing with a deserialization error (mirrors HS Direct).
             res.response
                 .parse_struct("DatatransErrorResponse")
-                .change_context(
-                    crate::utils::response_deserialization_fail(
-                        res.status_code,
-                    "datatrans: response body did not match the expected format; confirm API version and connector documentation."),
-                )?
+                .ok()
+                .unwrap_or_else(|| {
+                    datatrans::DatatransErrorResponse::from_non_json_body(res.response.as_ref())
+                })
         };
 
         with_error_response_body!(event_builder, response);
@@ -329,7 +358,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
             status_code: res.status_code,
             code: response.code(),
             message: response.message(),
-            reason: None,
+            reason: Some(response.message()),
             attempt_status: None,
             connector_transaction_id: None,
             network_decline_code: None,
@@ -362,7 +391,21 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, IntegrationError> {
-            Ok(format!("{}/v1/transactions/authorize", self.connector_base_url_payments(req)))
+            let base_url = self.connector_base_url_payments(req);
+            // Endpoint selection mirrors HS Direct:
+            // - Native 3DS (Datatrans-driven challenge, no external authentication data) OR a CIT
+            //   alias registration (`is_mandate_payment`) use the redirect-capable
+            //   `/v1/transactions` endpoint (both may return a 3DS redirect).
+            // - Passthrough external 3DS (cavv present) and no-3DS payments use the split
+            //   `/v1/transactions/authorize` endpoint that authorizes immediately, no redirect.
+            // (MIT is served by the separate RepeatPayment flow -> `/v1/transactions/authorize`.)
+            let native_three_ds =
+                req.resource_common_data.is_three_ds() && req.request.authentication_data.is_none();
+            if native_three_ds || req.request.is_mandate_payment() {
+                Ok(format!("{base_url}/v1/transactions"))
+            } else {
+                Ok(format!("{base_url}/v1/transactions/authorize"))
+            }
         }
     }
 );
@@ -574,14 +617,72 @@ macros::macro_connector_implementation!(
     }
 );
 
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Datatrans,
+    curl_request: Json(DatatransSetupMandateRequest<T>),
+    curl_response: DatatransSetupMandateResponse,
+    flow_name: SetupMandate,
+    resource_common_data: PaymentFlowData,
+    flow_request: SetupMandateRequestData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<SetupMandate, PaymentFlowData, SetupMandateRequestData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            // Zero-auth CIT alias creation uses the redirect-capable `/v1/transactions`
+            // endpoint (createAlias + native 3DS), never the split authorize endpoint.
+            Ok(format!("{}/v1/transactions", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Datatrans,
+    curl_request: Json(DatatransRepeatPaymentRequest<T>),
+    curl_response: DatatransRepeatPaymentResponse,
+    flow_name: RepeatPayment,
+    resource_common_data: PaymentFlowData,
+    flow_request: RepeatPaymentData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+        fn get_url(
+            &self,
+            req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            // MIT charges the stored alias via the split authorize endpoint (no redirect):
+            // the alias was already 3DS-authenticated at SetupMandate time.
+            Ok(format!("{}/v1/transactions/authorize", self.connector_base_url_payments(req)))
+        }
+    }
+);
+
 macros::macro_connector_flow_status_impls!(
     connector: Datatrans,
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     not_implemented: [
         IncrementalAuthorization,
-        SetupMandate,
-        RepeatPayment,
         CreateOrder,
         ServerSessionAuthenticationToken,
         Accept,

--- a/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
@@ -1,24 +1,30 @@
+use std::collections::HashMap;
+
 use crate::types::ResponseRouterData;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common_enums::{AttemptStatus, Currency, PostCaptureVoidStatus, RefundStatus};
-use common_utils::MinorUnit;
-use domain_types::errors::{ConnectorError, IntegrationError};
+use common_utils::{pii::Email, request::Method, MinorUnit};
+use domain_types::errors::{ConnectorError, IntegrationError, IntegrationErrorContext};
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, ClientAuthenticationToken, PSync, RSync, Refund, Void, VoidPC,
+        Authorize, Capture, ClientAuthenticationToken, PSync, RSync, Refund, RepeatPayment,
+        SetupMandate, Void, VoidPC,
     },
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData,
         ConnectorSpecificClientAuthenticationResponse,
         DatatransClientAuthenticationResponse as DatatransClientAuthenticationResponseDomain,
-        PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCancelPostCaptureData,
-        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
-        RefundSyncData, RefundsData, RefundsResponseData, ResponseId,
+        MandateReference, MandateReferenceId, PaymentFlowData, PaymentVoidData,
+        PaymentsAuthorizeData, PaymentsCancelPostCaptureData, PaymentsCaptureData,
+        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
+        RefundsResponseData, RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
-    router_data::ConnectorSpecificConfig,
+    router_data::{ConnectorSpecificConfig, ErrorResponse},
     router_data_v2::RouterDataV2,
+    router_response_types::RedirectForm,
+    types::{AdditionalCardInfo, AdditionalPaymentData},
 };
 use hyperswitch_masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
@@ -26,7 +32,52 @@ use serde::{Deserialize, Serialize};
 // Error message constants
 const DEFAULT_ERROR_CODE: &str = "UNKNOWN_ERROR";
 const DEFAULT_ERROR_MESSAGE: &str = "Unknown error occurred";
+/// Code used when Datatrans returns a non-JSON error body (e.g. an HTML gateway error page)
+/// that carries no structured error code. Mirrors HS Direct's HTML fallback.
+const NO_ERROR_CODE: &str = "NO_ERROR_CODE";
 const UNSUPPORTED_PAYMENT_METHOD_ERROR: &str = "Only card payments are supported for Datatrans";
+
+/// Datatrans hosted redirect/challenge host — sandbox environment
+/// (paired with the `api.sandbox.datatrans.com` API base_url).
+const REDIRECTION_SBX_URL: &str = "https://pay.sandbox.datatrans.com";
+/// Datatrans hosted redirect/challenge host — production environment.
+const REDIRECTION_PROD_URL: &str = "https://pay.datatrans.com";
+
+/// Selects the Datatrans hosted challenge host that mirrors the API `base_url`
+/// environment: the sandbox API base (`api.sandbox.datatrans.com`) pairs with
+/// `pay.sandbox.datatrans.com`, and production with `pay.datatrans.com`.
+///
+/// Derived from `base_url` (not `test_mode`) because HS does not forward
+/// `test_mode` in the SetupRecurring gRPC request; relying on `test_mode` would
+/// otherwise route sandbox challenges to the production host.
+fn datatrans_redirection_host(base_url: &str) -> &'static str {
+    if base_url.contains("sandbox") {
+        REDIRECTION_SBX_URL
+    } else {
+        REDIRECTION_PROD_URL
+    }
+}
+/// Card `type` discriminator sent to Datatrans for raw PAN card data.
+const CARD_TYPE_PLAIN: &str = "PLAIN";
+/// Card `type` discriminator sent to Datatrans for a stored-alias charge
+/// (MIT / RepeatPayment): the alias created by SetupMandate is reused in place of a PAN.
+const CARD_TYPE_ALIAS: &str = "ALIAS";
+/// Error surfaced when a Datatrans MIT/RepeatPayment carries a mandate reference type
+/// this connector cannot charge via an alias (only connector-stored alias mandates work).
+const UNSUPPORTED_MANDATE_REFERENCE_ERROR: &str =
+    "Only connector-stored alias mandates are supported for Datatrans repeat payments";
+/// Datatrans `authenticationResponse` value flagging a completed external 3DS
+/// authentication (`Y` = authenticated) when forwarding passthrough cavv/eci/xid.
+const THREE_DS_AUTHENTICATION_RESPONSE_Y: &str = "Y";
+
+/// Builds an `IntegrationErrorContext` carrying Datatrans-specific remediation detail,
+/// so error sites never fall back to a context-free `Default::default()`.
+fn datatrans_context(additional_context: &str) -> IntegrationErrorContext {
+    IntegrationErrorContext {
+        additional_context: Some(additional_context.to_string()),
+        ..Default::default()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct DatatransAuthType {
@@ -85,6 +136,18 @@ impl DatatransErrorResponse {
     pub fn message(&self) -> String {
         self.error.message.clone()
     }
+
+    /// Builds an error from a non-JSON body (e.g. an HTML gateway error page) so the raw page
+    /// text is surfaced instead of a deserialization failure. Mirrors HS Direct's HTML fallback
+    /// (decoded lossily as UTF-8 rather than pulling in an ISO-8859-10 codec).
+    pub fn from_non_json_body(body: &[u8]) -> Self {
+        Self {
+            error: DatatransErrorDetail {
+                code: NO_ERROR_CODE.to_string(),
+                message: String::from_utf8_lossy(body).trim().to_string(),
+            },
+        }
+    }
 }
 
 impl Default for DatatransErrorResponse {
@@ -117,6 +180,59 @@ pub struct DatatransCard<
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     pub card_type: Option<String>,
+    /// The `3D` object driving card 3DS: either merchant-supplied external
+    /// authentication artifacts (`Authentication`) or cardholder details that ask
+    /// Datatrans to run native 3DS (`Cardholder`). Omitted for non-3DS card payments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "3D")]
+    pub three_ds: Option<ThreeDSecureData>,
+}
+
+/// The `3D` object attached to a Datatrans card in an Authorize request.
+#[derive(Debug, Serialize, Clone)]
+#[serde(untagged)]
+pub enum ThreeDSecureData {
+    /// Native 3DS: Datatrans drives the ACS challenge using these cardholder details.
+    Cardholder(ThreedsInfo),
+    /// Passthrough external 3DS: the merchant already authenticated and forwards
+    /// the resulting cavv/eci/xid to Datatrans.
+    Authentication(ThreeDSData),
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ThreedsInfo {
+    pub cardholder: CardHolder,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CardHolder {
+    pub cardholder_name: Secret<String>,
+    pub email: Email,
+}
+
+/// External (passthrough) 3DS authentication data forwarded to Datatrans.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreeDSData {
+    #[serde(rename = "threeDSTransactionId")]
+    pub three_ds_transaction_id: Option<Secret<String>>,
+    pub cavv: Secret<String>,
+    pub eci: Option<String>,
+    pub xid: Option<Secret<String>>,
+    #[serde(rename = "threeDSVersion")]
+    pub three_ds_version: Option<String>,
+    #[serde(rename = "authenticationResponse")]
+    pub authentication_response: String,
+}
+
+/// Redirect return URLs supplied to Datatrans for the native 3DS challenge (`/v1/transactions`).
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RedirectUrls {
+    pub success_url: Option<String>,
+    pub cancel_url: Option<String>,
+    pub error_url: Option<String>,
 }
 
 // Authorize request structure based on tech spec
@@ -127,13 +243,33 @@ pub struct DatatransPaymentsRequest<
 > {
     pub currency: Currency,
     pub refno: String,
-    pub amount: MinorUnit,
+    /// Charge amount in minor units. Omitted (`None`) for zero-auth SetupMandate/CIT
+    /// alias creation, where no amount is captured; always present for Authorize.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<MinorUnit>,
     pub card: DatatransCard<T>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_settle: Option<bool>,
+    /// Present only for native 3DS: the cardholder is redirected here after the
+    /// ACS challenge. Omitted for passthrough external 3DS and no-3DS payments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect: Option<RedirectUrls>,
     // Don't skip serializing - we want "option": null to appear in JSON
     pub option: Option<DatatransPaymentOptions>,
 }
+
+/// SetupMandate (zero-auth CIT alias creation) reuses the Authorize request and
+/// response shapes verbatim. These aliases give the connector-service Bridge macro
+/// distinct templating type names per flow (the Bridge is keyed on request/response
+/// type identity) without duplicating the underlying structs.
+pub type DatatransSetupMandateRequest<T> = DatatransPaymentsRequest<T>;
+pub type DatatransSetupMandateResponse = DatatransPaymentsResponse;
+
+/// MIT / RepeatPayment reuses the Authorize request and response shapes: the stored alias
+/// is charged via the same `/v1/transactions/authorize` endpoint. These aliases give the
+/// Bridge macro distinct per-flow templating type names without duplicating the structs.
+pub type DatatransRepeatPaymentRequest<T> = DatatransPaymentsRequest<T>;
+pub type DatatransRepeatPaymentResponse = DatatransPaymentsResponse;
 
 // Payment options for Datatrans API
 #[derive(Debug, Serialize)]
@@ -170,18 +306,37 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
+        // Native 3DS = merchant asks Datatrans to run the challenge (auth_type is ThreeDs and no
+        // external authentication artifacts were supplied). This is the only case that needs the
+        // redirect return URLs; passthrough external 3DS and no-3DS payments do not redirect.
+        let is_native_three_ds = router_data.resource_common_data.is_three_ds()
+            && router_data.request.authentication_data.is_none();
+        // CIT ("purchase + save card"): a customer-initiated Authorize that also registers a
+        // reusable Datatrans alias for later MIT/RepeatPayment. Mirrors the HS Direct Authorize
+        // path, which sets `createAlias` and redirect URLs for `is_mandate_payment()`.
+        let is_mandate_payment = router_data.request.is_mandate_payment();
+
         // Extract card data or token
-        let card = match &router_data.request.payment_method_data {
+        let (card, redirect) = match &router_data.request.payment_method_data {
             PaymentMethodData::Card(card_data) => {
                 // Direct card flow - use raw card details
-                DatatransCard {
+                let card = DatatransCard {
                     alias: None,
                     number: Some(card_data.card_number.clone()),
                     expiry_month: Some(card_data.card_exp_month.clone()),
                     expiry_year: Some(card_data.get_card_expiry_year_2_digit()?),
                     cvv: Some(card_data.card_cvc.clone()),
-                    card_type: Some("PLAIN".to_string()),
-                }
+                    card_type: Some(CARD_TYPE_PLAIN.to_string()),
+                    three_ds: build_three_ds_data(router_data)?,
+                };
+                // Return URLs are required for a native-3DS challenge OR a CIT alias
+                // registration (which Datatrans runs through the redirect-capable endpoint).
+                let redirect = (is_native_three_ds || is_mandate_payment).then(|| RedirectUrls {
+                    success_url: router_data.request.router_return_url.clone(),
+                    cancel_url: router_data.request.router_return_url.clone(),
+                    error_url: router_data.request.router_return_url.clone(),
+                });
+                (card, redirect)
             }
             // TODO: CardToken flow for Datatrans Secure Fields SDK.
             // When the client SDK collects card data via Secure Fields, the transactionId
@@ -192,27 +347,29 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             PaymentMethodData::PaymentMethodToken(token_data) => {
                 let token = token_data.token.clone();
 
-                DatatransCard {
+                let card = DatatransCard {
                     alias: Some(token),
                     number: None,
                     expiry_month: None,
                     expiry_year: None,
                     cvv: None,
                     card_type: None,
-                }
+                    three_ds: None,
+                };
+                (card, None)
             }
             _ => Err(IntegrationError::NotImplemented(
                 UNSUPPORTED_PAYMENT_METHOD_ERROR.to_string(),
-                Default::default(),
+                datatrans_context(
+                    "Datatrans Authorize supports raw card or Secure Fields token payment methods only",
+                ),
             ))?,
         };
 
-        // Determine auto_settle based on capture method
-        let auto_settle = match router_data.request.capture_method {
-            Some(common_enums::CaptureMethod::Automatic) => Some(true),
-            Some(common_enums::CaptureMethod::Manual) => Some(false),
-            _ => None, // Let connector decide default behavior
-        };
+        // auto_settle mirrors is_auto_capture(): Automatic/SequentialAutomatic/None -> true,
+        // Manual/ManualMultiple/Scheduled -> false. (SequentialAutomatic previously fell through
+        // to None and let the connector default it — now correctly maps to true.)
+        let auto_settle = Some(router_data.request.is_auto_capture());
 
         Ok(Self {
             currency: router_data.request.currency,
@@ -220,11 +377,63 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .resource_common_data
                 .connector_request_reference_id
                 .clone(),
-            amount: router_data.request.minor_amount,
+            amount: Some(router_data.request.minor_amount),
             card,
             auto_settle,
-            option: None, // Set to null to match Hyperswitch
+            redirect,
+            // CIT mandate registration asks Datatrans to persist a reusable alias
+            // (surfaced later via PSync as `connector_mandate_id`); non-mandate Authorize
+            // sends `option: null`.
+            option: is_mandate_payment.then_some(DatatransPaymentOptions {
+                create_alias: Some(true),
+            }),
         })
+    }
+}
+
+/// Builds the optional `3D` object for a raw-card Authorize request.
+/// - external/passthrough 3DS (merchant supplied `authentication_data`) -> `Authentication`
+/// - Datatrans-native 3DS (`auth_type == ThreeDs`, no external data) -> `Cardholder`
+/// - no 3DS -> `None`
+fn build_three_ds_data<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+>(
+    router_data: &RouterDataV2<
+        Authorize,
+        PaymentFlowData,
+        PaymentsAuthorizeData<T>,
+        PaymentsResponseData,
+    >,
+) -> Result<Option<ThreeDSecureData>, error_stack::Report<IntegrationError>> {
+    if let Some(auth_data) = &router_data.request.authentication_data {
+        let cavv = auth_data.cavv.clone().ok_or_else(|| {
+            error_stack::report!(IntegrationError::MissingRequiredField {
+                field_name: "authentication_data.cavv",
+                context: datatrans_context(
+                    "Datatrans passthrough external 3DS requires the cavv authentication value"
+                ),
+            })
+        })?;
+        Ok(Some(ThreeDSecureData::Authentication(ThreeDSData {
+            three_ds_transaction_id: auth_data
+                .threeds_server_transaction_id
+                .clone()
+                .map(Secret::new),
+            cavv,
+            eci: auth_data.eci.clone(),
+            xid: auth_data.ds_trans_id.clone().map(Secret::new),
+            three_ds_version: auth_data.message_version.as_ref().map(|v| v.to_string()),
+            authentication_response: THREE_DS_AUTHENTICATION_RESPONSE_Y.to_string(),
+        })))
+    } else if router_data.resource_common_data.is_three_ds() {
+        Ok(Some(ThreeDSecureData::Cardholder(ThreedsInfo {
+            cardholder: CardHolder {
+                cardholder_name: router_data.resource_common_data.get_billing_full_name()?,
+                email: router_data.resource_common_data.get_billing_email()?,
+            },
+        })))
+    } else {
+        Ok(None)
     }
 }
 
@@ -234,17 +443,71 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 pub struct DatatransCardResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub masked: Option<String>,
+    /// Stored card token created when `option.createAlias=true` (SetupMandate/CIT).
+    /// Surfaced from PSync as the `connector_mandate_id` that MIT/RepeatPayment reuses.
+    /// Masked in logs; the domain `connector_mandate_id` boundary requires the plain value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<Secret<String>>,
 }
 
-// Authorize response structure based on tech spec
+// Authorize response — Datatrans returns either a settled/authorized transaction or,
+// for native 3DS, a 3DS-enrolled response carrying the redirect transactionId.
+// Variant order matters for `#[serde(untagged)]`: `ThreeDSResponse` requires the `3D`
+// object and is tried first, so a plain transaction response (no `3D`) falls through
+// to `TransactionResponse`. Connector errors (non-2xx) are handled by `build_error_response`.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum DatatransPaymentsResponse {
+    ThreeDSResponse(Datatrans3DSResponse),
+    TransactionResponse(DatatransSuccessResponse),
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DatatransPaymentsResponse {
+pub struct DatatransSuccessResponse {
     pub transaction_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acquirer_authorization_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card: Option<DatatransCardResponse>,
+}
+
+/// Native 3DS enrollment response. The `3D` object's presence discriminates this
+/// variant from a plain transaction response; the cardholder must be redirected to
+/// the Datatrans challenge page identified by `transaction_id`.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Datatrans3DSResponse {
+    pub transaction_id: String,
+    #[serde(rename = "3D")]
+    pub three_ds: ThreeDSEnrolled,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreeDSEnrolled {
+    /// Whether the card is enrolled in 3DS; drives untagged variant discrimination
+    /// (a plain transaction response has no `3D`/`enrolled` field).
+    pub enrolled: bool,
+}
+
+/// Derives the attempt status for a Datatrans Authorize response.
+/// Native 3DS responses need a cardholder challenge -> `AuthenticationPending`;
+/// a completed transaction is `Charged` when auto-captured, else `Authorized`.
+fn get_authorize_status(
+    response: &DatatransPaymentsResponse,
+    is_auto_capture: bool,
+) -> AttemptStatus {
+    match response {
+        DatatransPaymentsResponse::ThreeDSResponse(_) => AttemptStatus::AuthenticationPending,
+        DatatransPaymentsResponse::TransactionResponse(_) => {
+            if is_auto_capture {
+                AttemptStatus::Charged
+            } else {
+                AttemptStatus::Authorized
+            }
+        }
+    }
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -256,31 +519,462 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     fn try_from(
         item: ResponseRouterData<DatatransPaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Datatrans authorize endpoint returns 200 on success
-        // The presence of transactionId indicates success
-        // Status mapping:
-        // - If we get a 200 response with transactionId, the payment is authorized
-        // - Based on autoSettle parameter, it's either Charged or Authorized
-        let is_auto_settle =
-            item.router_data.request.capture_method == Some(common_enums::CaptureMethod::Automatic);
+        let is_auto_capture = item.router_data.request.is_auto_capture();
+        let status = get_authorize_status(&item.response, is_auto_capture);
 
-        let status = if is_auto_settle {
-            AttemptStatus::Charged
-        } else {
-            AttemptStatus::Authorized
+        let payments_response_data = match &item.response {
+            DatatransPaymentsResponse::TransactionResponse(response) => {
+                // Non-3DS / passthrough external 3DS: no redirect. The alias (for mandates)
+                // is surfaced later via PSync, not on this response.
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: response.acquirer_authorization_code.clone(),
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
+            DatatransPaymentsResponse::ThreeDSResponse(response) => {
+                // Native 3DS: redirect the cardholder to the Datatrans challenge page.
+                // Host is derived from the connector's configured API base_url so the
+                // sandbox challenge stays on the sandbox host (see
+                // `datatrans_redirection_host`).
+                let redirection_host = datatrans_redirection_host(
+                    &item
+                        .router_data
+                        .resource_common_data
+                        .connectors
+                        .datatrans
+                        .base_url,
+                );
+                let redirection_data = RedirectForm::Form {
+                    endpoint: format!("{}/v1/start/{}", redirection_host, response.transaction_id),
+                    method: Method::Get,
+                    form_fields: HashMap::new(),
+                };
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: Some(Box::new(redirection_data)),
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
         };
 
-        let payments_response_data = PaymentsResponseData::TransactionResponse {
-            resource_id: ResponseId::ConnectorTransactionId(item.response.transaction_id.clone()),
-            redirection_data: None,
-            mandate_reference: None,
-            connector_metadata: None,
-            network_txn_id: None,
-            network_txn_link_id: None,
-            connector_response_reference_id: item.response.acquirer_authorization_code.clone(),
-            incremental_authorization_allowed: None,
-            status_code: item.http_code,
-            splits: None,
+        Ok(Self {
+            response: Ok(payments_response_data),
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
+
+// ===== SETUP MANDATE (ZERO-AUTH CIT) FLOW =====
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        super::DatatransRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for DatatransPaymentsRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: super::DatatransRouterData<
+            RouterDataV2<
+                SetupMandate,
+                PaymentFlowData,
+                SetupMandateRequestData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        let card = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(card_data) => DatatransCard {
+                alias: None,
+                number: Some(card_data.card_number.clone()),
+                expiry_month: Some(card_data.card_exp_month.clone()),
+                expiry_year: Some(card_data.get_card_expiry_year_2_digit()?),
+                cvv: Some(card_data.card_cvc.clone()),
+                card_type: Some(CARD_TYPE_PLAIN.to_string()),
+                // Zero-auth alias creation always runs Datatrans-native 3DS: send the
+                // cardholder details so Datatrans can drive the ACS challenge.
+                three_ds: Some(ThreeDSecureData::Cardholder(ThreedsInfo {
+                    cardholder: CardHolder {
+                        cardholder_name: router_data
+                            .resource_common_data
+                            .get_billing_full_name()?,
+                        email: router_data.resource_common_data.get_billing_email()?,
+                    },
+                })),
+            },
+            PaymentMethodData::CardRedirect(_)
+            | PaymentMethodData::Wallet(_)
+            | PaymentMethodData::PayLater(_)
+            | PaymentMethodData::BankRedirect(_)
+            | PaymentMethodData::BankDebit(_)
+            | PaymentMethodData::BankTransfer(_)
+            | PaymentMethodData::Crypto(_)
+            | PaymentMethodData::MandatePayment
+            | PaymentMethodData::Reward
+            | PaymentMethodData::RealTimePayment(_)
+            | PaymentMethodData::Upi(_)
+            | PaymentMethodData::Voucher(_)
+            | PaymentMethodData::GiftCard(_)
+            | PaymentMethodData::PaymentMethodToken(_)
+            | PaymentMethodData::OpenBanking(_)
+            | PaymentMethodData::NetworkToken(_)
+            | PaymentMethodData::MobilePayment(_)
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_) => {
+                Err(IntegrationError::NotImplemented(
+                    UNSUPPORTED_PAYMENT_METHOD_ERROR.to_string(),
+                    datatrans_context(
+                        "Datatrans SetupMandate (zero-auth alias creation) supports raw card payment method only",
+                    ),
+                ))?
+            }
+        };
+
+        Ok(Self {
+            currency: router_data.request.currency,
+            refno: router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            // Zero-auth: no amount is charged; the field is omitted from the request.
+            amount: None,
+            card,
+            // Zero-auth alias creation cannot be manually captured.
+            auto_settle: Some(true),
+            redirect: Some(RedirectUrls {
+                success_url: router_data.request.router_return_url.clone(),
+                cancel_url: router_data.request.router_return_url.clone(),
+                error_url: router_data.request.router_return_url.clone(),
+            }),
+            // Ask Datatrans to persist a reusable alias for later MIT/RepeatPayment.
+            option: Some(DatatransPaymentOptions {
+                create_alias: Some(true),
+            }),
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<DatatransPaymentsResponse, Self>>
+    for RouterDataV2<
+        SetupMandate,
+        PaymentFlowData,
+        SetupMandateRequestData<T>,
+        PaymentsResponseData,
+    >
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<DatatransPaymentsResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        // Zero-auth alias creation cannot be manually captured, so status is derived
+        // with auto-capture semantics (`Charged` on a completed transaction).
+        let status = get_authorize_status(&item.response, true);
+
+        let payments_response_data = match &item.response {
+            DatatransPaymentsResponse::TransactionResponse(response) => {
+                // The reusable alias is surfaced later via PSync (`card.alias`),
+                // not on this setup response — matching the reference behaviour.
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: response.acquirer_authorization_code.clone(),
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
+            DatatransPaymentsResponse::ThreeDSResponse(response) => {
+                // Native 3DS: redirect the cardholder to the Datatrans challenge page.
+                // Host is derived from the connector's configured API base_url (not
+                // `test_mode`, which HS omits from the SetupRecurring request) so the
+                // sandbox challenge stays on the sandbox host.
+                let redirection_host = datatrans_redirection_host(
+                    &item
+                        .router_data
+                        .resource_common_data
+                        .connectors
+                        .datatrans
+                        .base_url,
+                );
+                let redirection_data = RedirectForm::Form {
+                    endpoint: format!("{}/v1/start/{}", redirection_host, response.transaction_id),
+                    method: Method::Get,
+                    form_fields: HashMap::new(),
+                };
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: Some(Box::new(redirection_data)),
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
+        };
+
+        Ok(Self {
+            response: Ok(payments_response_data),
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
+
+// ===== REPEAT PAYMENT (MIT) FLOW =====
+
+/// Datatrans expects a 2-digit `expiryYear`. The stored-card `card_exp_year` supplied in the
+/// MIT request's additional card data may arrive as `YY` or `YYYY`; take the last two digits.
+/// Vault template tokens (`{{...}}`) pass through unchanged for injector substitution.
+fn additional_card_expiry_year_2_digit(
+    additional_card: &AdditionalCardInfo,
+) -> Result<Secret<String>, error_stack::Report<IntegrationError>> {
+    let year = additional_card.card_exp_year.clone().ok_or_else(|| {
+        error_stack::report!(IntegrationError::MissingRequiredField {
+            field_name: "additional_payment_data.card.card_exp_year",
+            context: datatrans_context(
+                "Datatrans MIT requires the stored card expiry year for the alias charge",
+            ),
+        })
+    })?;
+    let year_value = year.peek();
+    let two_digit = if year_value.contains("{{") {
+        year_value.to_string()
+    } else {
+        year_value
+            .get(year_value.len().saturating_sub(2)..)
+            .ok_or_else(|| {
+                error_stack::report!(IntegrationError::InvalidDataFormat {
+                    field_name: "additional_payment_data.card.card_exp_year",
+                    context: datatrans_context("Expected expiry year format: YY or YYYY"),
+                })
+            })?
+            .to_string()
+    };
+    Ok(Secret::new(two_digit))
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        super::DatatransRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for DatatransPaymentsRequest<T>
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: super::DatatransRouterData<
+            RouterDataV2<
+                RepeatPayment,
+                PaymentFlowData,
+                RepeatPaymentData<T>,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+
+        // MIT reuses the Datatrans alias persisted by SetupMandate (createAlias=true), surfaced
+        // to HS as the `connector_mandate_id`. Only the connector-stored alias path is chargeable
+        // here; network-transaction-id / network-token MIT is not supported by this connector.
+        let alias = match &router_data.request.mandate_reference {
+            MandateReferenceId::ConnectorMandateId(connector_mandate_id) => connector_mandate_id
+                .get_connector_mandate_id()
+                .ok_or_else(|| {
+                    error_stack::report!(IntegrationError::MissingRequiredField {
+                        field_name: "mandate_reference.connector_mandate_id",
+                        context: datatrans_context(
+                            "Datatrans MIT requires the stored alias/connector_mandate_id created by SetupMandate",
+                        ),
+                    })
+                })?,
+            MandateReferenceId::NetworkMandateId(_)
+            | MandateReferenceId::NetworkTokenWithNTI(_) => {
+                // Datatrans MIT can only charge a connector-stored alias; scheme-level
+                // network-transaction-id / network-token mandates are not a Datatrans
+                // capability (NotSupported, not merely not-yet-built).
+                Err(IntegrationError::NotSupported {
+                    message: UNSUPPORTED_MANDATE_REFERENCE_ERROR.to_string(),
+                    connector: "datatrans",
+                    context: datatrans_context(
+                        "Datatrans MIT charges the stored connector alias only; network-transaction-id / network-token mandates are unsupported",
+                    ),
+                })?
+            }
+        };
+
+        // Card expiry for the alias charge comes from the stored card's additional data
+        // (there is no PAN in a MIT request). Mirrors the HS Direct `create_mandate_details`
+        // path that reads `additional_payment_method_data.Card`.
+        let additional_card = match &router_data.request.additional_payment_data {
+            Some(AdditionalPaymentData::Card(card)) => card,
+            None => Err(IntegrationError::MissingRequiredField {
+                field_name: "additional_payment_data",
+                context: datatrans_context(
+                    "Datatrans MIT requires stored card additional data (expiry) for the alias charge",
+                ),
+            })?,
+        };
+        let expiry_month = additional_card.card_exp_month.clone().ok_or_else(|| {
+            error_stack::report!(IntegrationError::MissingRequiredField {
+                field_name: "additional_payment_data.card.card_exp_month",
+                context: datatrans_context(
+                    "Datatrans MIT requires the stored card expiry month for the alias charge",
+                ),
+            })
+        })?;
+        let expiry_year = additional_card_expiry_year_2_digit(additional_card)?;
+
+        let card = DatatransCard {
+            alias: Some(Secret::new(alias)),
+            expiry_month: Some(expiry_month),
+            expiry_year: Some(expiry_year),
+            number: None,
+            cvv: None,
+            card_type: Some(CARD_TYPE_ALIAS.to_string()),
+            // MIT charges an already-3DS-authenticated alias; no cardholder challenge / redirect.
+            three_ds: None,
+        };
+
+        Ok(Self {
+            currency: router_data.request.currency,
+            refno: router_data
+                .resource_common_data
+                .connector_request_reference_id
+                .clone(),
+            amount: Some(router_data.request.minor_amount),
+            card,
+            // auto_settle mirrors is_auto_capture(): Automatic/SequentialAutomatic/None -> true,
+            // Manual/ManualMultiple/Scheduled -> false.
+            auto_settle: Some(router_data.request.is_auto_capture()),
+            // MIT never redirects and never re-creates an alias.
+            redirect: None,
+            option: None,
+        })
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<ResponseRouterData<DatatransPaymentsResponse, Self>>
+    for RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<DatatransPaymentsResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let is_auto_capture = item.router_data.request.is_auto_capture();
+        let status = get_authorize_status(&item.response, is_auto_capture);
+
+        let payments_response_data = match &item.response {
+            DatatransPaymentsResponse::TransactionResponse(response) => {
+                // Charged (auto-capture) or Authorized: the alias charge settles immediately;
+                // no redirect, and the mandate_reference is not re-surfaced on a MIT charge.
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: response.acquirer_authorization_code.clone(),
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
+            DatatransPaymentsResponse::ThreeDSResponse(response) => {
+                // Not expected for MIT (the alias is already 3DS-authenticated), but the untagged
+                // response can technically carry it; surface the challenge redirect defensively
+                // rather than treating it as a settled transaction.
+                let redirection_host = datatrans_redirection_host(
+                    &item
+                        .router_data
+                        .resource_common_data
+                        .connectors
+                        .datatrans
+                        .base_url,
+                );
+                let redirection_data = RedirectForm::Form {
+                    endpoint: format!("{}/v1/start/{}", redirection_host, response.transaction_id),
+                    method: Method::Get,
+                    form_fields: HashMap::new(),
+                };
+                PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(
+                        response.transaction_id.clone(),
+                    ),
+                    redirection_data: Some(Box::new(redirection_data)),
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    network_txn_link_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    status_code: item.http_code,
+                    splits: None,
+                }
+            }
         };
 
         Ok(Self {
@@ -321,9 +1015,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-// Payment Status Enumeration from Datatrans API
+// Payment Status Enumeration from Datatrans API.
+// Datatrans emits snake_case statuses (e.g. `challenge_ongoing`).
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum DatatransPaymentStatus {
     Initialized,
     Authenticated,
@@ -332,26 +1027,76 @@ pub enum DatatransPaymentStatus {
     Transmitted,
     Canceled,
     Failed,
+    /// 3DS challenge is in progress — the cardholder has not finished the ACS challenge.
+    ChallengeOngoing,
+    /// 3DS challenge is required before the transaction can proceed.
+    ChallengeRequired,
 }
 
-// Status mapping for sync responses
-impl From<DatatransPaymentStatus> for AttemptStatus {
-    fn from(status: DatatransPaymentStatus) -> Self {
-        match status {
-            // Success statuses - payment is completed/settled
-            DatatransPaymentStatus::Settled | DatatransPaymentStatus::Transmitted => Self::Charged,
+/// Datatrans transaction `type` reported on a sync response. Datatrans emits
+/// snake_case values. The type is required to interpret `status` correctly, because
+/// the same status means different things across transaction kinds (see
+/// [`sync_attempt_status`]).
+#[derive(Debug, Deserialize, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatatransTransactionType {
+    /// Standard Authorize/Capture payment transaction.
+    Payment,
+    /// Refund/credit transaction. Not an attempt-status carrier — refunds are tracked
+    /// via `RefundStatus`/RSync, so for `AttemptStatus` this maps to `Failure`
+    /// (mirrors the HS Direct reference).
+    Credit,
+    /// Zero-auth mandate alias creation (`option.createAlias=true`). A completed
+    /// `card_check` has no capture step, so `authorized`/`settled`/`transmitted` all
+    /// mean the alias was successfully created (→ `Charged`).
+    CardCheck,
+}
 
-            // Authorization status - payment is authorized but not captured
-            DatatransPaymentStatus::Authorized => Self::Authorized,
-
-            // Failure status
-            DatatransPaymentStatus::Failed | DatatransPaymentStatus::Canceled => Self::Failure,
-
-            // Pending statuses - payment is in progress
-            DatatransPaymentStatus::Initialized | DatatransPaymentStatus::Authenticated => {
-                Self::Pending
+/// Derives the PSync `AttemptStatus` from BOTH the Datatrans transaction `type` and its
+/// `status`, mirroring the HS Direct reference (`impl From<SyncResponse> for AttemptStatus`).
+///
+/// The mapping is type-aware because a status alone is ambiguous:
+/// - `Payment`: `Authorized` stays `Authorized` (a manual-capture auth must not read as
+///   captured until Capture settles it — capture-method-aware); `Settled`/`Transmitted` →
+///   `Charged`.
+/// - `CardCheck` (zero-auth mandate): `Authorized`/`Settled`/`Transmitted` all → `Charged`,
+///   because a completed alias creation is a success with no separate capture step. This is
+///   what makes a finished zero-auth mandate read as succeeded.
+/// - `Credit` (refund): `Failure` for `AttemptStatus` (refunds handled via RSync).
+///
+/// Each per-type `status` match is exhaustive (no wildcard) so a new `DatatransPaymentStatus`
+/// variant fails to compile rather than silently defaulting.
+fn sync_attempt_status(
+    transaction_type: &DatatransTransactionType,
+    status: DatatransPaymentStatus,
+) -> AttemptStatus {
+    match transaction_type {
+        DatatransTransactionType::Payment => match status {
+            DatatransPaymentStatus::Authorized => AttemptStatus::Authorized,
+            DatatransPaymentStatus::Settled | DatatransPaymentStatus::Transmitted => {
+                AttemptStatus::Charged
             }
-        }
+            DatatransPaymentStatus::ChallengeOngoing
+            | DatatransPaymentStatus::ChallengeRequired => AttemptStatus::AuthenticationPending,
+            DatatransPaymentStatus::Canceled => AttemptStatus::Voided,
+            DatatransPaymentStatus::Failed => AttemptStatus::Failure,
+            DatatransPaymentStatus::Initialized | DatatransPaymentStatus::Authenticated => {
+                AttemptStatus::Pending
+            }
+        },
+        DatatransTransactionType::CardCheck => match status {
+            DatatransPaymentStatus::Settled
+            | DatatransPaymentStatus::Transmitted
+            | DatatransPaymentStatus::Authorized => AttemptStatus::Charged,
+            DatatransPaymentStatus::ChallengeOngoing
+            | DatatransPaymentStatus::ChallengeRequired => AttemptStatus::AuthenticationPending,
+            DatatransPaymentStatus::Canceled => AttemptStatus::Voided,
+            DatatransPaymentStatus::Failed => AttemptStatus::Failure,
+            DatatransPaymentStatus::Initialized | DatatransPaymentStatus::Authenticated => {
+                AttemptStatus::Pending
+            }
+        },
+        DatatransTransactionType::Credit => AttemptStatus::Failure,
     }
 }
 
@@ -371,10 +1116,14 @@ pub struct DatatransHistoryEntry {
 pub struct DatatransSyncResponse {
     pub transaction_id: String,
     #[serde(rename = "type")]
-    pub transaction_type: String,
+    pub transaction_type: DatatransTransactionType,
     pub status: DatatransPaymentStatus,
-    pub currency: Currency,
-    pub refno: String,
+    // Optional: the reference does not require these and a minimal Datatrans sync body may
+    // omit them; keeping them optional avoids a deserialization failure on such responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<Currency>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refno: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refno2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -395,13 +1144,33 @@ pub struct DatatransTransactionDetail {
     pub authorize: Option<DatatransActionDetail>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settle: Option<DatatransActionDetail>,
+    /// Failure detail present on a failed transaction; surfaced as the connector error
+    /// code/message so a failed sync reports the reason (mirrors HS Direct).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail: Option<DatatransFailDetail>,
+}
+
+// Failure detail block from a failed Datatrans transaction sync.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatatransFailDetail {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 // Action detail structure
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatatransActionDetail {
-    pub amount: MinorUnit,
+    /// Amount for this action, in minor units. Optional: a `card_check` (zero-auth
+    /// mandate) transaction's `detail.authorize` carries only the
+    /// `acquirerAuthorizationCode` and no `amount`, whereas a `payment`/`settle`
+    /// action does include it. `Option` accepts both shapes so PSync deserialization
+    /// no longer fails on a card_check sync response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<MinorUnit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acquirer_authorization_code: Option<String>,
 }
@@ -416,32 +1185,79 @@ impl TryFrom<ResponseRouterData<DatatransSyncResponse, Self>>
     ) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Map Datatrans status to UCS status
-        let status = AttemptStatus::from(response.status.clone());
+        // Map Datatrans status to UCS status, type-aware: a `card_check` (zero-auth
+        // mandate) `authorized` means the alias was created successfully (→ Charged),
+        // whereas a `payment` `authorized` is only an authorization (→ Authorized).
+        let status = sync_attempt_status(&response.transaction_type, response.status.clone());
 
-        // Extract acquirer authorization code from detail or history
-        let connector_response_reference_id = response.detail.as_ref().and_then(|d| {
-            d.authorize
+        // On a failed sync, surface the connector failure detail (code/message/reason) instead
+        // of a silent Failure with no error — mirrors HS Direct.
+        let response = if status == AttemptStatus::Failure {
+            let (code, message) = match response.detail.as_ref().and_then(|d| d.fail.as_ref()) {
+                Some(fail) => (
+                    fail.reason
+                        .clone()
+                        .unwrap_or_else(|| DEFAULT_ERROR_CODE.to_string()),
+                    fail.message
+                        .clone()
+                        .unwrap_or_else(|| DEFAULT_ERROR_MESSAGE.to_string()),
+                ),
+                None => (
+                    DEFAULT_ERROR_CODE.to_string(),
+                    DEFAULT_ERROR_MESSAGE.to_string(),
+                ),
+            };
+            Err(ErrorResponse {
+                code,
+                message: message.clone(),
+                reason: Some(message),
+                status_code: item.http_code,
+                attempt_status: None,
+                connector_transaction_id: Some(response.transaction_id.clone()),
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+            })
+        } else {
+            // Extract acquirer authorization code from detail
+            let connector_response_reference_id = response.detail.as_ref().and_then(|d| {
+                d.authorize
+                    .as_ref()
+                    .and_then(|a| a.acquirer_authorization_code.clone())
+                    .or_else(|| {
+                        d.settle
+                            .as_ref()
+                            .and_then(|s| s.acquirer_authorization_code.clone())
+                    })
+            });
+
+            // Datatrans returns the stored-card `alias` on sync once `createAlias` succeeded
+            // (SetupMandate/CIT). Surface it as the `connector_mandate_id` that MIT reuses.
+            // `.peek()` exposes the value only at the domain `connector_mandate_id` boundary.
+            // Only surfaced on a non-failure sync (a failed transaction has no usable alias).
+            let mandate_reference = response
+                .card
                 .as_ref()
-                .and_then(|a| a.acquirer_authorization_code.clone())
-                .or_else(|| {
-                    d.settle
-                        .as_ref()
-                        .and_then(|s| s.acquirer_authorization_code.clone())
-                })
-        });
+                .and_then(|card| card.alias.as_ref())
+                .map(|alias| MandateReference {
+                    connector_mandate_id: Some(alias.peek().clone()),
+                    payment_method_id: None,
+                    connector_mandate_request_reference_id: None,
+                    mandate_metadata: None,
+                });
 
-        let payments_response_data = PaymentsResponseData::TransactionResponse {
-            resource_id: ResponseId::ConnectorTransactionId(response.transaction_id.clone()),
-            redirection_data: None,
-            mandate_reference: None,
-            connector_metadata: None,
-            network_txn_id: None,
-            network_txn_link_id: None,
-            connector_response_reference_id,
-            incremental_authorization_allowed: None,
-            status_code: item.http_code,
-            splits: None,
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(response.transaction_id.clone()),
+                redirection_data: None,
+                mandate_reference: mandate_reference.map(Box::new),
+                connector_metadata: None,
+                network_txn_id: None,
+                network_txn_link_id: None,
+                connector_response_reference_id,
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+                splits: None,
+            })
         };
 
         Ok(Self {
@@ -449,7 +1265,7 @@ impl TryFrom<ResponseRouterData<DatatransSyncResponse, Self>>
                 status,
                 ..item.router_data.resource_common_data.clone()
             },
-            response: Ok(payments_response_data),
+            response,
             ..item.router_data.clone()
         })
     }
@@ -589,10 +1405,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(Self {
             amount,
             currency: router_data.request.currency,
-            refno: router_data
-                .resource_common_data
-                .connector_request_reference_id
-                .clone(),
+            // Send the refund's own id as the Datatrans `refno` (mirrors HS Direct, which uses
+            // `refund_id`), so the credit is reconciled against the refund rather than the payment.
+            refno: router_data.request.refund_id.clone(),
             refno2: None,
         })
     }
@@ -659,41 +1474,47 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 }
 
 // Refund Status Enumeration from Datatrans API
-#[derive(Debug, Deserialize, Clone, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DatatransRefundStatus {
-    Initialized,
-    Settled,
-    Transmitted,
-    Failed,
-}
-
-// Status mapping for refund sync responses
-impl From<DatatransRefundStatus> for RefundStatus {
-    fn from(status: DatatransRefundStatus) -> Self {
-        match status {
-            // Success statuses - refund is completed
-            DatatransRefundStatus::Settled | DatatransRefundStatus::Transmitted => Self::Success,
-
-            // Failure status
-            DatatransRefundStatus::Failed => Self::Failure,
-
-            // Pending status - refund is in progress
-            DatatransRefundStatus::Initialized => Self::Pending,
+/// Type-aware refund-sync status mapping, mirroring HS Direct `From<SyncResponse> for RefundStatus`.
+/// A refund settles under the `credit` transaction type; a `payment`/`card_check` transaction
+/// synced on the refund endpoint is not a refund and maps to `Failure`. The full
+/// `DatatransPaymentStatus` enum is used so credit transactions in challenge/authorized/canceled
+/// states map correctly instead of failing to deserialize.
+fn sync_refund_status(
+    transaction_type: &DatatransTransactionType,
+    status: DatatransPaymentStatus,
+) -> RefundStatus {
+    match transaction_type {
+        DatatransTransactionType::Credit => match status {
+            DatatransPaymentStatus::Settled | DatatransPaymentStatus::Transmitted => {
+                RefundStatus::Success
+            }
+            DatatransPaymentStatus::ChallengeOngoing
+            | DatatransPaymentStatus::ChallengeRequired => RefundStatus::Pending,
+            DatatransPaymentStatus::Initialized
+            | DatatransPaymentStatus::Authenticated
+            | DatatransPaymentStatus::Authorized
+            | DatatransPaymentStatus::Canceled
+            | DatatransPaymentStatus::Failed => RefundStatus::Failure,
+        },
+        DatatransTransactionType::Payment | DatatransTransactionType::CardCheck => {
+            RefundStatus::Failure
         }
     }
 }
 
-// RSync Response structure - uses same structure as payment sync but for refund transaction
+// RSync Response structure - uses the same shape as payment sync but for a refund (credit)
+// transaction. `currency`/`refno` are optional (a minimal credit body may omit them).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatatransRefundSyncResponse {
     pub transaction_id: String,
     #[serde(rename = "type")]
-    pub transaction_type: String,
-    pub status: DatatransRefundStatus,
-    pub currency: Currency,
-    pub refno: String,
+    pub transaction_type: DatatransTransactionType,
+    pub status: DatatransPaymentStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<Currency>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refno: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refno2: Option<String>,
 }
@@ -708,8 +1529,8 @@ impl TryFrom<ResponseRouterData<DatatransRefundSyncResponse, Self>>
     ) -> Result<Self, Self::Error> {
         let response = &item.response;
 
-        // Map Datatrans refund status to UCS RefundStatus
-        let refund_status = RefundStatus::from(response.status.clone());
+        // Map Datatrans refund status to UCS RefundStatus, type-aware (credit vs payment/card_check).
+        let refund_status = sync_refund_status(&response.transaction_type, response.status.clone());
 
         let refunds_response_data = RefundsResponseData {
             connector_refund_id: response.transaction_id.clone(),

--- a/crates/internal/integration-tests/src/connector_specs/datatrans/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/datatrans/specs.json
@@ -7,6 +7,8 @@
     "PaymentService/Get",
     "PaymentService/Refund",
     "RefundService/Get",
-    "PaymentService/Void"
+    "PaymentService/Void",
+    "PaymentService/SetupRecurring",
+    "RecurringPaymentService/Charge"
   ]
 }

--- a/data/field_probe/datatrans.json
+++ b/data/field_probe/datatrans.json
@@ -10,91 +10,91 @@
     "authorize": {
       "Ach": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "AchBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Affirm": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Afterpay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Alfamart": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "AliPayRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "AmazonPayRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "ApplePay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "ApplePayDecrypted": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "ApplePayThirdPartySdk": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Bacs": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BacsBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BancontactCard": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BcaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Becs": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BillDeskRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Bizum": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Blik": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Bluecode": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BniVaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Boleto": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "BriVaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Card": {
         "status": "supported",
@@ -133,19 +133,19 @@
       },
       "CashappQr": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "CashfreeRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "CimbVaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "ClassicReward": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Crypto": {
         "status": "not_supported",
@@ -153,11 +153,11 @@
       },
       "Dana": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "DanamonVaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "DuitNow": {
         "status": "not_supported",
@@ -165,35 +165,35 @@
       },
       "EVoucher": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "EaseBuzzRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Efecty": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Eft": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Eps": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "FamilyMart": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "GCash": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Giropay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Givex": {
         "status": "not_supported",
@@ -201,87 +201,87 @@
       },
       "GoPay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "GooglePay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "GooglePayDecrypted": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "GooglePayThirdPartySdk": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Ideal": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Indomaret": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "IndonesianBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "InstantBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "InstantBankTransferFinland": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "InstantBankTransferPoland": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Interac": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "KakaoPay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Klarna": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Lawson": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "LazyPayRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "LocalBankRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "LocalBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "MandiriVaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "MbWay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Mifinity": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "MiniStop": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "MobilePayRedirect": {
         "status": "not_supported",
@@ -289,43 +289,43 @@
       },
       "Momo": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "MultibancoBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Netbanking": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingCzechRepublic": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingFinland": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingFpx": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingPoland": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingSlovakia": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OnlineBankingThailand": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OpenBanking": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "OpenBankingPis": {
         "status": "not_supported",
@@ -333,35 +333,35 @@
       },
       "OpenBankingUk": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Oxxo": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PagoEfectivo": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PayEasy": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PaySafeCard": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PayURedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PaypalRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PaypalSdk": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Paysera": {
         "status": "not_supported",
@@ -373,111 +373,111 @@
       },
       "PermataBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "PhonePeRedirect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Pix": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Przelewy24": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Pse": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "RedCompra": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "RedPagos": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "RevolutPay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "SamsungPay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Satispay": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Seicomart": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Sepa": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "SepaBankTransfer": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "SepaGuaranteedDebit": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "SevenEleven": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Skrill": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Sofort": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Swish": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "TouchNGo": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Trustly": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Twint": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "UpiCollect": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "UpiIntent": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "UpiQr": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Vipps": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "WeChatPayQr": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       },
       "Wero": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: Only card payments are supported for Datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans Authorize supports raw card or Secure Fields token payment methods only"
       }
     },
     "capture": {
@@ -675,14 +675,50 @@
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for datatrans"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "card_proxy": {
+            "card_number": "4111111111111111",
+            "card_exp_month": "03",
+            "card_exp_year": "2030",
+            "card_cvc": "123",
+            "card_holder_name": "John Doe",
+            "card_network": "VISA"
+          },
+          "address": {
+            "billing_address": {
+              "first_name": "John",
+              "email": "test@example.com"
+            }
+          },
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          },
+          "auth_type": "NO_THREE_DS",
+          "setup_future_usage": "OFF_SESSION"
+        },
+        "sample": {
+          "url": "https://api.sandbox.datatrans.com/v1/transactions",
+          "method": "Post",
+          "headers": {
+            "authorization": "Basic cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"currency\":\"USD\",\"refno\":\"probe_proxy_mandate_001\",\"card\":{\"expiryMonth\":\"{{$card_exp_month}}\",\"expiryYear\":\"{{$card_exp_year}}\",\"number\":\"{{$card_number}}\",\"cvv\":\"{{$card_cvc}}\",\"type\":\"PLAIN\",\"3D\":{\"cardholder\":{\"cardholderName\":\"John\",\"email\":\"test@example.com\"}}},\"autoSettle\":true,\"redirect\":{\"successUrl\":null,\"cancelUrl\":null,\"errorUrl\":null},\"option\":{\"createAlias\":true}}"
+        }
       }
     },
     "recurring_charge": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: repeat_payment flow for datatrans"
+        "status": "error",
+        "error": "Stuck on field: additional_payment_data. Datatrans MIT requires stored card additional data — Missing required field: additional_payment_data. Datatrans MIT requires stored card additional data (expiry) for the alias charge"
       }
     },
     "recurring_revoke": {
@@ -756,8 +792,48 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for datatrans"
+        "status": "supported",
+        "proto_request": {
+          "merchant_recurring_payment_id": "probe_mandate_001",
+          "amount": {
+            "minor_amount": 0,
+            "currency": "USD"
+          },
+          "payment_method": {
+            "card": {
+              "card_number": "4111111111111111",
+              "card_exp_month": "03",
+              "card_exp_year": "2030",
+              "card_cvc": "737",
+              "card_holder_name": "John Doe"
+            }
+          },
+          "address": {
+            "billing_address": {
+              "first_name": "John",
+              "email": "test@example.com"
+            }
+          },
+          "auth_type": "NO_THREE_DS",
+          "enrolled_for_3ds": false,
+          "return_url": "https://example.com/mandate-return",
+          "setup_future_usage": "OFF_SESSION",
+          "request_incremental_authorization": false,
+          "customer_acceptance": {
+            "acceptance_type": "OFFLINE",
+            "accepted_at": 0
+          }
+        },
+        "sample": {
+          "url": "https://api.sandbox.datatrans.com/v1/transactions",
+          "method": "Post",
+          "headers": {
+            "authorization": "Basic cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"currency\":\"USD\",\"refno\":\"probe_mandate_001\",\"card\":{\"expiryMonth\":\"03\",\"expiryYear\":\"30\",\"number\":\"4111111111111111\",\"cvv\":\"737\",\"type\":\"PLAIN\",\"3D\":{\"cardholder\":{\"cardholderName\":\"John\",\"email\":\"test@example.com\"}}},\"autoSettle\":true,\"redirect\":{\"successUrl\":\"https://example.com/mandate-return\",\"cancelUrl\":\"https://example.com/mandate-return\",\"errorUrl\":\"https://example.com/mandate-return\"},\"option\":{\"createAlias\":true}}"
+        }
       }
     },
     "token_authorize": {
@@ -791,7 +867,7 @@
     "token_setup_recurring": {
       "default": {
         "status": "not_implemented",
-        "error": "This feature is not implemented: setup_mandate flow for datatrans"
+        "error": "This feature is not implemented: Only card payments are supported for Datatrans. Datatrans SetupMandate (zero-auth alias creation) supports raw card payment method only"
       }
     },
     "tokenize": {

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -152,7 +152,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Checkout.com](connectors/checkout.md) | ✓ | ✓ | x | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | x | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [CryptoPay](connectors/cryptopay.md) | ✓ | x | x | x | x | ⚠ | x | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | x | ✓ | ✓ | x |
 | [CyberSource](connectors/cybersource.md) | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | ✓ | ⚠ | ? | ✓ | ? | ✓ | ? | ✓ | ✓ | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ? | ✓ | ✓ | ✓ | x | ⚠ | x | x | ⚠ | ⚠ | x |
-| [Datatrans](connectors/datatrans.md) | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
+| [Datatrans](connectors/datatrans.md) | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | ✓ | ✓ | ? | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [dLocal](connectors/dlocal.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ? | ? | ? | ? | ? | ? | ⚠ | ✓ | x | x | ⚠ | x | x | x | x | x | x | ⚠ | x | x | x | ⚠ | ⚠ | ⚠ | x | ✓ | ✓ | x |
 | [Easebuzz](connectors/easebuzz.md) | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Elavon](connectors/elavon.md) | ✓ | ⚠ | ⚠ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | x | ⚠ | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |

--- a/docs-generated/connectors/datatrans.md
+++ b/docs-generated/connectors/datatrans.md
@@ -127,7 +127,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py#L154) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L120) · [Rust](../../examples/datatrans/datatrans.rs#L193)
+**Examples:** [Python](../../examples/datatrans/datatrans.py#L216) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L122) · [Rust](../../examples/datatrans/datatrans.rs#L268)
 
 ### Card Payment (Authorize + Capture)
 
@@ -141,25 +141,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py#L173) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L136) · [Rust](../../examples/datatrans/datatrans.rs#L209)
+**Examples:** [Python](../../examples/datatrans/datatrans.py#L235) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L138) · [Rust](../../examples/datatrans/datatrans.rs#L284)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py#L198) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L158) · [Rust](../../examples/datatrans/datatrans.rs#L232)
+**Examples:** [Python](../../examples/datatrans/datatrans.py#L260) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L160) · [Rust](../../examples/datatrans/datatrans.rs#L307)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py#L223) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L180) · [Rust](../../examples/datatrans/datatrans.rs#L255)
+**Examples:** [Python](../../examples/datatrans/datatrans.py#L285) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L182) · [Rust](../../examples/datatrans/datatrans.rs#L330)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py#L245) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L199) · [Rust](../../examples/datatrans/datatrans.rs#L274)
+**Examples:** [Python](../../examples/datatrans/datatrans.py#L307) · [JavaScript](../../examples/datatrans/datatrans.js) · [Kotlin](../../examples/datatrans/datatrans.kt#L201) · [Rust](../../examples/datatrans/datatrans.rs#L349)
 
 ## API Reference
 
@@ -170,9 +170,11 @@ Retrieve current payment status from the connector.
 | [MerchantAuthenticationService.CreateClientAuthenticationToken](#merchantauthenticationservicecreateclientauthenticationtoken) | Authentication | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
+| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
 | [PaymentService.Reverse](#paymentservicereverse) | Payments | `PaymentServiceReverseRequest` |
+| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 | [PaymentService.TokenAuthorize](#paymentservicetokenauthorize) | Payments | `PaymentServiceTokenAuthorizeRequest` |
 | [PaymentService.Void](#paymentservicevoid) | Payments | `PaymentServiceVoidRequest` |
 
@@ -308,7 +310,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L281) · [Kotlin](../../examples/datatrans/datatrans.kt#L217) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L345) · [Kotlin](../../examples/datatrans/datatrans.kt#L219) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.Capture
 
@@ -319,7 +321,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L290) · [Kotlin](../../examples/datatrans/datatrans.kt#L229) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L354) · [Kotlin](../../examples/datatrans/datatrans.kt#L231) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.Get
 
@@ -330,7 +332,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L308) · [Kotlin](../../examples/datatrans/datatrans.kt#L255) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L372) · [Kotlin](../../examples/datatrans/datatrans.kt#L257) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -341,7 +343,18 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L317) · [Kotlin](../../examples/datatrans/datatrans.kt#L263) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L381) · [Kotlin](../../examples/datatrans/datatrans.kt#L265) · [Rust](../../examples/datatrans/datatrans.rs)
+
+#### PaymentService.ProxySetupRecurring
+
+Setup recurring mandate using vault-aliased card data.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceProxySetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L390) · [Kotlin](../../examples/datatrans/datatrans.kt#L294) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.Refund
 
@@ -352,7 +365,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L326) · [Kotlin](../../examples/datatrans/datatrans.kt#L292) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L399) · [Kotlin](../../examples/datatrans/datatrans.kt#L328) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.Reverse
 
@@ -363,7 +376,18 @@ Reverse a captured payment in full. Initiates a complete refund when you need to
 | **Request** | `PaymentServiceReverseRequest` |
 | **Response** | `PaymentServiceReverseResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L344) · [Kotlin](../../examples/datatrans/datatrans.kt#L314) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L417) · [Kotlin](../../examples/datatrans/datatrans.kt#L350) · [Rust](../../examples/datatrans/datatrans.rs)
+
+#### PaymentService.SetupRecurring
+
+Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceSetupRecurringRequest` |
+| **Response** | `PaymentServiceSetupRecurringResponse` |
+
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L426) · [Kotlin](../../examples/datatrans/datatrans.kt#L358) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -374,7 +398,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L353) · [Kotlin](../../examples/datatrans/datatrans.kt#L322) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L435) · [Kotlin](../../examples/datatrans/datatrans.kt#L399) · [Rust](../../examples/datatrans/datatrans.rs)
 
 #### PaymentService.Void
 
@@ -385,7 +409,7 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts) · [Kotlin](../../examples/datatrans/datatrans.kt#L343) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts) · [Kotlin](../../examples/datatrans/datatrans.kt#L420) · [Rust](../../examples/datatrans/datatrans.rs)
 
 ### Refunds
 
@@ -398,7 +422,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L335) · [Kotlin](../../examples/datatrans/datatrans.kt#L302) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L408) · [Kotlin](../../examples/datatrans/datatrans.kt#L338) · [Rust](../../examples/datatrans/datatrans.rs)
 
 ### Authentication
 
@@ -411,4 +435,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L299) · [Kotlin](../../examples/datatrans/datatrans.kt#L239) · [Rust](../../examples/datatrans/datatrans.rs)
+**Examples:** [Python](../../examples/datatrans/datatrans.py) · [TypeScript](../../examples/datatrans/datatrans.ts#L363) · [Kotlin](../../examples/datatrans/datatrans.kt#L241) · [Rust](../../examples/datatrans/datatrans.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -203,7 +203,7 @@ connector_id: datatrans
 doc: docs/connectors/datatrans.md
 scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: Card
-flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, refund, refund_get, reverse, token_authorize, void
+flows: authorize, capture, create_client_authentication_token, get, proxy_authorize, proxy_setup_recurring, refund, refund_get, reverse, setup_recurring, token_authorize, void
 examples_python: examples/datatrans/datatrans.py
 
 ## dLocal

--- a/examples/datatrans/datatrans.kt
+++ b/examples/datatrans/datatrans.kt
@@ -12,10 +12,12 @@ import types.PaymentMethods.*
 import payments.PaymentClient
 import payments.MerchantAuthenticationClient
 import payments.RefundClient
+import payments.AcceptanceType
 import payments.AuthenticationType
 import payments.CaptureMethod
 import payments.CardNetwork
 import payments.Currency
+import payments.FutureUsage
 import payments.ConnectorConfig
 import payments.SdkOptions
 import payments.Environment
@@ -23,7 +25,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.DatatransConfig
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "refund", "refund_get", "reverse", "token_authorize", "void")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "proxy_setup_recurring", "refund", "refund_get", "reverse", "setup_recurring", "token_authorize", "void")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -288,6 +290,40 @@ fun proxyAuthorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+fun proxySetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_proxy_mandate_001"
+        amountBuilder.apply {
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
+            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+            cardExpMonthBuilder.value = "03"
+            cardExpYearBuilder.value = "2030"
+            cardCvcBuilder.value = "123"
+            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            cardNetwork = CardNetwork.VISA
+        }
+        addressBuilder.apply {
+            billingAddressBuilder.apply {
+                firstNameBuilder.value = "John"  // Personal Information.
+                emailBuilder.value = "test@example.com"  // Contact Information.
+            }
+        }
+        customerAcceptanceBuilder.apply {
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+        authType = AuthenticationType.NO_THREE_DS
+        setupFutureUsage = FutureUsage.OFF_SESSION
+    }.build()
+    val response = client.proxy_setup_recurring(request)
+    println("Status: ${response.status.name}")
+}
+
 // Flow: PaymentService.Refund
 fun refund(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val client = PaymentClient(config)
@@ -316,6 +352,47 @@ fun reverse(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val request = buildReverseRequest("probe_connector_txn_001")
     val response = client.reverse(request)
     println("Status: ${response.status.name}")
+}
+
+// Flow: PaymentService.SetupRecurring
+fun setupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
+        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
+        amountBuilder.apply {  // Mandate Details.
+            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+        paymentMethodBuilder.apply {
+            cardBuilder.apply {  // Generic card payment.
+                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
+                cardExpMonthBuilder.value = "03"
+                cardExpYearBuilder.value = "2030"
+                cardCvcBuilder.value = "737"
+                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
+            }
+        }
+        addressBuilder.apply {  // Address Information.
+            billingAddressBuilder.apply {
+                firstNameBuilder.value = "John"  // Personal Information.
+                emailBuilder.value = "test@example.com"  // Contact Information.
+            }
+        }
+        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
+        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
+        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
+        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
+        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
+        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
+            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
+            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
+    }.build()
+    val response = client.setup_recurring(request)
+    when (response.status.name) {
+        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
+        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
+    }
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -364,11 +441,13 @@ fun main(args: Array<String>) {
         "createClientAuthenticationToken" -> createClientAuthenticationToken(txnId)
         "get" -> get(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
+        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
         "reverse" -> reverse(txnId)
+        "setupRecurring" -> setupRecurring(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "void" -> void(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, reverse, tokenAuthorize, void")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, reverse, setupRecurring, tokenAuthorize, void")
     }
 }

--- a/examples/datatrans/datatrans.py
+++ b/examples/datatrans/datatrans.py
@@ -12,7 +12,7 @@ from payments import MerchantAuthenticationClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "refund", "refund_get", "reverse", "token_authorize", "void"]
+SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "proxy_setup_recurring", "refund", "refund_get", "reverse", "setup_recurring", "token_authorize", "void"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -106,6 +106,35 @@ def _build_proxy_authorize_request():
         return_url="https://example.com/return",
     )
 
+def _build_proxy_setup_recurring_request():
+    return payment_pb2.PaymentServiceProxySetupRecurringRequest(
+        merchant_recurring_payment_id="probe_proxy_mandate_001",
+        amount=payment_pb2.Money(
+            minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
+            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+        ),
+        card_proxy=payment_methods_pb2.ProxyCardDetails(  # Card proxy for vault-aliased payments.
+            card_number=payment_methods_pb2.SecretString(value="4111111111111111"),  # Card Identification.
+            card_exp_month=payment_methods_pb2.SecretString(value="03"),
+            card_exp_year=payment_methods_pb2.SecretString(value="2030"),
+            card_cvc=payment_methods_pb2.SecretString(value="123"),
+            card_holder_name=payment_methods_pb2.SecretString(value="John Doe"),  # Cardholder Information.
+            card_network=payment_methods_pb2.CardNetwork.Value("VISA"),
+        ),
+        address=payment_pb2.PaymentAddress(
+            billing_address=payment_pb2.Address(
+                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
+                email=payment_methods_pb2.SecretString(value="test@example.com"),  # Contact Information.
+            ),
+        ),
+        customer_acceptance=payment_pb2.CustomerAcceptance(
+            acceptance_type=payment_pb2.AcceptanceType.Value("OFFLINE"),  # Type of acceptance (e.g., online, offline).
+            accepted_at=0,  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        ),
+        auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),
+        setup_future_usage=payment_pb2.FutureUsage.Value("OFF_SESSION"),
+    )
+
 def _build_refund_request(connector_transaction_id: str):
     return payment_pb2.PaymentServiceRefundRequest(
         merchant_refund_id="probe_refund_001",  # Identification.
@@ -129,6 +158,39 @@ def _build_reverse_request(connector_transaction_id: str):
     return payment_pb2.PaymentServiceReverseRequest(
         merchant_reverse_id="probe_reverse_001",  # Identification.
         connector_transaction_id=connector_transaction_id,
+    )
+
+def _build_setup_recurring_request():
+    return payment_pb2.PaymentServiceSetupRecurringRequest(
+        merchant_recurring_payment_id="probe_mandate_001",  # Identification.
+        amount=payment_pb2.Money(  # Mandate Details.
+            minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
+            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+        ),
+        payment_method=payment_methods_pb2.PaymentMethod(
+            card=payment_methods_pb2.CardDetails(
+                card_number=payment_methods_pb2.CardNumberType(value="4111111111111111"),  # Card Identification.
+                card_exp_month=payment_methods_pb2.SecretString(value="03"),
+                card_exp_year=payment_methods_pb2.SecretString(value="2030"),
+                card_cvc=payment_methods_pb2.SecretString(value="737"),
+                card_holder_name=payment_methods_pb2.SecretString(value="John Doe"),  # Cardholder Information.
+            ),
+        ),
+        address=payment_pb2.PaymentAddress(  # Address Information.
+            billing_address=payment_pb2.Address(
+                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
+                email=payment_methods_pb2.SecretString(value="test@example.com"),  # Contact Information.
+            ),
+        ),
+        auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),  # Type of authentication to be used.
+        enrolled_for_3ds=False,  # Indicates if the customer is enrolled for 3D Secure.
+        return_url="https://example.com/mandate-return",  # URL to redirect after setup.
+        setup_future_usage=payment_pb2.FutureUsage.Value("OFF_SESSION"),  # Indicates future usage intention.
+        request_incremental_authorization=False,  # Indicates if incremental authorization is requested.
+        customer_acceptance=payment_pb2.CustomerAcceptance(  # Details of customer acceptance.
+            acceptance_type=payment_pb2.AcceptanceType.Value("OFFLINE"),  # Type of acceptance (e.g., online, offline).
+            accepted_at=0,  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        ),
     )
 
 def _build_token_authorize_request():
@@ -309,6 +371,15 @@ async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_conf
     return {"status": proxy_response.status}
 
 
+async def process_proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.ProxySetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
+
+    return {"status": proxy_response.status}
+
+
 async def process_refund_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: RefundService.Get"""
     refund_client = RefundClient(config)
@@ -325,6 +396,15 @@ async def process_reverse(merchant_transaction_id: str, config: sdk_config_pb2.C
     reverse_response = await payment_client.reverse(_build_reverse_request("probe_connector_txn_001"))
 
     return {"status": reverse_response.status}
+
+
+async def process_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.SetupRecurring"""
+    payment_client = PaymentClient(config)
+
+    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
+
+    return {"status": setup_response.status, "mandate_id": setup_response.connector_recurring_payment_id}
 
 
 async def process_token_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/datatrans/datatrans.rs
+++ b/examples/datatrans/datatrans.rs
@@ -20,9 +20,11 @@ pub const SUPPORTED_FLOWS: &[&str] = &[
     "create_client_authentication_token",
     "get",
     "proxy_authorize",
+    "proxy_setup_recurring",
     "refund",
     "refund_get",
     "reverse",
+    "setup_recurring",
     "token_authorize",
     "void",
 ];
@@ -155,6 +157,42 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
     }
 }
 
+pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
+    PaymentServiceProxySetupRecurringRequest {
+        merchant_recurring_payment_id: "probe_proxy_mandate_001".to_string(),
+        amount: Some(Money {
+            minor_amount: 0,                // Amount in minor units (e.g., 1000 = $10.00).
+            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+        }),
+        card_proxy: Some(ProxyCardDetails {
+            // Card proxy for vault-aliased payments.
+            card_number: Some(Secret::new("4111111111111111".to_string())), // Card Identification.
+            card_exp_month: Some(Secret::new("03".to_string())),
+            card_exp_year: Some(Secret::new("2030".to_string())),
+            card_cvc: Some(Secret::new("123".to_string())),
+            card_holder_name: Some(Secret::new("John Doe".to_string())), // Cardholder Information.
+            card_network: Some(CardNetwork::Visa.into()),
+            ..Default::default()
+        }),
+        address: Some(PaymentAddress {
+            billing_address: Some(Address {
+                first_name: Some(Secret::new("John".to_string())), // Personal Information.
+                email: Some(Secret::new("test@example.com".to_string())), // Contact Information.
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        customer_acceptance: Some(CustomerAcceptance {
+            acceptance_type: AcceptanceType::Offline.into(), // Type of acceptance (e.g., online, offline).
+            accepted_at: 0, // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            ..Default::default()
+        }),
+        auth_type: AuthenticationType::NoThreeDs.into(),
+        setup_future_usage: Some(FutureUsage::OffSession.into()),
+        ..Default::default()
+    }
+}
+
 pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
     PaymentServiceRefundRequest {
         merchant_refund_id: Some("probe_refund_001".to_string()), // Identification.
@@ -182,6 +220,49 @@ pub fn build_reverse_request(connector_transaction_id: &str) -> PaymentServiceRe
     PaymentServiceReverseRequest {
         merchant_reverse_id: Some("probe_reverse_001".to_string()), // Identification.
         connector_transaction_id: connector_transaction_id.to_string(),
+        ..Default::default()
+    }
+}
+
+pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
+    PaymentServiceSetupRecurringRequest {
+        merchant_recurring_payment_id: "probe_mandate_001".to_string(), // Identification.
+        amount: Some(Money {
+            // Mandate Details.
+            minor_amount: 0, // Amount in minor units (e.g., 1000 = $10.00).
+            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+        }),
+        payment_method: Some(PaymentMethod {
+            payment_method: Some(payment_method::PaymentMethod::Card(CardDetails {
+                card_number: Some(CardNumber::from_str("4111111111111111").unwrap()), // Card Identification.
+                card_exp_month: Some(Secret::new("03".to_string())),
+                card_exp_year: Some(Secret::new("2030".to_string())),
+                card_cvc: Some(Secret::new("737".to_string())),
+                card_holder_name: Some(Secret::new("John Doe".to_string())), // Cardholder Information.
+                ..Default::default()
+            })),
+            ..Default::default()
+        }),
+        address: Some(PaymentAddress {
+            // Address Information.
+            billing_address: Some(Address {
+                first_name: Some(Secret::new("John".to_string())), // Personal Information.
+                email: Some(Secret::new("test@example.com".to_string())), // Contact Information.
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        auth_type: AuthenticationType::NoThreeDs.into(), // Type of authentication to be used.
+        enrolled_for_3ds: false, // Indicates if the customer is enrolled for 3D Secure.
+        return_url: Some("https://example.com/mandate-return".to_string()), // URL to redirect after setup.
+        setup_future_usage: Some(FutureUsage::OffSession.into()), // Indicates future usage intention.
+        request_incremental_authorization: false, // Indicates if incremental authorization is requested.
+        customer_acceptance: Some(CustomerAcceptance {
+            // Details of customer acceptance.
+            acceptance_type: AcceptanceType::Offline.into(), // Type of acceptance (e.g., online, offline).
+            accepted_at: 0, // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+            ..Default::default()
+        }),
         ..Default::default()
     }
 }
@@ -487,6 +568,18 @@ pub async fn process_proxy_authorize(
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+#[allow(dead_code)]
+pub async fn process_proxy_setup_recurring(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client
+        .proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None)
+        .await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: RefundService.Get
 #[allow(dead_code)]
 pub async fn process_refund_get(
@@ -513,6 +606,27 @@ pub async fn process_reverse(
         )
         .await?;
     Ok(format!("status: {:?}", response.status()))
+}
+
+// Flow: PaymentService.SetupRecurring
+#[allow(dead_code)]
+pub async fn process_setup_recurring(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client
+        .setup_recurring(build_setup_recurring_request(), &HashMap::new(), None)
+        .await?;
+    if response.status() == PaymentStatus::Failure {
+        return Err(format!("Setup failed: {:?}", response.error).into());
+    }
+    Ok(format!(
+        "Mandate: {}",
+        response
+            .connector_recurring_payment_id
+            .as_deref()
+            .unwrap_or("")
+    ))
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -563,12 +677,14 @@ async fn main() {
         }
         "process_get" => process_get(&client, "txn_001").await,
         "process_proxy_authorize" => process_proxy_authorize(&client, "txn_001").await,
+        "process_proxy_setup_recurring" => process_proxy_setup_recurring(&client, "txn_001").await,
         "process_refund_get" => process_refund_get(&client, "txn_001").await,
         "process_reverse" => process_reverse(&client, "txn_001").await,
+        "process_setup_recurring" => process_setup_recurring(&client, "txn_001").await,
         "process_token_authorize" => process_token_authorize(&client, "txn_001").await,
         "process_void" => process_void(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_get, process_proxy_authorize, process_refund_get, process_reverse, process_token_authorize, process_void", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_get, process_proxy_authorize, process_proxy_setup_recurring, process_refund_get, process_reverse, process_setup_recurring, process_token_authorize, process_void", flow);
             return;
         }
     };

--- a/examples/datatrans/datatrans.ts
+++ b/examples/datatrans/datatrans.ts
@@ -6,8 +6,8 @@
 // Run a scenario:  npx tsx datatrans.ts checkout_autocapture
 
 import { PaymentClient, MerchantAuthenticationClient, RefundClient, types } from 'hyperswitch-prism';
-const { Environment, AuthenticationType, CaptureMethod, CardNetwork, Currency } = types;
-export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "refund", "refund_get", "reverse", "token_authorize", "void"];
+const { Environment, AcceptanceType, AuthenticationType, CaptureMethod, CardNetwork, Currency, FutureUsage } = types;
+export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "get", "proxy_authorize", "proxy_setup_recurring", "refund", "refund_get", "reverse", "setup_recurring", "token_authorize", "void"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -108,6 +108,36 @@ function _buildProxyAuthorizeRequest(): types.IPaymentServiceProxyAuthorizeReque
     };
 }
 
+function _buildProxySetupRecurringRequest(): types.IPaymentServiceProxySetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
+        "amount": {
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "cardProxy": {  // Card proxy for vault-aliased payments.
+            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+            "cardExpMonth": {"value": "03"},
+            "cardExpYear": {"value": "2030"},
+            "cardCvc": {"value": "123"},
+            "cardHolderName": {"value": "John Doe"},  // Cardholder Information.
+            "cardNetwork": CardNetwork.VISA
+        },
+        "address": {
+            "billingAddress": {
+                "firstName": {"value": "John"},  // Personal Information.
+                "email": {"value": "test@example.com"}  // Contact Information.
+            }
+        },
+        "customerAcceptance": {
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        },
+        "authType": AuthenticationType.NO_THREE_DS,
+        "setupFutureUsage": FutureUsage.OFF_SESSION
+    };
+}
+
 function _buildRefundRequest(connectorTransactionId: string): types.IPaymentServiceRefundRequest {
     return {
         "merchantRefundId": "probe_refund_001",  // Identification.
@@ -133,6 +163,40 @@ function _buildReverseRequest(connectorTransactionId: string): types.IPaymentSer
     return {
         "merchantReverseId": "probe_reverse_001",  // Identification.
         "connectorTransactionId": connectorTransactionId
+    };
+}
+
+function _buildSetupRecurringRequest(): types.IPaymentServiceSetupRecurringRequest {
+    return {
+        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
+        "amount": {  // Mandate Details.
+            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        },
+        "paymentMethod": {
+            "card": {  // Generic card payment.
+                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
+                "cardExpMonth": {"value": "03"},
+                "cardExpYear": {"value": "2030"},
+                "cardCvc": {"value": "737"},
+                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
+            }
+        },
+        "address": {  // Address Information.
+            "billingAddress": {
+                "firstName": {"value": "John"},  // Personal Information.
+                "email": {"value": "test@example.com"}  // Contact Information.
+            }
+        },
+        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
+        "enrolledFor_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
+        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
+        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
+        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
+        "customerAcceptance": {  // Details of customer acceptance.
+            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
+            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
+        }
     };
 }
 
@@ -322,6 +386,15 @@ async function proxyAuthorize(merchantTransactionId: string, config: types.IConn
     return proxyResponse;
 }
 
+// Flow: PaymentService.ProxySetupRecurring
+async function proxySetupRecurring(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
+
+    return proxyResponse;
+}
+
 // Flow: PaymentService.Refund
 async function refund(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -349,6 +422,15 @@ async function reverse(merchantTransactionId: string, config: types.IConnectorCo
     return reverseResponse;
 }
 
+// Flow: PaymentService.SetupRecurring
+async function setupRecurring(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
+
+    return setupResponse;
+}
+
 // Flow: PaymentService.TokenAuthorize
 async function tokenAuthorize(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -370,7 +452,7 @@ async function voidPayment(merchantTransactionId: string, config: types.IConnect
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, refund, refundGet, reverse, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildReverseRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, get, proxyAuthorize, proxySetupRecurring, refund, refundGet, reverse, setupRecurring, tokenAuthorize, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildGetRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRefundRequest, _buildRefundGetRequest, _buildReverseRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Datatrans UCS: Card 3DS + Recurring (SetupMandate + MIT) to parity with Hyperswitch Direct

Fills the known Datatrans UCS gaps vs. HS Direct across three flows, implemented and verified sequentially on this single branch (single stacked PR — one PR for all three). Each flow passed three gates: **grpcurl direct-to-UCS**, **HS→UCS end-to-end (primary execution)**, and **code parity vs the HS Direct reference**.

Reference mirrored (read-only): `hyperswitch/crates/hyperswitch_connectors/src/connectors/datatrans{.rs,/transformers.rs}`.

### Flow 1 — Card 3DS (native challenge + passthrough external 3DS)
- Authorize `get_url` made conditional: native 3DS (`is_three_ds()` && no `authentication_data`) → bare redirect-capable `/v1/transactions`; passthrough external-3DS / no-3DS → `/v1/transactions/authorize`.
- Added the `3D` request object — `Cardholder{cardholderName,email}` (native) and `Authentication{cavv,eci,xid,threeDSTransactionId,threeDSVersion,authenticationResponse:"Y"}` (passthrough).
- Parse `ThreeDSResponse{3D:{enrolled}}` → `AuthenticationPending` + `RedirectForm` to `{sbx|prod}/v1/start/{txn}`. Redirect return finalized via **PSync** (no CompleteAuthorize needed — matches the reference). Fixed `SequentialAutomatic` → `auto_settle:true`; PSync `Canceled`→Voided, challenge states→AuthenticationPending.
- Commit: `523a5270d`. Parity: `.grace/parity/3DS.md`. HS→UCS evidence: `.grace/hs_ucs/3DS.md` (full ACS challenge completed via browser automation, OTP 4000 → final `succeeded`).

### Flow 2 — SetupMandate (zero-auth CIT alias creation)
- Implemented the SetupMandate flow (removed from `not_implemented`): `amount:None`, `autoSettle:true`, `option.createAlias:true`, redirect URLs, native-3DS Cardholder form → `/v1/transactions`.
- Alias surfaced from PSync (`card.alias`) as `connector_mandate_id` for later MIT.
- Commits: `a6810c7ed`, plus two GATE-C-discovered fixes: `7bd59bf96` (derive 3DS redirect host from the connector `base_url` — HS does **not** forward `test_mode` on the SetupRecurring gRPC request, which sent sandbox challenges to the prod host) and `edff8847e` (type-aware PSync status: `card_check` `authorized`→Charged, and `detail.authorize.amount` made optional since a card-check has no amount).
- Parity: `.grace/parity/SetupMandate.md`. HS→UCS evidence: `.grace/hs_ucs/SetupMandate.md` (full 3DS mandate setup → `succeeded`; alias stored on mandate + payment method).

### Flow 3 — MIT (RepeatPayment via stored alias)
- Implemented the RepeatPayment flow (removed from `not_implemented`): charges the stored alias as `card:{type:"ALIAS", alias, expiryMonth, expiryYear}` to `/v1/transactions/authorize`, `option:None`, `redirect:None`. Network-transaction-id / network-token mandates → `NotSupported` (Datatrans charges only its connector-stored alias). Mirrors the reference `create_mandate_details` path.
- Commit: `694a71546`. Parity: `.grace/parity/MIT.md`. HS→UCS evidence: `.grace/hs_ucs/MIT.md` (off-session charge via the Flow-2 alias → `succeeded`).

### Verification (all HS router → UCS gRPC → Datatrans sandbox, `execution_mode: primary`)
| Flow | grpcurl | HS→UCS E2E | parity |
|------|:------:|:----------:|:-----:|
| 3DS | pass | pass — full ACS challenge → `succeeded` | pass |
| SetupMandate | pass | pass — 3DS mandate → `succeeded` + alias | pass |
| MIT | pass | pass — alias charge → `succeeded` | pass |

GATE C (real production path) surfaced three bugs the isolated grpcurl gate could not, all fixed and re-verified: prod redirect host in sandbox, card-check PSync deserialization, and non-type-aware sync status. Recurring-review checklist mined from prior merged PRs (`.grace/recurring_review_checklist.md`) was applied and self-reviewed per flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
