### PR TITLE
fix: preserve connector HTTP client error semantics

### DIFF
--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -381,9 +381,7 @@ impl IntoGrpcStatus for Report<ConnectorFlowError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{connector_http_status_to_grpc_code, ToGrpcStatus};
-    use domain_types::{errors::ConnectorError, router_data::ErrorResponse};
-    use prost::Message;
+    use super::connector_http_status_to_grpc_code;
     use tonic::Code;
 
     #[test]
@@ -412,36 +410,6 @@ mod tests {
                 expected_grpc_code,
                 "unexpected gRPC mapping for connector HTTP status {http_status}"
             );
-        }
-    }
-
-    #[test]
-    fn leaves_non_error_and_non_http_statuses_unknown() {
-        for status in [0, 200, 399, 600, u16::MAX] {
-            assert_eq!(
-                connector_http_status_to_grpc_code(status),
-                Code::Unknown,
-                "unexpected gRPC mapping for non-error status {status}"
-            );
-        }
-    }
-
-    #[test]
-    fn preserves_connector_409_in_grpc_error_details() {
-        let connector_error = ConnectorError::ConnectorErrorResponse(ErrorResponse {
-            code: "409".to_string(),
-            message: "idempotency key reused with a different request body".to_string(),
-            status_code: 409,
-            ..ErrorResponse::default()
-        });
-
-        let status = connector_error.to_grpc_status_unlogged();
-        let details = grpc_api_types::payments::ConnectorError::decode(status.details());
-
-        assert_eq!(status.code(), Code::Aborted);
-        assert!(details.is_ok(), "connector error details should decode");
-        if let Ok(details) = details {
-            assert_eq!(details.http_status_code, Some(409));
         }
     }
 }

--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -221,11 +221,18 @@ impl ToGrpcStatus for ConnectorError {
         let _ = connector_error.encode(&mut buf);
 
         match self {
-            Self::ConnectorErrorResponse(error_response) => Status::with_details(
-                connector_http_status_to_grpc_code(error_response.status_code),
-                msg,
-                buf.into(),
-            ),
+            Self::ConnectorErrorResponse(error_response) => match error_response.status_code {
+                400 => Status::with_details(tonic::Code::InvalidArgument, msg, buf.into()),
+                401 => Status::with_details(tonic::Code::Unauthenticated, msg, buf.into()),
+                403 => Status::with_details(tonic::Code::PermissionDenied, msg, buf.into()),
+                404 => Status::with_details(tonic::Code::NotFound, msg, buf.into()),
+                429 => Status::with_details(tonic::Code::ResourceExhausted, msg, buf.into()),
+                500 => Status::with_details(tonic::Code::Internal, msg, buf.into()),
+                501 => Status::with_details(tonic::Code::Unimplemented, msg, buf.into()),
+                503 => Status::with_details(tonic::Code::Unavailable, msg, buf.into()),
+                504 => Status::with_details(tonic::Code::DeadlineExceeded, msg, buf.into()),
+                _ => Status::with_details(tonic::Code::Unknown, msg, buf.into()),
+            },
             Self::ResponseDeserializationFailed { .. }
             | Self::ResponseHandlingFailed { .. }
             | Self::UnexpectedResponseError { .. }
@@ -233,28 +240,6 @@ impl ToGrpcStatus for ConnectorError {
                 Status::with_details(tonic::Code::Internal, msg, buf.into())
             }
         }
-    }
-}
-
-/// Maps a connector's HTTP response status to the closest canonical gRPC code.
-///
-/// The exact connector status is retained in `ConnectorError.http_status_code`.
-/// Unknown connector 4xx responses remain caller-visible errors rather than being
-/// converted to `Unknown`, which the HTTP bridge exposes as a UCS 500 response.
-fn connector_http_status_to_grpc_code(status_code: u16) -> tonic::Code {
-    match status_code {
-        401 => tonic::Code::Unauthenticated,
-        403 => tonic::Code::PermissionDenied,
-        404 => tonic::Code::NotFound,
-        408 | 504 => tonic::Code::DeadlineExceeded,
-        409 => tonic::Code::Aborted,
-        412 => tonic::Code::FailedPrecondition,
-        429 => tonic::Code::ResourceExhausted,
-        501 => tonic::Code::Unimplemented,
-        502 | 503 => tonic::Code::Unavailable,
-        400..=499 => tonic::Code::InvalidArgument,
-        500..=599 => tonic::Code::Unknown,
-        _ => tonic::Code::Unknown,
     }
 }
 
