### PR TITLE
fix(stripe): send payment_method_options[card][moto] on setup_mandate

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -277,6 +277,9 @@ pub struct SetupMandateRequest<
     pub expand: Option<ExpandableObjects>,
     #[serde(flatten)]
     pub browser_info: Option<StripeBrowserInformation>,
+    #[serde(rename = "payment_method_options[card][moto]")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub moto: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -4945,12 +4948,30 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .clone()
             .map(StripeBrowserInformation::from);
 
+        let is_moto = if matches!(
+            item.router_data.request.payment_method_data,
+            PaymentMethodData::Card(_)
+        ) && item.router_data.request.payment_channel
+            == Some(common_enums::PaymentChannel::MailOrder)
+            || item.router_data.request.payment_channel
+                == Some(common_enums::PaymentChannel::TelephoneOrder)
+        {
+            Some(true)
+        } else {
+            None
+        };
+
+        let usage = match (item.router_data.request.setup_future_usage, is_moto) {
+            (Some(common_enums::FutureUsage::OnSession), Some(true)) => None,
+            _ => item.router_data.request.setup_future_usage,
+        };
+
         Ok(Self {
             confirm: true,
             payment_data,
             return_url: item.router_data.request.router_return_url.clone(),
             off_session: item.router_data.request.off_session,
-            usage: item.router_data.request.setup_future_usage,
+            usage,
             payment_method_options: None,
             customer: item
                 .router_data
@@ -4962,6 +4983,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             payment_method_types: Some(pm_type),
             expand: Some(ExpandableObjects::LatestAttempt),
             browser_info,
+            moto: is_moto,
         })
     }
 }


### PR DESCRIPTION
## What

The Stripe **SetupMandate** (SetupIntent) request builder in prism never emitted the
`payment_method_options[card][moto]` field. Hyperswitch's Direct gateway sets it to `true` for
card payments initiated over a mail-order / telephone-order channel
(`payment_channel = MailOrder | TelephoneOrder`), so the shadow UCS leg diverged from Direct.

Fixes shadow-validation issue **juspay/hyperswitch-cloud#20285** (`stripe` / `setup_mandate`, prod,
merchant `abo_factory`).

### Before (prod diff signature)
```
body.keyDiff.payment_method_options[card][moto] = {"hyperswitch": true, "ucs": false}
```
`grep moto` over the prism Stripe connector returned **0 hits** — the key was structurally impossible
to emit on the UCS side, hence the keyDiff.

## Root cause

`hyperswitch/crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs`
(`TryFrom<&SetupMandateRouterData> for SetupIntentRequest`) computes:
```rust
let is_moto = matches!(pmd, Card{..}) && payment_channel == Some(MailOrder)
              || payment_channel == Some(TelephoneOrder);
```
and emits `moto: is_moto` → `payment_method_options[card][moto]`. It also suppresses
`setup_future_usage` (`OnSession + moto → None`). The prism `SetupMandateRequest` had neither.
The source signal is already present: `SetupMandateRequestData.payment_channel` is wired through from
proto `PaymentServiceSetupRecurringRequest.payment_channel` (field 27). This is a UCS-only transformer
gap — no proto change needed.

## Fix

Add a top-level `moto` field to `SetupMandateRequest`, serialized as
`payment_method_options[card][moto]` with `skip_serializing_if = Option::is_none`, computed with the
exact same condition as hyperswitch, plus the matching `OnSession + moto → usage=None` coupling so the
`usage` field stays in parity too.

## Verification (local shadow stack)

Fired the UCS leg directly at prism `:8000` `PaymentService/SetupRecurring` with
`payment_channel = MAIL_ORDER` + a card, and inspected the **outbound Stripe SetupIntent body**:

**After — MAIL_ORDER (MOTO):**
```
"expand[0]":"latest_attempt","payment_method_options[card][moto]":true
```
✅ UCS now emits `payment_method_options[card][moto]=true`, matching hyperswitch Direct → `keyDiff: {}`.

**Negative — ECOMMERCE (non-MOTO):**
```
moto key absent (skip_serializing_if) — no spurious payment_method_options[card][moto]=false
```
✅ No new diff introduced for non-MOTO traffic.

Regression check (`check_20285.py`): `moto:true occurrences: 6, moto:false occurrences: 0 → GREEN`.

## Notes
- No proto/two-repo change: `payment_channel` already flows into `SetupMandateRequestData`.
- No credentials or local config included in this PR.
