### PR TITLE
fix(adyen): align repeat_payment outbound body with Authorize builder (captureDelayHours, holderName, splits)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -836,6 +836,7 @@ pub enum PaymentMethod<
     AdyenMandatePaymentMethod(Box<AdyenMandate>),
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdyenMandate {
@@ -5733,7 +5734,7 @@ fn get_additional_data_for_repeat_payment<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 >(
     item: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
-) -> Option<AdditionalData> {
+) -> Result<Option<AdditionalData>, Error> {
     let (authorisation_type, manual_capture) = match item.request.capture_method {
         Some(common_enums::CaptureMethod::Manual)
         | Some(common_enums::CaptureMethod::ManualMultiple) => {
@@ -5763,10 +5764,76 @@ fn get_additional_data_for_repeat_payment<
         MandateReferenceId::ConnectorMandateId(_) => None,
     };
 
-    Some(AdditionalData {
+    // Mirror hyperswitch: metadata.capture_delay_hours -> additionalData.captureDelayHours.
+    // hyperswitch runs MIT/repeat through its shared Authorize builder, so it emits this field;
+    // prism's dedicated repeat builder must apply the same mapping (see get_additional_data).
+    let capture_delay_hours = {
+        let metadata_capture_delay =
+            get_adyen_metadata(item.request.metadata.clone().map(|m| m.expose()))
+                .capture_delay_hours;
+
+        let capture_method = item.request.capture_method.unwrap_or_default();
+        match capture_method {
+            common_enums::CaptureMethod::Manual | common_enums::CaptureMethod::ManualMultiple => {
+                // For manual capture, capture_delay_hours should be None
+                if let Some(hours) = metadata_capture_delay {
+                    return Err(IntegrationError::InvalidDataFormat {
+                        field_name: "metadata.capture_delay_hours",
+                        context: IntegrationErrorContext {
+                            additional_context: Some(format!(
+                                "Adyen does not accept capture_delay_hours for manual capture \
+                                 (capture_method = {capture_method:?}), but metadata supplied {hours}"
+                            )),
+                            suggested_action: Some(
+                                "Remove capture_delay_hours from metadata when capture_method is \
+                                 Manual/ManualMultiple, or switch to automatic capture"
+                                    .to_string(),
+                            ),
+                            doc_url: Some(
+                                "https://docs.adyen.com/online-payments/capture/".to_string(),
+                            ),
+                        },
+                    }
+                    .into());
+                }
+                None
+            }
+            // For automatic capture, only 0 (or None) is valid
+            common_enums::CaptureMethod::Automatic
+            | common_enums::CaptureMethod::Scheduled
+            | common_enums::CaptureMethod::SequentialAutomatic => match metadata_capture_delay {
+                None => None,
+                Some(0) => Some(0),
+                Some(hours) => {
+                    return Err(IntegrationError::InvalidDataFormat {
+                        field_name: "metadata.capture_delay_hours",
+                        context: IntegrationErrorContext {
+                            additional_context: Some(format!(
+                                "Adyen only accepts capture_delay_hours of 0 (or unset) for \
+                                 automatic capture (capture_method = {capture_method:?}), but \
+                                 metadata supplied {hours}"
+                            )),
+                            suggested_action: Some(
+                                "Set metadata.capture_delay_hours to 0 (or omit it) for automatic \
+                                 capture"
+                                    .to_string(),
+                            ),
+                            doc_url: Some(
+                                "https://docs.adyen.com/online-payments/capture/".to_string(),
+                            ),
+                        },
+                    }
+                    .into());
+                }
+            },
+        }
+    };
+
+    Ok(Some(AdditionalData {
         authorisation_type,
         manual_capture,
         execute_three_d,
+        capture_delay_hours,
         network_tx_reference: None,
         recurring_detail_reference: None,
         recurring_shopper_reference: None,
@@ -5779,7 +5846,7 @@ fn get_additional_data_for_repeat_payment<
         }),
         transaction_link_id,
         ..AdditionalData::default()
-    })
+    }))
 }
 
 type RecurringDetails = (Option<AdyenRecurringModel>, Option<bool>, Option<String>);
@@ -6817,7 +6884,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let (recurring_processing_model, store_payment_method, shopper_reference) =
             get_recurring_processing_model_for_repeat_payment(&item.router_data)?;
         let browser_info = None;
-        let additional_data = get_additional_data_for_repeat_payment(&item.router_data);
+        let additional_data = get_additional_data_for_repeat_payment(&item.router_data)?;
         let return_url = item.router_data.request.router_return_url.clone().ok_or(
             IntegrationError::MissingRequiredField {
                 field_name: "return_url",
@@ -6943,7 +7010,14 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .map(|m| m.expose()),
         );
 
-        let (store, splits) = (adyen_metadata.store.clone(), None);
+        // Mirror hyperswitch: derive splits from request.split_payments (its shared Authorize
+        // builder does this for MIT). prism's repeat builder previously hardcoded splits = None.
+        let (store, splits) = match item.router_data.request.split_payments.as_ref() {
+            Some(SplitPaymentsDetails::AdyenSplitPayment(adyen_split_payment)) => {
+                get_adyen_split_request(adyen_split_payment, item.router_data.request.currency)
+            }
+            _ => (adyen_metadata.store.clone(), None),
+        };
         let device_fingerprint = adyen_metadata.device_fingerprint.clone();
         let platform_chargeback_logic = adyen_metadata.platform_chargeback_logic.clone();
 

--- a/data/field_probe/adyen.json
+++ b/data/field_probe/adyen.json
@@ -2557,7 +2557,7 @@
             "via": "HyperSwitch",
             "x-api-key": "probe_key"
           },
