### PR TITLE
fix(novalnet): keep attempt status on Authorize API FAILURE to match Hyperswitch (#21047)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -825,10 +825,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     transaction_id,
                 ));
                 Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status: common_enums::AttemptStatus::Failure,
-                        ..item.router_data.resource_common_data
-                    },
                     response,
                     ..item.router_data
                 })

--- a/grace/fixtures/novalnet/authorize/21047.json
+++ b/grace/fixtures/novalnet/authorize/21047.json
@@ -1,0 +1,15 @@
+{
+  "issue": 21047,
+  "child_issue": 21051,
+  "connector": "novalnet",
+  "flow": "authorize",
+  "merchant": "bu_de_micromobility",
+  "note": "Novalnet API-level FAILURE (HTTP 200, result.status=FAILURE) must NOT override attempt status. prism's Authorize Failure arm hard-wrote AttemptStatus::Failure while HS Direct leaves resource_common_data.status untouched -> router_diff valueDiff:status {hyperswitch:pending, ucs:failure}. Authorize sibling of prism #1853 (SetupMandate) / #1668 (PSync). Repro: any novalnet authorize whose response envelope is FAILURE (e.g. invalid auth header).",
+  "amount": 1000, "currency": "EUR", "capture_method": "automatic",
+  "payment_method": "card", "payment_method_type": "credit",
+  "authentication_type": "no_three_ds",
+  "card_number": "4111111111111111",
+  "card_exp_month": "03", "card_exp_year": "2030", "card_cvc": "123",
+  "billing": {"line1": "Hauptstr 1", "city": "Berlin", "country": "DE", "zip": "10115"},
+  "expected": {"routerData": {"keyDiff": {}, "valueDiff": {}}}
+}


### PR DESCRIPTION
## Summary

Novalnet signals application-level failures with **HTTP 200** and `result.status = FAILURE`. The UCS `Authorize` transformer's Failure arm hard-wrote `AttemptStatus::Failure` into `resource_common_data`, while Hyperswitch **Direct**'s equivalent arm leaves `router_data.status` untouched and lets the core derive the attempt status from the `Err` response.

That single line diverges on **every declined novalnet authorize**, producing the shadow `router_diff`:

```
valueDiff.status = {"hyperswitch": "pending", "ucs": "failure"}
```

This is the **Authorize sibling** of the identical divergence already addressed for `SetupMandate` in #1853 and `PSync` in #1668. The `Success` arm is unchanged.

Resolves the `router.valueDiff:status` facet of juspay/hyperswitch-cloud#21047 (child #21051).

## The divergence

| | Failure arm behaviour |
|---|---|
| HS Direct — `hyperswitch_connectors/src/connectors/novalnet/transformers.rs:827-839` | `Ok(Self { response, ..item.data })` — status untouched |
| prism (before) — `novalnet/transformers.rs:821-835` | overwrote `status: AttemptStatus::Failure` |

```rust
             Ok(Self {
-                resource_common_data: PaymentFlowData {
-                    status: common_enums::AttemptStatus::Failure,
-                    ..item.router_data.resource_common_data
-                },
                 response,
                 ..item.router_data
             })
```

## Verification (local shadow stack, router on `hyperswitch` main `97afdfa3aa`)

Forced a novalnet `result.status = FAILURE` (HTTP 200) so **both** legs take the Failure arm — no arm flip, isolating the override.

**BEFORE** — `GET :9100/validation-service/api/router-data/requests/router_data_novalnet_Authorize_019f8797-c018-7ed2-91c6-6f2cee230551_pay_ztJdRrusep8slP1pE6lt`

```json
"differences_found": true,
"comparison_results": {
  "keyDiff": {},
  "valueDiff": { "status": { "hyperswitch": "pending", "ucs": "failure" } },
  "typeDiff": { "response.Err.attempt_status": { "hyperswitch": "null", "ucs": "string" } }
}
```

**AFTER** — `router_data_novalnet_Authorize_019f879a-effc-7d41-a2e3-428bb496d3ef_pay_Lh2veiFzPd1t0AB1AuuY`

```json
"comparison_results": {
  "keyDiff": {},
  "valueDiff": {},
  "typeDiff": { "response.Err.attempt_status": { "hyperswitch": "null", "ucs": "string" } }
}
```

`keyDiff: {}` and the targeted `valueDiff.status` is **eliminated** — both legs now report `status = pending`, `connector_http_status_code = 200`, arm `Err`.

**Happy-path regression** (valid creds, same request shape) — `router_data_novalnet_Authorize_..._pay_v6AuUaQLg23Xfu5qQJDS` and the post-fix re-run:

```
differences_found = false      comparison_results = null
HS  | status=authentication_pending | chsc=200 | arm=Ok
UCS | status=authentication_pending | chsc=200 | arm=Ok
```

The outbound request comparison was already clean before and after (`bodyComparison.keyDiff: {}`), consistent with #21047 having zero `request_diff` children.

## Scope note — the other three facets of #21047 are NOT code bugs

| Child | Signature | Verdict |
|---|---|---|
| #21051 | `valueDiff:status` | **Fixed here** |
| #21048 / #21049 | `keyDiff:response.Err` + `keyDiff:response.Ok` | Benign — keyDiff on *both* arms for the same request is an **arm flip**: the shadow leg is a second *live* call (`hyperswitch_interfaces/src/api/gateway.rs:387-449`, `tokio::spawn` at `:413`), so a stateful connector can legitimately answer differently. No mapping bug. |
| #21050 | `typeDiff:connector_http_status_code` | **Deploy lag**, not a code gap — closed by merged hyperswitch #13003 (`bb5f225df2`, 2026-06-29), which added `router_data.connector_http_status_code = Some(status_code)` on the UCS connector-error early-return. Prod rollout of that binary is dated 2026-07-17; #21047's occurrences are 2026-07-08. Both legs populate `chsc` on current main (verified above). |

Rival hypothesis ruled out on shape: a prism strict-deser failure (novalnet's prism enums lack `#[serde(other)]`, `transformers.rs:634-651`) raises `ResponseDeserializationFailed`, whose `error_code != "CONNECTOR_ERROR_RESPONSE"`, so the router refuses to build an `ErrorResponse` (`hyperswitch_interfaces/src/unified_connector_service/transformers.rs:1150-1200`) and the shadow leg emits **no** router-data at all — it therefore cannot produce these facets.

## Follow-ups (not in scope here)

- The same `status: AttemptStatus::Failure` override still exists in prism's novalnet `repeat_payment` (`:1039`), `capture` (`:1651`), `void` (`:1861`) and `incremental_authorization` (`:2541`) arms; `setup_mandate`/`psync` are covered by #1853 / #1668.
- Latent: prism's `NovalnetTransactionStatus` / `NovalnetAPIStatus` lack `#[serde(other)]` and `ResultData.status_code` is non-`Option`, where HS Direct tolerates both.
- Residual `typeDiff: response.Err.attempt_status` is router-side (the UCS `ErrorResponse` is rebuilt from the proto status) and was present before this change; it is not one of #21047's reported facets.

No credentials in this diff; `config/development.toml` is excluded.
