### PR TITLE
feat(core): superposition URL override support for all connector variants (payout, FRM, surcharge)

### DIFF
--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -98,7 +98,6 @@ pub fn apply_url_overrides(
     environment: Option<&str>,
 ) -> CustomResult<domain_types::types::Connectors, IntegrationError> {
     use domain_types::errors::IntegrationErrorContext;
-    use std::str::FromStr;
 
     let connector_name = connector.get_connector_name();
 
@@ -121,33 +120,31 @@ pub fn apply_url_overrides(
             ) {
                 Some(urls) => {
                     tracing::info!("resolved URLs from superposition for environment: {}", env);
-                    match connector_types::ConnectorEnum::from_str(&connector_name) {
-                        Ok(payment_connector) => {
-                            let patched_connectors = config
-                                .connectors
-                                .patch_connector_urls(&payment_connector, &urls)
-                                .map_err(|e| {
-                                    Report::new(IntegrationError::ConfigurationError {
-                                        code: "URL_PATCHING_FAILED".to_string(),
-                                        message: format!("URL patching failed: {e}"),
-                                        context: IntegrationErrorContext::default(),
-                                    })
-                                })?;
-                            connectors_with_connector_config_overrides_on_connectors(
-                                connector_config,
-                                patched_connectors,
-                            )
+                    let patch_result = match connector {
+                        connector_types::ConnectorVariant::Payment(c) => {
+                            config.connectors.patch_connector_urls(c, &urls)
                         }
-                        // TODO: add superpositon support for payout, FRM, and surcharge connectors. For now, log a warning and fall back to static config.
-                        Err(_) => {
-                            tracing::warn!(
-                                connector = %connector_name,
-                                "connector not found in ConnectorEnum for URL patching, \
-                                 falling back to static config with overrides"
-                            );
-                            connectors_with_connector_config_overrides(connector_config, config)
+                        connector_types::ConnectorVariant::Payout(c) => {
+                            config.connectors.patch_payout_connector_urls(c, &urls)
                         }
-                    }
+                        connector_types::ConnectorVariant::Frm(c) => {
+                            config.connectors.patch_frm_connector_urls(c, &urls)
+                        }
+                        connector_types::ConnectorVariant::Surcharge(c) => {
+                            config.connectors.patch_surcharge_connector_urls(c, &urls)
+                        }
+                    };
+                    let patched_connectors = patch_result.map_err(|e| {
+                        Report::new(IntegrationError::ConfigurationError {
+                            code: "URL_PATCHING_FAILED".to_string(),
+                            message: format!("URL patching failed: {e}"),
+                            context: IntegrationErrorContext::default(),
+                        })
+                    })?;
+                    connectors_with_connector_config_overrides_on_connectors(
+                        connector_config,
+                        patched_connectors,
+                    )
                 }
                 None => {
                     tracing::info!(

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -7,9 +7,10 @@ use crate::{
     },
     connector_types::{
         self, CaptureSyncResponse, ConnectorEnum, CreatePaymentMethodData,
-        CreatePaymentMethodResponseData, GetPaymentMethodData, GetPaymentMethodResponseData,
-        PaymentMethodEligibilityData, PaymentMethodEligibilityResponse, RechargeRequestData,
-        RechargeResponseData,
+        CreatePaymentMethodResponseData, FrmConnectorEnum, GetPaymentMethodData,
+        GetPaymentMethodResponseData, PaymentMethodEligibilityData,
+        PaymentMethodEligibilityResponse, PayoutConnectorEnum, RechargeRequestData,
+        RechargeResponseData, SurchargeConnectorEnum,
     },
     payment_method_data::SamsungPayWalletCredentials,
     router_request_types::AuthoriseIntegrityObject,
@@ -759,6 +760,64 @@ impl Connectors {
             }
         }
 
+        Ok(patched)
+    }
+
+    pub fn patch_payout_connector_urls(
+        &self,
+        connector: &PayoutConnectorEnum,
+        urls: &common_utils::superposition_config::ConnectorUrls,
+    ) -> Result<Self, IntegrationError> {
+        let mut patched = self.clone();
+        let params_patch = ConnectorParamsPatch {
+            base_url: urls.base_url.clone(),
+            dispute_base_url: Some(urls.dispute_base_url.clone()),
+            secondary_base_url: Some(urls.secondary_base_url.clone()),
+            third_base_url: Some(urls.third_base_url.clone()),
+        };
+        match connector {
+            PayoutConnectorEnum::Loonio => patched.loonio.apply(params_patch),
+            PayoutConnectorEnum::Paypal => patched.paypal.apply(params_patch),
+            PayoutConnectorEnum::Itaubank => patched.itaubank.apply(params_patch),
+            PayoutConnectorEnum::Worldpayxml => patched.worldpayxml.apply(params_patch),
+            PayoutConnectorEnum::Cybersource => patched.cybersource.apply(params_patch),
+        }
+        Ok(patched)
+    }
+
+    pub fn patch_frm_connector_urls(
+        &self,
+        connector: &FrmConnectorEnum,
+        urls: &common_utils::superposition_config::ConnectorUrls,
+    ) -> Result<Self, IntegrationError> {
+        let mut patched = self.clone();
+        let params_patch = ConnectorParamsPatch {
+            base_url: urls.base_url.clone(),
+            dispute_base_url: Some(urls.dispute_base_url.clone()),
+            secondary_base_url: Some(urls.secondary_base_url.clone()),
+            third_base_url: Some(urls.third_base_url.clone()),
+        };
+        match connector {
+            FrmConnectorEnum::Kount => patched.kount.apply(params_patch),
+        }
+        Ok(patched)
+    }
+
+    pub fn patch_surcharge_connector_urls(
+        &self,
+        connector: &SurchargeConnectorEnum,
+        urls: &common_utils::superposition_config::ConnectorUrls,
+    ) -> Result<Self, IntegrationError> {
+        let mut patched = self.clone();
+        let params_patch = ConnectorParamsPatch {
+            base_url: urls.base_url.clone(),
+            dispute_base_url: Some(urls.dispute_base_url.clone()),
+            secondary_base_url: Some(urls.secondary_base_url.clone()),
+            third_base_url: Some(urls.third_base_url.clone()),
+        };
+        match connector {
+            SurchargeConnectorEnum::Interpayments => patched.interpayments.apply(params_patch),
+        }
         Ok(patched)
     }
 }

--- a/data/field_probe/finix.json
+++ b/data/field_probe/finix.json
@@ -785,7 +785,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"type\":\"PAYMENT_CARD\",\"name\":\"John Doe\",\"number\":\"4111111111111111\",\"security_code\":\"737\",\"expiration_month\":3,\"expiration_year\":2030,\"identity\":\"cust_probe_123\",\"tags\":{\"merchant_reference\":\"probe_mandate_001\"},\"address\":{\"line1\":null,\"line2\":null,\"city\":null,\"region\":null,\"postal_code\":null,\"country\":null}}"
+          "body": "{\"type\":\"PAYMENT_CARD\",\"name\":\"John Doe\",\"number\":\"4111111111111111\",\"security_code\":\"737\",\"expiration_month\":3,\"expiration_year\":2030,\"identity\":\"cust_probe_123\",\"tags\":{\"merchant_reference\":\"probe_mandate_001\"},\"address\":{\"line1\":null,\"line2\":null,\"city\":null,\"region\":null,\"postal_code\":null,\"country\":null},\"card_brand\":null,\"card_type\":null,\"additional_data\":null,\"merchant_identity\":null,\"third_party_token\":null}"
         }
       }
     },


