### PR TITLE
fix(demo): update prism and globalpay billing country

### DIFF
--- a/demo/e-commerce/client/css/styles.css
+++ b/demo/e-commerce/client/css/styles.css
@@ -93,6 +93,15 @@ main h2 {
   font-size: 1.8rem;
 }
 
+.routing-info {
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  background: #eff6ff;
+  border-left: 4px solid #2563eb;
+  border-radius: 6px;
+  color: #1e3a5f;
+}
+
 .products-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/demo/e-commerce/client/index.html
+++ b/demo/e-commerce/client/index.html
@@ -25,6 +25,10 @@
 
   <main class="container">
     <h2>Products</h2>
+    <p class="routing-info" role="note">
+      <strong>Demo payment routing:</strong>
+      USD orders up to $50 use Stripe; EUR orders up to €50 use GlobalPay; orders over 50 in the selected currency use Adyen.
+    </p>
     <div id="products-grid" class="products-grid">
       <!-- Products will be rendered here -->
     </div>

--- a/demo/e-commerce/package.json
+++ b/demo/e-commerce/package.json
@@ -15,7 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "hyperswitch-prism": "0.0.8",
+    "hyperswitch-prism": "0.4.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/demo/e-commerce/server/routes/payments.ts
+++ b/demo/e-commerce/server/routes/payments.ts
@@ -5,7 +5,7 @@ import { createClientAuthToken } from '../utils/auth.js';
 import { getPaymentStatusText } from '../utils/payment-status.js';
 
 const router = Router();
-const { Currency, CaptureMethod } = types;
+const { Currency, CaptureMethod, CountryAlpha2 } = types;
 
 interface AuthorizeRequestBody {
   token: string;
@@ -52,6 +52,7 @@ function buildAuthorizeRequest(
   serverToken?: string
 ): types.PaymentServiceTokenAuthorizeRequest {
   const currencyEnum = params.currency === 'EUR' ? Currency.EUR : Currency.USD;
+  const billingCountry = params.currency === 'EUR' ? CountryAlpha2.NL : CountryAlpha2.US;
 
   const request: types.PaymentServiceTokenAuthorizeRequest = {
     merchantTransactionId: params.merchantTransactionId,
@@ -62,7 +63,11 @@ function buildAuthorizeRequest(
     connectorToken: { value: params.token },
     captureMethod: CaptureMethod.AUTOMATIC,
     returnUrl: `${config.baseUrl}/checkout/return`,
-    address: {}
+    address: {
+      billingAddress: {
+        countryAlpha2Code: billingCountry
+      }
+    }
   };
 
   // For GlobalPay, add server access token in state


### PR DESCRIPTION
## Description
- Pin the e-commerce demo to `hyperswitch-prism@0.4.0`.
- Include the billing country required by GlobalPay token authorization, using the demo's existing EUR/NL and USD/US convention.
- Show the smart-routing rules on the storefront so testers can intentionally exercise Stripe, GlobalPay, and Adyen.

## Motivation and Context
GlobalPay checkout tokenization succeeds, but token authorization fails with `MISSING_REQUIRED_FIELD` when the demo sends an empty billing address. The previous UI also did not explain how to select each connector through currency and amount. These changes make the current demo flows discoverable and compatible with the deployed Prism SDK.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?
- Ran `npm install --no-package-lock` in `demo/e-commerce`.
- Ran `npm run build`; TypeScript compilation passes.
- Started the demo locally on port 3001.
- Verified `/health` returns `200`.
- Verified the storefront serves the payment-routing guidance.