@@ -376,40 +361,5 @@ impl IntoGrpcStatus for Report<InternalError> {
 impl IntoGrpcStatus for Report<ConnectorFlowError> {
     fn into_grpc_status(self) -> Status {
         self.to_grpc_error().into_grpc_status()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::connector_http_status_to_grpc_code;
-    use tonic::Code;
-
-    #[test]
-    fn maps_connector_http_statuses_to_canonical_grpc_codes() {
-        let cases = [
-            (400, Code::InvalidArgument),
-            (401, Code::Unauthenticated),
-            (403, Code::PermissionDenied),
-            (404, Code::NotFound),
-            (408, Code::DeadlineExceeded),
-            (409, Code::Aborted),
-            (412, Code::FailedPrecondition),
-            (422, Code::InvalidArgument),
-            (429, Code::ResourceExhausted),
-            (500, Code::Unknown),
-            (501, Code::Unimplemented),
-            (502, Code::Unavailable),
-            (503, Code::Unavailable),
-            (504, Code::DeadlineExceeded),
-            (599, Code::Unknown),
-        ];
-
-        for (http_status, expected_grpc_code) in cases {
-            assert_eq!(
-                connector_http_status_to_grpc_code(http_status),
-                expected_grpc_code,
-                "unexpected gRPC mapping for connector HTTP status {http_status}"
-            );
-        }
     }
 }

--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -221,18 +221,11 @@ impl ToGrpcStatus for ConnectorError {
         let _ = connector_error.encode(&mut buf);
 
         match self {
-            Self::ConnectorErrorResponse(error_response) => match error_response.status_code {
-                400 => Status::with_details(tonic::Code::InvalidArgument, msg, buf.into()),
-                401 => Status::with_details(tonic::Code::Unauthenticated, msg, buf.into()),
-                403 => Status::with_details(tonic::Code::PermissionDenied, msg, buf.into()),
-                404 => Status::with_details(tonic::Code::NotFound, msg, buf.into()),
-                429 => Status::with_details(tonic::Code::ResourceExhausted, msg, buf.into()),
-                500 => Status::with_details(tonic::Code::Internal, msg, buf.into()),
-                501 => Status::with_details(tonic::Code::Unimplemented, msg, buf.into()),
-                503 => Status::with_details(tonic::Code::Unavailable, msg, buf.into()),
-                504 => Status::with_details(tonic::Code::DeadlineExceeded, msg, buf.into()),
-                _ => Status::with_details(tonic::Code::Unknown, msg, buf.into()),
-            },
+            Self::ConnectorErrorResponse(error_response) => Status::with_details(
+                connector_http_status_to_grpc_code(error_response.status_code),
+                msg,
+                buf.into(),
+            ),
             Self::ResponseDeserializationFailed { .. }
             | Self::ResponseHandlingFailed { .. }
             | Self::UnexpectedResponseError { .. }
@@ -240,6 +233,28 @@ impl ToGrpcStatus for ConnectorError {
                 Status::with_details(tonic::Code::Internal, msg, buf.into())
             }
         }
+    }
+}
+
+/// Maps a connector's HTTP response status to the closest canonical gRPC code.
+///
+/// The exact connector status is retained in `ConnectorError.http_status_code`.
+/// Unknown connector 4xx responses remain caller-visible errors rather than being
+/// converted to `Unknown`, which the HTTP bridge exposes as a UCS 500 response.
+fn connector_http_status_to_grpc_code(status_code: u16) -> tonic::Code {
+    match status_code {
+        401 => tonic::Code::Unauthenticated,
+        403 => tonic::Code::PermissionDenied,
+        404 => tonic::Code::NotFound,
+        408 | 504 => tonic::Code::DeadlineExceeded,
+        409 => tonic::Code::Aborted,
+        412 => tonic::Code::FailedPrecondition,
+        429 => tonic::Code::ResourceExhausted,
+        501 => tonic::Code::Unimplemented,
+        502 | 503 => tonic::Code::Unavailable,
+        400..=499 => tonic::Code::InvalidArgument,
+        500..=599 => tonic::Code::Unknown,
+        _ => tonic::Code::Unknown,
     }
 }
 
@@ -361,5 +376,72 @@ impl IntoGrpcStatus for Report<InternalError> {
 impl IntoGrpcStatus for Report<ConnectorFlowError> {
     fn into_grpc_status(self) -> Status {
         self.to_grpc_error().into_grpc_status()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{connector_http_status_to_grpc_code, ToGrpcStatus};
+    use domain_types::{errors::ConnectorError, router_data::ErrorResponse};
+    use prost::Message;
+    use tonic::Code;
+
+    #[test]
+    fn maps_connector_http_statuses_to_canonical_grpc_codes() {
+        let cases = [
+            (400, Code::InvalidArgument),
+            (401, Code::Unauthenticated),
+            (403, Code::PermissionDenied),
+            (404, Code::NotFound),
+            (408, Code::DeadlineExceeded),
+            (409, Code::Aborted),
+            (412, Code::FailedPrecondition),
+            (422, Code::InvalidArgument),
+            (429, Code::ResourceExhausted),
+            (500, Code::Unknown),
+            (501, Code::Unimplemented),
+            (502, Code::Unavailable),
+            (503, Code::Unavailable),
+            (504, Code::DeadlineExceeded),
+            (599, Code::Unknown),
+        ];
+
+        for (http_status, expected_grpc_code) in cases {
+            assert_eq!(
+                connector_http_status_to_grpc_code(http_status),
+                expected_grpc_code,
+                "unexpected gRPC mapping for connector HTTP status {http_status}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_non_error_and_non_http_statuses_unknown() {
+        for status in [0, 200, 399, 600, u16::MAX] {
+            assert_eq!(
+                connector_http_status_to_grpc_code(status),
+                Code::Unknown,
+                "unexpected gRPC mapping for non-error status {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_connector_409_in_grpc_error_details() {
+        let connector_error = ConnectorError::ConnectorErrorResponse(ErrorResponse {
+            code: "409".to_string(),
+            message: "idempotency key reused with a different request body".to_string(),
+            status_code: 409,
+            ..ErrorResponse::default()
+        });
+
+        let status = connector_error.to_grpc_status_unlogged();
+        let details = grpc_api_types::payments::ConnectorError::decode(status.details());
+
+        assert_eq!(status.code(), Code::Aborted);
+        assert!(details.is_ok(), "connector error details should decode");
+        if let Ok(details) = details {
+            assert_eq!(details.http_status_code, Some(409));
+        }
     }
 }

--- a/crates/grpc-server/grpc-server/src/http/error.rs
+++ b/crates/grpc-server/grpc-server/src/http/error.rs
@@ -190,23 +190,17 @@ fn extract_error_details_from_status(status: &tonic::Status) -> Option<ErrorDeta
 /// Extract the connector's exact HTTP error status when the decoded details identify a
 /// connector-originated 4xx/5xx response.
 fn connector_http_status_from_error_details(details: Option<&ErrorDetails>) -> Option<StatusCode> {
-    let Some(ErrorDetails::ConnectorError {
-        error_code,
-        http_status_code: Some(http_status_code),
-        ..
-    }) = details
-    else {
-        return None;
-    };
-
-    if error_code != "CONNECTOR_ERROR_RESPONSE" {
-        return None;
+    match details {
+        Some(ErrorDetails::ConnectorError {
+            error_code,
+            http_status_code: Some(http_status_code),
+            ..
+        }) if error_code == "CONNECTOR_ERROR_RESPONSE" => u16::try_from(*http_status_code)
+            .ok()
+            .and_then(|status_code| StatusCode::from_u16(status_code).ok())
+            .filter(|status_code| status_code.is_client_error() || status_code.is_server_error()),
+        _ => None,
     }
-
-    let status_code = u16::try_from(*http_status_code).ok()?;
-    let status_code = StatusCode::from_u16(status_code).ok()?;
-
-    (status_code.is_client_error() || status_code.is_server_error()).then_some(status_code)
 }
 
 fn grpc_code_to_http_status(code: tonic::Code) -> StatusCode {

--- a/crates/grpc-server/grpc-server/src/http/error.rs
+++ b/crates/grpc-server/grpc-server/src/http/error.rs
@@ -187,17 +187,23 @@ fn extract_error_details_from_status(status: &tonic::Status) -> Option<ErrorDeta
     None
 }
 
-/// Extract the connector's exact HTTP error status when the gRPC details identify a
+/// Extract the connector's exact HTTP error status when the decoded details identify a
 /// connector-originated 4xx/5xx response.
-fn connector_http_status_from_grpc_status(status: &tonic::Status) -> Option<StatusCode> {
-    let connector_error =
-        grpc_api_types::payments::ConnectorError::decode(status.details()).ok()?;
+fn connector_http_status_from_error_details(details: Option<&ErrorDetails>) -> Option<StatusCode> {
+    let Some(ErrorDetails::ConnectorError {
+        error_code,
+        http_status_code: Some(http_status_code),
+        ..
+    }) = details
+    else {
+        return None;
+    };
 
-    if connector_error.error_code != "CONNECTOR_ERROR_RESPONSE" {
+    if error_code != "CONNECTOR_ERROR_RESPONSE" {
         return None;
     }
 
-    let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
+    let status_code = u16::try_from(*http_status_code).ok()?;
     let status_code = StatusCode::from_u16(status_code).ok()?;
 
     (status_code.is_client_error() || status_code.is_server_error()).then_some(status_code)
@@ -228,17 +234,16 @@ fn grpc_code_to_http_status(code: tonic::Code) -> StatusCode {
 // Convert tonic::Status to HTTP error
 impl From<tonic::Status> for HttpError {
     fn from(status: tonic::Status) -> Self {
+        let details = extract_error_details_from_status(&status);
+
         // Preserve the exact connector HTTP status when available; otherwise use the
         // canonical gRPC-to-HTTP fallback.
-        let http_status = match connector_http_status_from_grpc_status(&status) {
+        let http_status = match connector_http_status_from_error_details(details.as_ref()) {
             Some(connector_status) => connector_status,
             None => grpc_code_to_http_status(status.code()),
         };
 
         let message = status.message().to_string();
-
-        // Extract SDK error details from Status
-        let details = extract_error_details_from_status(&status);
 
         Self {
             status: http_status,

--- a/crates/grpc-server/grpc-server/src/http/error.rs
+++ b/crates/grpc-server/grpc-server/src/http/error.rs
@@ -189,7 +189,7 @@ fn extract_error_details_from_status(status: &tonic::Status) -> Option<ErrorDeta
 
 /// Extract the connector's exact HTTP error status when the gRPC details identify a
 /// connector-originated 4xx/5xx response.
-fn connector_http_status_from_status(status: &tonic::Status) -> Option<StatusCode> {
+fn connector_http_status_from_grpc_status(status: &tonic::Status) -> Option<StatusCode> {
     let connector_error =
         grpc_api_types::payments::ConnectorError::decode(status.details()).ok()?;
 
@@ -228,8 +228,12 @@ fn grpc_code_to_http_status(code: tonic::Code) -> StatusCode {
 // Convert tonic::Status to HTTP error
 impl From<tonic::Status> for HttpError {
     fn from(status: tonic::Status) -> Self {
-        let http_status = connector_http_status_from_status(&status)
-            .unwrap_or_else(|| grpc_code_to_http_status(status.code()));
+        // Preserve the exact connector HTTP status when available; otherwise use the
+        // canonical gRPC-to-HTTP fallback.
+        let http_status = match connector_http_status_from_grpc_status(&status) {
+            Some(connector_status) => connector_status,
+            None => grpc_code_to_http_status(status.code()),
+        };
 
         let message = status.message().to_string();
 

--- a/crates/grpc-server/grpc-server/src/http/error.rs
+++ b/crates/grpc-server/grpc-server/src/http/error.rs
@@ -263,10 +263,7 @@ mod tests {
             http_status_code,
             error_info: None,
         };
-        let mut encoded = Vec::new();
-        connector_error
-            .encode(&mut encoded)
-            .expect("encoding ConnectorError should succeed");
+        let encoded = connector_error.encode_to_vec();
 
         tonic::Status::with_details(grpc_code, "connector error", encoded.into())
     }

--- a/crates/grpc-server/grpc-server/src/http/error.rs
+++ b/crates/grpc-server/grpc-server/src/http/error.rs
@@ -187,28 +187,49 @@ fn extract_error_details_from_status(status: &tonic::Status) -> Option<ErrorDeta
     None
 }
 
+/// Extract the connector's exact HTTP error status when the gRPC details identify a
+/// connector-originated 4xx/5xx response.
+fn connector_http_status_from_status(status: &tonic::Status) -> Option<StatusCode> {
+    let connector_error =
+        grpc_api_types::payments::ConnectorError::decode(status.details()).ok()?;
+
+    if connector_error.error_code != "CONNECTOR_ERROR_RESPONSE" {
+        return None;
+    }
+
+    let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
+    let status_code = StatusCode::from_u16(status_code).ok()?;
+
+    (status_code.is_client_error() || status_code.is_server_error()).then_some(status_code)
+}
+
+fn grpc_code_to_http_status(code: tonic::Code) -> StatusCode {
+    match code {
+        tonic::Code::Ok => StatusCode::OK,
+        tonic::Code::Cancelled => StatusCode::REQUEST_TIMEOUT,
+        tonic::Code::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::AlreadyExists => StatusCode::CONFLICT,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
+        tonic::Code::Aborted => StatusCode::CONFLICT,
+        tonic::Code::OutOfRange => StatusCode::RANGE_NOT_SATISFIABLE,
+        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+        tonic::Code::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        tonic::Code::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
+        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+    }
+}
+
 // Convert tonic::Status to HTTP error
 impl From<tonic::Status> for HttpError {
     fn from(status: tonic::Status) -> Self {
-        let http_status = match status.code() {
-            tonic::Code::Ok => StatusCode::OK,
-            tonic::Code::Cancelled => StatusCode::REQUEST_TIMEOUT,
-            tonic::Code::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
-            tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
-            tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
-            tonic::Code::NotFound => StatusCode::NOT_FOUND,
-            tonic::Code::AlreadyExists => StatusCode::CONFLICT,
-            tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
-            tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
-            tonic::Code::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
-            tonic::Code::Aborted => StatusCode::CONFLICT,
-            tonic::Code::OutOfRange => StatusCode::RANGE_NOT_SATISFIABLE,
-            tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
-            tonic::Code::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            tonic::Code::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
-            tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
-        };
+        let http_status = connector_http_status_from_status(&status)
+            .unwrap_or_else(|| grpc_code_to_http_status(status.code()));
 
         let message = status.message().to_string();
 
@@ -220,5 +241,91 @@ impl From<tonic::Status> for HttpError {
             message,
             details,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status_with_connector_error(
+        grpc_code: tonic::Code,
+        error_code: &str,
+        http_status_code: Option<u32>,
+    ) -> tonic::Status {
+        let connector_error = grpc_api_types::payments::ConnectorError {
+            error_message: "connector error".to_string(),
+            error_code: error_code.to_string(),
+            http_status_code,
+            error_info: None,
+        };
+        let mut encoded = Vec::new();
+        connector_error
+            .encode(&mut encoded)
+            .expect("encoding ConnectorError should succeed");
+
+        tonic::Status::with_details(grpc_code, "connector error", encoded.into())
+    }
+
+    #[test]
+    fn connector_http_status_takes_precedence_over_grpc_mapping() {
+        let cases = [
+            (tonic::Code::Unknown, 409),
+            (tonic::Code::Unknown, 422),
+            (tonic::Code::DeadlineExceeded, 408),
+            (tonic::Code::Unavailable, 502),
+            (tonic::Code::Unknown, 599),
+        ];
+
+        for (grpc_code, connector_http_status) in cases {
+            let status = status_with_connector_error(
+                grpc_code,
+                "CONNECTOR_ERROR_RESPONSE",
+                Some(connector_http_status.into()),
+            );
+
+            let http_error = HttpError::from(status);
+
+            assert_eq!(
+                http_error.status.as_u16(),
+                connector_http_status,
+                "connector HTTP status should be preserved for {grpc_code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_connector_response_errors_use_grpc_fallback() {
+        let status = status_with_connector_error(
+            tonic::Code::Internal,
+            "RESPONSE_HANDLING_FAILED",
+            Some(422),
+        );
+
+        let http_error = HttpError::from(status);
+
+        assert_eq!(http_error.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn invalid_connector_http_status_uses_grpc_fallback() {
+        for connector_http_status in [200, 600] {
+            let status = status_with_connector_error(
+                tonic::Code::Unknown,
+                "CONNECTOR_ERROR_RESPONSE",
+                Some(connector_http_status),
+            );
+
+            let http_error = HttpError::from(status);
+
+            assert_eq!(http_error.status, StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[test]
+    fn missing_details_use_grpc_fallback() {
+        let http_error = HttpError::from(tonic::Status::invalid_argument("invalid request"));
+
+        assert_eq!(http_error.status, StatusCode::BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## Description

- Map common connector HTTP error statuses to canonical gRPC codes, including `409 -> ABORTED`.
- Treat otherwise-unmapped connector 4xx responses as `INVALID_ARGUMENT` instead of `UNKNOWN`.
- Keep unclassified connector 5xx responses as `UNKNOWN` so they are not mislabeled as internal UCS failures.
- Preserve the exact upstream status in `ConnectorError.http_status_code`.
- Add one table-driven unit test for the mapping and fallback boundaries.

## Motivation and Context

PPRO can return HTTP 409 when an idempotency key is reused with a different request body. Previously, 409 fell through to gRPC `UNKNOWN`; UCS HTTP mode then translated that to HTTP 500 even though the structured connector details correctly contained `http_status_code: 409`.

This change maps generic conflicts to gRPC `ABORTED`, which the HTTP bridge returns as HTTP 409, and prevents other connector 4xx responses from being reported as UCS 500 errors.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ucs_env`
- `cargo clippy -p ucs_env --all-targets -- -D warnings`