### PR DESCRIPTION
## Problem

Superposition URL patching in `apply_url_overrides` only worked for payment connectors (`ConnectorEnum`). For payout, FRM, and surcharge connectors, the code did a `ConnectorEnum::from_str` round-trip that silently fell back to static config — superposition had no effect for those flows.

## Solution

Add typed URL patch methods for each non-payment connector variant and dispatch directly on the `ConnectorVariant` enum — no string round-trip, no silent fallback.

### New methods on `Connectors`
- `patch_payout_connector_urls(&PayoutConnectorEnum, &urls)` — Loonio, Paypal, Itaubank, Worldpayxml, Cybersource
- `patch_frm_connector_urls(&FrmConnectorEnum, &urls)` — Kount
- `patch_surcharge_connector_urls(&SurchargeConnectorEnum, &urls)` — Interpayments

### Updated dispatch in `apply_url_overrides`
```rust
// Before: fragile from_str round-trip, non-payment connectors silently fell back
match ConnectorEnum::from_str(&connector_name) { ... }

// After: direct typed dispatch on ConnectorVariant
match connector {
    ConnectorVariant::Payment(c)   => patch_connector_urls(c, &urls),
    ConnectorVariant::Payout(c)    => patch_payout_connector_urls(c, &urls),
    ConnectorVariant::Frm(c)       => patch_frm_connector_urls(c, &urls),
    ConnectorVariant::Surcharge(c) => patch_surcharge_connector_urls(c, &urls),
}
```

Adding a new payout/FRM/surcharge connector now only requires adding it to the corresponding match arm — the superposition path is covered automatically.

## Changes
- `domain_types/src/types.rs`: three new typed patch methods on `Connectors`
- `grpc-server/src/utils.rs`: remove `from_str` round-trip in `apply_url_overrides`, dispatch directly on `ConnectorVariant`

## Testing

Tested FRM connector through superposition

<img width="1301" height="544" alt="Screenshot 2026-07-30 at 4 49 57 PM" src="https://github.com/user-attachments/assets/c44f470b-fc58-494d-bd52-30f80d2acaa0" />

