### PR TITLE
feat(vault): thread optional egress proxy_url into HyperswitchVault injector calls

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -67,10 +67,11 @@ pub struct VaultConnectorAuth {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum ExternalVaultProxyMetadata {
+    /// HyperswitchVault data variant — must be first so serde matches vault_endpoint+vault_auth_data
+    /// before falling through to VgsMetadata (which only needs proxy_url+certificate).
+    HyperswitchVaultMetadata(HyperswitchVaultMetadata),
     /// VGS proxy data variant
     VgsMetadata(VgsMetadata),
-    /// HyperswitchVault data variant
-    HyperswitchVaultMetadata(HyperswitchVaultMetadata),
 }
 
 /// Complete external vault proxy configuration to be serialized and sent to UCS
@@ -100,6 +101,13 @@ pub struct HyperswitchVaultMetadata {
     pub vault_endpoint: Url,
     /// Authentication data for the vault connector
     pub vault_auth_data: VaultConnectorAuth,
+    /// Optional egress proxy URL (e.g. Squid). Absent for in-cluster deployments.
+    #[serde(default)]
+    pub proxy_url: Option<Url>,
+    /// Optional CA certificate for TLS verification (needed for MITM proxies like VGS,
+    /// not needed for CONNECT-tunnel proxies like Squid).
+    #[serde(default)]
+    pub certificate: Option<Secret<String>>,
 }
 
 pub trait ConnectorRequestReference {
@@ -1753,6 +1761,10 @@ fn apply_vault_config_to_injector(
                     api_key: hsv.vault_auth_data.api_key,
                     profile_id: hsv.vault_auth_data.profile_id,
                 });
+            // Thread optional proxy egress (e.g. Squid) through to the injector.
+            injector_request.connection_config.proxy_url =
+                hsv.proxy_url.map(|u| Secret::new(u.to_string()));
+            injector_request.connection_config.ca_cert = hsv.certificate;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Mirrors `HyperswitchVaultMetadata` after the existing VGS variant so a per-MCA `proxy_url` (and CA certificate) set on the `hyperswitch_vault` connector account is passed through to the injector's `connection_config`, letting self-hosted Hyperswitch deployments route detokenize/charge calls to a SaaS vault through an egress proxy (e.g. Squid).
- Reorders the untagged `ExternalVaultProxyMetadata` enum so `HyperswitchVaultMetadata` is matched before `VgsMetadata`, avoiding deserialization ambiguity now that both variants can structurally overlap (both may carry `proxy_url`/`certificate`).

Companion PR in hyperswitch: juspay/hyperswitch#13434

## Test plan
- [x] `cargo check -p external-services` — clean
- [x] Verified locally end-to-end (via hyperswitch's `[patch]` override pointing at the in-tree injector) against a mock SaaS vault behind a local Squid proxy: both the detokenize call and the injector's charge call appear in Squid's access log
- [ ] Once merged, bump the `injector` tag pin in `crates/common/external-services/Cargo.toml` to a release containing the corresponding hyperswitch injector change

🤖 Generated with [Claude Code](https://claude.com/claude-code)