### PR TITLE
feat(events): stamp deployment version metadata on every connector event

### DIFF
--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -293,6 +293,34 @@ impl Event {
         });
     }
 
+    /// The application / microservice name (e.g. `connector-service-http`). Sourced from the
+    /// `APPLICATION_NAME` env, not the internal gRPC `service_name`.
+    pub fn add_application_name(&mut self, application_name: &str) {
+        self.push_version_field("application_name", application_name);
+    }
+
+    /// The deployed build version (e.g. `2026.07.08.0`). A/B groups on this field directly.
+    pub fn add_version(&mut self, version: &str) {
+        self.push_version_field("version", version);
+    }
+
+    /// The rollout / replicaset id (k8s downward API).
+    pub fn add_deployment_id(&mut self, deployment_id: &str) {
+        self.push_version_field("deployment_id", deployment_id);
+    }
+
+    /// The pod name (k8s downward API `metadata.name`).
+    pub fn add_pod_name(&mut self, pod_name: &str) {
+        self.push_version_field("pod_name", pod_name);
+    }
+
+    /// Insert a masked top-level version-metadata field into `additional_fields`.
+    fn push_version_field(&mut self, key: &str, value: &str) {
+        MaskedSerdeValue::from_masked_optional(&value.to_string(), key).map(|masked| {
+            self.additional_fields.insert(key.to_string(), masked);
+        });
+    }
+
     pub fn set_grpc_error_response(&mut self, tonic_error: &tonic::Status) {
         self.status_code = Some(tonic_error.code().into());
         let error_body = serde_json::json!({

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -1085,8 +1085,9 @@ fn create_event(
     event.add_service_name(event_params.service_name);
     event.add_tenant_id(event_params.tenant_id);
 
-    // Version metadata (Option A): stamp the four deployment fields on every event so A/B can
-    // group builds. Sourced from env (read once, cached); each field lands top-level in the event JSON.
+    // Version metadata: stamp the four deployment fields on every event so A/B can group builds.
+    // `version` is the compiled build (injected by the binary); `application_name`/`deployment_id`/
+    // `pod_name` are derived from the pod name in `HOSTNAME`. Computed once and cached.
     let version_metadata = version_metadata();
     if let Some(application_name) = &version_metadata.application_name {
         event.add_application_name(application_name);
@@ -1104,10 +1105,23 @@ fn create_event(
     event
 }
 
-/// Deployment version metadata, read once from the environment and cached.
-/// `application_name` = `APPLICATION_NAME` (the microservice name, e.g. `connector-service-http`),
-/// `version` = `VERSION` (the deployed build, e.g. `2026.07.08.0`), `deployment_id` = `DEPLOYMENT_ID`,
-/// `pod_name` = `POD_NAME`. Absent env vars leave the corresponding field off the event.
+/// The compiled build version, injected once by the binary at startup (e.g. from
+/// `ucs_env::git_describe!()`). Sourced from the binary rather than `ucs_env` directly to avoid a
+/// dependency cycle (`ucs_env` already depends on this crate), and rather than a config/env value
+/// because A/B groups on `version` and it must reflect the actual running build per deployment.
+static BUILD_VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Record the compiled build version so every event can be tagged with it. Called once by the
+/// binary at startup. No-op if called again.
+pub fn set_build_version(version: String) {
+    let _ = BUILD_VERSION.set(version);
+}
+
+/// Deployment version metadata, computed once and cached.
+/// - `version`: the compiled build (via [`set_build_version`]; falls back to the `VERSION` env var).
+/// - `application_name` / `deployment_id` / `pod_name`: derived from the pod name in `HOSTNAME`,
+///   which k8s sets to `<application_name>-<replicaset_hash>-<pod_suffix>` — so no plain env var or
+///   downward-API `fieldRef` is required from the deployment pipeline.
 struct VersionMetadata {
     application_name: Option<String>,
     version: Option<String>,
@@ -1117,11 +1131,34 @@ struct VersionMetadata {
 
 fn version_metadata() -> &'static VersionMetadata {
     static VERSION_METADATA: std::sync::OnceLock<VersionMetadata> = std::sync::OnceLock::new();
-    VERSION_METADATA.get_or_init(|| VersionMetadata {
-        application_name: std::env::var("APPLICATION_NAME").ok(),
-        version: std::env::var("VERSION").ok(),
-        deployment_id: std::env::var("DEPLOYMENT_ID").ok(),
-        pod_name: std::env::var("POD_NAME").ok(),
+    VERSION_METADATA.get_or_init(|| {
+        let version = BUILD_VERSION
+            .get()
+            .cloned()
+            .or_else(|| std::env::var("VERSION").ok());
+
+        // k8s sets HOSTNAME to the pod name: `<application_name>-<replicaset_hash>-<pod_suffix>`.
+        let (application_name, deployment_id, pod_name) = match std::env::var("HOSTNAME") {
+            Ok(hostname) if !hostname.is_empty() => {
+                let segments: Vec<&str> = hostname.split('-').collect();
+                if segments.len() >= 3 {
+                    let deployment_id = segments[segments.len() - 2].to_string();
+                    let application_name = segments[..segments.len() - 2].join("-");
+                    (Some(application_name), Some(deployment_id), Some(hostname))
+                } else {
+                    // Not a standard k8s pod name; keep the pod name only.
+                    (None, None, Some(hostname))
+                }
+            }
+            _ => (None, None, None),
+        };
+
+        VersionMetadata {
+            application_name,
+            version,
+            deployment_id,
+            pod_name,
+        }
     })
 }
 

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -1085,7 +1085,44 @@ fn create_event(
     event.add_service_name(event_params.service_name);
     event.add_tenant_id(event_params.tenant_id);
 
+    // Version metadata (Option A): stamp the four deployment fields on every event so A/B can
+    // group builds. Sourced from env (read once, cached); each field lands top-level in the event JSON.
+    let version_metadata = version_metadata();
+    if let Some(application_name) = &version_metadata.application_name {
+        event.add_application_name(application_name);
+    }
+    if let Some(version) = &version_metadata.version {
+        event.add_version(version);
+    }
+    if let Some(deployment_id) = &version_metadata.deployment_id {
+        event.add_deployment_id(deployment_id);
+    }
+    if let Some(pod_name) = &version_metadata.pod_name {
+        event.add_pod_name(pod_name);
+    }
+
     event
+}
+
+/// Deployment version metadata, read once from the environment and cached.
+/// `application_name` = `APPLICATION_NAME` (the microservice name, e.g. `connector-service-http`),
+/// `version` = `VERSION` (the deployed build, e.g. `2026.07.08.0`), `deployment_id` = `DEPLOYMENT_ID`,
+/// `pod_name` = `POD_NAME`. Absent env vars leave the corresponding field off the event.
+struct VersionMetadata {
+    application_name: Option<String>,
+    version: Option<String>,
+    deployment_id: Option<String>,
+    pod_name: Option<String>,
+}
+
+fn version_metadata() -> &'static VersionMetadata {
+    static VERSION_METADATA: std::sync::OnceLock<VersionMetadata> = std::sync::OnceLock::new();
+    VERSION_METADATA.get_or_init(|| VersionMetadata {
+        application_name: std::env::var("APPLICATION_NAME").ok(),
+        version: std::env::var("VERSION").ok(),
+        deployment_id: std::env::var("DEPLOYMENT_ID").ok(),
+        pod_name: std::env::var("POD_NAME").ok(),
+    })
 }
 
 pub enum ApplicationResponse<R> {

--- a/crates/grpc-server/grpc-server/src/main.rs
+++ b/crates/grpc-server/grpc-server/src/main.rs
@@ -9,6 +9,11 @@ use ucs_env::{configs, logger};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(debug_assertions)]
     verify_other_config_files();
+
+    // Record the compiled build version so the event system can tag every event with it
+    // (A/B groups on this `version`). Sourced from the binary because it must be per-build.
+    external_services::set_build_version(ucs_env::git_describe!().to_string());
+
     #[allow(clippy::expect_used)]
     let mut config = configs::Config::new().expect("Failed while parsing config");
 


### PR DESCRIPTION
What
----
Adds a version tag to every connector event so releases can be A/B-monitored (compare
old build vs new build). Each event now carries four top-level fields:

- version — the deployed build (A/B groups on this)
- application_name — the microservice (e.g. connector-service-http)
- deployment_id — the rollout / replicaset id
- pod_name — the pod name

How it is sourced (no deployment-config or infra changes required)
----
- version: injected once by the binary at startup from ucs_env::git_describe!()
  (compiled, per-build → correct for A/B grouping), via
  external_services::set_build_version(). Sourced from the binary rather than ucs_env
  directly to avoid a dependency cycle (ucs_env already depends on external-services),
  and rather than a config/env value because it must reflect the actual running build.
- application_name / deployment_id / pod_name: derived from the pod name in HOSTNAME,
  which k8s sets to <application_name>-<replicaset_hash>-<pod_suffix>.

This means the fields require nothing from the generate-env-configs pipeline (which only
emits CS__-prefixed vars from TOML) and no downward-API/valueFrom in the deployment
template — k8s already provides HOSTNAME and the version is compiled in.

Changes
----
- crates/common/common_utils/src/events.rs: add add_application_name / add_version /
  add_deployment_id / add_pod_name setters (masked, land in additional_fields).
- crates/common/external-services/src/service.rs: set_build_version() + version_metadata()
  (git_describe for version; HOSTNAME-derived for the rest); stamped in create_event.
- crates/grpc-server/grpc-server/src/main.rs: inject the compiled build version at startup.

Scope
----
- Applies to ConnectorCall-stage events (the connector events A/B compares).
- Works for both the grpc and http deployments (same grpc-server binary).

Testing
----
Live-verified against a real connector Authorize (2C2P PACO UAT, 200 CHARGED): the
ConnectorCall event carried all four fields, e.g.
application_name=connector-service-http, deployment_id=7d9f8b6c5,
pod_name=connector-service-http-7d9f8b6c5-x2k9p, version=2026.07.03.0-60-g433499aee.

Deployment note
----
No hyperswitch-infra changes needed. Requires deploying an image built from this branch;
HOSTNAME is set by k8s automatically.