### PR TITLE
fix(tsys_transit): correct amount_captured for auth-only + valid voidReason on cancel

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -2365,18 +2365,27 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             )
         })?;
 
-        // On A0002 (partial approval) TSYS returns the actually approved
-        // value in <processedAmount>. Forward it as MinorUnit so the core
-        // can reconcile the partial capture/authorization against the
-        // requested amount; for the fully-approved A0000 case this is also
-        // harmless to populate.
-        let minor_amount_captured = body.processed_amount.as_ref().and_then(|amount| {
-            crate::connectors::tsys_transit::TsysTransitAmountConvertor::convert_back(
-                amount.clone(),
-                router_data.request.currency,
-            )
-            .ok()
-        });
+        // <processedAmount> reflects settled funds, so amount_captured must be
+        // populated ONLY when the transaction actually captured: a Sale (Charged)
+        // or a partial approval (PartialCharged). For an auth-only (Authorized)
+        // manual-capture flow nothing is captured yet — populating it there made
+        // HS record amount_received == amount at authorization, pushing later
+        // voids/captures into a wrong partially-captured state.
+        let is_settled = matches!(
+            status,
+            AttemptStatus::Charged | AttemptStatus::PartialCharged
+        );
+        let minor_amount_captured = is_settled
+            .then(|| {
+                body.processed_amount.as_ref().and_then(|amount| {
+                    crate::connectors::tsys_transit::TsysTransitAmountConvertor::convert_back(
+                        amount.clone(),
+                        router_data.request.currency,
+                    )
+                    .ok()
+                })
+            })
+            .flatten();
         let amount_captured = minor_amount_captured.map(|m| m.get_amount_as_i64());
 
         let payments_response_data = PaymentsResponseData::TransactionResponse {

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -2976,18 +2976,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 super::TsysTransitAmountConvertor::convert(amount.amount, amount.currency)
             })
             .transpose()?;
-        let void_reason = {
-            let raw = router_data
-                .request
-                .cancellation_reason
-                .clone()
-                .unwrap_or_else(|| "RETURN_REVERSAL".to_string());
-            if raw.len() > 80 {
-                raw.chars().take(80).collect()
-            } else {
-                raw
-            }
-        };
+        // TSYS <voidReason> only accepts a fixed set of enum values, so an
+        // arbitrary caller-supplied cancellation_reason (free text) is rejected
+        // with "The value of element 'voidReason' is not valid." Ignore the
+        // request value and always send a valid connector default.
+        let void_reason = "RETURN_REVERSAL".to_string();
 
         Ok(Self {
             device_id: auth.device_id,
@@ -3094,18 +3087,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             )?),
             _ => None,
         };
-        let void_reason = {
-            let raw = router_data
-                .request
-                .cancellation_reason
-                .clone()
-                .unwrap_or_else(|| "POST_AUTH_USER_DECLINE".to_string());
-            if raw.len() > 80 {
-                raw.chars().take(80).collect()
-            } else {
-                raw
-            }
-        };
+        // TSYS <voidReason> only accepts a fixed set of enum values, so an
+        // arbitrary caller-supplied cancellation_reason (free text) is rejected
+        // with "The value of element 'voidReason' is not valid." Ignore the
+        // request value and always send a valid connector default.
+        let void_reason = "POST_AUTH_USER_DECLINE".to_string();
 
         Ok(Self {
             device_id: auth.device_id,


### PR DESCRIPTION
## Summary

Two related `tsys_transit` correctness fixes for the manual-capture / cancel lifecycle.

### 1. Auth-only authorization wrongly reported as captured
The authorize response populated `amount_captured` / `minor_amount_captured` from `<processedAmount>` for **every** approved response, including auth-only (manual capture) authorizations where nothing is settled yet. Hyperswitch applies the connector's `captured_amount` unconditionally on the authorize path (`authorize_gateway.rs`), so a manual-capture auth was recorded with `amount_received == amount` while still in `requires_capture` — corrupting capture/void accounting downstream.

**Fix:** populate `amount_captured` only when the transaction actually settled — `Charged` (Sale) or `PartialCharged`. Auth-only (`Authorized`) now carries no captured amount.

### 2. Void rejected on caller-supplied cancellation_reason
TSYS `<voidReason>` only accepts a fixed set of enum values. The void and refund-reversal requests forwarded the caller-supplied `cancellation_reason` verbatim, so any free-text reason (e.g. `"customer changed mind"`) was rejected with *"The value of element 'voidReason' is not valid."* and the cancel landed in a failed / partially-captured state.

**Fix:** ignore the request `cancellation_reason` and always send a valid connector default (`POST_AUTH_USER_DECLINE` for void, `RETURN_REVERSAL` for refund reversal).

## Testing (end-to-end: HS → UCS → TSYS staging)

| Scenario | Before | After |
| --- | --- | --- |
| Manual auth (auth-only) | `amount_received = amount` ❌ | `amount_received = null` ✅ |
| Manual auth → capture | ok | `amount_received = amount` ✅ |
| Auto-capture (Sale) | ok | unchanged ✅ |
| Cancel with free-text `cancellation_reason` | `failed` (voidReason invalid) ❌ | `cancelled` ✅ |
