### PR TITLE
chore(twoc_twop_paco): log pre-encoding request body at info level

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/macros.rs
+++ b/crates/integrations/connector-integration/src/connectors/macros.rs
@@ -335,7 +335,7 @@ macro_rules! expand_fn_get_request_body {
 };
                 let request = bridge.request_body(input_data)?;
                 if let Ok(masked_body) = hyperswitch_masking::masked_serialize(&request) {
-                    tracing::debug!(
+                    tracing::info!(
                         connector = stringify!($connector),
                         flow = stringify!($flow),
                         request_body = %masked_body,


### PR DESCRIPTION
## What

Bump the masked *pre-encoding* connector request-body log from `debug!` to `info!` in the `preprocess_request` macro arm (`get_request_body`).

```diff
-                    tracing::debug!(
+                    tracing::info!(
                         connector = stringify!($connector),
                         flow = stringify!($flow),
                         request_body = %masked_body,
                         "connector request body (pre-encoding)"
```

## Why

Opaque-body connectors (JOSE-encrypted, e.g. `twoc_twop_paco`) send `RequestContent::RawBytes`, so the outgoing "Golden Log Line" only shows `{"request_type":"RAW_BYTES"}` — the request is not inspectable. The existing masked log restores visibility by serializing the typed request via `masked_serialize` (so `Secret` PII fields stay masked) before it's encrypted.

However it was emitted at `debug`, and the Kafka log sink runs at `info` (`log_kafka_level = "info"`, `log_kafka_filtering_directive = "info"`). So the line never entered the shipped log pipeline / LogViewer — it was only visible on console stdout. Raising it to `info` makes the masked request body surface in the shipped logs.

## Safety

- PII stays masked: serialization goes through `hyperswitch_masking::masked_serialize` (the `PIISerializer` path), so `Secret` fields (`cardNumber`, `cvvCode`, `cardExpiryMMYY`, `cardHolderName`, `officeId`, …) render as `*** … ***`. Verified locally against 2c2p PACO sandbox — real PAN never appears in the log.

## Scope

- Applies to the `preprocess_request` macro arm — currently used only by `twoc_twop_paco`.
- Emits on the POST/JOSE flows: **Authorize, Capture, Void, VoidPC, Refund**. Not PSync/RSync (GET inquiries with no request body).