### PR TITLE
fix(tsys_transit): infer card family from PAN when network is absent (Visa MIT NTI)

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/card_family.rs
@@ -33,6 +33,35 @@ impl CardFamily {
         }
     }
 
+    /// Fallback when the card network is not supplied — infer the family from
+    /// the card number's BIN. A MIT card fetched from the locker
+    /// (`CardDetailsForNetworkTransactionId`) can arrive without a network, and
+    /// cert-critical fields (cardOnFile / cardOnFileTransactionIdentifier) are
+    /// gated on the family, so the network must still be recognised from the PAN.
+    pub fn from_card_number(card_number: &str) -> Self {
+        use domain_types::utils::CardIssuer;
+        match domain_types::utils::get_card_issuer(card_number) {
+            Ok(CardIssuer::Visa) => Self::Visa,
+            Ok(CardIssuer::Master | CardIssuer::Maestro) => Self::Mastercard,
+            Ok(CardIssuer::AmericanExpress) => Self::Amex,
+            Ok(CardIssuer::Discover) => Self::Discover,
+            Ok(CardIssuer::JCB) => Self::Jcb,
+            Ok(CardIssuer::DinersClub | CardIssuer::CarteBlanche | CardIssuer::CartesBancaires) => {
+                Self::Diners
+            }
+            Ok(CardIssuer::UnionPay) => Self::UnionPay,
+            Err(_) => Self::Unknown,
+        }
+    }
+
+    /// Prefer the explicit network; fall back to BIN detection from the PAN.
+    pub fn from_network_or_number(network: Option<&CardNetwork>, card_number: &str) -> Self {
+        match Self::from_network(network) {
+            Self::Unknown => Self::from_card_number(card_number),
+            family => family,
+        }
+    }
+
     /// AMEX and JCB share the "MANUALLY_ENTERED_WITH_KEYED_CID_AMEX_JCB"
     /// `cardDataInputMode` rule when a CVV is sent.
     pub fn is_amex_or_jcb(self) -> bool {

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
@@ -111,16 +111,27 @@ impl TxProfile {
         T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
     {
         let request = &router_data.request;
-        let card_network = match &request.payment_method_data {
-            PaymentMethodData::Card(card) => card.card_network.clone(),
-            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => nti.card_network.clone(),
-            _ => None,
+        let (card_network, card_number) = match &request.payment_method_data {
+            PaymentMethodData::Card(card) => (
+                card.card_network.clone(),
+                Some(card.card_number.peek().to_string()),
+            ),
+            PaymentMethodData::CardDetailsForNetworkTransactionId(nti) => (
+                nti.card_network.clone(),
+                Some(nti.card_number.peek().to_string()),
+            ),
+            _ => (None, None),
         };
         let acceptance = AcceptanceProfile::derive(
             request.payment_channel.clone(),
             request.mit_category.clone(),
         );
-        let card_family = CardFamily::from_network(card_network.as_ref());
+        // A MIT card fetched from the locker can arrive without a network; fall
+        // back to BIN detection so cert-critical Visa fields still fire.
+        let card_family = match card_number.as_deref() {
+            Some(number) => CardFamily::from_network_or_number(card_network.as_ref(), number),
+            None => CardFamily::from_network(card_network.as_ref()),
+        };
         let cof_phase = CofPhase::derive(
             request.mandate_id.as_ref(),
             request.mit_category.clone(),

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -789,6 +789,28 @@ fn recurring_mit_card_data_source_follows_channel_not_recurring() {
 }
 
 #[test]
+fn card_family_falls_back_to_bin_when_network_absent() {
+    // A MIT card fetched from the locker (CardDetailsForNetworkTransactionId)
+    // can arrive without a network. cardOnFile / cardOnFileTransactionIdentifier
+    // are gated on CardFamily::Visa, so the family must be recovered from the
+    // PAN when the network is absent.
+    use common_enums::CardNetwork;
+    assert!(matches!(
+        CardFamily::from_card_number("4012000098765439"),
+        CardFamily::Visa
+    ));
+    assert!(matches!(
+        CardFamily::from_network_or_number(None, "4012000098765439"),
+        CardFamily::Visa
+    ));
+    // An explicit network still wins over BIN detection.
+    assert!(matches!(
+        CardFamily::from_network_or_number(Some(&CardNetwork::Mastercard), "4012000098765439"),
+        CardFamily::Mastercard
+    ));
+}
+
+#[test]
 fn recurring_mit_mastercard_cardholder_present_detail_is_recurring() {
     // Cert (Recurring tab): Mastercard recurring CIT uses
     // CARDHOLDER_NOT_PRESENT_RECURRING_TRANSACTION.


### PR DESCRIPTION
## Summary

A MIT card fetched from the locker (`CardDetailsForNetworkTransactionId`) can
arrive **without `card_network`**. The `tsys_transit` connector derives its
`CardFamily` purely from the supplied network, so such a card was classified as
`CardFamily::Unknown` — and the Visa-only `cardOnFileTransactionIdentifier` (the
stored network transaction id) was **skipped** on unscheduled / merchant-initiated
Visa transactions, losing the link to the original stored credential.

This adds a BIN fallback: when the network is not supplied, infer the family from
the card number via `get_card_issuer`.

- `CardFamily::from_card_number(&str)` — map the PAN's issuer → family.
- `CardFamily::from_network_or_number(network, pan)` — prefer the explicit
  network, fall back to BIN detection.
- `derive_for_authorize` uses the fallback for both `Card` and
  `CardDetailsForNetworkTransactionId`.

## Verification (live, TSYS staging)

An unscheduled Visa MIT (`recurring_details: payment_method_id`,
`mit_category: unscheduled`) — before: no `cardOnFileTransactionIdentifier`;
after: `<cardOnFileTransactionIdentifier>000000003878032</cardOnFileTransactionIdentifier>`,
TSYS `A0000`.

## Test

`card_family_falls_back_to_bin_when_network_absent` — asserts Visa is recovered
from the PAN, and that an explicit network still wins over BIN detection.
