### PR TITLE
feat(connector): implement IncrementalAuthorization for paypal (Card + Wallet(PayPal))

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paypal.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal.rs
@@ -21,11 +21,11 @@ use domain_types::{
     connector_types::{
         ClientAuthenticationTokenRequestData, EventContext, PaymentCreateOrderData,
         PaymentCreateOrderResponse, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
-        PaymentsCaptureData, PaymentsPostAuthenticateData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        RequestDetails, ServerAuthenticationTokenRequestData,
-        ServerAuthenticationTokenResponseData, SetupMandateRequestData,
-        VerifyWebhookSourceFlowData,
+        PaymentsCaptureData, PaymentsIncrementalAuthorizationData, PaymentsPostAuthenticateData,
+        PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData,
+        RefundsResponseData, RepeatPaymentData, RequestDetails,
+        ServerAuthenticationTokenRequestData, ServerAuthenticationTokenResponseData,
+        SetupMandateRequestData, VerifyWebhookSourceFlowData,
     },
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, WalletData},
@@ -49,11 +49,12 @@ use crate::{
     connectors::paypal::transformers::{
         self as paypal, auth_headers, constants as paypal_constants, PaypalAuthResponse,
         PaypalAuthUpdateRequest, PaypalAuthUpdateResponse, PaypalCaptureResponse,
-        PaypalClientAuthTokenRequest, PaypalClientAuthTokenResponse, PaypalOrderCreateRequest,
-        PaypalOrderCreateResponse, PaypalPaymentsCancelResponse, PaypalPaymentsCaptureRequest,
-        PaypalPaymentsRequest, PaypalRefundRequest, PaypalRepeatPaymentRequest,
-        PaypalRepeatPaymentResponse, PaypalSetupMandatesResponse, PaypalSyncResponse,
-        PaypalZeroMandateRequest, RefundResponse, RefundSyncResponse,
+        PaypalClientAuthTokenRequest, PaypalClientAuthTokenResponse, PaypalIncrementalAuthRequest,
+        PaypalIncrementalAuthResponse, PaypalOrderCreateRequest, PaypalOrderCreateResponse,
+        PaypalPaymentsCancelResponse, PaypalPaymentsCaptureRequest, PaypalPaymentsRequest,
+        PaypalRefundRequest, PaypalRepeatPaymentRequest, PaypalRepeatPaymentResponse,
+        PaypalSetupMandatesResponse, PaypalSyncResponse, PaypalZeroMandateRequest, RefundResponse,
+        RefundSyncResponse,
     },
     types::ResponseRouterData,
     utils::{self, ConnectorErrorType, ConnectorErrorTypeMapping},
@@ -104,6 +105,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::PaymentCapture for Paypal<T>
+{
+}
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::PaymentIncrementalAuthorization for Paypal<T>
 {
 }
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -460,6 +465,12 @@ macros::create_all_prerequisites!(
             flow: Void,
             response_body: PaypalPaymentsCancelResponse,
             router_data: RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ),
+        (
+            flow: IncrementalAuthorization,
+            request_body: PaypalIncrementalAuthRequest,
+            response_body: PaypalIncrementalAuthResponse,
+            router_data: RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
         ),
         (
             flow: ServerAuthenticationToken,
@@ -1031,6 +1042,118 @@ macros::macro_connector_implementation!(
                 "{}v2/payments/authorizations/{}/void",
                 self.connector_base_url_payments(req),
                 authorize_id,
+            ))
+        }
+    }
+);
+
+// IncrementalAuthorization — POST /v2/payments/authorizations/{id}/reauthorize.
+//
+// PayPal has no dedicated incremental-authorization API; "Reauthorize Authorized Payment" is the
+// operation this flow maps onto. It targets the authorization id that the original Authorize call
+// handed back in `connector_feature_data`, and mints a NEW authorization id in the response.
+// Both HTTP 201 (created) and HTTP 200 (idempotent replay of the same `PayPal-Request-Id`) are
+// success and carry the same `authorization-2` schema.
+// Doc: https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Paypal,
+    curl_request: Json(PaypalIncrementalAuthRequest),
+    curl_response: PaypalIncrementalAuthResponse,
+    flow_name: IncrementalAuthorization,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentsIncrementalAuthorizationData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            let access_token = req.resource_common_data
+                .access_token
+                .clone()
+                .ok_or_else(|| report!(IntegrationError::FailedToObtainAuthType {
+                    context: paypal::paypal_err_ctx(
+                        "PayPal authorizes every Payments v2 call with an OAuth 2.0 bearer token; \
+                         no access token was present on the IncrementalAuthorization request",
+                        "Call MerchantAuthenticationService/CreateServerAuthenticationToken first \
+                         and pass the result in `state.access_token`",
+                    ),
+                }))
+                .attach_printable("Missing access_token for PayPal reauthorize")?;
+            let connector_metadata = req.resource_common_data.connector_feature_data
+                .as_ref()
+                .map(|secret| secret.clone().expose());
+            self.build_headers(
+                &access_token.access_token.expose(),
+                &req.resource_common_data.connector_request_reference_id,
+                &req.connector_config,
+                connector_metadata.as_ref(),
+            )
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<IncrementalAuthorization, PaymentFlowData, PaymentsIncrementalAuthorizationData, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            let connector_metadata_value = req
+                .request
+                .connector_feature_data
+                .clone()
+                .map(|secret| secret.expose())
+                .ok_or_else(|| report!(IntegrationError::MissingRequiredField {
+                    field_name: "connector_feature_data",
+                    context: paypal::paypal_err_ctx(
+                        "PayPal reauthorize is addressed by the authorization id minted by the \
+                         original Authorize call, which UCS returns to the caller inside \
+                         `connector_feature_data`",
+                        "Echo the `connector_feature_data` from the Authorize response back on the \
+                         IncrementalAuthorization request",
+                    ),
+                }))
+                .attach_printable(
+                    "connector_feature_data absent on PayPal IncrementalAuthorization request",
+                )?;
+
+            let paypal_meta: paypal::PaypalMeta = serde_json::from_value(connector_metadata_value)
+                .change_context(IntegrationError::InvalidDataFormat {
+                    field_name: "connector_feature_data",
+                    context: paypal::paypal_err_ctx(
+                        "`connector_feature_data` could not be parsed as the PayPal connector \
+                         metadata object that the Authorize response emits",
+                        "Pass the `connector_feature_data` value through unmodified instead of \
+                         reconstructing it",
+                    ),
+                })
+                .attach_printable("Failed to deserialize PaypalMeta from connector_feature_data")?;
+
+            let incremental_authorization_id = paypal_meta
+                .incremental_authorization_id
+                .ok_or_else(|| report!(IntegrationError::MissingRequiredField {
+                    field_name: "connector_feature_data.incremental_authorization_id",
+                    context: paypal::paypal_err_ctx(
+                        "PayPal only populates an incremental authorization id when the original \
+                         payment was created with intent AUTHORIZE and \
+                         `request_incremental_authorization` set; there is nothing to reauthorize \
+                         without it",
+                        "Authorize with `capture_method: MANUAL` and \
+                         `request_incremental_authorization: true`, then reuse the resulting \
+                         `connector_feature_data`",
+                    ),
+                }))
+                .attach_printable(
+                    "PaypalMeta.incremental_authorization_id missing — cannot build reauthorize URL",
+                )?;
+
+            Ok(format!(
+                "{}{}/{}/{}",
+                self.connector_base_url_payments(req),
+                paypal_constants::AUTHORIZATIONS_PATH,
+                incremental_authorization_id,
+                paypal_constants::REAUTHORIZE_ACTION,
             ))
         }
     }