-          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"paypal\",\"storedPaymentMethodId\":\"probe-mandate-123\",\"holderName\":null},\"reference\":\"\",\"returnUrl\":\"https://example.com/recurring-return\",\"shopperInteraction\":\"ContAuth\",\"recurringProcessingModel\":\"UnscheduledCardOnFile\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperReference\":\"cust_probe_123\"}"
+          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"paypal\",\"storedPaymentMethodId\":\"probe-mandate-123\"},\"reference\":\"\",\"returnUrl\":\"https://example.com/recurring-return\",\"shopperInteraction\":\"ContAuth\",\"recurringProcessingModel\":\"UnscheduledCardOnFile\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperReference\":\"cust_probe_123\"}"
         }
       }
     },
@@ -2700,7 +2700,7 @@
             "via": "HyperSwitch",
             "x-api-key": "probe_key"
           },
-          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"scheme\",\"storedPaymentMethodId\":\"pm_1AbcXyzStripeTestToken\",\"holderName\":null},\"reference\":\"probe_tokenized_txn_001\",\"returnUrl\":\"https://example.com/return\",\"shopperInteraction\":\"Ecommerce\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperName\":{}}"
+          "body": "{\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantAccount\":\"probe_merchant\",\"paymentMethod\":{\"type\":\"scheme\",\"storedPaymentMethodId\":\"pm_1AbcXyzStripeTestToken\"},\"reference\":\"probe_tokenized_txn_001\",\"returnUrl\":\"https://example.com/return\",\"shopperInteraction\":\"Ecommerce\",\"additionalData\":{\"executeThreeD\":\"false\"},\"shopperName\":{}}"
         }
       }
     },


### PR DESCRIPTION
## What

Aligns prism's dedicated **adyen `repeat_payment` (MIT)** request builder with hyperswitch, which reuses its shared `Authorize` builder for MIT. The two builders had drifted, producing three outbound-body divergences flagged by shadow validation on `juspay/hyperswitch-cloud#20450` / child `#20451` (`adyen` / `repeat_payment`, 1404 occurrences).

Root cause: hyperswitch (Direct) has **no** separate RepeatPayment path — MIT recurring goes through `AdyenPaymentRequest::try_from((.., MandateReferenceId))` (the Authorize builder). prism has a **dedicated** `AdyenRepeatPaymentRequest::try_from` whose slimmer helpers omitted logic the shared hyperswitch path performs.

### Three facets (all in `connectors/adyen/transformers.rs`)

1. **`additionalData.captureDelayHours`** — `{hyperswitch:true, ucs:false}`
   `get_additional_data_for_repeat_payment` never computed `capture_delay_hours`. Now mirrors `get_additional_data`: maps `metadata.capture_delay_hours` → `captureDelayHours` (with the same manual-capture / non-zero validation). Helper now returns `Result<Option<AdditionalData>, Error>`.
2. **`paymentMethod.holderName`** — `{hyperswitch:false, ucs:true}`
   prism's `AdyenMandate` struct lacked `#[serde_with::skip_serializing_none]` (hyperswitch's has it), so a `None` `holder_name` serialized as `"holderName": null`. Added the attribute → the null field is omitted, matching hyperswitch.
3. **`splits`** — `{hyperswitch:true, ucs:false}`
   The repeat builder hardcoded `let (store, splits) = (adyen_metadata.store.clone(), None);`. Now derives splits from `request.split_payments` via the existing `get_adyen_split_request`, exactly as the Authorize path does. `split_payments` is already present on `RepeatPaymentData` — no proto change.

This is **UCS-only** (all data already available in `RepeatPaymentData`).

## Verification (local shadow stack, matched repro)

Adyen sandbox CIT (off-session mandate) → MIT `repeat_payment` with `metadata.capture_delay_hours=0`, read from the validation service `bodyComparison`:

**BEFORE** (main `40e5644a5`, x-req `019f801e-c072-7d42-8a47-d1b8e2ba9cf4`):
```
keyDiff = {
  "paymentMethod.holderName":         {"hyperswitch": false, "ucs": true},
  "additionalData.captureDelayHours": {"hyperswitch": true,  "ucs": false}
}
```
→ reproduces the issue signature exactly (the `splits` facet needs Adyen balance-platform `split_payments`, which is sandbox-gated and not exercised here; its fix is line-for-line parity with the Authorize path).

**AFTER** (this branch, x-req `019f801f-cf6b-7670-b1d8-d791ba5ac6ca`):
```
bodyComparison.keyDiff   = {}
bodyComparison.valueDiff = {}
bodyComparison.typeDiff  = {}
headerComparison.keyDiff = {"x-merchant-id": ...}   # ignore-listed
```

Both CIT and MIT returned `succeeded` on Adyen sandbox.

## Notes
- The `router_diff` children of #20450 (`connector_http_status_code`, `valueDiff:status`, `keyDiff:response.Ok/Err`, `amount_captured`, `network_*_code`, the `response.Err.*` cascade, etc.) are benign stateful-shadow / double-execution artifacts (post-response router-data comparison), not outbound-request bugs, and are out of scope for this transformer fix.
- No creds or `config/development.toml` in the diff.

Fixes juspay/hyperswitch-cloud#20451 (and the request-diff portion of #20450).
