### PR TITLE
fix(noon): payment-status mapping parity with Direct (UCS repeat_payment diffs #20501)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/noon.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon.rs
@@ -291,7 +291,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             noon::NoonPaymentStatus::Initiated
             | noon::NoonPaymentStatus::PaymentInfoAdded
             | noon::NoonPaymentStatus::Authenticated => AttemptStatus::Started,
-            noon::NoonPaymentStatus::Locked => AttemptStatus::Unspecified,
+            noon::NoonPaymentStatus::Locked | noon::NoonPaymentStatus::Unknown => {
+                AttemptStatus::Unspecified
+            }
         };
 
         let connector_order_id = webhook_object.order_id.to_string();

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -561,9 +561,12 @@ pub enum NoonPaymentStatus {
     Reversed,
     Rejected,
     Locked,
+    #[serde(other)]
+    Unknown,
 }
 
-fn get_payment_status(item: NoonPaymentStatus) -> AttemptStatus {
+fn get_payment_status(data: (NoonPaymentStatus, AttemptStatus)) -> AttemptStatus {
+    let (item, current_status) = data;
     match item {
         NoonPaymentStatus::Authorized => AttemptStatus::Authorized,
         NoonPaymentStatus::Captured
@@ -583,7 +586,14 @@ fn get_payment_status(item: NoonPaymentStatus) -> AttemptStatus {
         NoonPaymentStatus::Initiated
         | NoonPaymentStatus::PaymentInfoAdded
         | NoonPaymentStatus::Authenticated => AttemptStatus::Started,
-        NoonPaymentStatus::Locked => AttemptStatus::Unspecified,
+        NoonPaymentStatus::Locked => current_status,
+        NoonPaymentStatus::Unknown => {
+            tracing::warn!(
+                "Received unknown noon payment status; retaining previous status {:?}",
+                current_status
+            );
+            current_status
+        }
     }
 }
 
@@ -627,7 +637,10 @@ impl<F, T> TryFrom<ResponseRouterData<NoonPaymentsResponse, Self>>
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<NoonPaymentsResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status((
+            order.status,
+            item.router_data.resource_common_data.status,
+        ));
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1440,7 +1453,10 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<SetupMandateResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status((
+            order.status,
+            item.router_data.resource_common_data.status,
+        ));
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1658,7 +1674,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         } = item;
 
         let order = payments_response.result.order;
-        let status = get_payment_status(order.status);
+        let status = get_payment_status((
+            order.status,
+            router_data.resource_common_data.status,
+        ));
         let redirection_data = payments_response
             .result
             .checkout_data

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -637,10 +637,8 @@ impl<F, T> TryFrom<ResponseRouterData<NoonPaymentsResponse, Self>>
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<NoonPaymentsResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status((
-            order.status,
-            item.router_data.resource_common_data.status,
-        ));
+        let status =
+            get_payment_status((order.status, item.router_data.resource_common_data.status));
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1453,10 +1451,8 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
     type Error = error_stack::Report<ConnectorError>;
     fn try_from(item: ResponseRouterData<SetupMandateResponse, Self>) -> Result<Self, Self::Error> {
         let order = item.response.result.order;
-        let status = get_payment_status((
-            order.status,
-            item.router_data.resource_common_data.status,
-        ));
+        let status =
+            get_payment_status((order.status, item.router_data.resource_common_data.status));
         let redirection_data = item.response.result.checkout_data.map(|redirection_data| {
             Box::new(RedirectForm::Form {
                 endpoint: redirection_data.post_url.to_string(),
@@ -1674,10 +1670,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         } = item;
 
         let order = payments_response.result.order;
-        let status = get_payment_status((
-            order.status,
-            router_data.resource_common_data.status,
-        ));
+        let status = get_payment_status((order.status, router_data.resource_common_data.status));
         let redirection_data = payments_response
             .result
             .checkout_data

--- a/grace/fixtures/noon/repeat_payment/20501.json
+++ b/grace/fixtures/noon/repeat_payment/20501.json
@@ -1,0 +1,14 @@
+{
+  "_issue": "juspay/hyperswitch-cloud#20501 (noon/repeat_payment status-mapping parity)",
+  "_note": "MIT repeat_payment. Requires a prior CIT with setup_future_usage=off_session to mint mandate_id. Card 4111111111111111 exp 03/2030.",
+  "amount": 1700,
+  "currency": "AED",
+  "confirm": true,
+  "capture_method": "automatic",
+  "customer_id": "noon_mit_cust",
+  "email": "noon@example.com",
+  "description": "noon mit repeat",
+  "off_session": true,
+  "connector_metadata": {"noon": {"order_category": "pay"}},
+  "recurring_details": {"type": "mandate_id", "data": "<mandate_id_from_CIT>"}
+}


### PR DESCRIPTION
## What

Aligns the **noon** connector's payment-status mapping in prism (UCS) with hyperswitch **Direct**, closing a real UCS-parity gap in prism's handling of unenumerated / `LOCKED` noon statuses. Surfaced while triaging the production shadow-validation diffs on `juspay / noon / repeat_payment` ([`#20501`](https://github.com/juspay/hyperswitch-cloud/issues/20501) family).

> **Attribution corrected 2026-07-22 — this PR does _not_ fix #21217 / #21218 / #21219.** An earlier revision of this description claimed it did. That claim did not survive code review; see [_"What this PR does not fix"_](#what-this-pr-does-not-fix) below. The parity gap fixed here is real and independently worth closing, but those three issues are one benign event with a different cause.

## Root cause (the real gap)

hyperswitch Direct (`hyperswitch_connectors/src/connectors/noon/transformers.rs`) maps noon status like this:

- `NoonPaymentStatus` has a `#[serde(other)] Unknown` fallback (`:556-557`, added 2026-07-09 in `3c4fee8eb3b`).
- `get_payment_status((status, current_status))` (`:560`) threads the **current** attempt status; both `Locked` (`:581`) and `Unknown` (`:582-588`) return `current_status`.

Prism is behind on both counts:

- `NoonPaymentStatus` has **no** `#[serde(other)]` arm (`:539-564`) → any unenumerated noon status makes `parse_struct` **fail**, so the whole response falls into the deserialization-error branch. Direct instead parses it to `Unknown` and produces `Ok(TransactionResponse)` carrying the previous status.
- Prism maps `Locked => AttemptStatus::Unspecified` (`:586`) rather than threading `current_status`.

The consequence that actually matters is **not** shadow-mode noise — it is that in **live UCS mode** any noon status outside the enumerated set hard-fails a payment that Direct would have handled gracefully. That is a genuine robustness regression relative to Direct, and it is what this PR closes.

All other status arms and the entire error-code/message mapping were already **byte-identical** between the two repos.

## Fix (UCS-only, no proto change)

- Add `#[serde(other)] Unknown` to `NoonPaymentStatus`.
- Change `get_payment_status` to accept `(NoonPaymentStatus, AttemptStatus)` and map `Locked => current_status`, `Unknown => current_status` (with a warn), mirroring Direct exactly.
- Thread `resource_common_data.status` at the three response call sites (Authorize/PSync `:637`, SetupMandate `:1451`, RepeatPayment `:1670`).
- Webhook path (`noon.rs:294`, no prior-status context) maps `Unknown` alongside `Locked` to `Unspecified`.

## Verification (re-run 2026-07-22 on latest `main`)

Rebased onto `main` @ `f2585b22a` (was 10 commits behind; **zero conflicts**), rebuilt `cargo build -p grpc-server` ✅, prism restarted, noon MIT `repeat_payment` re-fired through the local shadow stack (CIT `off_session` + `mandate_data.multi_use` → mandate → MIT via `recurring_details`).

x-request-id `019f889a-c763-7e82-84db-714cb36f0139`, payment `pay_UyV7N0muN6aKRVAp6JVk`:

```
request_diff  bodyComparison.keyDiff:   {}
              bodyComparison.valueDiff: {}
              bodyComparison.typeDiff:  {}

router_data   comparison_metadata.differences_found: false
              response arm   Ok == Ok
              status         charged == charged
              connector_http_status_code  200 == 200  (both number)
```

Full RouterData leg diff is a single line — `external_latency` 1117 vs 102 — i.e. byte-identical apart from timing.

The `Locked` / unenumerated-status paths cannot be forced against the noon **sandbox** (it only ever returns enumerated statuses), so those arms are validated by exact code-parity with Direct plus the green happy-path regression above.

<a name="what-this-pr-does-not-fix"></a>
## What this PR does **not** fix

`#21217` (`keyDiff:response.Err`), `#21218` (`keyDiff:response.Ok`) and `#21219` (`valueDiff:status`) share **one** x-request-id (`019f428f-5fb0-7ad2-b2d6-98cd415e509f` → 2026-07-08T16:28:40.240Z) and **one** payment id — they are three facets of a single event, not three bugs. Two independent code arguments rule this change out as their fix:

1. **A prism deser failure cannot produce a `valueDiff:status`.** `hyperswitch_interfaces/src/helpers.rs:65-75` serialises a failed shadow leg as a flat `{"error": "<string>"}` object — it has **no** `status` key and **no** `connector_http_status_code` key. A missing `#[serde(other)]` could therefore only ever yield *keyDiffs* on those fields. A reported `valueDiff:status` proves the UCS leg returned a **full** `RouterData`, i.e. prism parsed the response fine. (Independently: Direct itself only gained `Unknown` on 2026-07-09, ~24 h *after* the event — pre-fix both sides would have failed identically.)

2. **The `Locked` mapping converges on the wire; it cannot diverge.** prism `Locked => AttemptStatus::Unspecified` → `domain_types/src/types.rs:6862` `Unspecified => PaymentStatus::Unspecified` → hs `hyperswitch_interfaces/src/unified_connector_service/transformers.rs:601` `PaymentStatus::Unspecified => Ok(prev_status)`. For repeat_payment, `prev_status` is `router_data.status` (`authorize_gateway.rs:180-184` → `unified_connector_service.rs:2351-2354`), which is exactly the same pre-call status Direct passes as `current_status` (`noon/transformers.rs:634`). Both legs land on the identical value.

Those three issues are instead the benign 2026-07-08 stateful-shadow **arm flip**: the shadow leg is a second *live* MIT call (`hyperswitch_interfaces/src/api/gateway.rs:413` `tokio::spawn`), noon answers it differently (duplicate/decline vs the original), so the Ok/Err arm and `status` diverge while both legs return HTTP 200 — which is why the trio has **no** `connector_http_status_code` facet. `#21217` and `#21218` were already triaged and closed as benign on that basis; `#21219` is the un-closed third facet of the same event.

### Note on the two high-volume siblings (#20502, #20503)

`#20502` (`typeDiff:connector_http_status_code`) and `#20503` (`valueDiff:response.Err.code`, **both** legs `Err` with different codes) are the same benign stateful-shadow / double-execution artifact. No code change addresses those; they are not fixed here.

_Regression fixture: `grace/fixtures/noon/repeat_payment/20501.json`. No creds; `config/development.toml` excluded._
