### PR TITLE
feat(netcetera): app-based 3DS (deviceChannel=01) over external vault

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/netcetera/netcetera_types.rs
+++ b/crates/integrations/connector-integration/src/connectors/netcetera/netcetera_types.rs
@@ -515,3 +515,121 @@ pub enum ChallengeWindowSizeEnum {
     #[serde(rename = "05")]
     FullScreen,
 }
+
+// ---------------------------------------------------------------------------
+// App-channel (device_channel = 01 / APP) SDK data
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
+pub struct Sdk {
+    #[serde(rename = "sdkAppID")]
+    sdk_app_id: Option<String>,
+    sdk_enc_data: Option<String>,
+    sdk_ephem_pub_key: Option<std::collections::HashMap<String, String>>,
+    sdk_max_timeout: Option<u8>,
+    sdk_reference_number: Option<String>,
+    #[serde(rename = "sdkTransID")]
+    sdk_trans_id: Option<String>,
+    sdk_server_signed_content: Option<String>,
+    sdk_type: Option<SdkType>,
+    default_sdk_type: Option<DefaultSdkType>,
+    split_sdk_type: Option<SplitSdkType>,
+}
+
+impl From<domain_types::connector_types::SdkInformation> for Sdk {
+    fn from(sdk_info: domain_types::connector_types::SdkInformation) -> Self {
+        Self {
+            sdk_app_id: Some(sdk_info.sdk_app_id),
+            sdk_enc_data: Some(sdk_info.sdk_enc_data),
+            sdk_ephem_pub_key: Some(sdk_info.sdk_ephem_pub_key),
+            sdk_max_timeout: Some(sdk_info.sdk_max_timeout),
+            sdk_reference_number: Some(sdk_info.sdk_reference_number),
+            sdk_trans_id: Some(sdk_info.sdk_trans_id),
+            sdk_server_signed_content: None,
+            sdk_type: sdk_info
+                .sdk_type
+                .map(SdkType::from)
+                .or(Some(SdkType::DefaultSdk)),
+            default_sdk_type: Some(DefaultSdkType {
+                sdk_variant: "01".to_string(),
+                wrapped_ind: None,
+            }),
+            split_sdk_type: None,
+        }
+    }
+}
+
+impl From<domain_types::connector_types::SdkType> for SdkType {
+    fn from(sdk_type: domain_types::connector_types::SdkType) -> Self {
+        match sdk_type {
+            domain_types::connector_types::SdkType::DefaultSdk => Self::DefaultSdk,
+            domain_types::connector_types::SdkType::SplitSdk => Self::SplitSdk,
+            domain_types::connector_types::SdkType::LimitedSdk => Self::LimitedSdk,
+            domain_types::connector_types::SdkType::BrowserSdk => Self::BrowserSdk,
+            domain_types::connector_types::SdkType::ShellSdk => Self::ShellSdk,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkType {
+    #[serde(rename = "01")]
+    DefaultSdk,
+    #[serde(rename = "02")]
+    SplitSdk,
+    #[serde(rename = "03")]
+    LimitedSdk,
+    #[serde(rename = "04")]
+    BrowserSdk,
+    #[serde(rename = "05")]
+    ShellSdk,
+    #[serde(untagged)]
+    PsSpecific(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DefaultSdkType {
+    sdk_variant: String,
+    wrapped_ind: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SplitSdkType {
+    sdk_variant: String,
+    limited_ind: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceRenderingOptionsSupported {
+    pub sdk_interface: SdkInterface,
+    pub sdk_ui_type: Vec<SdkUiType>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkInterface {
+    #[serde(rename = "01")]
+    Native,
+    #[serde(rename = "02")]
+    Html,
+    #[serde(rename = "03")]
+    Both,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkUiType {
+    #[serde(rename = "01")]
+    Text,
+    #[serde(rename = "02")]
+    SingleSelect,
+    #[serde(rename = "03")]
+    MultiSelect,
+    #[serde(rename = "04")]
+    Oob,
+    #[serde(rename = "05")]
+    HtmlOther,
+}

--- a/crates/integrations/connector-integration/src/connectors/netcetera/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/netcetera/transformers.rs
@@ -611,8 +611,10 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                                 "threeDSServerTransID".to_string(),
                                 response.three_ds_server_trans_id.clone(),
                             );
-                            if let Some(acs_reference_number) =
-                                response.authentication_response.acs_reference_number.clone()
+                            if let Some(acs_reference_number) = response
+                                .authentication_response
+                                .acs_reference_number
+                                .clone()
                             {
                                 form_fields
                                     .insert("acsReferenceNumber".to_string(), acs_reference_number);

--- a/crates/integrations/connector-integration/src/connectors/netcetera/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/netcetera/transformers.rs
@@ -29,6 +29,7 @@ use domain_types::{
     router_request_types::AuthenticationData,
     router_response_types::RedirectForm,
 };
+use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, Secret};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -331,6 +332,8 @@ pub struct NetceteraAuthenticateRequest<
     pub acquirer: Option<netcetera_types::AcquirerData>,
     pub merchant: Option<netcetera_types::MerchantData>,
     pub browser_information: Option<netcetera_types::Browser>,
+    pub sdk_information: Option<netcetera_types::Sdk>,
+    pub device_render_options: Option<netcetera_types::DeviceRenderingOptionsSupported>,
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -425,10 +428,43 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             }
         });
 
-        let browser_information = request
-            .browser_info
-            .clone()
-            .map(netcetera_types::Browser::from);
+        let is_app = matches!(
+            request.device_channel,
+            Some(domain_types::connector_types::DeviceChannel::App)
+        );
+
+        let browser_information = if is_app {
+            None
+        } else {
+            request
+                .browser_info
+                .clone()
+                .map(netcetera_types::Browser::from)
+        };
+
+        let sdk_information = if is_app {
+            request
+                .sdk_information
+                .clone()
+                .map(netcetera_types::Sdk::from)
+        } else {
+            None
+        };
+
+        let device_render_options = if is_app {
+            Some(netcetera_types::DeviceRenderingOptionsSupported {
+                sdk_interface: netcetera_types::SdkInterface::Both,
+                sdk_ui_type: vec![
+                    netcetera_types::SdkUiType::Text,
+                    netcetera_types::SdkUiType::SingleSelect,
+                    netcetera_types::SdkUiType::MultiSelect,
+                    netcetera_types::SdkUiType::Oob,
+                    netcetera_types::SdkUiType::HtmlOther,
+                ],
+            })
+        } else {
+            None
+        };
 
         let cardholder = netcetera_types::Cardholder::try_from((
             common_data.address.get_payment_billing().cloned(),
@@ -452,10 +488,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         Ok(Self {
             preferred_protocol_version: message_version,
-            enforce_preferred_protocol_version: Some(false),
-            // UCS PaymentsAuthenticateData has no device_channel; browser flow is
-            // the only supported use case for now.
-            device_channel: netcetera_types::NetceteraDeviceChannel::Browser,
+            enforce_preferred_protocol_version: Some(is_app),
+            device_channel: if is_app {
+                netcetera_types::NetceteraDeviceChannel::AppBased
+            } else {
+                netcetera_types::NetceteraDeviceChannel::Browser
+            },
             message_category: netcetera_types::NetceteraMessageCategory::PaymentAuthentication,
             three_ds_comp_ind: Some(netcetera_types::ThreeDSMethodCompletionIndicator::U),
             three_ds_requestor: Some(three_ds_requestor),
@@ -475,6 +513,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             acquirer,
             merchant,
             browser_information,
+            sdk_information,
+            device_render_options,
         })
     }
 }
@@ -520,6 +560,14 @@ pub struct AuthenticationResponse {
     pub trans_status_reason: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct NetceteraChallengeFeatureData {
+    pub acs_signed_content: Option<String>,
+    pub acs_reference_number: Option<String>,
+    pub acs_trans_id: Option<String>,
+    pub three_ds_server_trans_id: String,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum ACSChallengeMandatedIndicator {
     /// Challenge is mandated
@@ -559,6 +607,27 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         (Some(acs_url), Some(creq)) => {
                             let mut form_fields = std::collections::HashMap::new();
                             form_fields.insert("creq".to_string(), creq);
+                            form_fields.insert(
+                                "threeDSServerTransID".to_string(),
+                                response.three_ds_server_trans_id.clone(),
+                            );
+                            if let Some(acs_reference_number) =
+                                response.authentication_response.acs_reference_number.clone()
+                            {
+                                form_fields
+                                    .insert("acsReferenceNumber".to_string(), acs_reference_number);
+                            }
+                            if let Some(acs_trans_id) =
+                                response.authentication_response.acs_trans_id.clone()
+                            {
+                                form_fields.insert("acsTransID".to_string(), acs_trans_id);
+                            }
+                            if let Some(acs_signed_content) =
+                                response.authentication_response.acs_signed_content.clone()
+                            {
+                                form_fields
+                                    .insert("acsSignedContent".to_string(), acs_signed_content);
+                            }
                             Some(Box::new(RedirectForm::Form {
                                 endpoint: acs_url.to_string(),
                                 method: common_utils::Method::Post,
@@ -570,6 +639,26 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 } else {
                     None
                 };
+
+                let connector_feature_data = is_challenge
+                    .then(|| {
+                        serde_json::to_value(NetceteraChallengeFeatureData {
+                            acs_signed_content: response
+                                .authentication_response
+                                .acs_signed_content
+                                .clone(),
+                            acs_reference_number: response
+                                .authentication_response
+                                .acs_reference_number
+                                .clone(),
+                            acs_trans_id: response.authentication_response.acs_trans_id.clone(),
+                            three_ds_server_trans_id: response.three_ds_server_trans_id.clone(),
+                        })
+                    })
+                    .transpose()
+                    .change_context(ConnectorError::ResponseHandlingFailed {
+                        context: Default::default(),
+                    })?;
 
                 let authentication_data = AuthenticationData {
                     trans_status: Some(response.trans_status),
@@ -596,7 +685,7 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         } else {
                             Some(authentication_data)
                         },
-                        connector_feature_data: None,
+                        connector_feature_data,
                         connector_response_reference_id: Some(response.three_ds_server_trans_id),
                         status_code: item.http_code,
                     }),

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2094,6 +2094,48 @@ impl<T: PaymentMethodDataTypes> PaymentsPreAuthenticateData<T> {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SdkInformation {
+    pub sdk_app_id: String,
+    pub sdk_enc_data: String,
+    pub sdk_ephem_pub_key: std::collections::HashMap<String, String>,
+    pub sdk_trans_id: String,
+    pub sdk_reference_number: String,
+    pub sdk_max_timeout: u8,
+    pub sdk_type: Option<SdkType>,
+    pub device_details: Option<DeviceDetails>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeviceDetails {
+    pub device_type: Option<String>,
+    pub device_brand: Option<String>,
+    pub device_os: Option<String>,
+    pub device_display: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum SdkType {
+    #[serde(rename = "01")]
+    DefaultSdk,
+    #[serde(rename = "02")]
+    SplitSdk,
+    #[serde(rename = "03")]
+    LimitedSdk,
+    #[serde(rename = "04")]
+    BrowserSdk,
+    #[serde(rename = "05")]
+    ShellSdk,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq)]
+pub enum DeviceChannel {
+    #[serde(rename = "APP")]
+    App,
+    #[serde(rename = "BRW")]
+    Browser,
+}
+
 #[derive(Debug, Clone)]
 pub struct PaymentsAuthenticateData<T: PaymentMethodDataTypes> {
     pub payment_method_data: Option<PaymentMethodData<T>>,
@@ -2111,6 +2153,8 @@ pub struct PaymentsAuthenticateData<T: PaymentMethodDataTypes> {
     pub webhook_url: Option<String>,
     /// Domain-specific data (e.g. student fields) for connectors that need it.
     pub domain_data: Option<DomainData>,
+    pub sdk_information: Option<SdkInformation>,
+    pub device_channel: Option<DeviceChannel>,
 }
 
 impl<T: PaymentMethodDataTypes> PaymentsAuthenticateData<T> {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -14664,8 +14664,24 @@ impl<
                 .domain_data
                 .map(connector_types::DomainData::foreign_try_from)
                 .transpose()?,
+            sdk_information: value
+                .metadata
+                .as_ref()
+                .and_then(|m| serde_json::from_str::<AuthenticateSdkMetadata>(m.peek()).ok())
+                .and_then(|m| m.sdk_information),
+            device_channel: value
+                .metadata
+                .as_ref()
+                .and_then(|m| serde_json::from_str::<AuthenticateSdkMetadata>(m.peek()).ok())
+                .and_then(|m| m.device_channel),
         })
     }
+}
+
+#[derive(serde::Deserialize)]
+struct AuthenticateSdkMetadata {
+    device_channel: Option<connector_types::DeviceChannel>,
+    sdk_information: Option<connector_types::SdkInformation>,
 }
 
 impl<


### PR DESCRIPTION
- add app-channel SDK data types (sdk_information, device_channel) and carry them into the Netcetera AReq
- surface app challenge ACS fields (acs_signed_content, acs_reference_number, acs_trans_id) to the router via connector_feature_data on the challenge AReq response, since app challenges have a null acsURL
- thread device_channel + sdk_information through domain connector types

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
