### PR TITLE
fix(nmi): drop customer-email fallback for email/shipping_email on repeat_payment (MIT)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1972,12 +1972,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             zip: common_data.get_optional_billing_zip(),
             country: common_data.get_optional_billing_country(),
             phone: common_data.get_optional_billing_phone_number(),
-            // Prefer the billing-address email (mirrors the hyperswitch reference
-            // NMI MIT path), falling back to the top-level `RepeatPaymentData.email`
-            // so the customer email is still sent when no billing email is present.
-            email: common_data
-                .get_optional_billing_email()
-                .or_else(|| router_data.request.email.clone()),
+            // Source `email` from the billing address only, matching the hyperswitch
+            // reference NMI MIT path (`get_billing_details` -> `get_optional_billing_email`).
+            // No fallback to the top-level `RepeatPaymentData.email`: the reference omits
+            // the field entirely when the billing address carries no email, so falling
+            // back to the customer email would send `email` when Direct sends nothing.
+            email: common_data.get_optional_billing_email(),
             shipping_details: Some(NmiShippingDetails {
                 shipping_firstname: common_data.get_optional_shipping_first_name(),
                 shipping_lastname: common_data.get_optional_shipping_last_name(),
@@ -1987,11 +1987,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 shipping_state: common_data.get_optional_shipping_state(),
                 shipping_zip: common_data.get_optional_shipping_zip(),
                 shipping_country: common_data.get_optional_shipping_country(),
-                // Same precedence for the shipping email: shipping-address email
-                // first, then the top-level `RepeatPaymentData.email` fallback.
-                shipping_email: common_data
-                    .get_optional_shipping_email()
-                    .or_else(|| router_data.request.email.clone()),
+                // Same as billing: shipping email comes from the shipping address only,
+                // matching the reference (`get_shipping_details` -> `get_optional_shipping_email`),
+                // with no `RepeatPaymentData.email` fallback.
+                shipping_email: common_data.get_optional_shipping_email(),
             }),
         })
     }

--- a/fixtures/nmi/repeat_payment/20218.json
+++ b/fixtures/nmi/repeat_payment/20218.json
@@ -1,0 +1,22 @@
+{
+  "_issue": "hyperswitch-cloud#20218 (parent #20217) — nmi/repeat_payment/greenstone_rx",
+  "_signature": "body.keyDiff.email={hyperswitch:false,ucs:true} | body.keyDiff.shipping_email={hyperswitch:false,ucs:true}",
+  "_scenario": "MIT (repeat_payment) with a billing address that has NO email + a top-level customer email set, no shipping. Direct sources email/shipping_email from the billing/shipping address only (omits them here); prism previously fell back to RepeatPaymentData.email and over-sent both fields. Fix removes the fallback -> parity.",
+  "cit": {
+    "amount": 200, "currency": "USD", "confirm": true, "capture_method": "automatic",
+    "off_session": false, "setup_future_usage": "off_session",
+    "customer_acceptance": {"acceptance_type": "online", "accepted_at": "2026-07-13T10:00:00Z", "online": {"ip_address": "127.0.0.1", "user_agent": "repro"}},
+    "payment_method": "card", "payment_method_type": "credit",
+    "payment_method_data": {"card": {"card_number": "4111111111111111", "card_exp_month": "03", "card_exp_year": "2030", "card_holder_name": "John Doe", "card_cvc": "999"}},
+    "billing": {"address": {"first_name": "John", "last_name": "Doe", "line1": "1 Market St", "city": "San Francisco", "state": "CA", "zip": "94105", "country": "US"}},
+    "email": "customer.20218@example.com"
+  },
+  "mit": {
+    "amount": 200, "currency": "USD", "confirm": true, "capture_method": "automatic",
+    "off_session": true,
+    "recurring_details": {"type": "payment_method_id", "data": "<pm_from_cit>"},
+    "payment_method": "card", "payment_method_type": "credit",
+    "billing": {"address": {"first_name": "John", "last_name": "Doe", "line1": "1 Market St", "city": "San Francisco", "state": "CA", "zip": "94105", "country": "US"}},
+    "email": "customer.20218@example.com"
+  }
+}


### PR DESCRIPTION
## What

NMI `repeat_payment` (MIT) request builder no longer falls back to the customer email for `email` / `shipping_email` — it now sources them from the billing / shipping address only, matching the hyperswitch Direct reference.

Fixes the shadow request diff in juspay/hyperswitch-cloud#20218 (parent #20217), `greenstone_rx` / `nmi` / `repeat_payment`, `235` occurrences.

## Root cause

Direct routes NMI MIT charges through the Authorize flow's `NmiPaymentsRequest` (the `MandatePayment` branch), which builds billing/shipping via `get_billing_details` / `get_shipping_details`:

- `email = get_optional_billing_email()` — billing address email only
- `shipping_email = get_optional_shipping_email()` — shipping address email only

Both structs are `#[skip_serializing_none]`, so when the address carries no email the field is **dropped from the wire body**. There is no fallback to the customer email.

Prism's `NmiRepeatPaymentRequest` builder (added in #1682) instead did:

```rust
email: common_data.get_optional_billing_email().or_else(|| router_data.request.email.clone()),
shipping_email: common_data.get_optional_shipping_email().or_else(|| router_data.request.email.clone()),
```

For a repeat charge whose billing/shipping addresses have **no** email but a customer-level email is set, prism populated `email`/`shipping_email` from the customer email while Direct sent nothing — producing:

```
body.keyDiff.email          = {"hyperswitch":false,"ucs":true}
body.keyDiff.shipping_email = {"hyperswitch":false,"ucs":true}
```

## Fix

Remove the `.or_else(|| router_data.request.email.clone())` fallback on both fields so the MIT request mirrors Direct byte-for-byte.

## Verification (local shadow stack)

Reproduced end-to-end through the router → shadow-UCS → validation-service (`nmi_repro` merchant, CIT setup-mandate then MIT repeat_payment; billing address with **no** email + a top-level customer email, no shipping — the exact prod scenario).

**BEFORE (this branch reverted to `main`)** — `diff_result_repeat_payment:nmi:019f7cda-459d-76b1-a13c-fa7ceabc6b2d`:
```json
"bodyComparison": {
  "keyDiff": {
    "email":          {"hyperswitch": false, "ucs": true},
    "shipping_email": {"hyperswitch": false, "ucs": true}
  },
  "valueDiff": {}, "typeDiff": {}
}
```
(exactly the #20218 signature)

**AFTER (this branch)** — `diff_result_repeat_payment:nmi:019f7cdb-3a91-7162-bdbd-639ec3e3a633`:
```json
"bodyComparison": { "keyDiff": {}, "valueDiff": {}, "typeDiff": {} }
```
`bodyComparison.keyDiff == {}` ✅ (only the ignore-listed `via` / `x-merchant-id` headers remain in headerComparison, as expected). MIT charge succeeded (nmi `12323073431`).

Regression fixture: `fixtures/nmi/repeat_payment/20218.json`.

## Classification

UCS-only (prism transformer). No proto or hyperswitch-client change required.
