### PR TITLE
fix(connector): [paypal] populate sender_payment_instrument_id from payer response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -2191,6 +2191,12 @@ pub struct PaypalOrdersResponse {
     status: Option<PaypalOrderStatus>,
     purchase_units: Vec<PurchaseUnitItem>,
     payment_source: Option<PaymentSourceItemResponse>,
+    payer: Option<Payer>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Payer {
+    payer_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2212,6 +2218,7 @@ pub struct PaypalRedirectResponse {
     purchase_units: Vec<RedirectPurchaseUnitItem>,
     links: Vec<PaypalLinks>,
     payment_source: Option<PaymentSourceItemResponse>,
+    payer: Option<Payer>,
 }
 
 // Note: Don't change order of deserialization of variant, priority is in descending order
@@ -2246,6 +2253,7 @@ pub struct PaypalPaymentsSyncResponse {
     amount: OrderAmount,
     invoice_id: Option<String>,
     supplementary_data: PaypalSupplementaryData,
+    payer: Option<Payer>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2435,6 +2443,11 @@ where
             false => Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
+                    sender_payment_instrument_id: item
+                        .response
+                        .payer
+                        .as_ref()
+                        .and_then(|payer| payer.payer_id.clone()),
                     ..item.router_data.resource_common_data
                 },
                 response: Ok(PaymentsResponseData::TransactionResponse {
@@ -2575,6 +2588,11 @@ impl TryFrom<ResponseRouterData<PaypalRedirectResponse, Self>>
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                sender_payment_instrument_id: item
+                    .response
+                    .payer
+                    .as_ref()
+                    .and_then(|payer| payer.payer_id.clone()),
                 ..item.router_data.resource_common_data
             },
             response: Ok(PaymentsResponseData::TransactionResponse {
@@ -2739,6 +2757,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                sender_payment_instrument_id: item
+                    .response
+                    .payer
+                    .as_ref()
+                    .and_then(|payer| payer.payer_id.clone()),
                 ..item.router_data.resource_common_data
             },
             response: Ok(PaymentsResponseData::TransactionResponse {
@@ -2805,6 +2828,11 @@ impl<F, T> TryFrom<ResponseRouterData<PaypalPaymentsSyncResponse, Self>>
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status: common_enums::AttemptStatus::from(item.response.status),
+                sender_payment_instrument_id: item
+                    .response
+                    .payer
+                    .as_ref()
+                    .and_then(|payer| payer.payer_id.clone()),
                 ..item.router_data.resource_common_data
             },
             response: Ok(PaymentsResponseData::TransactionResponse {


### PR DESCRIPTION
## Description

Populates `sender_payment_instrument_id` in the PayPal connector's Authorize and PSync router-data responses, resolving the validation-service diff:

```
typeDiff: sender_payment_instrument_id { hyperswitch: string, ucs: null }
```

Hyperswitch parses `payer.payer_id` from the PayPal orders/redirect/payments-sync responses and exposes it as `sender_payment_instrument_id` (required for the closed-loop payouts feature tracked. — `payer_id` is returned in psync and used as `payout_method_data.wallet.paypal.paypal_id`). UCS never populated the field, so every paypal wallet transaction with a payer produced a typeDiff.

Observed on prod for paypal wallet payments (merchant `abo_factory`): 17 diffs in the last 30 days (16x Authorize across 10 payments + 7x PSync polls on one payment).

## Changes

- Add `payer: Option<Payer>` (with `payer_id`) to `PaypalOrdersResponse`, `PaypalRedirectResponse`, `PaypalPaymentsSyncResponse` — mirrors Hyperswitch's response structs.
- Set `sender_payment_instrument_id` from `response.payer.payer_id` in the success arms of:
  - Orders Authorize/PSync (`RouterDataV2<F, PaymentFlowData, Req, PaymentsResponseData>`)
  - Redirect PSync
  - Redirect Authorize
  - Payments sync
- Mirrors Hyperswitch behavior (HS populates it in orders authorize/psync, redirect, payments sync — not in 3DS/capture/void/setup-mandate).

Failure arms are untouched (HS also leaves the field unset on error responses).

## Testing

- `cargo check -p connector-integration` passes.