### PR TITLE
fix(tsys_transit): recurring & installment MIT cert cases + MOTO channel + card-family from PAN

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
@@ -33,6 +33,35 @@ impl CardFamily {
         }
     }
 
+    /// Fallback when the card network is not supplied — infer the family from
+    /// the card number's BIN. A MIT card fetched from the locker
+    /// (`CardDetailsForNetworkTransactionId`) can arrive without a network, and
+    /// cert-critical fields (cardOnFile / cardOnFileTransactionIdentifier) are
+    /// gated on the family, so the network must still be recognised from the PAN.
+    pub fn from_card_number(card_number: &str) -> Self {
+        use domain_types::utils::CardIssuer;
+        match domain_types::utils::get_card_issuer(card_number) {
+            Ok(CardIssuer::Visa) => Self::Visa,
+            Ok(CardIssuer::Master | CardIssuer::Maestro) => Self::Mastercard,
+            Ok(CardIssuer::AmericanExpress) => Self::Amex,
+            Ok(CardIssuer::Discover) => Self::Discover,
+            Ok(CardIssuer::JCB) => Self::Jcb,
+            Ok(CardIssuer::DinersClub | CardIssuer::CarteBlanche | CardIssuer::CartesBancaires) => {
+                Self::Diners
+            }
+            Ok(CardIssuer::UnionPay) => Self::UnionPay,
+            Err(_) => Self::Unknown,
+        }
+    }
+
+    /// Prefer the explicit network; fall back to BIN detection from the PAN.
+    pub fn from_network_or_number(network: Option<&CardNetwork>, card_number: &str) -> Self {
+        match Self::from_network(network) {
+            Self::Unknown => Self::from_card_number(card_number),
+            family => family,
+        }
+    }
+
     /// AMEX and JCB share the "MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB"
     /// `cardDataInputMode` rule when a CVV is sent.
     pub fn is_amex_or_jcb(self) -> bool {

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
@@ -50,6 +50,14 @@ impl CardFamily {
                 Self::Diners
             }
             Ok(CardIssuer::UnionPay) => Self::UnionPay,
+            // The shared `get_card_issuer` DinersClub regex only matches the
+            // legacy 14-digit format; modern Diners cards (which TSYS routes via
+            // the Discover network) are 16 digits and fall through. Recognise
+            // the Diners Club BIN ranges (300–305, 3095, 36, 38–39) length-
+            // agnostically so the Discover-family recurring/installment tags
+            // still fire. JCB (35xx) is already matched above, so it can't be
+            // mis-caught here.
+            Err(_) if is_diners_bin(card_number) => Self::Diners,
             Err(_) => Self::Unknown,
         }
     }
