### PR TITLE
fix(tsys_transit): don't store network transaction id as a connector_mandate_id (PSP token)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -10,11 +10,10 @@ use domain_types::{
         VoidPostRefund,
     },
     connector_types::{
-        MandateIds, MandateReferenceId, PaymentFlowData, PaymentVoidData,
-        PaymentsAuthorizeData, PaymentsCancelPostCaptureData, PaymentsCaptureData,
-        PaymentsResponseData, PaymentsSyncData, RecurringMandatePaymentData, RefundFlowData,
-        RefundSyncData, RefundVoidPostRefundData, RefundsData, RefundsResponseData,
-        RepeatPaymentData, ResponseId, SetupMandateRequestData,
+        MandateIds, MandateReferenceId, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
+        PaymentsCancelPostCaptureData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
+        RecurringMandatePaymentData, RefundFlowData, RefundSyncData, RefundVoidPostRefundData,
+        RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     errors::{ConnectorError, IntegrationError},
     payment_method_data::{

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -10,7 +10,7 @@ use domain_types::{
         VoidPostRefund,
     },
     connector_types::{
-        MandateIds, MandateReference, MandateReferenceId, PaymentFlowData, PaymentVoidData,
+        MandateIds, MandateReferenceId, PaymentFlowData, PaymentVoidData,
         PaymentsAuthorizeData, PaymentsCancelPostCaptureData, PaymentsCaptureData,
         PaymentsResponseData, PaymentsSyncData, RecurringMandatePaymentData, RefundFlowData,
         RefundSyncData, RefundVoidPostRefundData, RefundsData, RefundsResponseData,
@@ -3494,25 +3494,21 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 )
             })?;
 
-        let path_a_mandate_id = format!("ntid:{ntid_source}");
-        let mandate_reference = Box::new(MandateReference {
-            connector_mandate_id: Some(path_a_mandate_id),
-            payment_method_id: None,
-            connector_mandate_request_reference_id: None,
-            mandate_metadata: None,
-        });
-
         let connector_txn_id = response
             .transaction_id
             .clone()
             .unwrap_or_else(|| ntid_source.clone());
 
+        // Do NOT fake the network transaction id as a connector_mandate_id (PSP
+        // token). The NTI is stored as network_txn_id; a connector-agnostic MIT
+        // replays it from the payment method's network_transaction_id together with
+        // the locker card, so no connector mandate / PSP token is needed.
         let payments_response_data = PaymentsResponseData::TransactionResponse {
             resource_id: ResponseId::ConnectorTransactionId(connector_txn_id.clone()),
             redirection_data: None,
-            mandate_reference: Some(mandate_reference),
+            mandate_reference: None,
             connector_metadata: None,
-            network_txn_id: response.auth_code.clone(),
+            network_txn_id: Some(ntid_source.clone()),
             network_txn_link_id: None,
             connector_response_reference_id: Some(connector_txn_id),
             incremental_authorization_allowed: None,

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -2269,13 +2269,10 @@ fn decode_mandate_id_string(raw: &str) -> MandateDispatch {
             _ => {}
         }
     }