@@ -1744,6 +1867,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
                 .or(Some(err_reason)),
             None => Some(response.message.to_owned()),
         };
+        // PayPal's non-2xx envelope always carries a top-level `name` (e.g. UNPROCESSABLE_ENTITY)
+        // and `message`, and usually a more specific `details[].issue`
+        // (e.g. REAUTHORIZATION_TOO_SOON). Prefer the issue, fall back to the envelope's own
+        // name/message, and only report the NO_ERROR_* placeholders if PayPal really sent neither.
+        let error_name = response.name.clone();
+        let error_message = response.message.clone();
         let errors_list = response.details.unwrap_or_default();
         let option_error_code_message = utils::get_error_code_error_message_based_on_priority(
             self.clone(),
@@ -1758,9 +1887,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
             code: option_error_code_message
                 .clone()
                 .map(|error_code_message| error_code_message.error_code)
+                .or(error_name)
                 .unwrap_or(NO_ERROR_CODE.to_string()),
             message: option_error_code_message
                 .map(|error_code_message| error_code_message.error_message)
+                .or(Some(error_message))
                 .unwrap_or(NO_ERROR_MESSAGE.to_string()),
             reason,
             attempt_status: None,
@@ -1791,7 +1922,6 @@ macros::macro_connector_flow_status_impls!(
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     not_implemented: [
-        IncrementalAuthorization,
         Accept,
         SubmitEvidence,
         DefendDispute,

--- a/crates/integrations/connector-integration/src/connectors/paypal.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal.rs
@@ -1054,6 +1054,15 @@ macros::macro_connector_implementation!(
 // handed back in `connector_feature_data`, and mints a NEW authorization id in the response.
 // Both HTTP 201 (created) and HTTP 200 (idempotent replay of the same `PayPal-Request-Id`) are
 // success and carry the same `authorization-2` schema.
+//
+// The endpoint is funding-source agnostic, so this block is deliberately free of any
+// payment-method branch: the path selector is an authorization id (not an order or a funding
+// instrument), the request body accepts only `amount`, and `authorization-2` carries no
+// funding-instrument block. PayPal's own operation description is in fact written for the wallet
+// case — "Reauthorizes an authorized PayPal account payment, by ID." Card and
+// Wallet(PayPal) — both `PaypalRedirect` and `PaypalSdk` — therefore share this code verbatim;
+// they differ only in which Authorize leg mints the authorization id (see
+// `extract_incremental_authorization_id`).
 // Doc: https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize
 macros::macro_connector_implementation!(
     connector_default_implementations: [get_content_type, get_error_response_v2],

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -1917,6 +1917,9 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalAuthUpdateResponse, Self>>
 /// reauthorize endpoint.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, strum::Display)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+// `serde(rename_all)` governs the wire format only; `strum` needs its own casing directive or
+// `Display` would log `PartiallyCaptured` where PayPal sent `PARTIALLY_CAPTURED`.
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum PaypalIncrementalStatus {
     /// Funds are held under the newly minted authorization — the success terminal state for a
     /// reauthorization.

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -13,13 +13,14 @@ use common_utils::{
 };
 use domain_types::{
     connector_flow::{
-        Authorize, Capture, ClientAuthenticationToken, CreateOrder, PSync, PostAuthenticate,
-        RepeatPayment, VerifyWebhookSource,
+        Authorize, Capture, ClientAuthenticationToken, CreateOrder, IncrementalAuthorization,
+        PSync, PostAuthenticate, RepeatPayment, VerifyWebhookSource,
     },
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData, MandateReference,
         PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData, PaymentsAuthorizeData,
-        PaymentsCaptureData, PaymentsPostAuthenticateData, PaymentsResponseData, PaymentsSyncData,
+        PaymentsCaptureData, PaymentsIncrementalAuthorizationData, PaymentsPostAuthenticateData,
+        PaymentsResponseData, PaymentsSyncData,
         PaypalClientAuthenticationResponse as PaypalClientAuthenticationResponseDomain,
         PaypalFlow as PaypalFlowDomain, PaypalTransactionInfo as PaypalTransactionInfoDomain,
         RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
@@ -84,6 +85,34 @@ pub mod constants {
     pub const DEFAULT_NOTIFICATION_LANGUAGE: &str = "en-US";
     pub const DEFAULT_PARTNER_ATTRIBUTION_ID: &str = "HyperSwitchPPCP_SP";
     pub const DEFAULT_LEGACY_PARTNER_ATTRIBUTION_ID: &str = "HyperSwitchlegacy_Ecom";
+
+    /// Path prefix of the PayPal Payments v2 authorization resource.
+    /// Doc: <https://developer.paypal.com/docs/api/payments/v2/#authorizations_get>
+    pub const AUTHORIZATIONS_PATH: &str = "v2/payments/authorizations";
+
+    /// Sub-resource action that reauthorizes an already authorized payment. PayPal offers no
+    /// dedicated incremental-authorization API; `reauthorize` is the operation Hyperswitch's
+    /// `IncrementalAuthorization` flow maps onto.
+    /// Doc: <https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize>
+    pub const REAUTHORIZE_ACTION: &str = "reauthorize";
+}
+
+/// Documentation surfaced on every `IntegrationError` this connector raises, so a caller who hits
+/// a validation failure has a direct pointer to the PayPal reference for the field in question.
+pub const PAYPAL_INTEGRATION_DOC_URL: &str = "https://developer.paypal.com/docs/api/payments/v2/";
+
+/// Single construction point for [`domain_types::errors::IntegrationErrorContext`] in the PayPal
+/// connector. Every error site passes a concrete `additional_context` (what is missing and why
+/// PayPal needs it) and a concrete `suggested_action` (what the caller should change).
+pub(crate) fn paypal_err_ctx(
+    additional_context: impl Into<String>,
+    suggested_action: impl Into<String>,
+) -> domain_types::errors::IntegrationErrorContext {
+    domain_types::errors::IntegrationErrorContext {
+        additional_context: Some(additional_context.into()),
+        suggested_action: Some(suggested_action.into()),
+        doc_url: Some(PAYPAL_INTEGRATION_DOC_URL.to_string()),
+    }
 }
 
 const ORDER_QUANTITY: u16 = 1;
@@ -1874,55 +1903,232 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalAuthUpdateResponse, Self>>
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+// ----------------------------------------------------------------------------
+// IncrementalAuthorization — POST /v2/payments/authorizations/{id}/reauthorize
+//
+// PayPal exposes no dedicated incremental-authorization API. The closest operation, and the one
+// Hyperswitch's `IncrementalAuthorization` flow maps onto, is "Reauthorize Authorized Payment":
+// it refreshes the 3-day honor period on an existing authorization and, where the network and
+// geography permit, changes the held amount. It mints a NEW authorization id.
+// Doc: <https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize>
+// ----------------------------------------------------------------------------
+
+/// Status of a PayPal authorization resource (`authorization-2.status`), as returned by the
+/// reauthorize endpoint.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, strum::Display)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PaypalIncrementalStatus {
-    CREATED,
-    CAPTURED,
-    DENIED,
-    PARTIALLYCAPTURED,
-    VOIDED,
-    PENDING,
+    /// Funds are held under the newly minted authorization — the success terminal state for a
+    /// reauthorization.
+    Created,
+    Captured,
+    PartiallyCaptured,
+    Denied,
+    Pending,
+    Voided,
+    Expired,
+    /// PayPal's published OpenAPI enum and its integration guides disagree on the exact variant
+    /// list for this field, so an unrecognised value must not fail deserialization of an
+    /// otherwise successful reauthorization. Mapped to `AuthorizationStatus::Unresolved`.
+    #[serde(other)]
+    Unknown,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PaypalNetworkTransactionReference {
     id: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PaypalIncrementalAuthStatusDetails {
+    /// PayPal only populates a reason when it has one to give (risk hold / manual review), so it
+    /// is absent on a plain `PENDING`.
     reason: Option<PaypalStatusPendingReason>,
 }
 
-#[derive(Debug, Deserialize, Serialize, strum::Display)]
+#[derive(Debug, Clone, Deserialize, Serialize, strum::Display)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PaypalStatusPendingReason {
-    PENDINGREVIEW,
-    DECLINEDBYRISKFRAUDFILTERS,
+    PendingReview,
+    DeclinedByRiskFraudFilters,
+    /// PayPal documents only the two reasons above but does not declare the enum closed; an
+    /// unrecognised reason is diagnostic-only and must never fail the response mapping.
+    #[serde(other)]
+    Unknown,
 }
 
 impl From<PaypalIncrementalStatus> for common_enums::AuthorizationStatus {
     fn from(item: PaypalIncrementalStatus) -> Self {
+        // Exhaustive on purpose — no wildcard arm, so a newly added PayPal status is a compile
+        // error here rather than a silently mis-mapped authorization.
         match item {
-            PaypalIncrementalStatus::CREATED
-            | PaypalIncrementalStatus::CAPTURED
-            | PaypalIncrementalStatus::PARTIALLYCAPTURED => Self::Success,
-            PaypalIncrementalStatus::PENDING => Self::Processing,
-            PaypalIncrementalStatus::DENIED | PaypalIncrementalStatus::VOIDED => Self::Failure,
+            // `CREATED` is the normal outcome of a reauthorization; `CAPTURED` /
+            // `PARTIALLY_CAPTURED` mean the (re)authorized funds have since been drawn down, which
+            // is still a successfully held authorization from this flow's point of view.
+            PaypalIncrementalStatus::Created
+            | PaypalIncrementalStatus::Captured
+            | PaypalIncrementalStatus::PartiallyCaptured => Self::Success,
+            PaypalIncrementalStatus::Pending => Self::Processing,
+            PaypalIncrementalStatus::Denied
+            | PaypalIncrementalStatus::Voided
+            | PaypalIncrementalStatus::Expired => Self::Failure,
+            PaypalIncrementalStatus::Unknown => {
+                tracing::warn!(
+                    connector = "paypal",
+                    flow = "incremental_authorization",
+                    "PayPal returned an authorization status outside the documented enum; \
+                     reporting the authorization as Unresolved so it is reconciled rather than \
+                     wrongly settled or wrongly failed"
+                );
+                Self::Unresolved
+            }
         }
     }
 }
 
-impl From<PaypalIncrementalStatus> for common_enums::AttemptStatus {
-    fn from(item: PaypalIncrementalStatus) -> Self {
-        match item {
-            PaypalIncrementalStatus::CREATED
-            | PaypalIncrementalStatus::CAPTURED
-            | PaypalIncrementalStatus::PARTIALLYCAPTURED => Self::Authorized,
-            PaypalIncrementalStatus::PENDING => Self::Pending,
-            PaypalIncrementalStatus::DENIED | PaypalIncrementalStatus::VOIDED => Self::Failure,
+/// Request body for `POST /v2/payments/authorizations/{authorization_id}/reauthorize`.
+///
+/// PayPal documents `amount` as the only accepted request parameter on this endpoint — no
+/// `invoice_id`, `final_capture`, `soft_descriptor` or `payment_instruction`. The body itself is
+/// optional (omitting it reauthorizes the original amount unchanged), but UCS always carries an
+/// explicit target amount on `PaymentsIncrementalAuthorizationData`, so it is always sent and the
+/// field is therefore not optional.
+#[derive(Debug, Clone, Serialize)]
+pub struct PaypalIncrementalAuthRequest {
+    amount: OrderAmount,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        PaypalRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    > for PaypalIncrementalAuthRequest
+{
+    type Error = Report<IntegrationError>;
+    fn try_from(
+        item: PaypalRouterData<
+            RouterDataV2<
+                IncrementalAuthorization,
+                PaymentFlowData,
+                PaymentsIncrementalAuthorizationData,
+                PaymentsResponseData,
+            >,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let request = &item.router_data.request;
+        // PayPal money values are currency-scaled decimal strings ("10.99"), never minor units,
+        // so reuse the connector's configured StringMajorUnit converter.
+        let value = item
+            .connector
+            .amount_converter
+            .convert(request.minor_amount, request.currency)
+            .change_context(IntegrationError::AmountConversionFailed {
+                context: paypal_err_ctx(
+                    "PayPal expects the reauthorization amount as a currency-scaled decimal \
+                     string (for example \"10.99\"); converting the requested minor amount to \
+                     that representation failed",
+                    "Check that `amount.minor_amount` and `amount.currency` form a valid amount \
+                     for the currency",
+                ),
+            })
+            .attach_printable(
+                "Failed to convert minor_amount to StringMajorUnit for PayPal reauthorize",
+            )?;
+        Ok(Self {
+            amount: OrderAmount {
+                // PayPal rejects a reauthorization whose currency differs from the original
+                // authorization with issue `AUTH_CURRENCY_MISMATCH`.
+                currency_code: request.currency,
+                value,
+            },
+        })
+    }
+}
+
+/// Response body of `POST /v2/payments/authorizations/{authorization_id}/reauthorize`
+/// (schema `authorization-2`). HTTP 201 is the normal success; HTTP 200 is returned on an
+/// idempotent replay of a previously seen `PayPal-Request-Id` and carries the same schema.
+///
+/// Only `id` and `status` are guaranteed: with the default `Prefer: return=minimal` PayPal
+/// returns just `id`, `status` and `links`. This connector sends `Prefer: return=representation`
+/// (see `build_headers`), which is what populates the optional blocks below — but the header is a
+/// preference, not a contract, so every one of them stays optional.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PaypalIncrementalAuthResponse {
+    /// The **new** PayPal-generated authorization id produced by the reauthorization. The previous
+    /// authorization id is superseded and must not be reused for capture or void.
+    id: String,
+    status: PaypalIncrementalStatus,
+    /// Present only when PayPal has a reason to report alongside the status — in practice when
+    /// `status` is `PENDING` because the authorization is risk-held or queued for manual review.
+    status_details: Option<PaypalIncrementalAuthStatusDetails>,
+    /// The reauthorized amount. Omitted under `Prefer: return=minimal`.
+    amount: Option<OrderAmount>,
+    /// Merchant invoice number carried over from the original authorization; absent when the
+    /// original order carried none, and under `Prefer: return=minimal`.
+    invoice_id: Option<String>,
+    /// Merchant free-form identifier; absent when it was not set on the original order, and under
+    /// `Prefer: return=minimal`.
+    custom_id: Option<String>,
+    /// Card-network transaction reference. PayPal only returns it for card-funded authorizations
+    /// where the network supplied one, so it is absent for PayPal-wallet-funded authorizations.
+    network_transaction_reference: Option<PaypalNetworkTransactionReference>,
+    /// HATEOAS links for the new authorization (`self`, `capture`, `void`, `reauthorize`).
+    /// Modelled as optional because PayPal omits the block entirely on some minimal
+    /// representations rather than returning an empty array.
+    links: Option<Vec<PaypalLinks>>,
+}
+
+impl TryFrom<ResponseRouterData<PaypalIncrementalAuthResponse, Self>>
+    for RouterDataV2<
+        IncrementalAuthorization,
+        PaymentFlowData,
+        PaymentsIncrementalAuthorizationData,
+        PaymentsResponseData,
+    >
+{
+    type Error = Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<PaypalIncrementalAuthResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let response = item.response;
+
+        // Diagnostic only: PayPal explains a held authorization through `status_details.reason`,
+        // which has no representation on `IncrementalAuthorizationResponse`. Log it rather than
+        // dropping it silently, and never fail an otherwise valid response on account of it.
+        if let Some(reason) = response
+            .status_details
+            .as_ref()
+            .and_then(|details| details.reason.as_ref())
+        {
+            tracing::warn!(
+                connector = "paypal",
+                flow = "incremental_authorization",
+                paypal_status = %response.status,
+                paypal_status_reason = %reason,
+                "PayPal reported a status reason on the reauthorized authorization"
+            );
         }
+
+        Ok(Self {
+            response: Ok(PaymentsResponseData::IncrementalAuthorizationResponse {
+                status: common_enums::AuthorizationStatus::from(response.status),
+                // The reauthorization mints a new authorization id; surfacing it lets the caller
+                // address the subsequent capture/void at the authorization that actually holds
+                // the funds.
+                connector_authorization_id: Some(response.id),
+                status_code: item.http_code,
+            }),
+            ..item.router_data
+        })
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2518,6 +2518,28 @@ fn get_id_based_on_intent(
     })
 }
 
+/// Pulls the authorization id that `IncrementalAuthorization` later reauthorizes out of an
+/// `intent: AUTHORIZE` order response.
+///
+/// This is funding-source agnostic — every funding source converges on
+/// `purchase_units[].payments.authorizations[0].id`. What differs is which Authorize leg produces
+/// the response this runs against:
+///
+/// * **Card** — the create-order call itself (`POST /v2/checkout/orders` with
+///   `payment_source.card`) already carries the authorization, so the id is available on the first
+///   Authorize.
+/// * **Wallet — `PaypalRedirect`** — create-order returns `PAYER_ACTION_REQUIRED` with no
+///   `payments` block at all, so it deserializes as [`PaypalRedirectResponse`] and correctly yields
+///   no id. The authorization only exists after the buyer approves at PayPal and the caller issues
+///   a second Authorize carrying `connector_order_id`, which posts to
+///   `/v2/checkout/orders/{order_id}/authorize`; that response is a full order object and lands
+///   here.
+/// * **Wallet — `PaypalSdk`** — the JS SDK performs create-order plus approval client-side, so the
+///   single Authorize posts straight to `/v2/checkout/orders/{sdk_token}/authorize` and lands here
+///   on the first call.
+///
+/// Returns `None` rather than erroring: an order that legitimately has no authorization yet (the
+/// wallet redirect leg, or an `intent: CAPTURE` order) must not fail an otherwise valid response.
 fn extract_incremental_authorization_id(response: &PaypalOrdersResponse) -> Option<String> {
     for unit in &response.purchase_units {
         if let Some(authorizations) = &unit.payments.authorizations {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -9358,6 +9358,25 @@ impl
 
         let merchant_id_from_header = extract_merchant_id_from_metadata(metadata)?;
 
+        // Connectors whose incremental-authorization endpoint is OAuth-protected (PayPal) read the
+        // bearer token off `PaymentFlowData`, so carry `state.access_token` through exactly as the
+        // Capture flow does.
+        let access_token = value
+            .state
+            .as_ref()
+            .and_then(|state| state.access_token.as_ref())
+            .map(ServerAuthenticationTokenResponseData::foreign_try_from)
+            .transpose()?;
+
+        // Header construction (for example PayPal's partner-attribution headers) reads the feature
+        // data off `PaymentFlowData`, while URL construction reads it off the request data; both
+        // are sourced from the same caller-supplied `connector_feature_data`.
+        let connector_feature_data = value
+            .connector_feature_data
+            .clone()
+            .map(|m| ForeignTryFrom::foreign_try_from((m, "feature data")))
+            .transpose()?;
+
         Ok(Self {
             raw_connector_status: None,
             merchant_id: merchant_id_from_header,
@@ -9374,10 +9393,10 @@ impl
             connector_customer: None,
             description: None,
             return_url: None,
-            connector_feature_data: None,
+            connector_feature_data,
             amount_captured: None,
             minor_amount_captured: None,
-            access_token: None,
+            access_token,
             session_token: None,
             reference_id: None,
             connector_order_id: None,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -9309,9 +9309,20 @@ impl ForeignTryFrom<PaymentServiceIncrementalAuthorizationRequest>
             .map(|metadata| serde_json::from_str(&metadata.expose()))
             .transpose()
             .change_context(IntegrationError::InvalidDataFormat {
-                field_name: "unknown",
+                field_name: "connector_feature_data",
                 context: IntegrationErrorContext {
-                    additional_context: Some("Failed to parse connector metadata".to_string()),
+                    additional_context: Some(
+                        "Failed to parse connector_feature_data on the IncrementalAuthorization \
+                         request as JSON. This field carries the connector-specific metadata \
+                         persisted by the original Authorize (for PayPal, the authorization id \
+                         the reauthorize call targets)."
+                            .to_string(),
+                    ),
+                    suggested_action: Some(
+                        "Send connector_feature_data exactly as it was returned by the Authorize \
+                         response for this payment, without re-encoding it."
+                            .to_string(),
+                    ),
                     ..Default::default()
                 },
             })?;

--- a/data/field_probe/paypal.json
+++ b/data/field_probe/paypal.json
@@ -1029,8 +1029,8 @@
     },
     "incremental_authorization": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: incremental_authorization flow for paypal"
+        "status": "error",
+        "error": "Stuck on field: connector_feature_data.incremental_authorization_id. PayPal only populates an incremental authorization id when the original payment was created with intent AUTHORIZE and `request_incremental_authorization` set; there is nothing to reauthorize without it — Missing required field: connector_feature_data.incremental_authorization_id. PayPal only populates an incremental authorization id when the original payment was created with intent AUTHORIZE and `request_incremental_authorization` set; there is nothing to reauthorize without it"
       }
     },
     "parse_event": {

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -196,7 +196,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Payconex](connectors/payconex.md) | ✓ | ✓ | x | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Payload](connectors/payload.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ✓ | ✓ | x | ✓ | ✓ | ✓ | x | ✓ | x | ✓ | ⚠ | ⚠ | x | x | x | x | x | x | x | ✓ | x | x | x | x | ⚠ | x | x | ✓ | ⚠ | x |
 | [Payme](connectors/payme.md) | ✓ | ✓ | x | ✓ | ✓ | ✓ | x | ⚠ | ⚠ | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
-| [Paypal](connectors/paypal.md) | ✓ | ✓ | x | ✓ | ✓ | ✓ | ⚠ | ⚠ | ✓ | x | x | ✓ | ? | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | ✓ | x | ✓ | ⚠ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
+| [Paypal](connectors/paypal.md) | ✓ | ✓ | x | ✓ | ✓ | ✓ | ? | ⚠ | ✓ | x | x | ✓ | ? | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | ✓ | x | ✓ | ⚠ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
 | [Paysafe](connectors/paysafe.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ? | ⚠ | ? | ⚠ | ✓ | x | ✓ | ⚠ | ✓ | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Paytm](connectors/paytm.md) | ✓ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ? | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | x | ✓ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [PayU](connectors/payu.md) | ✓ | ✓ | x | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |


### PR DESCRIPTION
## Summary

Implement **IncrementalAuthorization** flow for the **Paypal** connector.

PayPal has no dedicated incremental-authorization API, so the flow is mapped onto PayPal's
**REAUTHORIZE** operation:

```
POST {base}/v2/payments/authorizations/{authorization_id}/reauthorize
```

`IncrementalAuthorization` was removed from `paypal.rs`'s
`macro_connector_flow_status_impls!(not_implemented: [...])` list and implemented with the standard UCS
`macro_connector_implementation!` idiom (cybersource-shaped). The authorization id is read out of
`PaypalMeta` in `connector_feature_data`. Both **HTTP 201** (normal) and **HTTP 200** (PayPal's
idempotent replay of a previously seen `PayPal-Request-Id`) are treated as success.

This implementation was generated and validated by **GRACE** (automated connector integration pipeline).

## Changes

- Added `IncrementalAuthorization` to `create_all_prerequisites!` and a new
  `macro_connector_implementation!` block in `paypal.rs`, with `get_headers` (OAuth bearer +
  partner-attribution headers) and `get_url` (authorization id from `PaypalMeta`).
- Added `PaypalIncrementalAuthRequest` / `PaypalIncrementalAuthResponse` (`authorization-2` schema) and
  their `TryFrom` implementations in `paypal/transformers.rs`, plus the
  `AUTHORIZATIONS_PATH` / `REAUTHORIZE_ACTION` constants and a `paypal_err_ctx` helper that attaches
  doc URLs and suggested actions to every `IntegrationError` raised by the flow.
- Fixed a latent bug in the previously-dead `PaypalIncrementalStatus` enum: the `PARTIALLYCAPTURED` /
  `PENDINGREVIEW` variants serialized **without** the underscore PayPal actually sends. Renamed to
  CamelCase so `SCREAMING_SNAKE_CASE` produces the correct wire values (`PARTIALLY_CAPTURED`,
  `PENDING_REVIEW`), added `Expired`, and added `#[serde(other)] Unknown` with a `tracing::warn` so an
  undocumented status is reconciled as `Unresolved` rather than failing deserialization.

### Why `domain_types/src/types.rs` is in scope (required core plumbing)

`PaymentFlowData::foreign_try_from(PaymentServiceIncrementalAuthorizationRequest, ...)` hardcoded
`access_token: None` and `connector_feature_data: None`. As a result PayPal's OAuth bearer header could
never be built and the flow was **unreachable** — it returned `FailedToObtainAuthType` regardless of what
the connector code did. The fix mirrors the existing `Capture` impl exactly: it threads
`state.access_token` and the caller-supplied `connector_feature_data` through onto `PaymentFlowData`.

### Behaviour change that affects other flows — please read

`Paypal::build_error_response` is **shared by Capture / Void / Refund / RSync**. It previously hardcoded
`NO_ERROR_CODE` / `NO_ERROR_MESSAGE` whenever PayPal's `details[]` array was empty, discarding the
top-level `name` / `message` that PayPal always sends on a non-2xx envelope. This PR adds `.or(name)` /
`.or(message)` fallbacks so real error codes surface instead of the placeholders.

This is **strictly additive** — the existing `details[].issue` priority path is unchanged, so any error
that already produced a real code produces exactly the same code as before. Only the
previously-placeholder case changes.

## Files Modified

- `crates/integrations/connector-integration/src/connectors/paypal.rs`
- `crates/integrations/connector-integration/src/connectors/paypal/transformers.rs`
- `crates/types-traits/domain_types/src/types.rs`

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl output (credentials redacted)</summary>

```
1. Access token (prerequisite)
   types.MerchantAuthenticationService/CreateServerAuthenticationToken

   Response:
   {
     "accessToken": { ... },
     "expiresInSeconds": "32400",
     "status": "OPERATION_STATUS_SUCCESS",
     "statusCode": 200
   }

--------------------------------------------------------------------------------

2. Authorize (Card, MANUAL capture, request_incremental_authorization=true)
   types.PaymentService/Authorize

   grpcurl -plaintext \
     -H 'x-connector: paypal' -H 'x-auth: body-key' \
     -H 'x-api-key: <REDACTED>' -H 'x-key1: <REDACTED>' \
     -H 'x-merchant-id: <REDACTED>' -H 'x-tenant-id: default' \
     -H 'x-request-id: auth_paypal_incauth_001' \
     -d '{
       "merchant_transaction_id": "test_paypal_incauth_001",
       "amount": {"minor_amount": 1000, "currency": "USD"},
       "payment_method": {"card": {
         "card_number": {"value": "<REDACTED>"},
         "card_exp_month": {"value": "<REDACTED>"},
         "card_exp_year": {"value": "<REDACTED>"},
         "card_cvc": {"value": "<REDACTED>"},
         "card_holder_name": {"value": "John Doe"}
       }},
       "capture_method": "MANUAL",
       "request_incremental_authorization": true,
       "address": {"billing_address": {
         "first_name": {"value": "John"}, "last_name": {"value": "Doe"},
         "line1": {"value": "123 Test St"}, "city": {"value": "San Jose"},
         "state": {"value": "CA"}, "zip_code": {"value": "95131"},
         "country_alpha2_code": "US", "email": {"value": "test@example.com"}
       }},
       "auth_type": "NO_THREE_DS", "enrolled_for_3ds": false,
       "return_url": "https://example.com/return",
       "webhook_url": "https://example.com/webhook",
       "state": {"access_token": {"token": {"value": "<REDACTED>"},
                 "expires_in_seconds": 32400, "token_type": "Bearer"}}
     }' localhost:8101 types.PaymentService/Authorize

   Response:
   {
     "merchantTransactionId": "test_paypal_incauth_001",
     "connectorTransactionId": "52Y49830NP854041V",
     "status": "AUTHORIZED",
     "statusCode": 201,
     "incrementalAuthorizationAllowed": true,
     "connectorFeatureData": {"value": "{\"authorize_id\":\"4LH39595US586263G\",\"capture_id\":null,\"incremental_authorization_id\":\"4LH39595US586263G\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}"},
     "connectorReferenceId": "test_paypal_incauth_001"
   }

--------------------------------------------------------------------------------

3. IncrementalAuthorization against LIVE PayPal sandbox
   types.PaymentService/IncrementalAuthorization

   grpcurl -plaintext \
     -H 'x-connector: paypal' -H 'x-auth: body-key' \
     -H 'x-api-key: <REDACTED>' -H 'x-key1: <REDACTED>' \
     -H 'x-merchant-id: <REDACTED>' -H 'x-tenant-id: default' \
     -H 'x-request-id: incauth_paypal_002' \
     -d '{
       "merchant_authorization_id": "test_paypal_incauth_001",
       "connector_transaction_id": "52Y49830NP854041V",
       "amount": {"minor_amount": 1500, "currency": "USD"},
       "reason": "order total increased",
       "connector_feature_data": {"value": "{\"authorize_id\":\"4LH39595US586263G\",\"capture_id\":null,\"incremental_authorization_id\":\"4LH39595US586263G\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}"},
       "state": {"access_token": {"token": {"value": "<REDACTED>"},
                 "expires_in_seconds": 32400, "token_type": "Bearer"}}
     }' localhost:8101 types.PaymentService/IncrementalAuthorization

   Response — HTTP 422 REAUTHORIZATION_TOO_SOON:
     Code: Internal, grpc-message="REAUTHORIZATION_TOO_SOON"
     CONNECTOR_ERROR_RESPONSE code="REAUTHORIZATION_TOO_SOON" status=422
     reason="description - A reauthorization is only allowed once from Day 4 to Day 29 since the
             date of the original authorization. ;"
     debug_id="f854943117ab3"

   This is the expected and acceptable live result: PayPal only permits reauthorization from Day 4
   to Day 29 after the original authorization, so a freshly created sandbox authorization can never
   succeed. It proves the request was built, signed, routed and the error correctly parsed.

   Exact wire contract emitted (matches the hyperswitch reference):
     POST https://api-m.sandbox.paypal.com/v2/payments/authorizations/4LH39595US586263G/reauthorize
     headers: Content-Type: application/json
              Authorization: Bearer <REDACTED>
              PayPal-Request-Id: <REDACTED>
              Prefer: return=representation
              PayPal-Partner-Attribution-Id: HyperSwitchlegacy_Ecom
     body:    {"amount":{"currency_code":"USD","value":"15.00"}}
     -> real error code from details[].issue (not NO_ERROR_CODE), real HTTP status (not None),
        real debug_id.

--------------------------------------------------------------------------------

4. Success path verification (HTTP 201)
   Same binary with base_url pointed at a local stub replaying PayPal's documented
   `authorization-2` 201 response body, since live PayPal cannot return 201 inside the honor period.

   Outbound request observed:
     POST /v2/payments/authorizations/4LH39595US586263G/reauthorize
     body={"amount":{"currency_code":"USD","value":"15.00"}}

   Response:
   {
     "connectorAuthorizationId": "0AW2184448108334S",
     "status": "AUTHORIZATION_SUCCESS",
     "statusCode": 201
   }

--------------------------------------------------------------------------------

5. Idempotent replay path (HTTP 200)
   Identical call, stub answers 200.

   Response:
   {
     "connectorAuthorizationId": "0AW2184448108334S",
     "status": "AUTHORIZATION_SUCCESS",
     "statusCode": 200
   }

   Confirms 201 and 200 are both treated as success, the full `authorization-2` body deserializes,
   CREATED maps to AUTHORIZATION_SUCCESS, and the NEW authorization id is surfaced as
   `connector_authorization_id`.
```

</details>

## Validation Checklist

- [x] `cargo build -p connector-integration` passed with zero errors
- [x] `cargo clippy -p connector-integration -p domain_types` clean
- [x] `cargo fmt --check` clean
- [x] grpcurl Authorize returned success status (201)
- [x] IncrementalAuthorization verified end-to-end against live PayPal sandbox (422
      `REAUTHORIZATION_TOO_SOON` — the only reachable live outcome inside the honor period) and on both
      the 201 and 200 success paths against a stub replaying PayPal's documented response body
- [x] No credentials in committed source code
- [x] Only the three intended files modified


---

# Follow-up: Wallet(PayPal) coverage for IncrementalAuthorization

*(Added by commit `39c85e1` on this same branch — an add-payment-method follow-up to the Card work
described above, which landed in `e0a969e`.)*

## Summary

Extends **IncrementalAuthorization** for **Paypal** to **Wallet(PayPal)**, covering both the
`PaypalRedirect` and `PaypalSdk` sub-variants.

**No functional change was required.** PayPal's REAUTHORIZE endpoint
(`POST /v2/payments/authorizations/{id}/reauthorize`) is **funding-source agnostic**, and the
existing implementation was verified — in code and at runtime — to already work for Wallet(PayPal).
**The diff is documentation only.**

Why the endpoint cannot need a funding-source branch:

- the path selector is an **authorization id**, not an order id or a funding instrument;
- the request body accepts **only `amount`**;
- the `authorization-2` response carries **no funding-instrument block**;
- PayPal's own OpenAPI operation description is in fact written for the wallet case —
  *"Reauthorizes an authorized PayPal account payment, by ID."*

What genuinely differs between funding sources is only **which Authorize leg mints the
authorization id**, and that is upstream of this flow:

| Funding source | Authorize leg that mints the authorization id |
|---|---|
| Card | the create-order call itself (`POST /v2/checkout/orders` with `payment_source.card`) |
| Wallet — `PaypalRedirect` | the **second** Authorize carrying `connector_order_id` → `POST /v2/checkout/orders/{order_id}/authorize` (create-order returns `PAYER_ACTION_REQUIRED` with no `payments` block, so no id exists pre-approval) |
| Wallet — `PaypalSdk` | the single Authorize, with the SDK token used as the order id → `POST /v2/checkout/orders/{sdk_token}/authorize` |

## Changes

- `paypal.rs` — comment on the `IncrementalAuthorization` `macro_connector_implementation!` block
  recording why it deliberately carries **no** funding-source branch.
- `paypal/transformers.rs` — doc comment on `extract_incremental_authorization_id` recording which
  Authorize leg mints the authorization id per funding source, and why the function returns `None`
  rather than erroring for orders that legitimately have no authorization yet.

## Files Modified

- `crates/integrations/connector-integration/src/connectors/paypal.rs`
- `crates/integrations/connector-integration/src/connectors/paypal/transformers.rs`

## gRPC Test Results — Wallet(PayPal)

**Status: PASS**

Summary of what was verified:

- **Wallet(PaypalRedirect) create-order against real PayPal sandbox** → `PAYER_ACTION_REQUIRED`,
  `incremental_authorization_id: null`. Correct — no authorization exists before buyer approval.
- **Second Authorize with `connector_order_id` against real PayPal** → 422 `ORDER_NOT_APPROVED`
  (expected; buyer approval requires a browser). Proves the wallet leg routes to
  `/v2/checkout/orders/{id}/authorize` with **no card gating**, and that the real PayPal error code
  is surfaced verbatim rather than `NO_ERROR_CODE`.
- **Direct sandbox call** (create order → confirm-payment-source → authorize) confirmed the live
  wallet order-authorize response **does** contain `"intent": "AUTHORIZE"`, so it deserializes into
  `PaypalOrdersResponse` (the first untagged variant) and reaches
  `extract_incremental_authorization_id` — the id is **not** silently lost to the
  `PaypalThreeDsResponse` fallback.
- **Post-approval wallet order-authorize body replayed against a local stub** → `AUTHORIZED`,
  `incrementalAuthorizationAllowed: true`, and `connectorFeatureData` carrying
  `authorize_id` / `incremental_authorization_id`. Same result for the `PaypalSdk` sub-variant.
- **IncrementalAuthorization driven from that wallet-derived id** → stub received
  `POST /v2/payments/authorizations/3XY12345AB6789012/reauthorize` with body
  `{"amount":{"currency_code":"USD","value":"15.00"}}`; response mapped to
  `connectorAuthorizationId: "9WV12345KL6789012"`, `status: AUTHORIZATION_SUCCESS`,
  `statusCode: 201`.
- **IncrementalAuthorization against real PayPal with a real authorization id** → 422
  `REAUTHORIZATION_TOO_SOON`. Expected and correctly mapped — PayPal only permits reauthorization
  on days 4–29 after the original authorization, so a freshly minted sandbox authorization can
  never succeed.
- `cargo check -p connector-integration` clean; clippy clean.

<details>
<summary>Full grpcurl transcript (credentials redacted)</summary>

```
Common headers ($H):
  -H 'x-connector: paypal' -H 'x-auth: body-key' -H 'x-api-key: <REDACTED>'
  -H 'x-key1: <REDACTED>' -H 'x-merchant-id: <REDACTED>' -H 'x-tenant-id: default'

--- T0: CreateServerAuthenticationToken (REAL PayPal) ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_000' -d '{"connector":"PAYPAL"}' \
  localhost:27311 types.MerchantAuthenticationService/CreateServerAuthenticationToken
{
  "accessToken": { "value": "<REDACTED>" },
  "expiresInSeconds": "29429",
  "status": "OPERATION_STATUS_SUCCESS",
  "statusCode": 200
}

--- T1: Authorize — Wallet(PaypalRedirect) create-order, intent=AUTHORIZE (REAL PayPal) ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_001' -d '{
  "merchant_transaction_id": "pp_wallet_final_001",
  "amount": {"minor_amount": 1000, "currency": "USD"},
  "payment_method": {"paypal_redirect": {}},
  "capture_method": "MANUAL",
  "auth_type": "NO_THREE_DS",
  "request_incremental_authorization": true,
  "return_url": "https://example.com/return",
  "complete_authorize_url": "https://example.com/complete",
  "webhook_url": "https://example.com/webhook",
  "address": {"billing_address": {"first_name":{"value":"John"},"last_name":{"value":"Doe"},
      "line1":{"value":"123 Test St"},"city":{"value":"San Jose"},"state":{"value":"CA"},
      "zip_code":{"value":"95131"},"country_alpha2_code":"US","email":{"value":"test@example.com"}}},
  "state": {"access_token": {"token": {"value":"<REDACTED>"},
      "expires_in_seconds": 30240, "token_type": "Bearer"}}
}' localhost:27311 types.PaymentService/Authorize
{
  "merchantTransactionId": "pp_wallet_final_001",
  "connectorTransactionId": "69X69486CY2070043",
  "status": "AUTHENTICATION_PENDING",
  "statusCode": 200,
  "redirectionData": { "form": { "endpoint": "https://www.sandbox.paypal.com/checkoutnow",
      "method": "HTTP_METHOD_GET", "formFields": { "token": "69X69486CY2070043" } } },
  "connectorFeatureData": { "value": "{\"authorize_id\":null,\"capture_id\":null,\"incremental_authorization_id\":null,\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}" },
  "connectorReferenceId": "pp_wallet_final_001"
}
=> incremental_authorization_id is null, which is CORRECT: no authorization exists before the
   buyer approves at PayPal.

--- T2: Authorize #2 — order-authorize on the still-unapproved order (REAL PayPal) ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_002' \
  -d '<T1 payload + "connector_order_id":"69X69486CY2070043">' \
  localhost:27311 types.PaymentService/Authorize
ERROR: grpc-message="ORDER_NOT_APPROVED", status=422
  details: ORDER_NOT_APPROVED / "Payer has not yet approved the Order for payment. Please redirect
  the payer to the 'rel':'approve' url returned as part of the HATEOAS links within the Create Order
  call or provide a valid payment_source in the request."  debug_id=f739497009865
(EXPECTED — buyer approval needs a browser. Proves the wallet leg routes to
 /v2/checkout/orders/{id}/authorize with no card gating, and that the real PayPal issue code is
 surfaced instead of NO_ERROR_CODE.)

--- T3: Authorize #2 — post-approval PayPal wallet body replayed via local stub ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_003' -d '<same payload as T2>' \
  localhost:27321 types.PaymentService/Authorize
{
  "merchantTransactionId": "pp_wallet_final_001",
  "connectorTransactionId": "4N051495R5567400G",
  "status": "AUTHORIZED",
  "statusCode": 201,
  "incrementalAuthorizationAllowed": true,
  "connectorFeatureData": { "value": "{\"authorize_id\":\"3XY12345AB6789012\",\"capture_id\":null,\"incremental_authorization_id\":\"3XY12345AB6789012\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}" },
  "connectorReferenceId": "pp_wallet_ia_001"
}
Stub observed: POST /v2/checkout/orders/4N051495R5567400G/authorize, empty body,
headers `prefer: return=representation`, `paypal-request-id: <REDACTED>`,
`paypal-partner-attribution-id: HyperSwitchlegacy_Ecom`.

--- T4: Authorize — Wallet(PaypalSdk) single-call variant (stub) ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_004' -d '{
  ..., "merchant_transaction_id":"pp_wallet_sdk_001",
  "payment_method": {"paypal_sdk": {"token": {"value":"4N051495R5567400G"}}}, ...
}' localhost:27321 types.PaymentService/Authorize
{
  "status": "AUTHORIZED",
  "statusCode": 201,
  "incrementalAuthorizationAllowed": true,
  "connectorFeatureData": { "value": "{\"authorize_id\":\"3XY12345AB6789012\",\"capture_id\":null,\"incremental_authorization_id\":\"3XY12345AB6789012\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}" }
}
Stub observed: POST /v2/checkout/orders/4N051495R5567400G/authorize (SDK token used as order id).

--- T5: IncrementalAuthorization — wallet-derived authorization id, PayPal 201 replayed (stub) ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_005' -d '{
  "merchant_authorization_id": "pp_wallet_ia_001",
  "connector_transaction_id": "4N051495R5567400G",
  "amount": {"minor_amount": 1500, "currency": "USD"},
  "reason": "wallet incremental authorization test",
  "connector_feature_data": {"value": "{\"authorize_id\":\"3XY12345AB6789012\",\"capture_id\":null,\"incremental_authorization_id\":\"3XY12345AB6789012\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}"},
  "state": {"access_token": {"token": {"value":"<REDACTED>"},
      "expires_in_seconds": 30240, "token_type": "Bearer"}}
}' localhost:27321 types.PaymentService/IncrementalAuthorization
{
  "connectorAuthorizationId": "9WV12345KL6789012",
  "status": "AUTHORIZATION_SUCCESS",
  "statusCode": 201
}
Stub observed: POST /v2/payments/authorizations/3XY12345AB6789012/reauthorize
  body {"amount":{"currency_code":"USD","value":"15.00"}}

--- T6: IncrementalAuthorization — REAL PayPal, real authorization id ---
grpcurl -plaintext $H -H 'x-request-id: req_pp_final_006' -d '{
  "merchant_authorization_id": "probe_shape_001",
  "connector_transaction_id": "2LU033217V089323S",
  "amount": {"minor_amount": 1500, "currency": "USD"},
  "reason": "real paypal reauthorize",
  "connector_feature_data": {"value": "{\"authorize_id\":\"1FR795384L687463D\",\"capture_id\":null,\"incremental_authorization_id\":\"1FR795384L687463D\",\"psync_flow\":\"AUTHORIZE\",\"next_action\":null,\"order_id\":null}"},
  "state": {"access_token": {"token": {"value":"<REDACTED>"},
      "expires_in_seconds": 30240, "token_type": "Bearer"}}
}' localhost:27311 types.PaymentService/IncrementalAuthorization
ERROR: grpc-message="REAUTHORIZATION_TOO_SOON", status=422
  details: REAUTHORIZATION_TOO_SOON / "A reauthorization is only allowed once from Day 4 to Day 29
  since the date of the original authorization."  debug_id=f457760674c19
(EXPECTED and correctly mapped — real PayPal issue code surfaced, not NO_ERROR_CODE.)
```

</details>

## Known items flagged but deliberately NOT fixed here

Both are **pre-existing** and affect Card identically; they are called out as follow-ups rather than
being bundled into a documentation-only change.

1. `crates/types-traits/domain_types/src/types.rs:9386` hardcodes
   `payment_method: PaymentMethod::Card, //TODO` when building `PaymentFlowData` for the
   `IncrementalAuthorization` request. Harmless for PayPal (nothing on the reauthorize path reads
   it) but semantically wrong for a wallet payment. Fixing it properly needs a proto field that does
   not currently exist.
2. Reauthorization mints a **new** authorization id, but
   `PaymentServiceIncrementalAuthorizationResponse` has no `connector_feature_data` field, so a
   caller's stored `PaypalMeta.authorize_id` still holds the superseded id for a later
   Capture/Void.

## Validation Checklist — Wallet(PayPal)

- [x] `cargo check -p connector-integration` passed with zero errors
- [x] `cargo clippy` clean
- [x] Wallet(PaypalRedirect) Authorize verified against live PayPal sandbox
- [x] Wallet order-authorize response shape confirmed against live PayPal (carries
      `"intent": "AUTHORIZE"`, so it reaches `extract_incremental_authorization_id`)
- [x] Wallet-derived IncrementalAuthorization verified end-to-end (201 success path via stub; live
      PayPal returns the expected `REAUTHORIZATION_TOO_SOON` inside the honor period)
- [x] No credentials in committed source code
- [x] Only the two intended connector files modified by this follow-up commit
