### PR TITLE
chore: add backward compatibility comments on merchant_*_id fields

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -6272,12 +6272,7 @@ pub fn generate_payment_authorize_response<T: PaymentMethodDataTypes>(
                     network_transaction_id: network_txn_id,
                     connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_transaction_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_transaction_id: connector_response_reference_id.clone(),
                     mandate_reference: mandate_reference_grpc,
                     mandate_reference_details,
                     incremental_authorization_allowed,
@@ -7282,14 +7277,9 @@ pub fn generate_payment_void_response(
                         &grpc_resource_id,
                     ),
                     status: grpc_status.into(),
-                    connector_reference_id: connector_response_reference_id,
+                    connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_void_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_void_id: connector_response_reference_id,
                     error: None,
                     status_code: u32::from(status_code),
                     response_headers: router_data_v2
@@ -7439,14 +7429,9 @@ pub fn generate_payment_void_post_capture_response(
                         &grpc_resource_id,
                     ),
                     status: grpc_status.into(),
-                    connector_reference_id: connector_response_reference_id,
+                    connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_reverse_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_reverse_id: connector_response_reference_id,
                     error: None,
                     status_code: u32::from(status_code),
                     response_headers: router_data_v2
@@ -7477,14 +7462,9 @@ pub fn generate_payment_void_post_capture_response(
                 Ok(PaymentServiceReverseResponse {
                     connector_transaction_id: connector_reference_id.clone().unwrap_or_default(),
                     status: grpc_status.into(),
-                    connector_reference_id,
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_reverse_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_reverse_id: connector_reference_id.clone(),
+                    connector_reference_id,
                     error: None,
                     status_code: u32::from(status_code),
                     response_headers: router_data_v2
@@ -7745,14 +7725,9 @@ pub fn generate_payment_sync_response(
                     connector_transaction_id: extract_connector_request_reference_id(
                         &grpc_resource_id,
                     ),
-                    connector_reference_id: connector_response_reference_id,
+                    connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_transaction_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_transaction_id: connector_response_reference_id,
                     redirection_data: redirection_data
                         .map(|form| grpc_api_types::payments::RedirectForm::foreign_try_from(*form))
                         .transpose()?,
@@ -7870,14 +7845,9 @@ pub fn generate_payment_sync_response(
                         .clone()
                         .map(ForeignFrom::foreign_from),
                     connector_transaction_id: resource_id.unwrap_or_default(),
-                    connector_reference_id: connector_response_reference_id,
+                    connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_transaction_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_transaction_id: connector_response_reference_id,
                     redirection_data: None,
                     status: grpc_status as i32,
                     mandate_reference: None,
@@ -8882,8 +8852,9 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentServiceGetResponse {
                     .transpose()?
                     .unwrap_or_default(),
             ),
-            connector_reference_id: value.connector_response_reference_id,
-            merchant_transaction_id: None,
+            connector_reference_id: value.connector_response_reference_id.clone(),
+            // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
+            merchant_transaction_id: value.connector_response_reference_id,
             status: status as i32,
             mandate_reference: mandate_reference_grpc,
             mandate_reference_details,
@@ -9485,8 +9456,9 @@ impl ForeignTryFrom<RefundWebhookDetailsResponse> for RefundResponse {
             connector_transaction_id: None,
             connector_refund_id: value.connector_refund_id.unwrap_or_default(),
             status: status.into(),
-            connector_reference_id: value.connector_response_reference_id,
-            merchant_refund_id: None,
+            connector_reference_id: value.connector_response_reference_id.clone(),
+            // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
+            merchant_refund_id: value.connector_response_reference_id,
             merchant_transaction_id: value.merchant_transaction_id,
             error: Some(grpc_api_types::payments::ErrorInfo {
                 unified_details: None,
@@ -9558,8 +9530,9 @@ impl ForeignTryFrom<DisputeWebhookDetailsResponse> for DisputeResponse {
             evidence_documents: vec![],
             dispute_reason: None,
             dispute_message: value.dispute_message,
-            connector_reference_id: value.connector_response_reference_id,
-            merchant_dispute_id: None,
+            connector_reference_id: value.connector_response_reference_id.clone(),
+            // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
+            merchant_dispute_id: value.connector_response_reference_id,
             status_code: value.status_code as u32,
             response_headers,
             raw_connector_request: None,
@@ -10765,14 +10738,9 @@ pub fn generate_payment_capture_response(
                     connector_transaction_id: extract_connector_request_reference_id(
                         &grpc_resource_id,
                     ),
-                    connector_reference_id: connector_response_reference_id,
+                    connector_reference_id: connector_response_reference_id.clone(),
                     // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
-                    merchant_capture_id: Some(
-                        router_data_v2
-                            .resource_common_data
-                            .connector_request_reference_id
-                            .clone(),
-                    ),
+                    merchant_capture_id: connector_response_reference_id,
                     error: None,
                     status: grpc_status.into(),
                     status_code: status_code as u32,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -6271,6 +6271,7 @@ pub fn generate_payment_authorize_response<T: PaymentMethodDataTypes>(
                     ),
                     network_transaction_id: network_txn_id,
                     connector_reference_id: connector_response_reference_id.clone(),
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_transaction_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -7282,6 +7283,7 @@ pub fn generate_payment_void_response(
                     ),
                     status: grpc_status.into(),
                     connector_reference_id: connector_response_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_void_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -7438,6 +7440,7 @@ pub fn generate_payment_void_post_capture_response(
                     ),
                     status: grpc_status.into(),
                     connector_reference_id: connector_response_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_reverse_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -7475,6 +7478,7 @@ pub fn generate_payment_void_post_capture_response(
                     connector_transaction_id: connector_reference_id.clone().unwrap_or_default(),
                     status: grpc_status.into(),
                     connector_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_reverse_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -7742,6 +7746,7 @@ pub fn generate_payment_sync_response(
                         &grpc_resource_id,
                     ),
                     connector_reference_id: connector_response_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_transaction_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -7866,6 +7871,7 @@ pub fn generate_payment_sync_response(
                         .map(ForeignFrom::foreign_from),
                     connector_transaction_id: resource_id.unwrap_or_default(),
                     connector_reference_id: connector_response_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_transaction_id: Some(
                         router_data_v2
                             .resource_common_data
@@ -8728,6 +8734,7 @@ pub fn generate_refund_sync_response(
                 connector_refund_id: response.connector_refund_id.clone(),
                 status: grpc_status as i32,
                 connector_reference_id: None,
+                // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                 merchant_refund_id: Some(
                     router_data_v2
                         .resource_common_data
@@ -9137,6 +9144,7 @@ pub fn generate_void_post_refund_response(
                 connector_refund_id: response.connector_refund_id,
                 status: grpc_api_types::payments::RefundStatus::RefundSuccess as i32,
                 connector_reference_id: None,
+                // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                 merchant_refund_id: Some(
                     router_data_v2
                         .resource_common_data
@@ -10174,6 +10182,7 @@ pub fn generate_refund_response(
                 connector_refund_id: response.connector_refund_id,
                 status: grpc_status as i32,
                 connector_reference_id: None,
+                // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                 merchant_refund_id: Some(
                     router_data_v2
                         .resource_common_data
@@ -10757,6 +10766,7 @@ pub fn generate_payment_capture_response(
                         &grpc_resource_id,
                     ),
                     connector_reference_id: connector_response_reference_id,
+                    // Populated for backward compatibility; will be removed once Hyperswitch migrates to connector_reference_id
                     merchant_capture_id: Some(
                         router_data_v2
                             .resource_common_data


### PR DESCRIPTION
## Summary

- Adds inline comments on all 10 `merchant_*_id` field assignments (OK paths) that are populated for backward compatibility, marking them for removal once Hyperswitch migrates to `connector_reference_id`
- Follows up on #1968 which added `connector_reference_id` and fixed the misuse of `merchant_*_id` fields

Fields annotated:
- `merchant_transaction_id` (authorize, psync × 2)
- `merchant_void_id` (void)
- `merchant_reverse_id` (reverse × 2)
- `merchant_capture_id` (capture)
- `merchant_refund_id` (refund, refund_sync, void_post_refund)

## Test plan

- [x] `cargo check -p domain_types` passes — comment-only change, no logic affected