-    if let Some(ntid) = raw.strip_prefix("ntid:") {
-        if !ntid.is_empty() {
-            return MandateDispatch::Ntid {
-                ntid: ntid.to_string(),
-            };
-        }
-    }
+    // Network transaction id is never stored as a connector_mandate_id (PSP
+    // token) for tsys_transit — it arrives via `NetworkMandateId` and is
+    // decoded in `decode_mandate_dispatch`. Nothing writes an `ntid:` prefixed
+    // connector_mandate_id, so there is nothing to strip here.
     MandateDispatch::None
 }
 fn map_authorize_status(response: &TsysTransitAuthorizeResponse) -> AttemptStatus {


### PR DESCRIPTION
## Summary

`tsys_transit` faked the network transaction id (NTI) as a **connector_mandate_id** (`"ntid:<value>"`) in the CardAuthentication response — i.e. it stored the NTI as if it were a PSP token. That is not a real connector mandate, and it forces HS down the connector-mandate replay path (`ConnectorMandateId`) instead of the connector-agnostic network-transaction-id path.

A `payment_method_id` MIT for `tsys_transit` is a **connector-agnostic MIT**: HS replays it from the payment method's stored `network_transaction_id` + the card fetched from the locker (`CardDetailsForNetworkTransactionId`), which the connector already handles. No PSP token is needed.

## Changes
- **Drop the fake `mandate_reference`** (`connector_mandate_id = "ntid:..."`) from the response — nothing is stored in `connector_mandate_id` anymore. The NTI is stored in `network_txn_id` instead.
- **Drop the now-dead `ntid:` decode path** in `decode_mandate_id_string` — since nothing writes an `ntid:`-prefixed `connector_mandate_id`, there is nothing to strip. The NTI arrives via `NetworkMandateId` and is decoded in `decode_mandate_dispatch`.

## Why
- The saved pm still shows in the SDK — the payment-method list treats a pm as usable when it has an NTI + connector-agnostic MIT enabled (`mca_enabled = agnostic_mit || mandate_match`), so a missing connector token doesn't hide it.
- Faking the NTI as a connector mandate only mis-routes the MIT.

---

## When does this flow run? (required flags)

| Where | Flag / field | Value | Why |
|-------|--------------|-------|-----|
| **Business profile** | `is_connector_agnostic_mit_enabled` | `true` | Enables NTI-based connector-agnostic MIT — makes the saved pm usable in the SDK and routes the MIT down the `CardDetailsForNetworkTransactionId` (locker card + NTI) path instead of the connector-token path. |
| **CIT request** | `setup_future_usage` | `"off_session"` | Saves the payment method and persists the `network_transaction_id` on it. |
| **MIT request** | `off_session` | `true` | Marks the replay as merchant-initiated. |
| **MIT request** | `recurring_details.type` | `"payment_method_id"` | Replay by stored pm — HS fetches the card from the locker + the stored NTI. |

> If `is_connector_agnostic_mit_enabled` is **off**, HS falls back to the connector-mandate (`ConnectorMandateId`) path, which tsys_transit no longer produces — so agnostic MIT is required for this connector.

---

## HS-side request / response

### 1. CIT — save the card + capture the NTI

**Request**
```jsonc
POST /payments
{
  "amount": 512,
  "currency": "USD",
  "confirm": true,
  "customer_id": "cus_xxx",
  "setup_future_usage": "off_session",       // ← saves pm + stores NTI
  "capture_method": "automatic",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4012000098765439",
      "card_exp_month": "12",
      "card_exp_year": "2027",
      "card_cvc": "999",
      "card_holder_name": "John Doe"
    }
  },
  "billing": {
    "address": {
      "line1": "123 Main St", "city": "NYC", "state": "NY",
      "zip": "10001", "country": "US",
      "first_name": "John", "last_name": "Doe"
    }
  },
  "profile_id": "pro_xxx"
}
```

**Response** (trimmed)
```jsonc
{
  "status": "succeeded",
  "payment_method_id": "pm_xxx",
  "network_transaction_id": "000000003878032",   // ← stored on the pm
  "connector_mandate_id": null,                   // ← no PSP token (this PR)
  "connector_transaction_id": "83846901"
}
```

The saved payment method: `network_transaction_id` set, `connector_mandate_details = NULL` (no PSP token) — and it still lists in the SDK.

### 2. MIT — replay by `payment_method_id` (connector-agnostic)

**Request**
```jsonc
POST /payments
{
  "amount": 877,
  "currency": "USD",
  "confirm": true,
  "off_session": true,                            // ← merchant-initiated
  "capture_method": "automatic",
  "customer_id": "cus_xxx",
  "recurring_details": {
    "type": "payment_method_id",                  // ← replay by stored pm
    "data": "pm_xxx"
  },
  "profile_id": "pro_xxx"
}
```

**Response** (trimmed)
```jsonc
{
  "status": "succeeded",
  "connector_mandate_id": null,                   // ← still no PSP token
  "network_transaction_id": "000000003890106",
  "connector_transaction_id": "83846983"
}
```

Under the hood HS sends the card fetched from the locker as `CardDetailsForNetworkTransactionId` + the NTI as `NetworkMandateId`; tsys_transit replays it and TSYS returns `A0000 Success`.

---

## Verified end-to-end
`is_connector_agnostic_mit_enabled = true` profile → CIT (`off_session`, pm saved with NTI, `connector_mandate_id = null`) → MIT (`payment_method_id`) → UCS variant `card_details_for_network_transaction_id` → TSYS `A0000 Success`. No `connector_mandate_id` is written or read anywhere in the flow.