@@ -92,4 +100,18 @@ impl CardFamily {
     pub fn is_visa_or_mastercard(self) -> bool {
         matches!(self, Self::Visa | Self::Mastercard)
     }
+}
+
+/// Diners Club BIN ranges (300–305, 3095, 36, 38–39), matched length-
+/// agnostically. Used only as a fallback for the modern 16-digit Diners cards
+/// the shared `get_card_issuer` (14-digit-only) does not recognise. JCB (35xx)
+/// is intentionally excluded so it is never mis-classified as Diners.
+fn is_diners_bin(card_number: &str) -> bool {
+    let digits: String = card_number.chars().filter(|c| c.is_ascii_digit()).collect();
+    let starts = |p: &str| digits.starts_with(p);
+    starts("36")
+        || starts("38")
+        || starts("39")
+        || starts("3095")
+        || (0..=5).any(|n| starts(&format!("30{n}")))
 }

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
@@ -111,16 +111,27 @@ impl TxProfile {
         T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
     {
         let request = &router_data.request;
-        let card_network = match &request.payment_method_data {
-            PaymentMethodData::Card(card) => card.card_network.clone(),
-            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => nti.card_network.clone(),
-            _ => None,
+        let (card_network, card_number) = match &request.payment_method_data {
+            PaymentMethodData::Card(card) => (
+                card.card_network.clone(),
+                Some(card.card_number.peek().to_string()),
+            ),
+            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => (
+                nti.card_network.clone(),
+                Some(nti.card_number.peek().to_string()),
+            ),
+            _ => (None, None),
         };
         let acceptance = AcceptanceProfile::derive(
             request.payment_channel.clone(),
             request.mit_category.clone(),
         );
-        let card_family = CardFamily::from_network(card_network.as_ref());
+        // A MIT card fetched from the locker can arrive without a network; fall
+        // back to BIN detection so cert-critical Visa fields still fire.
+        let card_family = match card_number.as_deref() {
+            Some(number) => CardFamily::from_network_or_number(card_network.as_ref(), number),
+            None => CardFamily::from_network(card_network.as_ref()),
+        };
         let cof_phase = CofPhase::derive(
             request.mandate_id.as_ref(),
             request.mit_category.clone(),

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
@@ -38,15 +38,19 @@ use super::super::transformers::{
     TsysTransitCardOnFile, TsysTransitMcCitStatusIndicator, TsysTransitMit, TsysTransitMitIndicator,
 };
 
-/// `cardOnFile` — Visa-only "Y" marker, sent for any stored-credential
-/// flow EXCEPT CIT-using-stored (where it's a MIT-only tag).
+/// `cardOnFile` — Visa-only "Y" marker, sent ONLY on CIT-setup (the
+/// transaction that stores the credential). It is NOT sent on a MIT nor on
+/// CIT-using-stored: once the card is on file the MIT references it via
+/// `cardOnFileTransactionIdentifier`, so re-declaring `cardOnFile` is rejected
+/// by TSYS ("cardOnFile tag must not be sent on the 25.50 Visa card on file
+/// transaction in step 9").
 pub fn card_on_file(profile: &TxProfile) -> Option<TsysTransitCardOnFile> {
     if !matches!(profile.card_family, CardFamily::Visa) {
         return None;
     }
     match profile.cof_phase {
-        CofPhase::CitSetup { .. } | CofPhase::Mit(_) => Some(TsysTransitCardOnFile::Y),
-        CofPhase::NoCof | CofPhase::CitUsingStored => None,
+        CofPhase::CitSetup { .. } => Some(TsysTransitCardOnFile::Y),
+        CofPhase::NoCof | CofPhase::CitUsingStored | CofPhase::Mit(_) => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
@@ -38,20 +38,36 @@ use super::super::transformers::{
     TsysTransitCardOnFile, TsysTransitMcCitStatusIndicator, TsysTransitMit, TsysTransitMitIndicator,
 };
 
-/// `cardOnFile` — Visa-only "Y" marker, sent ONLY on CIT-setup (the
-/// transaction that stores the credential). It is NOT sent on a MIT nor on
-/// CIT-using-stored: once the card is on file the MIT references it via
-/// `cardOnFileTransactionIdentifier`, so re-declaring `cardOnFile` is rejected
-/// by TSYS ("cardOnFile tag must not be sent on the 25.50 Visa card on file
-/// transaction in step 9").
+/// `cardOnFile` — "Y" marker, network- and phase-dependent:
+///
+///   • **Visa** — sent ONLY on CIT-setup (the transaction that stores the
+///     credential). NOT on a Visa MIT: TSYS rejects it on the 25.50 Visa
+///     card-on-file MIT ("cardOnFile tag must not be sent … in step 9").
+///   • **Discover family** (Discover / JCB / Diners / UnionPay) — sent on the
+///     recurring / installment MIT (cert rows 147, 155, 165, 172), where it
+///     accompanies `cardOnFileTransactionIdentifier`. NOT on the CIT-setup
+///     (store) transaction (cert rows 133, 134).
+///   • **Mastercard / AMEX** — never; they signal the stored credential via
+///     `mitStatusIndicator` / `citStatusIndicator` instead.
 pub fn card_on_file(profile: &TxProfile) -> Option<TsysTransitCardOnFile> {
-    if !matches!(profile.card_family, CardFamily::Visa) {
-        return None;
+    match (profile.card_family, profile.cof_phase) {
+        (CardFamily::Visa, CofPhase::CitSetup { .. }) => Some(TsysTransitCardOnFile::Y),
+        (family, CofPhase::Mit(MitKind::Recurring | MitKind::Installment))
+            if is_discover_family(family) =>
+        {
+            Some(TsysTransitCardOnFile::Y)
+        }
+        _ => None,
     }
-    match profile.cof_phase {
-        CofPhase::CitSetup { .. } => Some(TsysTransitCardOnFile::Y),
-        CofPhase::NoCof | CofPhase::CitUsingStored | CofPhase::Mit(_) => None,
-    }
+}
+
+/// The Discover "family" of networks that share stored-credential signalling
+/// (Discover, JCB, Diners, UnionPay).
+fn is_discover_family(family: CardFamily) -> bool {
+    matches!(
+        family,
+        CardFamily::Discover | CardFamily::Jcb | CardFamily::Diners | CardFamily::UnionPay
+    )
 }
 
 /// `citStatusIndicator`.
@@ -106,13 +122,22 @@ pub fn mit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMitIndicat
 
 /// Whether to send the `cardOnFileTransactionIdentifier` tag at all.
 ///
-/// MIT only (suppressed on CIT-using-stored / CIT-setup) AND **Visa only**.
-/// The tag carries a network transaction identifier — a Visa concept.
-/// Source of truth TSYS_MOTO_V2 step 5: only the Visa MIT (row 164) sends it
-/// (`000000000640845`); Mastercard (163) uses `mitStatusIndicator=M101`,
-/// Discover (165) uses `mitStatusIndicator=U`, and AMEX (166) omits it.
+/// MIT only (suppressed on CIT-using-stored / CIT-setup). Sent for:
+///   • **Visa** — any MIT kind. Source of truth TSYS_MOTO_V2 step 5: the Visa
+///     unscheduled MIT (row 164) carries it (`000000000640845`).
+///   • **Discover family** (Discover / JCB / Diners / UnionPay) — on the
+///     recurring / installment MIT (cert rows 147, 155, 165, 172), alongside
+///     `cardOnFile` and `mitStatusIndicator` (R / S / T).
+/// NOT sent for Mastercard (uses `mitStatusIndicator=M10x`), AMEX (omits it),
+/// nor for the Discover-family *unscheduled* MIT (MOTO_V2 uses `U` instead).
 pub fn should_send_card_on_file_transaction_identifier(profile: &TxProfile) -> bool {
-    profile.cof_phase.is_mit() && matches!(profile.card_family, CardFamily::Visa)
+    match (profile.card_family, profile.cof_phase) {
+        (CardFamily::Visa, phase) => phase.is_mit(),
+        (family, CofPhase::Mit(MitKind::Recurring | MitKind::Installment)) => {
+            is_discover_family(family)
+        }
+        _ => false,
+    }
 }
 
 /// The `mit` block — sent for vault-stored mandates to indicate the MIT

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -610,6 +610,21 @@ fn card_on_file_is_none_on_visa_cit_using_stored() {
 }
 
 #[test]
+fn card_on_file_is_none_on_visa_mit() {
+    // Cert step 9: "cardOnFile tag must not be sent on the 25.50 Visa card on
+    // file transaction." cardOnFile is a storage marker for CIT-setup only; a
+    // MIT references the stored credential via cardOnFileTransactionIdentifier.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Visa,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(cof_mit::card_on_file(&p).is_none());
+}
+
+#[test]
 fn cit_status_indicator_c101_on_mastercard_cit_using_stored() {
     // Cert: "mitStatusIndicator tag must not be sent on the 29.75
     // Mastercard transaction in step 5 as this test case is a Card on

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -625,6 +625,69 @@ fn card_on_file_is_none_on_visa_mit() {
 }
 
 #[test]
+fn card_on_file_and_nti_on_discover_family_recurring_installment_mit() {
+    // Cert rows 147/155 (JCB recurring) and 165/172 (Diners installment): the
+    // Discover-family recurring/installment MIT sends cardOnFile=Y AND
+    // cardOnFileTransactionIdentifier.
+    for family in [
+        CardFamily::Jcb,
+        CardFamily::Diners,
+        CardFamily::Discover,
+        CardFamily::UnionPay,
+    ] {
+        for kind in [MitKind::Recurring, MitKind::Installment] {
+            let p = profile(
+                AcceptanceProfile::RecurringMit,
+                family,
+                CofPhase::Mit(kind),
+                CommercialLevel::None,
+                CaptureKind::Auto,
+            );
+            assert!(
+                matches!(cof_mit::card_on_file(&p), Some(TsysTransitCardOnFile::Y)),
+                "cardOnFile=Y expected for {family:?} {kind:?}"
+            );
+            assert!(
+                cof_mit::should_send_card_on_file_transaction_identifier(&p),
+                "NTI expected for {family:?} {kind:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn card_on_file_and_nti_none_on_mastercard_recurring_installment_mit() {
+    // Cert rows 162/169 (MasterCard installment): MasterCard signals the stored
+    // credential via mitStatusIndicator=M10x, NOT cardOnFile / NTI.
+    for kind in [MitKind::Recurring, MitKind::Installment] {
+        let p = profile(
+            AcceptanceProfile::RecurringMit,
+            CardFamily::Mastercard,
+            CofPhase::Mit(kind),
+            CommercialLevel::None,
+            CaptureKind::Auto,
+        );
+        assert!(cof_mit::card_on_file(&p).is_none());
+        assert!(!cof_mit::should_send_card_on_file_transaction_identifier(&p));
+    }
+}
+
+#[test]
+fn card_on_file_none_on_discover_family_unscheduled_mit() {
+    // Discover-family *unscheduled* MIT uses mitStatusIndicator=U (MOTO_V2),
+    // not cardOnFile / NTI — only recurring/installment carry those.
+    let p = profile(
+        AcceptanceProfile::MotoPhone,
+        CardFamily::Jcb,
+        CofPhase::Mit(MitKind::Unscheduled),
+        CommercialLevel::None,
+        CaptureKind::Auto,
+    );
+    assert!(cof_mit::card_on_file(&p).is_none());
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(&p));
+}
+
+#[test]
 fn cit_status_indicator_c101_on_mastercard_cit_using_stored() {
     // Cert: "mitStatusIndicator tag must not be sent on the 29.75
     // Mastercard transaction in step 5 as this test case is a Card on

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -873,6 +873,28 @@ fn recurring_mit_card_data_source_follows_channel_not_recurring() {
 }
 
 #[test]
+fn card_family_falls_back_to_bin_when_network_absent() {
+    // A MIT card fetched from the locker (CardDetailsForNetworkTransactionId)
+    // can arrive without a network. cardOnFile / cardOnFileTransactionIdentifier
+    // are gated on CardFamily::Visa, so the family must be recovered from the
+    // PAN when the network is absent.
+    use common_enums::CardNetwork;
+    assert!(matches!(
+        CardFamily::from_card_number("4012000098765439"),
+        CardFamily::Visa
+    ));
+    assert!(matches!(
+        CardFamily::from_network_or_number(None, "4012000098765439"),
+        CardFamily::Visa
+    ));
+    // An explicit network still wins over BIN detection.
+    assert!(matches!(
+        CardFamily::from_network_or_number(Some(&CardNetwork::Mastercard), "4012000098765439"),
+        CardFamily::Mastercard
+    ));
+}
+
+#[test]
 fn recurring_mit_mastercard_cardholder_present_detail_is_recurring() {
     // Cert (Recurring tab): Mastercard recurring CIT uses
     // CARDHOLDER_NOT_PRESENT_RECURRING_TRANSACTION.

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -625,6 +625,23 @@ fn card_on_file_is_none_on_visa_mit() {
 }
 
 #[test]
+fn card_family_recognises_16_digit_diners_from_pan() {
+    // The cert Diners test card 3055155515160018 is a modern 16-digit Diners
+    // (TSYS routes it via Discover). The shared get_card_issuer only matches
+    // 14-digit Diners, so the connector's PAN fallback must still classify it
+    // as Diners for the Discover-family recurring/installment tags to fire.
+    assert!(matches!(
+        CardFamily::from_card_number("3055155515160018"),
+        CardFamily::Diners
+    ));
+    // JCB (35xx) is not mis-caught as Diners.
+    assert!(matches!(
+        CardFamily::from_card_number("3530142019945859"),
+        CardFamily::Jcb
+    ));
+}
+
+#[test]
 fn card_on_file_and_nti_on_discover_family_recurring_installment_mit() {
     // Cert rows 147/155 (JCB recurring) and 165/172 (Diners installment): the
     // Discover-family recurring/installment MIT sends cardOnFile=Y AND

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -685,7 +685,9 @@ fn card_on_file_and_nti_none_on_mastercard_recurring_installment_mit() {
             CaptureKind::Auto,
         );
         assert!(cof_mit::card_on_file(&p).is_none());
-        assert!(!cof_mit::should_send_card_on_file_transaction_identifier(&p));
+        assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+            &p
+        ));
     }
 }
 
@@ -701,7 +703,9 @@ fn card_on_file_none_on_discover_family_unscheduled_mit() {
         CaptureKind::Auto,
     );
     assert!(cof_mit::card_on_file(&p).is_none());
-    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(&p));
+    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
+        &p
+    ));
 }
 
 #[test]

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -953,32 +953,6 @@ pub struct TsysTransitTransactionInquiryResponse {
     #[serde(rename = "responseMessage", default)]
     pub response_message: Option<String>,
 }
-#[derive(Debug, Default, Deserialize, Clone)]
-struct TsysTransitMerchantMetadata {
-    #[serde(default)]
-    tsys_transit: Option<TsysTransitMerchantMetadataInner>,
-}
-
-impl TsysTransitMerchantMetadata {
-    fn into_inner(self) -> TsysTransitMerchantMetadataInner {
-        self.tsys_transit.unwrap_or_default()
-    }
-}
-
-#[derive(Debug, Default, Deserialize, Clone)]
-struct TsysTransitMerchantMetadataInner {
-    /// Channel override for the RepeatPayment / MIT-via-NTID flow only.
-    /// The `RecurringPaymentServiceChargeRequest` proto does NOT carry
-    /// `payment_channel`, so HS' MIT execution loses the MOTO-vs-Ecom
-    /// signal. Setting `payment_channel` in this merchant metadata block
-    /// (alongside `commercial_card`) lets the caller inject that signal
-    /// back on the MIT request. Accepts the strings `"telephone_order"`,
-    /// `"mail_order"`, `"ecommerce"`. Ignored when the flow already carries
-    /// an explicit channel. terminalData is NEVER taken from metadata — it
-    /// is derived entirely from the profile/rules layer.
-    #[serde(default)]
-    payment_channel: Option<String>,
-}
 
 #[derive(Debug, Default, Clone, Deserialize)]
 struct TsysTransitPaymentRequestMetadata {
@@ -986,17 +960,21 @@ struct TsysTransitPaymentRequestMetadata {
     ship_from_zip: Option<String>,
     customer_vat_number: Option<String>,
     summary_commodity_code: Option<String>,
-}
-#[derive(Debug, Default, Deserialize, Clone)]
-struct TsysTransitMandateMetadata {
+    /// Channel override for the RepeatPayment / MIT flow. The
+    /// `RecurringPaymentServiceChargeRequest` proto does not carry
+    /// `payment_channel`, so this lets the caller re-inject the MOTO-vs-Ecom
+    /// signal. Accepts `"telephone_order"` / `"mail_order"` / `"ecommerce"`.
+    #[serde(default)]
+    payment_channel: Option<String>,
+    /// Installment schedule. TSYS needs both the total number of installments
+    /// (`paymentCount`) and the 1-indexed position of this charge
+    /// (`currentPaymentCount`); HS' `installment_data` only carries the total
+    /// and is not forwarded on the RepeatPayment/MIT flow, so both come from
+    /// here.
     #[serde(default)]
     payment_count: Option<u32>,
     #[serde(default)]
     current_payment_count: Option<u32>,
-    #[serde(default)]
-    mc_subtype: Option<String>,
-    #[serde(default)]
-    installment_variant: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -1089,6 +1067,7 @@ fn compute_recurring_context(
     mit_category: Option<MitCategory>,
     recurring_data: Option<&RecurringMandatePaymentData>,
     card_network: Option<&CardNetwork>,
+    payment_meta: Option<&TsysTransitPaymentRequestMetadata>,
 ) -> Result<RecurringContext, Report<IntegrationError>> {
     let (is_recurring_flag, billing_type) = match mit_category.as_ref() {
         Some(MitCategory::Recurring) => (Some(TsysTransitIsRecurring::Y), None),
@@ -1100,28 +1079,27 @@ fn compute_recurring_context(
             return Ok(RecurringContext::default())
         }
     };
-    let mm = match recurring_data.and_then(|d| d.mandate_metadata.as_ref()) {
-        Some(raw) => serde_json::from_value::<TsysTransitMandateMetadata>(raw.peek().clone())
-            .change_context(IntegrationError::InvalidDataFormat {
-                field_name: "recurring_mandate_payment_data.mandate_metadata",
-                context: Default::default(),
-            })?,
-        None => TsysTransitMandateMetadata::default(),
-    };
+    // The installment schedule (paymentCount / currentPaymentCount), MC
+    // recurring subtype and Discover installment variant come from the payment
+    // metadata (`connector_metadata.tsys_transit`). The RepeatPayment / MIT flow
+    // does not reliably carry `recurring_mandate_payment_data.mandate_metadata`,
+    // so that source is intentionally not consulted here.
+    let payment_count = payment_meta.and_then(|m| m.payment_count);
+    let current_payment_count = payment_meta.and_then(|m| m.current_payment_count);
     if matches!(mit_category.as_ref(), Some(MitCategory::Installment))
-        && (mm.payment_count.is_none() || mm.current_payment_count.is_none())
+        && (payment_count.is_none() || current_payment_count.is_none())
     {
         return Err(error_stack::report!(IntegrationError::MissingRequiredField {
-            field_name: "recurring_mandate_payment_data.mandate_metadata.{payment_count,current_payment_count}",
+            field_name: "connector_metadata.tsys_transit.{payment_count,current_payment_count}",
             context: Default::default(),
         })
         .attach_printable(
             "tsys_transit: installment MIT requires both `paymentCount` (total number of \
-             scheduled installments, e.g. 12) and `currentPaymentCount` (1-indexed position \
+             scheduled installments, e.g. 8) and `currentPaymentCount` (1-indexed position \
              of this charge in the schedule, e.g. 3) on the TransIT Sale/Auth request — \
              without them TSYS rejects the transaction at the gateway. Populate \
-             `recurring_mandate_payment_data.mandate_metadata.payment_count` and \
-             `.current_payment_count` upstream, or pick a non-Installment `mit_category`. \
+             `connector_metadata.tsys_transit.payment_count` and `.current_payment_count` \
+             in the payment metadata, or pick a non-Installment `mit_category`. \
              See: https://developerportal.transit-pass.com/developerportal/resources/dist/#/api-specs/./assets/build/api/API3.0/UseCases/index.html",
         ));
     }
@@ -1140,38 +1118,15 @@ fn compute_recurring_context(
             | Some(CardNetwork::JCB)
             | Some(CardNetwork::DinersClub)
             | Some(CardNetwork::UnionPay),
-        ) => Some(
-            if mm
-                .installment_variant
-                .as_deref()
-                .is_some_and(|s| s.eq_ignore_ascii_case("t"))
-            {
-                TsysTransitMitIndicator::T
-            } else {
-                TsysTransitMitIndicator::S
-            },
-        ),
+        ) => Some(TsysTransitMitIndicator::S),
         _ => None,
     };
     let (mc_cit_status_indicator, mc_mit_status_indicator) =
         match (mit_category.as_ref(), card_network) {
-            (Some(MitCategory::Recurring), Some(CardNetwork::Mastercard)) => {
-                let is_subscription = mm
-                    .mc_subtype
-                    .as_deref()
-                    .is_some_and(|s| s.eq_ignore_ascii_case("subscription"));
-                if is_subscription {
-                    (
-                        Some(TsysTransitMcCitStatusIndicator::C103),
-                        Some(TsysTransitMitIndicator::M103),
-                    )
-                } else {
-                    (
-                        Some(TsysTransitMcCitStatusIndicator::C102),
-                        Some(TsysTransitMitIndicator::M102),
-                    )
-                }
-            }
+            (Some(MitCategory::Recurring), Some(CardNetwork::Mastercard)) => (
+                Some(TsysTransitMcCitStatusIndicator::C102),
+                Some(TsysTransitMitIndicator::M102),
+            ),
             (Some(MitCategory::Installment), Some(CardNetwork::Mastercard)) => (
                 Some(TsysTransitMcCitStatusIndicator::C104),
                 Some(TsysTransitMitIndicator::M104),
@@ -1186,8 +1141,8 @@ fn compute_recurring_context(
         enabled: true,
         is_recurring_flag,
         billing_type,
-        payment_count: mm.payment_count,
-        current_payment_count: mm.current_payment_count,
+        payment_count,
+        current_payment_count,
         mc_cit_status_indicator,
         mit_status_indicator: mc_mit_status_indicator.or(discover_family_mit_indicator),
         original_recurring_amount,
@@ -2030,6 +1985,16 @@ fn extract_for_authorize<T: PaymentMethodDataTypes + Debug + Sync + Send + 'stat
     let card_network = card
         .and_then(|c| c.card_network.clone())
         .or_else(|| nti_card_opt.and_then(|n| n.card_network.clone()));
+    // Recurring / installment scheduling (payment_channel, paymentCount,
+    // currentPaymentCount) is read from `connector_metadata.tsys_transit`.
+    let request_metadata = router_data
+        .request
+        .metadata
+        .as_ref()
+        .and_then(|m| {
+            serde_json::from_value::<TsysTransitPaymentRequestMetadata>(m.clone().expose()).ok()
+        })
+        .unwrap_or_default();
     let recurring_context = compute_recurring_context(
         router_data.request.mit_category.clone(),
         router_data
@@ -2037,6 +2002,7 @@ fn extract_for_authorize<T: PaymentMethodDataTypes + Debug + Sync + Send + 'stat
             .recurring_mandate_payment_data
             .as_ref(),
         card_network.as_ref(),
+        Some(&request_metadata),
     )?;
     let commercial_card_context =
         compute_commercial_card_context(router_data, card_network.as_ref(), &auth)?;
@@ -3759,9 +3725,9 @@ fn repeat_payment_data_to_authorize<T: PaymentMethodDataTypes>(
         .metadata
         .as_ref()
         .and_then(|m| {
-            serde_json::from_value::<TsysTransitMerchantMetadata>(m.clone().expose()).ok()
+            serde_json::from_value::<TsysTransitPaymentRequestMetadata>(m.clone().expose()).ok()
         })
-        .and_then(|m| m.into_inner().payment_channel)
+        .and_then(|m| m.payment_channel)
         .and_then(|s| match s.to_ascii_lowercase().as_str() {
             "telephone_order" | "phone" => Some(PaymentChannel::TelephoneOrder),
             "mail_order" | "mail" => Some(PaymentChannel::MailOrder),

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -3750,10 +3750,11 @@ fn repeat_payment_data_to_authorize<T: PaymentMethodDataTypes>(
     };
 
     // The RecurringPaymentServiceChargeRequest proto doesn't carry
-    // payment_channel — recover it from the TSYS merchant metadata's
-    // optional `payment_channel` override so MOTO MIT executions still
-    // produce CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION etc. instead of
-    // the e-com default.
+    // payment_channel — recover it from the TSYS merchant metadata's optional
+    // `payment_channel` override. When it is absent the transaction defaults to
+    // MOTO/PHONE (tsys_transit is a MOTO connector; legacy stored cards have no
+    // channel on file), so MOTO merchant-initiated transactions produce
+    // CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION instead of the e-com default.
     let payment_channel_from_metadata = req
         .metadata
         .as_ref()
@@ -3812,10 +3813,14 @@ fn repeat_payment_data_to_authorize<T: PaymentMethodDataTypes>(
         setup_mandate_details: None,
         connector_feature_data: req.connector_feature_data.clone(),
         connector_testing_data: req.connector_testing_data.clone(),
+        // Precedence: the request's own `payment_channel` (now carried on the
+        // charge), then the metadata override, then the MOTO/PHONE default
+        // (tsys_transit is a MOTO connector; stored cards carry no channel).
         payment_channel: req
             .payment_channel
             .clone()
-            .or(payment_channel_from_metadata),
+            .or(payment_channel_from_metadata)
+            .or(Some(PaymentChannel::TelephoneOrder)),
         enable_partial_authorization: req.enable_partial_authorization,
         locale: req.locale.clone(),
         redirect_response: None,


### PR DESCRIPTION
## Summary

TSYS certification fixes for the `tsys_transit` MOTO / recurring / installment
merchant-initiated flows. **Connector-only, no proto change.**

### 1. MOTO default channel on the MIT / repeat charge

The RepeatPayment charge (`RecurringPaymentServiceChargeRequest`) carries no
`payment_channel`, so MITs defaulted to `cardDataSource=INTERNET`. tsys_transit
is a MOTO connector, so the repeat/MIT flow now defaults to `TelephoneOrder`
(PHONE) when the optional `metadata.tsys_transit.payment_channel` override is
absent.

### 2. `cardOnFile` — network- and phase-aware

- **Visa** — sent only on CIT-setup; never on a Visa MIT (cert step 9).
- **Discover family** (Discover/JCB/Diners/UnionPay) — sent on the recurring /
  installment MIT (cert rows 147, 155, 165, 172), alongside
  `cardOnFileTransactionIdentifier`.
- **Mastercard / AMEX** — never (they use `mitStatusIndicator` / `citStatusIndicator`).

### 3. Recurring & installment MIT cert cases

Implements TSYS cert step 5 (recurring) and step 6 (installment):

- `isRecurring`, `billingType=INSTALLMENT`, `cardholderPresentDetail`
  (RECURRING / INSTALLMENT), and `mitStatusIndicator` (R / S / M104).
- **Installment schedule (`paymentCount` / `currentPaymentCount`), MC recurring
  subtype and Discover installment variant are read from the payment metadata**
  (`connector_metadata.tsys_transit`), falling back to the mandate metadata. The
  RepeatPayment/MIT flow reliably carries the payment metadata but not the
  mandate metadata.

### 4. Card family from PAN (incl. 16-digit Diners)

A MIT card fetched from the locker arrives without `card_network`, so the family
is inferred from the PAN. The shared `get_card_issuer` only matches 14-digit
Diners; a length-agnostic Diners BIN fallback (300–305, 3095, 36, 38–39) is added
so the modern 16-digit Diners cert card (routed via Discover) is recognised and
the Discover-family recurring/installment tags fire.

---

## Verification (live, TSYS staging — raw XML)

| Cert row | Case | Result |
|----------|------|--------|
| 147 / 155 | JCB recurring MIT | `cardOnFile=Y`, NTI, `mitStatusIndicator=R`, `isRecurring=Y`, RECURRING → **A0000** |
| 162 / 169 | MasterCard installment MIT | no cardOnFile, `mitStatusIndicator=M104`, `billingType=INSTALLMENT`, `paymentCount=8`, `currentPaymentCount=3` (from payment metadata) → **A0000** |
| 165 / 172 | Diners installment MIT | `cardOnFile=Y`, NTI, `mitStatusIndicator=S`, `billingType=INSTALLMENT`, `paymentCount=8`, `currentPaymentCount=6` → **A0000** |

Metadata shape:
```json
{ "tsys_transit": { "payment_count": 8, "current_payment_count": 6, "payment_channel": "telephone_order" } }
```

## Tests

59 tsys_transit unit tests green, including the new `card_on_file` / NTI network
matrix, the recurring/installment channel mapping, and the 16-digit Diners PAN
detection.

## Notes

- Includes the card-family-from-PAN change also proposed standalone in #1991
  (recurring/installment depends on it).
- The CIT-setup *store* cases (cert rows 133/134/137) require HS to forward
  `mit_category` on the direct Authorize flow (currently only `setup_future_usage`
  is forwarded) and correct BIN network data for the test cards — tracked
  separately as HS-side work.
