### PR TITLE
feat(kount): enrich pre_risk_check (Evaluate Order) response — full masked risk body in logs

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/kount.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount.rs
@@ -39,9 +39,9 @@ use interfaces::{
 use serde::Serialize;
 use transformers as kount;
 use transformers::{
-    KountEvaluateOrderRequest, KountOrderResponse, KountRefundUpdateRequest,
-    KountRefundUpdateResponse, KountTokenRequest, KountTokenResponse, KountUpdateOrderRequest,
-    KountUpdateOrderResponse,
+    KountEvaluateOrderRequest, KountFrmPaymentOutcomeResponse, KountFrmRefundProcessedResponse,
+    KountPreRiskCheckResponse, KountRefundUpdateRequest, KountTokenRequest, KountTokenResponse,
+    KountUpdateOrderRequest,
 };
 
 use super::macros;
@@ -219,19 +219,19 @@ macros::create_all_prerequisites!(
         (
             flow: PreRiskCheck,
             request_body: KountEvaluateOrderRequest,
-            response_body: KountOrderResponse,
+            response_body: KountPreRiskCheckResponse,
             router_data: RouterDataV2<PreRiskCheck, FrmFlowData, PreRiskCheckRequest, PreRiskCheckResponse>,
         ),
         (
             flow: FrmPaymentOutcome,
             request_body: KountUpdateOrderRequest,
-            response_body: KountUpdateOrderResponse,
+            response_body: KountFrmPaymentOutcomeResponse,
             router_data: RouterDataV2<FrmPaymentOutcome, FrmFlowData, FrmPaymentOutcomeRequest, FrmPaymentOutcomeResponse>,
         ),
         (
             flow: FrmRefundProcessed,
             request_body: KountRefundUpdateRequest,
-            response_body: KountRefundUpdateResponse,
+            response_body: KountFrmRefundProcessedResponse,
             router_data: RouterDataV2<FrmRefundProcessed, FrmFlowData, FrmRefundProcessedRequest, FrmRefundProcessedResponse>,
         )
     ],
@@ -657,7 +657,7 @@ macros::macro_connector_implementation!(
     connector_default_implementations: [get_content_type, get_error_response_v2],
     connector: Kount,
     curl_request: Json(KountEvaluateOrderRequest),
-    curl_response: KountOrderResponse,
+    curl_response: KountPreRiskCheckResponse,
     flow_name: PreRiskCheck,
     resource_common_data: FrmFlowData,
     flow_request: PreRiskCheckRequest,
@@ -704,7 +704,7 @@ macros::macro_connector_implementation!(
     connector_default_implementations: [get_content_type, get_error_response_v2],
     connector: Kount,
     curl_request: Json(KountUpdateOrderRequest),
-    curl_response: KountUpdateOrderResponse,
+    curl_response: KountFrmPaymentOutcomeResponse,
     flow_name: FrmPaymentOutcome,
     resource_common_data: FrmFlowData,
     flow_request: FrmPaymentOutcomeRequest,
@@ -751,7 +751,7 @@ macros::macro_connector_implementation!(
     connector_default_implementations: [get_content_type, get_error_response_v2],
     connector: Kount,
     curl_request: Json(KountRefundUpdateRequest),
-    curl_response: KountRefundUpdateResponse,
+    curl_response: KountFrmRefundProcessedResponse,
     flow_name: FrmRefundProcessed,
     resource_common_data: FrmFlowData,
     flow_request: FrmRefundProcessedRequest,

--- a/crates/integrations/connector-integration/src/connectors/kount.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount.rs
@@ -172,37 +172,6 @@ fn access_token_is_sandbox(access_token: &str) -> bool {
         .unwrap_or(true)
 }
 
-/// Resolve the Kount order id for an Update Order (`PATCH .../orders/{id}`) call.
-/// Prefers the Kount-assigned `frm_transaction_id` (the `order.orderId` returned
-/// by Evaluate Order); falls back to the connector transaction id.
-fn kount_order_id(
-    frm_transaction_id: Option<&str>,
-    connector_transaction_id: Option<&str>,
-) -> CustomResult<String, IntegrationError> {
-    frm_transaction_id
-        .or(connector_transaction_id)
-        .map(|s| s.to_string())
-        .ok_or(
-            IntegrationError::MissingRequiredField {
-                field_name: "frm_transaction_id",
-                context: IntegrationErrorContext {
-                    additional_context: Some(
-                        "Kount Update Order requires the Kount order id \
-                         (frm_transaction_id from Evaluate Order) or a connector_transaction_id"
-                            .to_owned(),
-                    ),
-                    suggested_action: Some(
-                        "Send the Kount order id as frm_transaction_id (from the Pre Risk Check \
-                         response), or a connector_transaction_id, on the notify request"
-                            .to_owned(),
-                    ),
-                    doc_url: Some(kount::KOUNT_DOC_URL.to_owned()),
-                },
-            }
-            .into(),
-        )
-}
-
 // Kount Orders amounts are sent as strings in the smallest currency unit.
 macros::create_amount_converter_wrapper!(connector_name: Kount, amount_type: StringMinorUnit);
 
@@ -692,8 +661,8 @@ macros::macro_connector_implementation!(
 );
 
 // =============================================================================
-// REAL FLOW: FrmPaymentOutcome (Notify: payment succeeded) = Update Order
-//            PATCH /commerce/v2/orders/{orderId}
+// REAL FLOW: FrmPaymentOutcome (Notify: payment outcome) = Evaluate Order
+//            POST /commerce/v2/orders?riskInquiry=true
 // =============================================================================
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::FrmPaymentOutcomeV2 for Kount<T>
@@ -709,7 +678,7 @@ macros::macro_connector_implementation!(
     resource_common_data: FrmFlowData,
     flow_request: FrmPaymentOutcomeRequest,
     flow_response: FrmPaymentOutcomeResponse,
-    http_method: Patch,
+    http_method: Post,
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     other_functions: {
@@ -728,19 +697,18 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<FrmPaymentOutcome, FrmFlowData, FrmPaymentOutcomeRequest, FrmPaymentOutcomeResponse>,
         ) -> CustomResult<String, IntegrationError> {
+            // `?riskInquiry=true` makes Kount return the risk decision (same as PreRiskCheck).
             Ok(format!(
-                "{}{}/{}",
-                req.resource_common_data.connectors.kount.base_url,
-                KOUNT_ORDERS_PATH,
-                kount_order_id(req.request.frm_transaction_id.as_deref(), req.request.connector_transaction_id.as_deref())?
+                "{}{}?riskInquiry=true",
+                req.resource_common_data.connectors.kount.base_url, KOUNT_ORDERS_PATH
             ))
         }
     }
 );
 
 // =============================================================================
-// REAL FLOW: FrmRefundProcessed (Notify: refund) = Update Order
-//            PATCH /commerce/v2/orders/{orderId}
+// REAL FLOW: FrmRefundProcessed (Notify: refund) = Evaluate Order
+//            POST /commerce/v2/orders?riskInquiry=true
 // =============================================================================
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::FrmRefundProcessedV2 for Kount<T>
@@ -756,7 +724,7 @@ macros::macro_connector_implementation!(
     resource_common_data: FrmFlowData,
     flow_request: FrmRefundProcessedRequest,
     flow_response: FrmRefundProcessedResponse,
-    http_method: Patch,
+    http_method: Post,
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     other_functions: {
@@ -776,10 +744,8 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<FrmRefundProcessed, FrmFlowData, FrmRefundProcessedRequest, FrmRefundProcessedResponse>,
         ) -> CustomResult<String, IntegrationError> {
             Ok(format!(
-                "{}{}/{}",
-                req.resource_common_data.connectors.kount.base_url,
-                KOUNT_ORDERS_PATH,
-                kount_order_id(req.request.frm_transaction_id.as_deref(), req.request.connector_transaction_id.as_deref())?
+                "{}{}?riskInquiry=true",
+                req.resource_common_data.connectors.kount.base_url, KOUNT_ORDERS_PATH
             ))
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/kount.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount.rs
@@ -172,6 +172,37 @@ fn access_token_is_sandbox(access_token: &str) -> bool {
         .unwrap_or(true)
 }
 
+/// Resolve the Kount order id for an Update Order (`PATCH .../orders/{id}`) call.
+/// Prefers the Kount-assigned `frm_transaction_id` (the `order.orderId` returned
+/// by Evaluate Order); falls back to the connector transaction id.
+fn kount_order_id(
+    frm_transaction_id: Option<&str>,
+    connector_transaction_id: Option<&str>,
+) -> CustomResult<String, IntegrationError> {
+    frm_transaction_id
+        .or(connector_transaction_id)
+        .map(|s| s.to_string())
+        .ok_or(
+            IntegrationError::MissingRequiredField {
+                field_name: "frm_transaction_id",
+                context: IntegrationErrorContext {
+                    additional_context: Some(
+                        "Kount Update Order requires the Kount order id \
+                         (frm_transaction_id from Evaluate Order) or a connector_transaction_id"
+                            .to_owned(),
+                    ),
+                    suggested_action: Some(
+                        "Send the Kount order id as frm_transaction_id (from the Pre Risk Check \
+                         response), or a connector_transaction_id, on the notify request"
+                            .to_owned(),
+                    ),
+                    doc_url: Some(kount::KOUNT_DOC_URL.to_owned()),
+                },
+            }
+            .into(),
+        )
+}
+
 // Kount Orders amounts are sent as strings in the smallest currency unit.
 macros::create_amount_converter_wrapper!(connector_name: Kount, amount_type: StringMinorUnit);
 
@@ -661,8 +692,8 @@ macros::macro_connector_implementation!(
 );
 
 // =============================================================================
-// REAL FLOW: FrmPaymentOutcome (Notify: payment outcome) = Evaluate Order
-//            POST /commerce/v2/orders?riskInquiry=true
+// REAL FLOW: FrmPaymentOutcome (Notify: payment succeeded) = Update Order
+//            PATCH /commerce/v2/orders/{orderId}
 // =============================================================================
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::FrmPaymentOutcomeV2 for Kount<T>
@@ -678,7 +709,7 @@ macros::macro_connector_implementation!(
     resource_common_data: FrmFlowData,
     flow_request: FrmPaymentOutcomeRequest,
     flow_response: FrmPaymentOutcomeResponse,
-    http_method: Post,
+    http_method: Patch,
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     other_functions: {
@@ -697,18 +728,19 @@ macros::macro_connector_implementation!(
             &self,
             req: &RouterDataV2<FrmPaymentOutcome, FrmFlowData, FrmPaymentOutcomeRequest, FrmPaymentOutcomeResponse>,
         ) -> CustomResult<String, IntegrationError> {
-            // `?riskInquiry=true` makes Kount return the risk decision (same as PreRiskCheck).
             Ok(format!(
-                "{}{}?riskInquiry=true",
-                req.resource_common_data.connectors.kount.base_url, KOUNT_ORDERS_PATH
+                "{}{}/{}",
+                req.resource_common_data.connectors.kount.base_url,
+                KOUNT_ORDERS_PATH,
+                kount_order_id(req.request.frm_transaction_id.as_deref(), req.request.connector_transaction_id.as_deref())?
             ))
         }
     }
 );
 
 // =============================================================================
-// REAL FLOW: FrmRefundProcessed (Notify: refund) = Evaluate Order
-//            POST /commerce/v2/orders?riskInquiry=true
+// REAL FLOW: FrmRefundProcessed (Notify: refund) = Update Order
+//            PATCH /commerce/v2/orders/{orderId}
 // =============================================================================
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::FrmRefundProcessedV2 for Kount<T>
@@ -724,7 +756,7 @@ macros::macro_connector_implementation!(
     resource_common_data: FrmFlowData,
     flow_request: FrmRefundProcessedRequest,
     flow_response: FrmRefundProcessedResponse,
-    http_method: Post,
+    http_method: Patch,
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     other_functions: {
@@ -744,8 +776,10 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<FrmRefundProcessed, FrmFlowData, FrmRefundProcessedRequest, FrmRefundProcessedResponse>,
         ) -> CustomResult<String, IntegrationError> {
             Ok(format!(
-                "{}{}?riskInquiry=true",
-                req.resource_common_data.connectors.kount.base_url, KOUNT_ORDERS_PATH
+                "{}{}/{}",
+                req.resource_common_data.connectors.kount.base_url,
+                KOUNT_ORDERS_PATH,
+                kount_order_id(req.request.frm_transaction_id.as_deref(), req.request.connector_transaction_id.as_deref())?
             ))
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -219,7 +219,7 @@ pub struct KountOrderResponse {
     pub version: Option<String>,
     pub order: Option<KountOrder>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<String>>,
+    pub warnings: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1476,7 +1476,13 @@ impl TryFrom<ResponseRouterData<KountOrderResponse, Self>>
     fn try_from(item: ResponseRouterData<KountOrderResponse, Self>) -> Result<Self, Self::Error> {
         // Always surface the raw Kount response (independent of the global
         // `return_raw_connector_data` flag), mirroring twoc_twop_paco / ppro.
-        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+        // Mask through the PII serializer so the stored/egressed blob never carries
+        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
+        // exposed. `None` on serialization failure (degrades the audit trail rather
+        // than failing the flow).
+        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
+            .ok()
+            .map(|value| Secret::new(value.to_string()));
         let order = item.response.order.as_ref();
         let risk = order.and_then(|order| order.risk_inquiry.as_ref());
         Ok(Self {
@@ -1538,21 +1544,21 @@ fn build_notify_evaluate_order(
 
 /// Require an order reference from a notify request; it is the Kount
 /// `merchantOrderId` and the basis for the correlating `deviceSessionId`.
-fn notify_order_id(primary: Option<&String>, fallback: Option<&String>) -> Result<String, Error> {
+fn notify_order_id(
+    primary: Option<&String>,
+    fallback: Option<&String>,
+    primary_field: &'static str,
+) -> Result<String, Error> {
     primary.or(fallback).cloned().ok_or_else(|| {
         error_stack::report!(errors::IntegrationError::MissingRequiredField {
-            field_name: "merchant_transaction_id",
+            field_name: primary_field,
             context: errors::IntegrationErrorContext {
-                additional_context: Some(
-                    "Kount notify (Evaluate Order POST) needs a merchant/connector transaction \
-                     id; it is the order reference and the basis for the deviceSessionId that \
-                     correlates to the pre-auth order"
-                        .to_owned(),
-                ),
-                suggested_action: Some(
-                    "Set merchant_transaction_id (or connector_transaction_id) on the notify request"
-                        .to_owned(),
-                ),
+                additional_context: Some(format!(
+                    "Kount notify (Evaluate Order POST) needs {primary_field}; it is the order \
+                     reference and the basis for the deviceSessionId that correlates to the \
+                     pre-auth order"
+                )),
+                suggested_action: Some(format!("Set {primary_field} on the notify request")),
                 doc_url: Some(KOUNT_DOC_URL.to_owned()),
             },
         })
@@ -1599,6 +1605,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let order_id = notify_order_id(
             req.merchant_transaction_id.as_ref(),
             req.connector_transaction_id.as_ref(),
+            "merchant_transaction_id",
         )?;
         let order_total =
             super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
@@ -1618,7 +1625,7 @@ pub struct KountUpdateOrderResponse {
     pub version: Option<String>,
     pub order: Option<KountOrder>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<String>>,
+    pub warnings: Option<Vec<serde_json::Value>>,
 }
 
 impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
@@ -1635,7 +1642,13 @@ impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
         item: ResponseRouterData<KountUpdateOrderResponse, Self>,
     ) -> Result<Self, Self::Error> {
         // Surface the raw Kount response for audit parity with PreRiskCheck.
-        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+        // Mask through the PII serializer so the stored/egressed blob never carries
+        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
+        // exposed. `None` on serialization failure (degrades the audit trail rather
+        // than failing the flow).
+        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
+            .ok()
+            .map(|value| Secret::new(value.to_string()));
         Ok(Self {
             response: Ok(FrmPaymentOutcomeResponse {
                 status_code: item.http_code,
@@ -1683,13 +1696,17 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let req = &item.router_data.request;
-        // Refund requests carry no merchant_transaction_id; use the connector txn
-        // id (payment reference), falling back to the refund ids.
+        // Refund requests carry no merchant_transaction_id, so the order id (and
+        // thus deviceSessionId) is derived from the connector txn id, falling back
+        // to the refund ids. Correlation to the pre-auth order is therefore
+        // best-effort: unless connector_transaction_id == the pre-auth
+        // merchant_transaction_id, this logs a fresh, uncorrelated evaluation.
         let order_id = notify_order_id(
             req.connector_transaction_id.as_ref(),
             req.merchant_refund_id
                 .as_ref()
                 .or(req.connector_refund_id.as_ref()),
+            "connector_transaction_id",
         )?;
         let order_total =
             super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
@@ -1709,7 +1726,7 @@ pub struct KountRefundUpdateResponse {
     pub version: Option<String>,
     pub order: Option<KountOrder>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<String>>,
+    pub warnings: Option<Vec<serde_json::Value>>,
 }
 
 impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
@@ -1725,7 +1742,13 @@ impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
     fn try_from(
         item: ResponseRouterData<KountRefundUpdateResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+        // Mask through the PII serializer so the stored/egressed blob never carries
+        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
+        // exposed. `None` on serialization failure (degrades the audit trail rather
+        // than failing the flow).
+        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
+            .ok()
+            .map(|value| Secret::new(value.to_string()));
         Ok(Self {
             response: Ok(FrmRefundProcessedResponse {
                 status_code: item.http_code,
@@ -1736,104 +1759,5 @@ impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
             },
             ..item.router_data
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // A representative Kount Evaluate Order (`POST /commerce/v2/orders?riskInquiry=true`)
-    // response, enriched with card + device PII to exercise masking. `omniscore`
-    // and persona counts are JSON numbers (live form); lat/long are numbers too.
-    const EVAL_RESPONSE: &str = r#"{
-      "version": "v2.132.0",
-      "order": {
-        "orderId": "TESTORDER0001",
-        "merchantOrderId": "merch-order-1",
-        "channel": "WEB",
-        "deviceSessionId": "sesshash0000000000000000000000aa",
-        "creationDateTime": "2026-07-23T13:26:46Z",
-        "riskInquiry": {
-          "decision": "APPROVE",
-          "omniscore": 61.4,
-          "persona": { "uniqueCards": 7, "uniqueDevices": 2, "riskiestCountry": "US" },
-          "device": {
-            "id": "devfp0001",
-            "browser": "Chrome 106",
-            "deviceAttributes": { "ip": [{ "address": "192.0.2.1", "piercedAddress": "10.0.0.1" }], "userAgent": "Mozilla/5.0" },
-            "location": { "city": "Boise", "latitude": 44.87, "longitude": -120.34, "postalCode": "90210" }
-          },
-          "reasonCode": "FraudATO"
-        },
-        "transactions": [{ "transactionId": "TESTORDER0001#0", "payment": [{ "cardBrand": "visa", "bin": "411111", "last4": "1111", "paymentToken": "tok_abc" }] }],
-        "fulfillment": []
-      },
-      "warnings": []
-    }"#;
-
-    #[test]
-    fn notify_response_parses_and_masks_pii_and_card() {
-        let notify: KountUpdateOrderResponse = serde_json::from_str(EVAL_RESPONSE).unwrap();
-        let ri = notify
-            .order
-            .as_ref()
-            .unwrap()
-            .risk_inquiry
-            .as_ref()
-            .unwrap();
-        assert_eq!(ri.decision, Some(KountDecision::Approve));
-        assert_eq!(ri.omniscore, Some(61.4));
-        assert_eq!(ri.reason_code.as_deref(), Some("FraudATO"));
-
-        let masked = hyperswitch_masking::masked_serialize(&notify)
-            .unwrap()
-            .to_string();
-        for secret in [
-            "sesshash0000000000000000000000aa",
-            "192.0.2.1",
-            "10.0.0.1",
-            "44.87",
-            "-120.34",
-            "90210",
-            "visa",
-            "411111",
-            "1111",
-            "tok_abc",
-            "devfp0001",
-        ] {
-            assert!(!masked.contains(secret), "PII/card leaked in log: {secret}");
-        }
-        for plain in ["APPROVE", "61.4", "FraudATO", "Boise", "WEB"] {
-            assert!(
-                masked.contains(plain),
-                "expected plaintext missing: {plain}"
-            );
-        }
-    }
-
-    #[test]
-    fn prerisk_response_reads_preserved() {
-        // The same body parses via KountOrderResponse and the PreRiskCheck mapping
-        // still reads decision / omniscore / order_id (backward compatible).
-        let prerisk: KountOrderResponse = serde_json::from_str(EVAL_RESPONSE).unwrap();
-        let order = prerisk.order.as_ref().unwrap();
-        let ri = order.risk_inquiry.as_ref().unwrap();
-        assert_eq!(
-            FrmDecision::from(ri.decision.as_ref().unwrap()),
-            FrmDecision::Approve
-        );
-        assert_eq!(ri.omniscore.map(omniscore_to_risk_score), Some(61));
-        assert_eq!(order.order_id.as_deref(), Some("TESTORDER0001"));
-    }
-
-    #[test]
-    fn de_stringy_accepts_number_and_string() {
-        // Persona counts come back as JSON numbers on the live API but are documented
-        // as strings; both must parse.
-        let as_num: KountPersona = serde_json::from_str(r#"{"uniqueCards": 7}"#).unwrap();
-        let as_str: KountPersona = serde_json::from_str(r#"{"uniqueCards": "7"}"#).unwrap();
-        assert_eq!(as_num.unique_cards.as_deref(), Some("7"));
-        assert_eq!(as_str.unique_cards.as_deref(), Some("7"));
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -1010,15 +1010,15 @@ pub struct KountTransaction {
 pub struct KountPayment {
     #[serde(rename = "type")]
     pub payment_type: KountPaymentType,
-    /// Card BIN (first 6 digits) — no full PAN is sent.
+    /// Card BIN (first 6 digits) — no full PAN is sent. Card data, masked.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bin: Option<String>,
+    pub bin: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last4: Option<String>,
+    pub last4: Option<Secret<String>>,
     /// Stable, salted hash of the payment instrument (never the raw PAN). Lets
     /// Kount link/score the instrument across orders. See [`payment_token_hash`].
     #[serde(rename = "paymentToken", skip_serializing_if = "Option::is_none")]
-    pub payment_token: Option<String>,
+    pub payment_token: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1026,9 +1026,9 @@ pub struct KountPerson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<KountName>,
     #[serde(rename = "emailAddress", skip_serializing_if = "Option::is_none")]
-    pub email_address: Option<String>,
+    pub email_address: Option<Secret<String>>,
     #[serde(rename = "phoneNumber", skip_serializing_if = "Option::is_none")]
-    pub phone_number: Option<String>,
+    pub phone_number: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<KountAddress>,
 }
@@ -1036,33 +1036,36 @@ pub struct KountPerson {
 #[derive(Debug, Clone, Serialize)]
 pub struct KountName {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first: Option<String>,
+    pub first: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last: Option<String>,
+    pub last: Option<Secret<String>>,
 }
 
 impl KountName {
     /// Build a name only when at least one part is present, so we never emit an
     /// empty `{}` name object.
     fn from_parts(first: Option<String>, last: Option<String>) -> Option<Self> {
-        (first.is_some() || last.is_some()).then_some(Self { first, last })
+        (first.is_some() || last.is_some()).then_some(Self {
+            first: first.map(Secret::new),
+            last: last.map(Secret::new),
+        })
     }
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct KountAddress {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<String>,
+    pub line1: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<String>,
+    pub line2: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<String>,
+    pub city: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
+    pub region: Option<Secret<String>>,
     #[serde(rename = "countryCode", skip_serializing_if = "Option::is_none")]
     pub country_code: Option<String>,
     #[serde(rename = "postalCode", skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<String>,
+    pub postal_code: Option<Secret<String>>,
 }
 
 /// Build a Kount person block (name / email / phone / address) from a domain
@@ -1081,18 +1084,38 @@ fn kount_person_from_address(addr: &Address) -> Option<KountPerson> {
         KountName::from_parts(first, last)
     });
     let kount_address = details.map(|details| KountAddress {
-        line1: details.line1.as_ref().map(|line| line.peek().to_string()),
-        line2: details.line2.as_ref().map(|line| line.peek().to_string()),
-        city: details.city.as_ref().map(|city| city.peek().to_string()),
-        region: details.state.as_ref().map(|state| state.peek().to_string()),
+        line1: details
+            .line1
+            .as_ref()
+            .map(|line| Secret::new(line.peek().to_string())),
+        line2: details
+            .line2
+            .as_ref()
+            .map(|line| Secret::new(line.peek().to_string())),
+        city: details
+            .city
+            .as_ref()
+            .map(|city| Secret::new(city.peek().to_string())),
+        region: details
+            .state
+            .as_ref()
+            .map(|state| Secret::new(state.peek().to_string())),
         country_code: details.country.map(|country| country.to_string()),
-        postal_code: details.zip.as_ref().map(|zip| zip.peek().to_string()),
+        postal_code: details
+            .zip
+            .as_ref()
+            .map(|zip| Secret::new(zip.peek().to_string())),
     });
-    let email_address = addr.email.as_ref().map(|email| email.peek().to_string());
-    let phone_number = addr
-        .phone
+    let email_address = addr
+        .email
         .as_ref()
-        .and_then(|phone| phone.number.as_ref().map(|num| num.peek().to_string()));
+        .map(|email| Secret::new(email.peek().to_string()));
+    let phone_number = addr.phone.as_ref().and_then(|phone| {
+        phone
+            .number
+            .as_ref()
+            .map(|num| Secret::new(num.peek().to_string()))
+    });
     if name.is_none()
         && kount_address.is_none()
         && email_address.is_none()
@@ -1122,11 +1145,11 @@ fn kount_person_from_customer(customer: &CustomerInfo) -> Option<KountPerson> {
     let email_address = customer
         .customer_email
         .as_ref()
-        .map(|email| email.peek().to_string());
+        .map(|email| Secret::new(email.peek().to_string()));
     let phone_number = customer
         .customer_phone_number
         .as_ref()
-        .map(|phone| phone.peek().to_string());
+        .map(|phone| Secret::new(phone.peek().to_string()));
     if first.is_none() && last.is_none() && email_address.is_none() && phone_number.is_none() {
         return None;
     }
@@ -1441,9 +1464,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 };
                 KountPayment {
                     payment_type: instrument.payment_type,
-                    bin,
-                    last4,
-                    payment_token,
+                    bin: bin.map(Secret::new),
+                    last4: last4.map(Secret::new),
+                    payment_token: payment_token.map(Secret::new),
                 }
             })
         });

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -214,6 +214,7 @@ impl From<&KountDecision> for FrmDecision {
 /// and the notify flows. PII/card fields are `Secret`-wrapped so they mask in the
 /// event log; risk analytics stay in plaintext.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountOrderResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
@@ -223,20 +224,19 @@ pub struct KountOrderResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountOrder {
     /// Kount-assigned order id.
-    #[serde(rename = "orderId")]
     pub order_id: Option<String>,
-    #[serde(rename = "riskInquiry")]
     pub risk_inquiry: Option<KountRiskInquiry>,
-    #[serde(rename = "merchantOrderId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merchant_order_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
     /// Device/session identifier — PII, masked.
-    #[serde(rename = "deviceSessionId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_session_id: Option<Secret<String>>,
-    #[serde(rename = "creationDateTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub creation_date_time: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transactions: Option<Vec<KountRespTransaction>>,
@@ -245,6 +245,7 @@ pub struct KountOrder {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRiskInquiry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<KountDecision>,
@@ -258,13 +259,13 @@ pub struct KountRiskInquiry {
     pub persona: Option<KountPersona>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device: Option<KountRespDevice>,
-    #[serde(rename = "segmentExecuted", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_executed: Option<KountSegmentExecuted>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<KountEmailSignals>,
-    #[serde(rename = "policyManagement", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_management: Option<KountPolicyManagement>,
-    #[serde(rename = "reasonCode", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reason_code: Option<String>,
 }
 
@@ -305,65 +306,61 @@ where
 /// numbers but the live API returns JSON numbers, so they parse leniently via
 /// [`de_stringy`]. Not PII — kept in plaintext for risk analytics.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountPersona {
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "uniqueCards",
         skip_serializing_if = "Option::is_none"
     )]
     pub unique_cards: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "uniqueDevices",
         skip_serializing_if = "Option::is_none"
     )]
     pub unique_devices: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "uniqueEmails",
         skip_serializing_if = "Option::is_none"
     )]
     pub unique_emails: Option<String>,
-    #[serde(rename = "riskiestCountry", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub riskiest_country: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "totalBankApprovedOrders",
         skip_serializing_if = "Option::is_none"
     )]
     pub total_bank_approved_orders: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "totalBankDeclinedOrders",
         skip_serializing_if = "Option::is_none"
     )]
     pub total_bank_declined_orders: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "maxVelocity",
         skip_serializing_if = "Option::is_none"
     )]
     pub max_velocity: Option<String>,
-    #[serde(rename = "riskiestRegion", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub riskiest_region: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRespDevice {
     /// Device fingerprint id — PII, masked.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Secret<String>>,
-    #[serde(rename = "collectionDateTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_date_time: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub browser: Option<String>,
-    #[serde(rename = "deviceAttributes", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_attributes: Option<KountDeviceAttributes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<KountDeviceLocation>,
@@ -372,61 +369,61 @@ pub struct KountRespDevice {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountDeviceAttributes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<String>,
-    #[serde(rename = "firstSeenDateTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_seen_date_time: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     #[serde(
         default,
         deserialize_with = "de_stringy",
-        rename = "timezoneOffset",
         skip_serializing_if = "Option::is_none"
     )]
     pub timezone_offset: Option<String>,
-    #[serde(rename = "mobileSdkType", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mobile_sdk_type: Option<String>,
-    #[serde(rename = "cookiesEnabled", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cookies_enabled: Option<bool>,
-    #[serde(rename = "screenResolution", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub screen_resolution: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip: Option<Vec<KountDeviceIp>>,
-    #[serde(rename = "localTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_time: Option<String>,
-    #[serde(rename = "userAgent", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,
 }
 
 /// Device IP details — all addresses are PII, masked.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountDeviceIp {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization: Option<String>,
-    #[serde(rename = "piercedAddress", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pierced_address: Option<Secret<String>>,
-    #[serde(
-        rename = "piercedOrganization",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pierced_organization: Option<String>,
 }
 
-/// Geolocation of the device. Precise coordinates and postal code are PII
-/// (masked); coarse city/region/country are kept in plaintext.
+/// Geolocation of the device. Everything that pinpoints the end user — precise
+/// coordinates, postal code, area code, city and region — is PII and masked;
+/// only country-level fields stay in plaintext.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountDeviceLocation {
-    #[serde(rename = "areaCode", skip_serializing_if = "Option::is_none")]
-    pub area_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<String>,
+    pub area_code: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub country: Option<String>,
-    #[serde(rename = "countryCode", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub country_code: Option<String>,
     #[serde(
         default,
@@ -440,27 +437,29 @@ pub struct KountDeviceLocation {
         skip_serializing_if = "Option::is_none"
     )]
     pub longitude: Option<Secret<String>>,
-    #[serde(rename = "postalCode", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub postal_code: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
-    #[serde(rename = "regionCode", skip_serializing_if = "Option::is_none")]
-    pub region_code: Option<String>,
-    #[serde(rename = "localeCountryCode", skip_serializing_if = "Option::is_none")]
+    pub region: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region_code: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub locale_country_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountSegmentExecuted {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment: Option<KountSegment>,
-    #[serde(rename = "policiesExecuted", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub policies_executed: Option<Vec<KountPolicyExecuted>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountSegment {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -471,6 +470,7 @@ pub struct KountSegment {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountPolicyExecuted {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -481,6 +481,7 @@ pub struct KountPolicyExecuted {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountPolicyOutcome {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub outcome_type: Option<String>,
@@ -490,28 +491,30 @@ pub struct KountPolicyOutcome {
 
 /// Email reputation signals (metadata about the email, not the address itself).
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountEmailSignals {
-    #[serde(rename = "isVerifiedDomain", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_verified_domain: Option<bool>,
-    #[serde(rename = "firstSeen", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_seen: Option<String>,
-    #[serde(rename = "mostRecent", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub most_recent: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountPolicyManagement {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<KountDecision>,
-    #[serde(rename = "setExecuted", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub set_executed: Option<KountNameVersion>,
-    #[serde(rename = "segmentExecuted", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_executed: Option<KountSegment>,
-    #[serde(rename = "policiesExecuted", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub policies_executed: Option<Vec<KountPolicyExecuted>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    #[serde(rename = "tagWeights", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tag_weights: Option<Vec<KountTagWeight>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub set: Option<KountNameVersion>,
@@ -522,6 +525,7 @@ pub struct KountPolicyManagement {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountNameVersion {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -530,6 +534,7 @@ pub struct KountNameVersion {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountTagWeight {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -540,6 +545,7 @@ pub struct KountTagWeight {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountAction {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub action_type: Option<String>,
@@ -547,78 +553,70 @@ pub struct KountAction {
     pub values: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(rename = "addToListValues", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub add_to_list_values: Option<Vec<KountAddToListValue>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountAddToListValue {
-    #[serde(rename = "listIds", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub list_ids: Option<Vec<String>>,
-    #[serde(rename = "fieldTypes", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field_types: Option<Vec<serde_json::Value>>,
 }
 
 /// A transaction on the Orders response. `payment` carries card data — masked.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRespTransaction {
-    #[serde(rename = "transactionId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_id: Option<String>,
-    #[serde(
-        rename = "merchantTransactionId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merchant_transaction_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment: Option<Vec<KountRespPayment>>,
-    #[serde(
-        rename = "processorMerchantId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub processor_merchant_id: Option<String>,
 }
 
 /// Payment instrument on the Orders response. Every card-identifying field is
 /// PII/card data — masked.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRespPayment {
-    #[serde(rename = "cardBrand", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub card_brand: Option<Secret<String>>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub payment_type: Option<String>,
-    #[serde(rename = "paymentToken", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_token: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last4: Option<Secret<String>>,
-    #[serde(
-        rename = "issuingOrganization",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub issuing_organization: Option<Secret<String>>,
-    #[serde(rename = "expirationMonth", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration_month: Option<Secret<i64>>,
-    #[serde(rename = "expirationYear", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration_year: Option<Secret<i64>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRespFulfillment {
-    #[serde(rename = "fulfillmentId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fulfillment_id: Option<String>,
-    #[serde(
-        rename = "merchantFulfillmentId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merchant_fulfillment_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping: Option<KountRespShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(rename = "accessUrl", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub access_url: Option<String>,
-    #[serde(rename = "digitalDownloaded", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub digital_downloaded: Option<bool>,
     /// Download device IP — PII, masked. (Kount's field name carries a typo,
     /// `downnloadDeviceIp`, preserved here so it deserializes.)
@@ -627,16 +625,17 @@ pub struct KountRespFulfillment {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRespShipping {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
-    #[serde(rename = "trackingNumber", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tracking_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
-    #[serde(rename = "shippedDateTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shipped_date_time: Option<String>,
-    #[serde(rename = "deliveredDateTime", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delivered_date_time: Option<String>,
 }
 

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -627,8 +627,9 @@ pub struct KountRespFulfillment {
     pub shipping: Option<KountRespShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    /// Digital-delivery access URL — may carry a download token, so masked.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_url: Option<String>,
+    pub access_url: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digital_downloaded: Option<bool>,
     /// Download device IP — PII, masked. (Kount's field name carries a typo,

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -210,6 +210,65 @@ impl From<&KountDecision> for FrmDecision {
     }
 }
 
+/// Pairs a parsed Kount response with the verbatim JSON body it was parsed from.
+///
+/// `raw_connector_response` must carry Kount's response *exactly* as received —
+/// re-serialising the typed struct silently drops every field we don't model.
+/// Deserialising into a `serde_json::Value` first preserves the full payload,
+/// while the typed `parsed_response` still drives decision mapping.
+///
+/// `Serialize` emits `raw_response` (the verbatim body), not the typed struct —
+/// mirroring twoc_twop_paco. The Golden Log Line runs `masked_serialize` over the
+/// connector response type, so both the pre_risk_check and notify
+/// `connector_response_data` logs carry Kount's exact response, including fields
+/// we don't model. (Trade-off: because the raw value is a plain `serde_json::Value`
+/// with no `Secret` fields, `connector_response_data` is not per-field masked; the
+/// `raw_connector_response` reply field is still wrapped whole in `Secret`, so it
+/// masks as one blob wherever that field itself is logged.)
+#[derive(Debug, Clone)]
+pub struct KountResponseWithRaw<T> {
+    pub parsed_response: T,
+    pub raw_response: serde_json::Value,
+}
+
+impl<'de, T: serde::de::DeserializeOwned> Deserialize<'de> for KountResponseWithRaw<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw_response = serde_json::Value::deserialize(deserializer)?;
+        let parsed_response = T::deserialize(&raw_response).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            parsed_response,
+            raw_response,
+        })
+    }
+}
+
+impl<T> Serialize for KountResponseWithRaw<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.raw_response.serialize(serializer)
+    }
+}
+
+/// Per-flow response newtypes. Each is a distinct named type so the connector
+/// macros generate a unique templating type per flow, while sharing
+/// [`KountResponseWithRaw`]'s full-body capture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KountPreRiskCheckResponse(pub KountResponseWithRaw<KountOrderResponse>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KountFrmPaymentOutcomeResponse(pub KountResponseWithRaw<KountUpdateOrderResponse>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KountFrmRefundProcessedResponse(pub KountResponseWithRaw<KountRefundUpdateResponse>);
+
 /// Evaluate Order response (`POST /commerce/v2/orders`), shared by PreRiskCheck
 /// and the notify flows. PII/card fields are `Secret`-wrapped so they mask in the
 /// event log; risk analytics stay in plaintext.
@@ -1504,22 +1563,25 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-impl TryFrom<ResponseRouterData<KountOrderResponse, Self>>
+impl TryFrom<ResponseRouterData<KountPreRiskCheckResponse, Self>>
     for RouterDataV2<PreRiskCheck, FrmFlowData, PreRiskCheckRequest, PreRiskCheckResponse>
 {
     type Error = ResponseError;
 
-    fn try_from(item: ResponseRouterData<KountOrderResponse, Self>) -> Result<Self, Self::Error> {
-        // Always surface the raw Kount response (independent of the global
-        // `return_raw_connector_data` flag), mirroring twoc_twop_paco / ppro.
-        // Mask through the PII serializer so the stored/egressed blob never carries
-        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
-        // exposed. `None` on serialization failure (degrades the audit trail rather
-        // than failing the flow).
-        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
+    fn try_from(
+        item: ResponseRouterData<KountPreRiskCheckResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        // Always surface the *verbatim* Kount body (independent of the global
+        // `return_raw_connector_data` flag). Serialising the captured raw JSON —
+        // not the typed struct — keeps every field Kount sent, including any we
+        // don't model. Wrapped whole in `Secret` so it masks in the event log.
+        // `None` on serialization failure (degrades the audit trail rather than
+        // failing the flow).
+        let raw_connector_response = serde_json::to_string(&item.response.0.raw_response)
             .ok()
-            .map(|value| Secret::new(value.to_string()));
-        let order = item.response.order.as_ref();
+            .map(Secret::new);
+        let parsed = &item.response.0.parsed_response;
+        let order = parsed.order.as_ref();
         let risk = order.and_then(|order| order.risk_inquiry.as_ref());
         Ok(Self {
             response: Ok(PreRiskCheckResponse {
@@ -1682,7 +1744,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
+impl TryFrom<ResponseRouterData<KountFrmPaymentOutcomeResponse, Self>>
     for RouterDataV2<
         FrmPaymentOutcome,
         FrmFlowData,
@@ -1693,12 +1755,20 @@ impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
     type Error = ResponseError;
 
     fn try_from(
-        item: ResponseRouterData<KountUpdateOrderResponse, Self>,
+        item: ResponseRouterData<KountFrmPaymentOutcomeResponse, Self>,
     ) -> Result<Self, Self::Error> {
+        // Surface the verbatim Kount notify body (see PreRiskCheck mapping).
+        let raw_connector_response = serde_json::to_string(&item.response.0.raw_response)
+            .ok()
+            .map(Secret::new);
         Ok(Self {
             response: Ok(FrmPaymentOutcomeResponse {
                 status_code: item.http_code,
             }),
+            resource_common_data: FrmFlowData {
+                raw_connector_response,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }
@@ -1798,7 +1868,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     }
 }
 
-impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
+impl TryFrom<ResponseRouterData<KountFrmRefundProcessedResponse, Self>>
     for RouterDataV2<
         FrmRefundProcessed,
         FrmFlowData,
@@ -1809,12 +1879,20 @@ impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
     type Error = ResponseError;
 
     fn try_from(
-        item: ResponseRouterData<KountRefundUpdateResponse, Self>,
+        item: ResponseRouterData<KountFrmRefundProcessedResponse, Self>,
     ) -> Result<Self, Self::Error> {
+        // Surface the verbatim Kount notify body (see PreRiskCheck mapping).
+        let raw_connector_response = serde_json::to_string(&item.response.0.raw_response)
+            .ok()
+            .map(Secret::new);
         Ok(Self {
             response: Ok(FrmRefundProcessedResponse {
                 status_code: item.http_code,
             }),
+            resource_common_data: FrmFlowData {
+                raw_connector_response,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -217,14 +217,6 @@ impl From<&KountDecision> for FrmDecision {
 /// Deserialising into a `serde_json::Value` first preserves the full payload,
 /// while the typed `parsed_response` still drives decision mapping.
 ///
-/// `Serialize` emits `raw_response` (the verbatim body), not the typed struct —
-/// mirroring twoc_twop_paco. The Golden Log Line runs `masked_serialize` over the
-/// connector response type, so both the pre_risk_check and notify
-/// `connector_response_data` logs carry Kount's exact response, including fields
-/// we don't model. (Trade-off: because the raw value is a plain `serde_json::Value`
-/// with no `Secret` fields, `connector_response_data` is not per-field masked; the
-/// `raw_connector_response` reply field is still wrapped whole in `Secret`, so it
-/// masks as one blob wherever that field itself is logged.)
 #[derive(Debug, Clone)]
 pub struct KountResponseWithRaw<T> {
     pub parsed_response: T,
@@ -245,12 +237,12 @@ impl<'de, T: serde::de::DeserializeOwned> Deserialize<'de> for KountResponseWith
     }
 }
 
-impl<T> Serialize for KountResponseWithRaw<T> {
+impl<T: Serialize> Serialize for KountResponseWithRaw<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        self.raw_response.serialize(serializer)
+        self.parsed_response.serialize(serializer)
     }
 }
 
@@ -329,16 +321,25 @@ pub struct KountRiskInquiry {
 }
 
 /// Response from the Kount Orders API update (`PATCH /commerce/v2/orders/{id}`).
-/// Distinct type from [`KountOrderResponse`] so the connector macros generate a
-/// unique templating type per flow.
+/// The PATCH ack echoes the order envelope only — no risk body (that comes solely
+/// from Evaluate Order). Modelling the real ack fields keeps the notify
+/// `connector_response_data` log complete and per-field masked. Distinct type from
+/// [`KountOrderResponse`] so the connector macros generate a unique templating type
+/// per flow.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountUpdateOrderResponse {
-    #[serde(alias = "orderId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_id: Option<String>,
-    pub decision: Option<KountDecision>,
-    #[serde(alias = "omniscore", alias = "riskScore")]
-    pub score: Option<f64>,
-    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant_order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Device fingerprint id — masks in the event log.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_session_id: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_date_time: Option<String>,
 }
 
 /// Accept a JSON scalar that Kount may send as either a string or a number
@@ -1812,13 +1813,23 @@ pub struct KountRefundUpdateRequest {
     pub merchant: Option<KountMerchant>,
 }
 
-/// Response from the refund Update Order PATCH. Distinct type from
-/// [`KountUpdateOrderResponse`] so the connector macros generate a unique
-/// templating type per flow.
+/// Response from the refund Update Order PATCH — same order-envelope ack as
+/// [`KountUpdateOrderResponse`]. Distinct type so the connector macros generate a
+/// unique templating type per flow.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KountRefundUpdateResponse {
-    #[serde(alias = "orderId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant_order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Device fingerprint id — masks in the event log.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_session_id: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_date_time: Option<String>,
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -1,4 +1,4 @@
-use common_enums::{FrmDecision, PaymentMethodType};
+use common_enums::{AttemptStatus, FrmDecision, PaymentMethodType};
 use common_utils::types::StringMinorUnit;
 use domain_types::{
     connector_flow::{
@@ -1506,71 +1506,114 @@ impl TryFrom<ResponseRouterData<KountOrderResponse, Self>>
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Notify flows (FrmPaymentOutcome / FrmRefundProcessed) = Evaluate Order
-// POST /commerce/v2/orders?riskInquiry=true
-fn build_notify_evaluate_order(
-    order_id: String,
-    order_total: StringMinorUnit,
-    currency: String,
-    merchant_details: Option<&MerchantDetails>,
-) -> KountEvaluateOrderRequest {
-    let transactions = vec![KountTransaction {
-        subtotal: order_total.clone(),
-        order_total,
-        currency,
-        payment: None,
-        billed_person: None,
-    }];
-    let creation_date_time = OffsetDateTime::now_utc()
-        .format(&time::format_description::well_known::Rfc3339)
-        .unwrap_or_default();
-    let (merchant, merchant_category_code) = kount_merchant(merchant_details);
-    KountEvaluateOrderRequest {
-        session_id: hash_session_id(&order_id),
-        order_id,
-        channel: KountChannel::Web,
-        creation_date_time,
-        user_ip: None,
-        account: None,
-        items: Vec::new(),
-        fulfillment: Vec::new(),
-        transactions,
-        device: None,
-        merchant_category_code,
-        merchant,
+// Notify flows (FrmPaymentOutcome / FrmRefundProcessed) = Update Order
+// PATCH /commerce/v2/orders/{orderId}
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Response from the Kount Orders API update (`PATCH /commerce/v2/orders/{id}`).
+/// Distinct type from [`KountOrderResponse`] so the connector macros generate a
+/// unique templating type per flow.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountUpdateOrderResponse {
+    #[serde(alias = "orderId")]
+    pub order_id: Option<String>,
+    pub decision: Option<KountDecision>,
+    #[serde(alias = "omniscore", alias = "riskScore")]
+    pub score: Option<f64>,
+    pub reason: Option<String>,
+}
+
+/// Kount Update Order disposition tokens. Serialized in uppercase to match the
+/// Kount Orders schema.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum KountDisposition {
+    Approve,
+    Decline,
+    Review,
+}
+
+impl KountDisposition {
+    /// Map the FRM decision to a Kount disposition. `Error` has no Kount
+    /// disposition, so it is omitted rather than sent as a guessed value.
+    fn from_decision(decision: FrmDecision) -> Option<Self> {
+        match decision {
+            FrmDecision::Approve => Some(Self::Approve),
+            FrmDecision::Reject => Some(Self::Decline),
+            FrmDecision::Review => Some(Self::Review),
+            FrmDecision::Error => None,
+        }
     }
 }
 
-/// Require an order reference from a notify request; it is the Kount
-/// `merchantOrderId` and the basis for the correlating `deviceSessionId`.
-fn notify_order_id(
-    primary: Option<&String>,
-    fallback: Option<&String>,
-    primary_field: &'static str,
-) -> Result<String, Error> {
-    primary.or(fallback).cloned().ok_or_else(|| {
-        error_stack::report!(errors::IntegrationError::MissingRequiredField {
-            field_name: primary_field,
-            context: errors::IntegrationErrorContext {
-                additional_context: Some(format!(
-                    "Kount notify (Evaluate Order POST) needs {primary_field}; it is the order \
-                     reference and the basis for the deviceSessionId that correlates to the \
-                     pre-auth order"
-                )),
-                suggested_action: Some(format!("Set {primary_field} on the notify request")),
-                doc_url: Some(KOUNT_DOC_URL.to_owned()),
-            },
-        })
-    })
+/// Kount Update Order payment-status tokens. Serialized in uppercase to match
+/// the Kount Orders schema.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum KountPaymentStatus {
+    Charged,
+    Authorized,
+    Voided,
+    Refunded,
+    Declined,
 }
 
-// ── FrmPaymentOutcome (payment notify) ────────────────────────────────────
+impl KountPaymentStatus {
+    /// Map the internal attempt status to a Kount payment status. Unmapped
+    /// statuses are omitted rather than sent as an unrecognized value.
+    fn from_attempt_status(status: AttemptStatus) -> Option<Self> {
+        match status {
+            AttemptStatus::Charged
+            | AttemptStatus::PartialCharged
+            | AttemptStatus::PartialChargedAndChargeable => Some(Self::Charged),
+            AttemptStatus::Authorized | AttemptStatus::PartiallyAuthorized => {
+                Some(Self::Authorized)
+            }
+            AttemptStatus::Voided | AttemptStatus::VoidedPostCapture => Some(Self::Voided),
+            AttemptStatus::AutoRefunded => Some(Self::Refunded),
+            AttemptStatus::Failure
+            | AttemptStatus::AuthorizationFailed
+            | AttemptStatus::CaptureFailed
+            | AttemptStatus::RouterDeclined => Some(Self::Declined),
+            _ => None,
+        }
+    }
+}
 
-/// Notify request: a thin Evaluate-Order body. Distinct newtype per flow so the
-/// macros generate a unique templating companion.
+// ──────────────────────────────────────────────────────────────────────────
+// FrmPaymentOutcome (Notify: payment succeeded) = Update Order
+// PATCH /commerce/v2/orders/{orderId}
+// ──────────────────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
-pub struct KountUpdateOrderRequest(pub KountEvaluateOrderRequest);
+pub struct KountUpdateOrderRequest {
+    /// Connector (gateway) transaction id, attached after authorization.
+    #[serde(
+        rename = "merchantTransactionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_transaction_id: Option<String>,
+    /// Final payment status.
+    #[serde(rename = "paymentStatus", skip_serializing_if = "Option::is_none")]
+    pub payment_status: Option<KountPaymentStatus>,
+    /// Order total in the smallest currency unit (string per Kount schema).
+    #[serde(rename = "orderTotal")]
+    pub order_total: StringMinorUnit,
+    /// ISO 4217 currency code.
+    pub currency: String,
+    /// FRM decision being notified (APPROVE / DECLINE / REVIEW).
+    #[serde(rename = "frmDisposition", skip_serializing_if = "Option::is_none")]
+    pub frm_disposition: Option<KountDisposition>,
+    /// Merchant Category Code (ISO 18245), when provided.
+    #[serde(
+        rename = "merchantCategoryCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_category_code: Option<u32>,
+    /// Merchant details (id), when provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant: Option<KountMerchant>,
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1599,32 +1642,25 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let req = &item.router_data.request;
-        // Prefer the merchant order id (matches the pre-auth Evaluate Order, so
-        // the deviceSessionId correlates); fall back to the connector txn id.
-        let order_id = notify_order_id(
-            req.merchant_transaction_id.as_ref(),
-            req.connector_transaction_id.as_ref(),
-            "merchant_transaction_id",
-        )?;
-        let order_total =
-            super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
-        Ok(Self(build_notify_evaluate_order(
-            order_id,
-            order_total,
-            req.amount.currency.to_string(),
-            req.merchant_details.as_ref(),
-        )))
+        let (merchant, merchant_category_code) = kount_merchant(req.merchant_details.as_ref());
+        Ok(Self {
+            merchant_transaction_id: req
+                .merchant_transaction_id
+                .clone()
+                .or_else(|| req.connector_transaction_id.clone()),
+            payment_status: req
+                .payment_status
+                .and_then(KountPaymentStatus::from_attempt_status),
+            order_total: super::KountAmountConvertor::convert(
+                req.amount.amount,
+                req.amount.currency,
+            )?,
+            currency: req.amount.currency.to_string(),
+            frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
+            merchant_category_code,
+            merchant,
+        })
     }
-}
-
-/// Notify response: the Evaluate-Order body. Distinct type per flow (macro templating).
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct KountUpdateOrderResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    pub order: Option<KountOrder>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<serde_json::Value>>,
 }
 
 impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
@@ -1640,33 +1676,61 @@ impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
     fn try_from(
         item: ResponseRouterData<KountUpdateOrderResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Surface the raw Kount response for audit parity with PreRiskCheck.
-        // Mask through the PII serializer so the stored/egressed blob never carries
-        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
-        // exposed. `None` on serialization failure (degrades the audit trail rather
-        // than failing the flow).
-        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
-            .ok()
-            .map(|value| Secret::new(value.to_string()));
         Ok(Self {
             response: Ok(FrmPaymentOutcomeResponse {
                 status_code: item.http_code,
             }),
-            resource_common_data: FrmFlowData {
-                raw_connector_response,
-                ..item.router_data.resource_common_data
-            },
             ..item.router_data
         })
     }
 }
 
-// ── FrmRefundProcessed (refund notify) ────────────────────────────────────
+// ──────────────────────────────────────────────────────────────────────────
+// FrmRefundProcessed (Notify: refund) = Update Order
+// PATCH /commerce/v2/orders/{orderId}
+// ──────────────────────────────────────────────────────────────────────────
 
-/// Notify request: thin Evaluate-Order body (refund). Distinct templating type.
 #[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
-pub struct KountRefundUpdateRequest(pub KountEvaluateOrderRequest);
+pub struct KountRefundUpdateRequest {
+    /// Connector (gateway) transaction id the refund belongs to.
+    #[serde(
+        rename = "merchantTransactionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_transaction_id: Option<String>,
+    /// Connector refund id.
+    #[serde(rename = "refundId", skip_serializing_if = "Option::is_none")]
+    pub refund_id: Option<String>,
+    /// Reason supplied for the refund.
+    #[serde(rename = "refundReason", skip_serializing_if = "Option::is_none")]
+    pub refund_reason: Option<String>,
+    /// Refund amount in the smallest currency unit (string per Kount schema).
+    #[serde(rename = "refundAmount")]
+    pub refund_amount: StringMinorUnit,
+    /// ISO 4217 currency code.
+    pub currency: String,
+    /// FRM decision being notified (APPROVE / DECLINE / REVIEW).
+    #[serde(rename = "frmDisposition", skip_serializing_if = "Option::is_none")]
+    pub frm_disposition: Option<KountDisposition>,
+    /// Merchant Category Code (ISO 18245), when provided.
+    #[serde(
+        rename = "merchantCategoryCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_category_code: Option<u32>,
+    /// Merchant details (id), when provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant: Option<KountMerchant>,
+}
+
+/// Response from the refund Update Order PATCH. Distinct type from
+/// [`KountUpdateOrderResponse`] so the connector macros generate a unique
+/// templating type per flow.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRefundUpdateResponse {
+    #[serde(alias = "orderId")]
+    pub order_id: Option<String>,
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1695,37 +1759,24 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let req = &item.router_data.request;
-        // Refund requests carry no merchant_transaction_id, so the order id (and
-        // thus deviceSessionId) is derived from the connector txn id, falling back
-        // to the refund ids. Correlation to the pre-auth order is therefore
-        // best-effort: unless connector_transaction_id == the pre-auth
-        // merchant_transaction_id, this logs a fresh, uncorrelated evaluation.
-        let order_id = notify_order_id(
-            req.connector_transaction_id.as_ref(),
-            req.merchant_refund_id
-                .as_ref()
-                .or(req.connector_refund_id.as_ref()),
-            "connector_transaction_id",
-        )?;
-        let order_total =
-            super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
-        Ok(Self(build_notify_evaluate_order(
-            order_id,
-            order_total,
-            req.amount.currency.to_string(),
-            req.merchant_details.as_ref(),
-        )))
+        let (merchant, merchant_category_code) = kount_merchant(req.merchant_details.as_ref());
+        Ok(Self {
+            merchant_transaction_id: req.connector_transaction_id.clone(),
+            refund_id: req
+                .connector_refund_id
+                .clone()
+                .or_else(|| req.merchant_refund_id.clone()),
+            refund_reason: req.refund_reason.clone(),
+            refund_amount: super::KountAmountConvertor::convert(
+                req.amount.amount,
+                req.amount.currency,
+            )?,
+            currency: req.amount.currency.to_string(),
+            frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
+            merchant_category_code,
+            merchant,
+        })
     }
-}
-
-/// Notify response (refund). Distinct templating type.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct KountRefundUpdateResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    pub order: Option<KountOrder>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<serde_json::Value>>,
 }
 
 impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
@@ -1741,21 +1792,10 @@ impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
     fn try_from(
         item: ResponseRouterData<KountRefundUpdateResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Mask through the PII serializer so the stored/egressed blob never carries
-        // cleartext card/PII — a plain `serde_json::to_string` emits `Secret` fields
-        // exposed. `None` on serialization failure (degrades the audit trail rather
-        // than failing the flow).
-        let raw_connector_response = hyperswitch_masking::masked_serialize(&item.response)
-            .ok()
-            .map(|value| Secret::new(value.to_string()));
         Ok(Self {
             response: Ok(FrmRefundProcessedResponse {
                 status_code: item.http_code,
             }),
-            resource_common_data: FrmFlowData {
-                raw_connector_response,
-                ..item.router_data.resource_common_data
-            },
             ..item.router_data
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -1,4 +1,4 @@
-use common_enums::{AttemptStatus, FrmDecision, PaymentMethodType};
+use common_enums::{FrmDecision, PaymentMethodType};
 use common_utils::types::StringMinorUnit;
 use domain_types::{
     connector_flow::{
@@ -210,11 +210,16 @@ impl From<&KountDecision> for FrmDecision {
     }
 }
 
-/// Response from Evaluate Order (`POST /commerce/v2/orders`). Kount nests the
-/// order under an `order` object, with the risk decision under `riskInquiry`.
+/// Evaluate Order response (`POST /commerce/v2/orders`), shared by PreRiskCheck
+/// and the notify flows. PII/card fields are `Secret`-wrapped so they mask in the
+/// event log; risk analytics stay in plaintext.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct KountOrderResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     pub order: Option<KountOrder>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -224,27 +229,415 @@ pub struct KountOrder {
     pub order_id: Option<String>,
     #[serde(rename = "riskInquiry")]
     pub risk_inquiry: Option<KountRiskInquiry>,
+    #[serde(rename = "merchantOrderId", skip_serializing_if = "Option::is_none")]
+    pub merchant_order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Device/session identifier — PII, masked.
+    #[serde(rename = "deviceSessionId", skip_serializing_if = "Option::is_none")]
+    pub device_session_id: Option<Secret<String>>,
+    #[serde(rename = "creationDateTime", skip_serializing_if = "Option::is_none")]
+    pub creation_date_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transactions: Option<Vec<KountRespTransaction>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fulfillment: Option<Vec<KountRespFulfillment>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct KountRiskInquiry {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<KountDecision>,
-    #[serde(alias = "omniscore", alias = "score")]
+    // Kept as `f64` (the live Kount response returns a JSON number, e.g. `61.4`);
+    // the PreRiskCheck mapping reads this to derive the integer risk score.
+    #[serde(alias = "score", skip_serializing_if = "Option::is_none")]
     pub omniscore: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona: Option<KountPersona>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<KountRespDevice>,
+    #[serde(rename = "segmentExecuted", skip_serializing_if = "Option::is_none")]
+    pub segment_executed: Option<KountSegmentExecuted>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<KountEmailSignals>,
+    #[serde(rename = "policyManagement", skip_serializing_if = "Option::is_none")]
+    pub policy_management: Option<KountPolicyManagement>,
+    #[serde(rename = "reasonCode", skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
 }
 
-/// Response from the Kount Orders API update (`PATCH /commerce/v2/orders/{id}`).
-/// Distinct type from [`KountOrderResponse`] so the connector macros generate a
-/// unique templating type per flow.
+/// Accept a JSON scalar that Kount may send as either a string or a number
+/// (the Orders guide documents several count fields as stringified numbers —
+/// e.g. `"uniqueCards": "3"` — while the live sandbox returns JSON numbers).
+/// Normalises both into an `Option<String>` so the field always parses.
+fn de_stringy<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrNumber {
+        S(String),
+        N(serde_json::Number),
+        B(bool),
+    }
+    Ok(
+        Option::<StringOrNumber>::deserialize(deserializer)?.map(|value| match value {
+            StringOrNumber::S(s) => s,
+            StringOrNumber::N(n) => n.to_string(),
+            StringOrNumber::B(b) => b.to_string(),
+        }),
+    )
+}
+
+/// Like [`de_stringy`] but yields a masked `Secret` — for PII scalars (e.g.
+/// geo-coordinates) that Kount may send as a string or a number.
+fn de_stringy_secret<'de, D>(deserializer: D) -> Result<Option<Secret<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(de_stringy(deserializer)?.map(Secret::new))
+}
+
+/// Persona velocity/aggregate counts. Kount documents these as stringified
+/// numbers but the live API returns JSON numbers, so they parse leniently via
+/// [`de_stringy`]. Not PII — kept in plaintext for risk analytics.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct KountUpdateOrderResponse {
-    #[serde(alias = "orderId")]
-    pub order_id: Option<String>,
+pub struct KountPersona {
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "uniqueCards",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub unique_cards: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "uniqueDevices",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub unique_devices: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "uniqueEmails",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub unique_emails: Option<String>,
+    #[serde(rename = "riskiestCountry", skip_serializing_if = "Option::is_none")]
+    pub riskiest_country: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "totalBankApprovedOrders",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_bank_approved_orders: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "totalBankDeclinedOrders",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_bank_declined_orders: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "maxVelocity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_velocity: Option<String>,
+    #[serde(rename = "riskiestRegion", skip_serializing_if = "Option::is_none")]
+    pub riskiest_region: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRespDevice {
+    /// Device fingerprint id — PII, masked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Secret<String>>,
+    #[serde(rename = "collectionDateTime", skip_serializing_if = "Option::is_none")]
+    pub collection_date_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser: Option<String>,
+    #[serde(rename = "deviceAttributes", skip_serializing_if = "Option::is_none")]
+    pub device_attributes: Option<KountDeviceAttributes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<KountDeviceLocation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tor: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountDeviceAttributes {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+    #[serde(rename = "firstSeenDateTime", skip_serializing_if = "Option::is_none")]
+    pub first_seen_date_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy",
+        rename = "timezoneOffset",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timezone_offset: Option<String>,
+    #[serde(rename = "mobileSdkType", skip_serializing_if = "Option::is_none")]
+    pub mobile_sdk_type: Option<String>,
+    #[serde(rename = "cookiesEnabled", skip_serializing_if = "Option::is_none")]
+    pub cookies_enabled: Option<bool>,
+    #[serde(rename = "screenResolution", skip_serializing_if = "Option::is_none")]
+    pub screen_resolution: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<Vec<KountDeviceIp>>,
+    #[serde(rename = "localTime", skip_serializing_if = "Option::is_none")]
+    pub local_time: Option<String>,
+    #[serde(rename = "userAgent", skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+}
+
+/// Device IP details — all addresses are PII, masked.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountDeviceIp {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    #[serde(rename = "piercedAddress", skip_serializing_if = "Option::is_none")]
+    pub pierced_address: Option<Secret<String>>,
+    #[serde(
+        rename = "piercedOrganization",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pierced_organization: Option<String>,
+}
+
+/// Geolocation of the device. Precise coordinates and postal code are PII
+/// (masked); coarse city/region/country are kept in plaintext.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountDeviceLocation {
+    #[serde(rename = "areaCode", skip_serializing_if = "Option::is_none")]
+    pub area_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    #[serde(rename = "countryCode", skip_serializing_if = "Option::is_none")]
+    pub country_code: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy_secret",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub latitude: Option<Secret<String>>,
+    #[serde(
+        default,
+        deserialize_with = "de_stringy_secret",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub longitude: Option<Secret<String>>,
+    #[serde(rename = "postalCode", skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(rename = "regionCode", skip_serializing_if = "Option::is_none")]
+    pub region_code: Option<String>,
+    #[serde(rename = "localeCountryCode", skip_serializing_if = "Option::is_none")]
+    pub locale_country_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountSegmentExecuted {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment: Option<KountSegment>,
+    #[serde(rename = "policiesExecuted", skip_serializing_if = "Option::is_none")]
+    pub policies_executed: Option<Vec<KountPolicyExecuted>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountSegment {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountPolicyExecuted {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<KountPolicyOutcome>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountPolicyOutcome {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub outcome_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// Email reputation signals (metadata about the email, not the address itself).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountEmailSignals {
+    #[serde(rename = "isVerifiedDomain", skip_serializing_if = "Option::is_none")]
+    pub is_verified_domain: Option<bool>,
+    #[serde(rename = "firstSeen", skip_serializing_if = "Option::is_none")]
+    pub first_seen: Option<String>,
+    #[serde(rename = "mostRecent", skip_serializing_if = "Option::is_none")]
+    pub most_recent: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountPolicyManagement {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<KountDecision>,
-    #[serde(alias = "omniscore", alias = "riskScore")]
-    pub score: Option<f64>,
-    pub reason: Option<String>,
+    #[serde(rename = "setExecuted", skip_serializing_if = "Option::is_none")]
+    pub set_executed: Option<KountNameVersion>,
+    #[serde(rename = "segmentExecuted", skip_serializing_if = "Option::is_none")]
+    pub segment_executed: Option<KountSegment>,
+    #[serde(rename = "policiesExecuted", skip_serializing_if = "Option::is_none")]
+    pub policies_executed: Option<Vec<KountPolicyExecuted>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(rename = "tagWeights", skip_serializing_if = "Option::is_none")]
+    pub tag_weights: Option<Vec<KountTagWeight>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub set: Option<KountNameVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment: Option<KountSegment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<KountAction>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountNameVersion {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountTagWeight {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountAction {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub action_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(rename = "addToListValues", skip_serializing_if = "Option::is_none")]
+    pub add_to_list_values: Option<Vec<KountAddToListValue>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountAddToListValue {
+    #[serde(rename = "listIds", skip_serializing_if = "Option::is_none")]
+    pub list_ids: Option<Vec<String>>,
+    #[serde(rename = "fieldTypes", skip_serializing_if = "Option::is_none")]
+    pub field_types: Option<Vec<serde_json::Value>>,
+}
+
+/// A transaction on the Orders response. `payment` carries card data — masked.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRespTransaction {
+    #[serde(rename = "transactionId", skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<String>,
+    #[serde(
+        rename = "merchantTransactionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_transaction_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment: Option<Vec<KountRespPayment>>,
+    #[serde(
+        rename = "processorMerchantId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub processor_merchant_id: Option<String>,
+}
+
+/// Payment instrument on the Orders response. Every card-identifying field is
+/// PII/card data — masked.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRespPayment {
+    #[serde(rename = "cardBrand", skip_serializing_if = "Option::is_none")]
+    pub card_brand: Option<Secret<String>>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub payment_type: Option<String>,
+    #[serde(rename = "paymentToken", skip_serializing_if = "Option::is_none")]
+    pub payment_token: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bin: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last4: Option<Secret<String>>,
+    #[serde(
+        rename = "issuingOrganization",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub issuing_organization: Option<Secret<String>>,
+    #[serde(rename = "expirationMonth", skip_serializing_if = "Option::is_none")]
+    pub expiration_month: Option<Secret<i64>>,
+    #[serde(rename = "expirationYear", skip_serializing_if = "Option::is_none")]
+    pub expiration_year: Option<Secret<i64>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRespFulfillment {
+    #[serde(rename = "fulfillmentId", skip_serializing_if = "Option::is_none")]
+    pub fulfillment_id: Option<String>,
+    #[serde(
+        rename = "merchantFulfillmentId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merchant_fulfillment_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shipping: Option<KountRespShipping>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(rename = "accessUrl", skip_serializing_if = "Option::is_none")]
+    pub access_url: Option<String>,
+    #[serde(rename = "digitalDownloaded", skip_serializing_if = "Option::is_none")]
+    pub digital_downloaded: Option<bool>,
+    /// Download device IP — PII, masked. (Kount's field name carries a typo,
+    /// `downnloadDeviceIp`, preserved here so it deserializes.)
+    #[serde(rename = "downnloadDeviceIp", skip_serializing_if = "Option::is_none")]
+    pub download_device_ip: Option<Secret<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRespShipping {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(rename = "trackingNumber", skip_serializing_if = "Option::is_none")]
+    pub tracking_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    #[serde(rename = "shippedDateTime", skip_serializing_if = "Option::is_none")]
+    pub shipped_date_time: Option<String>,
+    #[serde(rename = "deliveredDateTime", skip_serializing_if = "Option::is_none")]
+    pub delivered_date_time: Option<String>,
 }
 
 /// Truncate a merchant-supplied id into a valid Kount `sessionId` (≤32 chars,
@@ -1107,97 +1500,72 @@ impl TryFrom<ResponseRouterData<KountOrderResponse, Self>>
     }
 }
 
-/// Kount Update Order disposition tokens. Serialized in uppercase to match the
-/// Kount Orders schema.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum KountDisposition {
-    Approve,
-    Decline,
-    Review,
-}
-
-impl KountDisposition {
-    /// Map the FRM decision to a Kount disposition. `Error` has no Kount
-    /// disposition, so it is omitted rather than sent as a guessed value.
-    fn from_decision(decision: FrmDecision) -> Option<Self> {
-        match decision {
-            FrmDecision::Approve => Some(Self::Approve),
-            FrmDecision::Reject => Some(Self::Decline),
-            FrmDecision::Review => Some(Self::Review),
-            FrmDecision::Error => None,
-        }
+// ──────────────────────────────────────────────────────────────────────────
+// Notify flows (FrmPaymentOutcome / FrmRefundProcessed) = Evaluate Order
+// POST /commerce/v2/orders?riskInquiry=true
+fn build_notify_evaluate_order(
+    order_id: String,
+    order_total: StringMinorUnit,
+    currency: String,
+    merchant_details: Option<&MerchantDetails>,
+) -> KountEvaluateOrderRequest {
+    let transactions = vec![KountTransaction {
+        subtotal: order_total.clone(),
+        order_total,
+        currency,
+        payment: None,
+        billed_person: None,
+    }];
+    let creation_date_time = OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+    let (merchant, merchant_category_code) = kount_merchant(merchant_details);
+    KountEvaluateOrderRequest {
+        session_id: hash_session_id(&order_id),
+        order_id,
+        channel: KountChannel::Web,
+        creation_date_time,
+        user_ip: None,
+        account: None,
+        items: Vec::new(),
+        fulfillment: Vec::new(),
+        transactions,
+        device: None,
+        merchant_category_code,
+        merchant,
     }
 }
 
-/// Kount Update Order payment-status tokens. Serialized in uppercase to match
-/// the Kount Orders schema.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum KountPaymentStatus {
-    Charged,
-    Authorized,
-    Voided,
-    Refunded,
-    Declined,
+/// Require an order reference from a notify request; it is the Kount
+/// `merchantOrderId` and the basis for the correlating `deviceSessionId`.
+fn notify_order_id(primary: Option<&String>, fallback: Option<&String>) -> Result<String, Error> {
+    primary.or(fallback).cloned().ok_or_else(|| {
+        error_stack::report!(errors::IntegrationError::MissingRequiredField {
+            field_name: "merchant_transaction_id",
+            context: errors::IntegrationErrorContext {
+                additional_context: Some(
+                    "Kount notify (Evaluate Order POST) needs a merchant/connector transaction \
+                     id; it is the order reference and the basis for the deviceSessionId that \
+                     correlates to the pre-auth order"
+                        .to_owned(),
+                ),
+                suggested_action: Some(
+                    "Set merchant_transaction_id (or connector_transaction_id) on the notify request"
+                        .to_owned(),
+                ),
+                doc_url: Some(KOUNT_DOC_URL.to_owned()),
+            },
+        })
+    })
 }
 
-impl KountPaymentStatus {
-    /// Map the internal attempt status to a Kount payment status. Unmapped
-    /// statuses are omitted rather than sent as an unrecognized value.
-    fn from_attempt_status(status: AttemptStatus) -> Option<Self> {
-        match status {
-            AttemptStatus::Charged
-            | AttemptStatus::PartialCharged
-            | AttemptStatus::PartialChargedAndChargeable => Some(Self::Charged),
-            AttemptStatus::Authorized | AttemptStatus::PartiallyAuthorized => {
-                Some(Self::Authorized)
-            }
-            AttemptStatus::Voided | AttemptStatus::VoidedPostCapture => Some(Self::Voided),
-            AttemptStatus::AutoRefunded => Some(Self::Refunded),
-            AttemptStatus::Failure
-            | AttemptStatus::AuthorizationFailed
-            | AttemptStatus::CaptureFailed
-            | AttemptStatus::RouterDeclined => Some(Self::Declined),
-            _ => None,
-        }
-    }
-}
+// ── FrmPaymentOutcome (payment notify) ────────────────────────────────────
 
-// ──────────────────────────────────────────────────────────────────────────
-// FrmPaymentOutcome (Notify: payment succeeded) = Update Order
-// PATCH /commerce/v2/orders/{orderId}
-// ──────────────────────────────────────────────────────────────────────────
-
+/// Notify request: a thin Evaluate-Order body. Distinct newtype per flow so the
+/// macros generate a unique templating companion.
 #[derive(Debug, Clone, Serialize)]
-pub struct KountUpdateOrderRequest {
-    /// Connector (gateway) transaction id, attached after authorization.
-    #[serde(
-        rename = "merchantTransactionId",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub merchant_transaction_id: Option<String>,
-    /// Final payment status.
-    #[serde(rename = "paymentStatus", skip_serializing_if = "Option::is_none")]
-    pub payment_status: Option<KountPaymentStatus>,
-    /// Order total in the smallest currency unit (string per Kount schema).
-    #[serde(rename = "orderTotal")]
-    pub order_total: StringMinorUnit,
-    /// ISO 4217 currency code.
-    pub currency: String,
-    /// FRM decision being notified (APPROVE / DECLINE / REVIEW).
-    #[serde(rename = "frmDisposition", skip_serializing_if = "Option::is_none")]
-    pub frm_disposition: Option<KountDisposition>,
-    /// Merchant Category Code (ISO 18245), when provided.
-    #[serde(
-        rename = "merchantCategoryCode",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub merchant_category_code: Option<u32>,
-    /// Merchant details (id), when provided.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchant: Option<KountMerchant>,
-}
+#[serde(transparent)]
+pub struct KountUpdateOrderRequest(pub KountEvaluateOrderRequest);
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1226,25 +1594,31 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let req = &item.router_data.request;
-        let (merchant, merchant_category_code) = kount_merchant(req.merchant_details.as_ref());
-        Ok(Self {
-            merchant_transaction_id: req
-                .merchant_transaction_id
-                .clone()
-                .or_else(|| req.connector_transaction_id.clone()),
-            payment_status: req
-                .payment_status
-                .and_then(KountPaymentStatus::from_attempt_status),
-            order_total: super::KountAmountConvertor::convert(
-                req.amount.amount,
-                req.amount.currency,
-            )?,
-            currency: req.amount.currency.to_string(),
-            frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
-            merchant_category_code,
-            merchant,
-        })
+        // Prefer the merchant order id (matches the pre-auth Evaluate Order, so
+        // the deviceSessionId correlates); fall back to the connector txn id.
+        let order_id = notify_order_id(
+            req.merchant_transaction_id.as_ref(),
+            req.connector_transaction_id.as_ref(),
+        )?;
+        let order_total =
+            super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
+        Ok(Self(build_notify_evaluate_order(
+            order_id,
+            order_total,
+            req.amount.currency.to_string(),
+            req.merchant_details.as_ref(),
+        )))
     }
+}
+
+/// Notify response: the Evaluate-Order body. Distinct type per flow (macro templating).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountUpdateOrderResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub order: Option<KountOrder>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
@@ -1260,61 +1634,27 @@ impl TryFrom<ResponseRouterData<KountUpdateOrderResponse, Self>>
     fn try_from(
         item: ResponseRouterData<KountUpdateOrderResponse, Self>,
     ) -> Result<Self, Self::Error> {
+        // Surface the raw Kount response for audit parity with PreRiskCheck.
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
         Ok(Self {
             response: Ok(FrmPaymentOutcomeResponse {
                 status_code: item.http_code,
             }),
+            resource_common_data: FrmFlowData {
+                raw_connector_response,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// FrmRefundProcessed (Notify: refund) = Update Order
-// PATCH /commerce/v2/orders/{orderId}
-// ──────────────────────────────────────────────────────────────────────────
+// ── FrmRefundProcessed (refund notify) ────────────────────────────────────
 
+/// Notify request: thin Evaluate-Order body (refund). Distinct templating type.
 #[derive(Debug, Clone, Serialize)]
-pub struct KountRefundUpdateRequest {
-    /// Connector (gateway) transaction id the refund belongs to.
-    #[serde(
-        rename = "merchantTransactionId",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub merchant_transaction_id: Option<String>,
-    /// Connector refund id.
-    #[serde(rename = "refundId", skip_serializing_if = "Option::is_none")]
-    pub refund_id: Option<String>,
-    /// Reason supplied for the refund.
-    #[serde(rename = "refundReason", skip_serializing_if = "Option::is_none")]
-    pub refund_reason: Option<String>,
-    /// Refund amount in the smallest currency unit (string per Kount schema).
-    #[serde(rename = "refundAmount")]
-    pub refund_amount: StringMinorUnit,
-    /// ISO 4217 currency code.
-    pub currency: String,
-    /// FRM decision being notified (APPROVE / DECLINE / REVIEW).
-    #[serde(rename = "frmDisposition", skip_serializing_if = "Option::is_none")]
-    pub frm_disposition: Option<KountDisposition>,
-    /// Merchant Category Code (ISO 18245), when provided.
-    #[serde(
-        rename = "merchantCategoryCode",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub merchant_category_code: Option<u32>,
-    /// Merchant details (id), when provided.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchant: Option<KountMerchant>,
-}
-
-/// Response from the refund Update Order PATCH. Distinct type from
-/// [`KountUpdateOrderResponse`] so the connector macros generate a unique
-/// templating type per flow.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct KountRefundUpdateResponse {
-    #[serde(alias = "orderId")]
-    pub order_id: Option<String>,
-}
+#[serde(transparent)]
+pub struct KountRefundUpdateRequest(pub KountEvaluateOrderRequest);
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1343,24 +1683,33 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let req = &item.router_data.request;
-        let (merchant, merchant_category_code) = kount_merchant(req.merchant_details.as_ref());
-        Ok(Self {
-            merchant_transaction_id: req.connector_transaction_id.clone(),
-            refund_id: req
-                .connector_refund_id
-                .clone()
-                .or_else(|| req.merchant_refund_id.clone()),
-            refund_reason: req.refund_reason.clone(),
-            refund_amount: super::KountAmountConvertor::convert(
-                req.amount.amount,
-                req.amount.currency,
-            )?,
-            currency: req.amount.currency.to_string(),
-            frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
-            merchant_category_code,
-            merchant,
-        })
+        // Refund requests carry no merchant_transaction_id; use the connector txn
+        // id (payment reference), falling back to the refund ids.
+        let order_id = notify_order_id(
+            req.connector_transaction_id.as_ref(),
+            req.merchant_refund_id
+                .as_ref()
+                .or(req.connector_refund_id.as_ref()),
+        )?;
+        let order_total =
+            super::KountAmountConvertor::convert(req.amount.amount, req.amount.currency)?;
+        Ok(Self(build_notify_evaluate_order(
+            order_id,
+            order_total,
+            req.amount.currency.to_string(),
+            req.merchant_details.as_ref(),
+        )))
     }
+}
+
+/// Notify response (refund). Distinct templating type.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountRefundUpdateResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub order: Option<KountOrder>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
@@ -1376,11 +1725,115 @@ impl TryFrom<ResponseRouterData<KountRefundUpdateResponse, Self>>
     fn try_from(
         item: ResponseRouterData<KountRefundUpdateResponse, Self>,
     ) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
         Ok(Self {
             response: Ok(FrmRefundProcessedResponse {
                 status_code: item.http_code,
             }),
+            resource_common_data: FrmFlowData {
+                raw_connector_response,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A representative Kount Evaluate Order (`POST /commerce/v2/orders?riskInquiry=true`)
+    // response, enriched with card + device PII to exercise masking. `omniscore`
+    // and persona counts are JSON numbers (live form); lat/long are numbers too.
+    const EVAL_RESPONSE: &str = r#"{
+      "version": "v2.132.0",
+      "order": {
+        "orderId": "TESTORDER0001",
+        "merchantOrderId": "merch-order-1",
+        "channel": "WEB",
+        "deviceSessionId": "sesshash0000000000000000000000aa",
+        "creationDateTime": "2026-07-23T13:26:46Z",
+        "riskInquiry": {
+          "decision": "APPROVE",
+          "omniscore": 61.4,
+          "persona": { "uniqueCards": 7, "uniqueDevices": 2, "riskiestCountry": "US" },
+          "device": {
+            "id": "devfp0001",
+            "browser": "Chrome 106",
+            "deviceAttributes": { "ip": [{ "address": "192.0.2.1", "piercedAddress": "10.0.0.1" }], "userAgent": "Mozilla/5.0" },
+            "location": { "city": "Boise", "latitude": 44.87, "longitude": -120.34, "postalCode": "90210" }
+          },
+          "reasonCode": "FraudATO"
+        },
+        "transactions": [{ "transactionId": "TESTORDER0001#0", "payment": [{ "cardBrand": "visa", "bin": "411111", "last4": "1111", "paymentToken": "tok_abc" }] }],
+        "fulfillment": []
+      },
+      "warnings": []
+    }"#;
+
+    #[test]
+    fn notify_response_parses_and_masks_pii_and_card() {
+        let notify: KountUpdateOrderResponse = serde_json::from_str(EVAL_RESPONSE).unwrap();
+        let ri = notify
+            .order
+            .as_ref()
+            .unwrap()
+            .risk_inquiry
+            .as_ref()
+            .unwrap();
+        assert_eq!(ri.decision, Some(KountDecision::Approve));
+        assert_eq!(ri.omniscore, Some(61.4));
+        assert_eq!(ri.reason_code.as_deref(), Some("FraudATO"));
+
+        let masked = hyperswitch_masking::masked_serialize(&notify)
+            .unwrap()
+            .to_string();
+        for secret in [
+            "sesshash0000000000000000000000aa",
+            "192.0.2.1",
+            "10.0.0.1",
+            "44.87",
+            "-120.34",
+            "90210",
+            "visa",
+            "411111",
+            "1111",
+            "tok_abc",
+            "devfp0001",
+        ] {
+            assert!(!masked.contains(secret), "PII/card leaked in log: {secret}");
+        }
+        for plain in ["APPROVE", "61.4", "FraudATO", "Boise", "WEB"] {
+            assert!(
+                masked.contains(plain),
+                "expected plaintext missing: {plain}"
+            );
+        }
+    }
+
+    #[test]
+    fn prerisk_response_reads_preserved() {
+        // The same body parses via KountOrderResponse and the PreRiskCheck mapping
+        // still reads decision / omniscore / order_id (backward compatible).
+        let prerisk: KountOrderResponse = serde_json::from_str(EVAL_RESPONSE).unwrap();
+        let order = prerisk.order.as_ref().unwrap();
+        let ri = order.risk_inquiry.as_ref().unwrap();
+        assert_eq!(
+            FrmDecision::from(ri.decision.as_ref().unwrap()),
+            FrmDecision::Approve
+        );
+        assert_eq!(ri.omniscore.map(omniscore_to_risk_score), Some(61));
+        assert_eq!(order.order_id.as_deref(), Some("TESTORDER0001"));
+    }
+
+    #[test]
+    fn de_stringy_accepts_number_and_string() {
+        // Persona counts come back as JSON numbers on the live API but are documented
+        // as strings; both must parse.
+        let as_num: KountPersona = serde_json::from_str(r#"{"uniqueCards": 7}"#).unwrap();
+        let as_str: KountPersona = serde_json::from_str(r#"{"uniqueCards": "7"}"#).unwrap();
+        assert_eq!(as_num.unique_cards.as_deref(), Some("7"));
+        assert_eq!(as_str.unique_cards.as_deref(), Some("7"));
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -269,6 +269,19 @@ pub struct KountRiskInquiry {
     pub reason_code: Option<String>,
 }
 
+/// Response from the Kount Orders API update (`PATCH /commerce/v2/orders/{id}`).
+/// Distinct type from [`KountOrderResponse`] so the connector macros generate a
+/// unique templating type per flow.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KountUpdateOrderResponse {
+    #[serde(alias = "orderId")]
+    pub order_id: Option<String>,
+    pub decision: Option<KountDecision>,
+    #[serde(alias = "omniscore", alias = "riskScore")]
+    pub score: Option<f64>,
+    pub reason: Option<String>,
+}
+
 /// Accept a JSON scalar that Kount may send as either a string or a number
 /// (the Orders guide documents several count fields as stringified numbers —
 /// e.g. `"uniqueCards": "3"` — while the live sandbox returns JSON numbers).
@@ -1503,24 +1516,6 @@ impl TryFrom<ResponseRouterData<KountOrderResponse, Self>>
             ..item.router_data
         })
     }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Notify flows (FrmPaymentOutcome / FrmRefundProcessed) = Update Order
-// PATCH /commerce/v2/orders/{orderId}
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Response from the Kount Orders API update (`PATCH /commerce/v2/orders/{id}`).
-/// Distinct type from [`KountOrderResponse`] so the connector macros generate a
-/// unique templating type per flow.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct KountUpdateOrderResponse {
-    #[serde(alias = "orderId")]
-    pub order_id: Option<String>,
-    pub decision: Option<KountDecision>,
-    #[serde(alias = "omniscore", alias = "riskScore")]
-    pub score: Option<f64>,
-    pub reason: Option<String>,
 }
 
 /// Kount Update Order disposition tokens. Serialized in uppercase to match the


### PR DESCRIPTION
## What & why

Enrich the **pre_risk_check** (Evaluate Order, `POST /commerce/v2/orders?riskInquiry=true`) response so the full documented Kount risk body is captured — masked — in the connector event log and `raw_connector_response`. Previously `KountOrderResponse` kept only `decision`/`omniscore`/`reason` and discarded the rest (persona, device, policyManagement, transactions, fulfillment…).

**The notify flows stay on PATCH.** An earlier revision of this branch moved the FRM notify flows (`FrmPaymentOutcome`/`FrmRefundProcessed`) to POST Evaluate Order; that was a mistake and has been reverted — notify is back to `PATCH /commerce/v2/orders/{orderId}` (Update Order), exactly as on `main`. Net change vs `main` is confined to `transformers.rs`.

## Changes (transformers.rs only)
- `KountOrderResponse` / `KountOrder` / `KountRiskInquiry` model the full documented Evaluate Order schema (+ ~20 nested types), using `#[serde(rename_all = "camelCase")]`.
- PII/card fields wrapped in `Secret` so they mask in logs: `deviceSessionId`, device id, IPs, card `bin`/`last4`/`paymentToken`/`cardBrand`, and granular device location (coordinates, postalCode, areaCode, city, region, regionCode). Country-level fields stay plaintext.
- Number-or-string tolerant parsing (`de_stringy`) for count/score fields; `warnings` typed as `Vec<serde_json::Value>` to tolerate structured shapes.
- `raw_connector_response` built via `masked_serialize` so the stored/egressed blob never carries cleartext card/PII.
- `PreRiskCheck` response reads (`decision`/`omniscore`/`reason`/`order_id`) are unchanged — backward compatible.
- **No proto or shared-type changes.**

## Not changed
- Notify (`FrmPaymentOutcome`/`FrmRefundProcessed`) → `PATCH /orders/{orderId}`, original body/response (`kount.rs` identical to `main`).
- prism gRPC contract unchanged. Full risk body is surfaced in logs + `raw_connector_response` only (no proto change to return it in `PreRiskCheckResponse`).

## Verification
- `cargo +nightly fmt --all --check` → clean; `RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets` → clean.
- Live sandbox: pre_risk_check returns the full `riskInquiry`; parsed into the enriched model with `deviceSessionId`/card fields masked (`*** … ***`) and `decision`/`omniscore` visible.
