### PR TITLE
feat(glomopay): map utr to refund_arn and enforce HTTPS callback URL

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
@@ -1770,7 +1770,7 @@ impl<F> TryFrom<ResponseRouterData<AciRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
@@ -1770,6 +1770,7 @@ impl<F> TryFrom<ResponseRouterData<AciRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -6158,7 +6158,7 @@ impl<F, Req> TryFrom<ResponseRouterData<AdyenRefundResponse, Self>>
             connector_refund_id: response.psp_reference,
             refund_status: status,
             status_code: http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -6158,6 +6158,7 @@ impl<F, Req> TryFrom<ResponseRouterData<AdyenRefundResponse, Self>>
             connector_refund_id: response.psp_reference,
             refund_status: status,
             status_code: http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/affirm/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/affirm/transformers.rs
@@ -799,6 +799,7 @@ impl TryFrom<ResponseRouterData<AffirmRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data.clone()
         })
@@ -851,6 +852,7 @@ impl TryFrom<ResponseRouterData<AffirmRSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/affirm/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/affirm/transformers.rs
@@ -799,7 +799,7 @@ impl TryFrom<ResponseRouterData<AffirmRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data.clone()
         })
@@ -852,7 +852,7 @@ impl TryFrom<ResponseRouterData<AffirmRSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
@@ -880,7 +880,7 @@ impl TryFrom<ResponseRouterData<AirwallexRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status,
@@ -912,7 +912,7 @@ impl TryFrom<ResponseRouterData<AirwallexRefundSyncResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status,

--- a/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
@@ -880,6 +880,7 @@ impl TryFrom<ResponseRouterData<AirwallexRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status,
@@ -911,6 +912,7 @@ impl TryFrom<ResponseRouterData<AirwallexRefundSyncResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status,

--- a/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
@@ -914,7 +914,7 @@ impl TryFrom<ResponseRouterData<AuthipayPaymentsResponse, Self>>
             connector_refund_id: item.response.ipg_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(router_data)
@@ -945,7 +945,7 @@ impl TryFrom<ResponseRouterData<AuthipayPaymentsResponse, Self>>
             connector_refund_id: item.response.ipg_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(router_data)

--- a/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authipay/transformers.rs
@@ -914,6 +914,7 @@ impl TryFrom<ResponseRouterData<AuthipayPaymentsResponse, Self>>
             connector_refund_id: item.response.ipg_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(router_data)
@@ -944,6 +945,7 @@ impl TryFrom<ResponseRouterData<AuthipayPaymentsResponse, Self>>
             connector_refund_id: item.response.ipg_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(router_data)

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2284,6 +2284,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRefundResponse, Self>>
                 connector_refund_id: transaction_response.transaction_id.clone(),
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
         };
 
@@ -2910,6 +2911,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRSyncResponse, Self>>
                     connector_refund_id: transaction.transaction_id,
                     refund_status,
                     status_code: http_code,
+                    refund_arn: None,
                 });
 
                 Ok(new_router_data)

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2284,7 +2284,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRefundResponse, Self>>
                 connector_refund_id: transaction_response.transaction_id.clone(),
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
         };
 
@@ -2911,7 +2911,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRSyncResponse, Self>>
                     connector_refund_id: transaction.transaction_id,
                     refund_status,
                     status_code: http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 });
 
                 Ok(new_router_data)

--- a/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
@@ -658,7 +658,7 @@ impl TryFrom<ResponseRouterData<BamboraPaymentsResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -690,7 +690,7 @@ impl TryFrom<ResponseRouterData<BamboraPaymentsResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
@@ -658,6 +658,7 @@ impl TryFrom<ResponseRouterData<BamboraPaymentsResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -689,6 +690,7 @@ impl TryFrom<ResponseRouterData<BamboraPaymentsResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
@@ -983,6 +983,7 @@ impl TryFrom<ResponseRouterData<BamboraapacRefundResponse, Self>>
             connector_refund_id: response.receipt.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -1116,6 +1117,7 @@ impl TryFrom<ResponseRouterData<BamboraapacSyncResponse, Self>>
             connector_refund_id: response.receipt.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
@@ -983,7 +983,7 @@ impl TryFrom<ResponseRouterData<BamboraapacRefundResponse, Self>>
             connector_refund_id: response.receipt.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1117,7 +1117,7 @@ impl TryFrom<ResponseRouterData<BamboraapacSyncResponse, Self>>
             connector_refund_id: response.receipt.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -1050,7 +1050,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -1136,7 +1136,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaRsyncResponse, Self>>
                         connector_refund_id: item.response.id.clone(),
                         refund_status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 }
             }

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -1050,6 +1050,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -1135,6 +1136,7 @@ impl<F> TryFrom<ResponseRouterData<BankOfAmericaRsyncResponse, Self>>
                         connector_refund_id: item.response.id.clone(),
                         refund_status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 }
             }

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -1228,7 +1228,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -1290,7 +1290,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRsyncResponse, Self>>
                         connector_refund_id: item.response.id,
                         refund_status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 }
             }
@@ -1301,7 +1301,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRsyncResponse, Self>>
                     Err(_) => common_enums::RefundStatus::Pending,
                 },
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
         };
 

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -1228,6 +1228,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -1289,6 +1290,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRsyncResponse, Self>>
                         connector_refund_id: item.response.id,
                         refund_status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 }
             }
@@ -1299,6 +1301,7 @@ impl TryFrom<ResponseRouterData<responses::BarclaycardRsyncResponse, Self>>
                     Err(_) => common_enums::RefundStatus::Pending,
                 },
                 status_code: item.http_code,
+                refund_arn: None,
             }),
         };
 

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -528,6 +528,7 @@ impl<F> TryFrom<RefundsResponseRouterData<F, RefundResponse>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.state),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -545,6 +546,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.state),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -528,7 +528,7 @@ impl<F> TryFrom<RefundsResponseRouterData<F, RefundResponse>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.state),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -546,7 +546,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.state),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/bluesnap/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bluesnap/transformers.rs
@@ -859,6 +859,7 @@ impl TryFrom<ResponseRouterData<BluesnapRefundResponse, Self>>
                 connector_refund_id: item.response.refund_transaction_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -924,6 +925,7 @@ impl TryFrom<ResponseRouterData<BluesnapRefundSyncResponse, Self>>
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/bluesnap/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bluesnap/transformers.rs
@@ -859,7 +859,7 @@ impl TryFrom<ResponseRouterData<BluesnapRefundResponse, Self>>
                 connector_refund_id: item.response.refund_transaction_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -925,7 +925,7 @@ impl TryFrom<ResponseRouterData<BluesnapRefundSyncResponse, Self>>
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -1330,7 +1330,7 @@ impl<F> TryFrom<ResponseRouterData<BraintreeRefundResponse, Self>>
                             connector_refund_id: refund_data.id.clone(),
                             refund_status,
                             status_code: item.http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         })
                     }
                 }
@@ -1533,7 +1533,7 @@ impl<F> TryFrom<ResponseRouterData<BraintreeRSyncResponse, Self>>
                     connector_refund_id: connector_refund_id.to_string(),
                     refund_status: enums::RefundStatus::from(edge_data.node.status.clone()),
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 });
                 Ok(Self {
                     response,

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -1330,6 +1330,7 @@ impl<F> TryFrom<ResponseRouterData<BraintreeRefundResponse, Self>>
                             connector_refund_id: refund_data.id.clone(),
                             refund_status,
                             status_code: item.http_code,
+                            refund_arn: None,
                         })
                     }
                 }
@@ -1532,6 +1533,7 @@ impl<F> TryFrom<ResponseRouterData<BraintreeRSyncResponse, Self>>
                     connector_refund_id: connector_refund_id.to_string(),
                     refund_status: enums::RefundStatus::from(edge_data.node.status.clone()),
                     status_code: item.http_code,
+                    refund_arn: None,
                 });
                 Ok(Self {
                     response,

--- a/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
@@ -1342,7 +1342,7 @@ impl TryFrom<ResponseRouterData<CashfreeRefundResponse, Self>>
                 connector_refund_id: response.refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1382,7 +1382,7 @@ impl TryFrom<ResponseRouterData<CashfreeRefundSyncResponse, Self>>
                 connector_refund_id: response.refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
@@ -1342,6 +1342,7 @@ impl TryFrom<ResponseRouterData<CashfreeRefundResponse, Self>>
                 connector_refund_id: response.refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1381,6 +1382,7 @@ impl TryFrom<ResponseRouterData<CashfreeRefundSyncResponse, Self>>
                 connector_refund_id: response.refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/celero/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/celero/transformers.rs
@@ -931,7 +931,7 @@ impl TryFrom<ResponseRouterData<CeleroRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1000,7 +1000,7 @@ impl TryFrom<ResponseRouterData<CeleroRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status: RefundStatus::Success,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..router_data.clone()
                 })

--- a/crates/integrations/connector-integration/src/connectors/celero/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/celero/transformers.rs
@@ -931,6 +931,7 @@ impl TryFrom<ResponseRouterData<CeleroRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -999,6 +1000,7 @@ impl TryFrom<ResponseRouterData<CeleroRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status: RefundStatus::Success,
                         status_code: item.http_code,
+                        refund_arn: None,
                     }),
                     ..router_data.clone()
                 })

--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -2342,7 +2342,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.action_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -2472,7 +2472,7 @@ impl<F> TryFrom<ResponseRouterData<RSyncResponse, Self>>
                 connector_refund_id: action_response.action_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -2342,6 +2342,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.action_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -2471,6 +2472,7 @@ impl<F> TryFrom<ResponseRouterData<RSyncResponse, Self>>
                 connector_refund_id: action_response.action_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -4680,6 +4680,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -4747,6 +4748,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRsyncResponse, Self>>
                         connector_refund_id: item.response.id,
                         refund_status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 }
             }
@@ -4758,6 +4760,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRsyncResponse, Self>>
                     Err(_) => common_enums::RefundStatus::Pending,
                 },
                 status_code: item.http_code,
+                refund_arn: None,
             }),
         };
 

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -4680,7 +4680,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -4748,7 +4748,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRsyncResponse, Self>>
                         connector_refund_id: item.response.id,
                         refund_status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 }
             }
@@ -4760,7 +4760,7 @@ impl<F> TryFrom<ResponseRouterData<CybersourceRsyncResponse, Self>>
                     Err(_) => common_enums::RefundStatus::Pending,
                 },
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
         };
 

--- a/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
@@ -1589,6 +1589,7 @@ impl TryFrom<ResponseRouterData<DatatransRefundResponse, Self>>
             connector_refund_id: item.response.transaction_id.clone(),
             refund_status: RefundStatus::Success, // 200 response indicates successful refund
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -1688,6 +1689,7 @@ impl TryFrom<ResponseRouterData<DatatransRefundSyncResponse, Self>>
             connector_refund_id: response.transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
@@ -1589,7 +1589,7 @@ impl TryFrom<ResponseRouterData<DatatransRefundResponse, Self>>
             connector_refund_id: item.response.transaction_id.clone(),
             refund_status: RefundStatus::Success, // 200 response indicates successful refund
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1689,7 +1689,7 @@ impl TryFrom<ResponseRouterData<DatatransRefundSyncResponse, Self>>
             connector_refund_id: response.transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -1424,7 +1424,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1442,7 +1442,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -1424,6 +1424,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1441,6 +1442,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
@@ -1042,6 +1042,7 @@ impl TryFrom<ResponseRouterData<EasebuzzRefundResponse, Self>>
                 connector_refund_id,
                 refund_status: RefundStatus::Pending,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..router_data
         })
@@ -1460,6 +1461,7 @@ impl TryFrom<ResponseRouterData<EasebuzzRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     }),
                     ..router_data
                 })

--- a/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
@@ -1042,7 +1042,7 @@ impl TryFrom<ResponseRouterData<EasebuzzRefundResponse, Self>>
                 connector_refund_id,
                 refund_status: RefundStatus::Pending,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })
@@ -1461,7 +1461,7 @@ impl TryFrom<ResponseRouterData<EasebuzzRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..router_data
                 })

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -1226,7 +1226,7 @@ impl<F> TryFrom<ResponseRouterData<ElavonRefundResponse, Self>>
                 connector_refund_id: payment_resp_struct.ssl_txn_id.clone(),
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             (_, Some(err_resp)) => Err(err_resp),
             (ElavonResult::Error(error_payload), None) => Err(ErrorResponse {
@@ -1385,7 +1385,7 @@ impl<F> TryFrom<ResponseRouterData<ElavonRSyncResponse, Self>>
             connector_refund_id: response.ssl_txn_id.clone(),
             refund_status,
             status_code: value.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -1226,6 +1226,7 @@ impl<F> TryFrom<ResponseRouterData<ElavonRefundResponse, Self>>
                 connector_refund_id: payment_resp_struct.ssl_txn_id.clone(),
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
             (_, Some(err_resp)) => Err(err_resp),
             (ElavonResult::Error(error_payload), None) => Err(ErrorResponse {
@@ -1384,6 +1385,7 @@ impl<F> TryFrom<ResponseRouterData<ElavonRSyncResponse, Self>>
             connector_refund_id: response.ssl_txn_id.clone(),
             refund_status,
             status_code: value.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -952,7 +952,7 @@ impl TryFrom<ResponseRouterData<FinixRSyncResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1068,7 +1068,7 @@ impl TryFrom<ResponseRouterData<FinixRefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -952,6 +952,7 @@ impl TryFrom<ResponseRouterData<FinixRSyncResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1067,6 +1068,7 @@ impl TryFrom<ResponseRouterData<FinixRefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
@@ -1107,6 +1107,7 @@ impl<F> TryFrom<ResponseRouterData<FiservRefundResponse, Self>>
                 }),
             refund_status,
             status_code: http_code,
+            refund_arn: None,
         };
 
         if refund_status == enums::RefundStatus::Failure {
@@ -1175,6 +1176,7 @@ impl<F> TryFrom<ResponseRouterData<FiservRefundSyncResponse, Self>>
                 }),
             refund_status,
             status_code: http_code,
+            refund_arn: None,
         };
 
         if refund_status == enums::RefundStatus::Failure {

--- a/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
@@ -1107,7 +1107,7 @@ impl<F> TryFrom<ResponseRouterData<FiservRefundResponse, Self>>
                 }),
             refund_status,
             status_code: http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         if refund_status == enums::RefundStatus::Failure {
@@ -1176,7 +1176,7 @@ impl<F> TryFrom<ResponseRouterData<FiservRefundSyncResponse, Self>>
                 }),
             refund_status,
             status_code: http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         if refund_status == enums::RefundStatus::Failure {

--- a/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
@@ -1216,6 +1216,7 @@ impl TryFrom<ResponseRouterData<FiservcommercehubRefundResponse, Self>>
                 connector_refund_id: txn.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1315,6 +1316,7 @@ impl TryFrom<ResponseRouterData<FiservcommercehubRSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservcommercehub/transformers.rs
@@ -1216,7 +1216,7 @@ impl TryFrom<ResponseRouterData<FiservcommercehubRefundResponse, Self>>
                 connector_refund_id: txn.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1316,7 +1316,7 @@ impl TryFrom<ResponseRouterData<FiservcommercehubRSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/fiservemea/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservemea/transformers.rs
@@ -941,7 +941,7 @@ impl TryFrom<ResponseRouterData<FiservemeaPaymentsResponse, Self>>
                 connector_refund_id: item.response.ipg_transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -967,7 +967,7 @@ impl TryFrom<ResponseRouterData<FiservemeaPaymentsResponse, Self>>
                 connector_refund_id: item.response.ipg_transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/fiservemea/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservemea/transformers.rs
@@ -941,6 +941,7 @@ impl TryFrom<ResponseRouterData<FiservemeaPaymentsResponse, Self>>
                 connector_refund_id: item.response.ipg_transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -966,6 +967,7 @@ impl TryFrom<ResponseRouterData<FiservemeaPaymentsResponse, Self>>
                 connector_refund_id: item.response.ipg_transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -1746,6 +1746,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundResponse, Self>>
                             connector_refund_id: refund_data.refund_id.clone().to_string(),
                             refund_status,
                             status_code: item.http_code,
+                            refund_arn: None,
                         }),
                         ..router_data
                     })
@@ -2524,6 +2525,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundSyncResponse, Self>>
                         connector_refund_id: refund.refund_id.clone(),
                         refund_status: common_enums::RefundStatus::from(refund.status.clone()),
                         status_code: item.http_code,
+                        refund_arn: None,
                     }),
                     ..router_data
                 })
@@ -2535,6 +2537,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundSyncResponse, Self>>
                         fiuu_webhooks_refund_response.status.clone(),
                     ),
                     status_code: item.http_code,
+                    refund_arn: None,
                 }),
                 ..router_data
             }),

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -1746,7 +1746,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundResponse, Self>>
                             connector_refund_id: refund_data.refund_id.clone().to_string(),
                             refund_status,
                             status_code: item.http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         }),
                         ..router_data
                     })
@@ -2525,7 +2525,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundSyncResponse, Self>>
                         connector_refund_id: refund.refund_id.clone(),
                         refund_status: common_enums::RefundStatus::from(refund.status.clone()),
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..router_data
                 })
@@ -2537,7 +2537,7 @@ impl<F> TryFrom<ResponseRouterData<FiuuRefundSyncResponse, Self>>
                         fiuu_webhooks_refund_response.status.clone(),
                     ),
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 }),
                 ..router_data
             }),

--- a/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
@@ -762,7 +762,7 @@ impl<F> TryFrom<ResponseRouterData<FlywireRefundResponse, Self>>
                 connector_refund_id: response.refund_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,
@@ -794,7 +794,7 @@ impl<F> TryFrom<ResponseRouterData<FlywireRefundResponse, Self>>
                 connector_refund_id: response.refund_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,
@@ -826,7 +826,7 @@ impl<F> TryFrom<ResponseRouterData<FlywirePayment, Self>>
                 connector_refund_id: response.payment_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,

--- a/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/flywire/transformers.rs
@@ -762,6 +762,7 @@ impl<F> TryFrom<ResponseRouterData<FlywireRefundResponse, Self>>
                 connector_refund_id: response.refund_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,
@@ -793,6 +794,7 @@ impl<F> TryFrom<ResponseRouterData<FlywireRefundResponse, Self>>
                 connector_refund_id: response.refund_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,
@@ -824,6 +826,7 @@ impl<F> TryFrom<ResponseRouterData<FlywirePayment, Self>>
                 connector_refund_id: response.payment_id.clone(),
                 refund_status: response.status.to_refund_status(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_response: raw_response,

--- a/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
@@ -938,7 +938,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.response.response_code),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -965,7 +965,7 @@ impl<F> TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
@@ -938,6 +938,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.response.response_code),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -964,6 +965,7 @@ impl<F> TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
@@ -1348,6 +1348,7 @@ impl TryFrom<ResponseRouterData<GetnetRefundResponse, Self>>
                 connector_refund_id: item.response.payment_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1372,6 +1373,7 @@ impl TryFrom<ResponseRouterData<GetnetRefundSyncResponse, Self>>
                 connector_refund_id: item.response.payment_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
@@ -1348,7 +1348,7 @@ impl TryFrom<ResponseRouterData<GetnetRefundResponse, Self>>
                 connector_refund_id: item.response.payment_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1373,7 +1373,7 @@ impl TryFrom<ResponseRouterData<GetnetRefundSyncResponse, Self>>
                 connector_refund_id: item.response.payment_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/gigadat/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/gigadat/transformers.rs
@@ -553,7 +553,7 @@ impl TryFrom<ResponseRouterData<GigadatRefundResponse, Self>>
             connector_refund_id: response.data.transaction_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(router_data)

--- a/crates/integrations/connector-integration/src/connectors/gigadat/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/gigadat/transformers.rs
@@ -553,6 +553,7 @@ impl TryFrom<ResponseRouterData<GigadatRefundResponse, Self>>
             connector_refund_id: response.data.transaction_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(router_data)

--- a/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
@@ -882,7 +882,7 @@ impl TryFrom<ResponseRouterData<GivepaymentsRefundResponseData, Self>>
                     connector_refund_id: item.response.id,
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 }),
                 ..item.router_data
             })
@@ -928,7 +928,7 @@ impl TryFrom<ResponseRouterData<GivepaymentsRefundResponseData, Self>>
                     connector_refund_id: response.id,
                     refund_status,
                     status_code: http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 }),
                 ..router_data
             })

--- a/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
@@ -882,6 +882,7 @@ impl TryFrom<ResponseRouterData<GivepaymentsRefundResponseData, Self>>
                     connector_refund_id: item.response.id,
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 }),
                 ..item.router_data
             })
@@ -927,6 +928,7 @@ impl TryFrom<ResponseRouterData<GivepaymentsRefundResponseData, Self>>
                     connector_refund_id: response.id,
                     refund_status,
                     status_code: http_code,
+                    refund_arn: None,
                 }),
                 ..router_data
             })

--- a/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
@@ -973,6 +973,7 @@ impl TryFrom<ResponseRouterData<GlobalpayRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -995,6 +996,7 @@ impl TryFrom<ResponseRouterData<GlobalpayRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay/transformers.rs
@@ -973,7 +973,7 @@ impl TryFrom<ResponseRouterData<GlobalpayRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -996,7 +996,7 @@ impl TryFrom<ResponseRouterData<GlobalpayRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
@@ -1099,7 +1099,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1144,7 +1144,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundSyncResponse, Self>>
         // If RSync returns no matching refund, default to Pending so the
         // next sync retries rather than prematurely marking Success/Failure
         // — Glomopay's list endpoint may lag due to eventual consistency.
-        let (refund_status, resolved_refund_id, refund_arn) = match refund_entry {
+        let (refund_status, resolved_refund_id, acquirer_reference_number) = match refund_entry {
             Some(entry) => (
                 RefundStatus::from(entry.status),
                 entry.id.clone(),
@@ -1158,7 +1158,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundSyncResponse, Self>>
                 connector_refund_id: resolved_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn,
+                acquirer_reference_number,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
@@ -828,21 +828,13 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
-        // Glomopay rejects non-HTTPS callback URLs. Local euler-api-txns setups
-        // send an `http://` return URL, which would fail Glomopay's validation.
-        // Substitute a placeholder HTTPS URL so the request goes through in
-        // local testing; production return URLs are already HTTPS so this is a
-        // no-op there.
-        let return_url = router_data
-            .resource_common_data
-            .return_url
-            .clone()
-            .ok_or_else(crate::utils::missing_field_err("return_url"))?;
-        let callback_url = Some(if return_url.starts_with("https://") {
-            return_url
-        } else {
-            "https://google.com".to_string()
-        });
+        let callback_url = Some(
+            router_data
+                .resource_common_data
+                .return_url
+                .clone()
+                .ok_or_else(crate::utils::missing_field_err("return_url"))?,
+        );
 
         Ok(Self {
             order_id,

--- a/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
@@ -828,13 +828,21 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
-        let callback_url = Some(
-            router_data
-                .resource_common_data
-                .return_url
-                .clone()
-                .ok_or_else(crate::utils::missing_field_err("return_url"))?,
-        );
+        // Glomopay rejects non-HTTPS callback URLs. Local euler-api-txns setups
+        // send an `http://` return URL, which would fail Glomopay's validation.
+        // Substitute a placeholder HTTPS URL so the request goes through in
+        // local testing; production return URLs are already HTTPS so this is a
+        // no-op there.
+        let return_url = router_data
+            .resource_common_data
+            .return_url
+            .clone()
+            .ok_or_else(crate::utils::missing_field_err("return_url"))?;
+        let callback_url = Some(if return_url.starts_with("https://") {
+            return_url
+        } else {
+            "https://google.com".to_string()
+        });
 
         Ok(Self {
             order_id,
@@ -1099,6 +1107,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1118,6 +1127,7 @@ pub struct GlomopayRefundSyncItem {
     pub id: String,
     pub status: GlomopayRefundStatus,
     pub amount: Option<MinorUnit>,
+    pub utr: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1142,9 +1152,13 @@ impl TryFrom<ResponseRouterData<GlomopayRefundSyncResponse, Self>>
         // If RSync returns no matching refund, default to Pending so the
         // next sync retries rather than prematurely marking Success/Failure
         // — Glomopay's list endpoint may lag due to eventual consistency.
-        let (refund_status, resolved_refund_id) = match refund_entry {
-            Some(entry) => (RefundStatus::from(entry.status), entry.id.clone()),
-            None => (RefundStatus::Pending, connector_refund_id),
+        let (refund_status, resolved_refund_id, refund_arn) = match refund_entry {
+            Some(entry) => (
+                RefundStatus::from(entry.status),
+                entry.id.clone(),
+                entry.utr.clone(),
+            ),
+            None => (RefundStatus::Pending, connector_refund_id, None),
         };
 
         Ok(Self {
@@ -1152,6 +1166,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundSyncResponse, Self>>
                 connector_refund_id: resolved_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
@@ -797,6 +797,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -813,6 +814,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
@@ -797,7 +797,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -814,7 +814,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
@@ -901,6 +901,7 @@ impl TryFrom<ResponseRouterData<HipayRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_reference.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -933,6 +934,7 @@ impl TryFrom<ResponseRouterData<HipayRSyncResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
@@ -901,7 +901,7 @@ impl TryFrom<ResponseRouterData<HipayRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_reference.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -934,7 +934,7 @@ impl TryFrom<ResponseRouterData<HipayRSyncResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/hyperpg/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hyperpg/transformers.rs
@@ -474,7 +474,7 @@ impl TryFrom<ResponseRouterData<HyperpgRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -509,7 +509,7 @@ impl TryFrom<ResponseRouterData<HyperpgRefundSyncResponse, Self>>
                 connector_refund_id: response.order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/hyperpg/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hyperpg/transformers.rs
@@ -474,6 +474,7 @@ impl TryFrom<ResponseRouterData<HyperpgRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -508,6 +509,7 @@ impl TryFrom<ResponseRouterData<HyperpgRefundSyncResponse, Self>>
                 connector_refund_id: response.order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/iatapay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/iatapay/transformers.rs
@@ -664,6 +664,7 @@ impl TryFrom<ResponseRouterData<IatapayRefundResponse, Self>>
                 connector_refund_id: response.iata_refund_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -709,6 +710,7 @@ impl TryFrom<ResponseRouterData<IatapayRefundSyncResponse, Self>>
                 connector_refund_id: response.iata_refund_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/iatapay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/iatapay/transformers.rs
@@ -664,7 +664,7 @@ impl TryFrom<ResponseRouterData<IatapayRefundResponse, Self>>
                 connector_refund_id: response.iata_refund_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -710,7 +710,7 @@ impl TryFrom<ResponseRouterData<IatapayRefundSyncResponse, Self>>
                 connector_refund_id: response.iata_refund_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -1597,7 +1597,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundResponseData, Self>>
                 connector_refund_id: item.response.psp_reference.to_string(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1661,7 +1661,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status,
                         status_code: http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..router_data
                 })
@@ -1702,7 +1702,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundSyncResponse, Self>>
                             connector_refund_id,
                             refund_status,
                             status_code: http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         }),
                         ..router_data
                     })

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -1597,6 +1597,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundResponseData, Self>>
                 connector_refund_id: item.response.psp_reference.to_string(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1660,6 +1661,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundSyncResponse, Self>>
                         connector_refund_id,
                         refund_status,
                         status_code: http_code,
+                        refund_arn: None,
                     }),
                     ..router_data
                 })
@@ -1700,6 +1702,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsRefundSyncResponse, Self>>
                             connector_refund_id,
                             refund_status,
                             status_code: http_code,
+                            refund_arn: None,
                         }),
                         ..router_data
                     })

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -834,6 +834,7 @@ impl TryFrom<&responses::JpmorganRefundResponse> for RefundsResponseData {
             connector_refund_id: item.transaction_id.clone(),
             refund_status,
             status_code: item.response_code.parse::<u16>().unwrap_or(0),
+            refund_arn: None,
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -834,7 +834,7 @@ impl TryFrom<&responses::JpmorganRefundResponse> for RefundsResponseData {
             connector_refund_id: item.transaction_id.clone(),
             refund_status,
             status_code: item.response_code.parse::<u16>().unwrap_or(0),
-            refund_arn: None,
+            acquirer_reference_number: None,
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
@@ -1202,7 +1202,7 @@ impl TryFrom<ResponseRouterData<JuspayRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1258,7 +1258,7 @@ impl TryFrom<ResponseRouterData<JuspayRefundSyncResponse, Self>>
                 connector_refund_id: resolved_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
@@ -1202,6 +1202,7 @@ impl TryFrom<ResponseRouterData<JuspayRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1257,6 +1258,7 @@ impl TryFrom<ResponseRouterData<JuspayRefundSyncResponse, Self>>
                 connector_refund_id: resolved_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
@@ -750,7 +750,7 @@ pub fn handle_refund_response(
             .unwrap_or_default(),
         refund_status: status,
         status_code: http_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
 
     Ok(RouterDataV2 {
@@ -796,7 +796,7 @@ pub fn handle_rsync_response(
             .unwrap_or_default(),
         refund_status: status,
         status_code: http_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
 
     Ok(RouterDataV2 {

--- a/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
@@ -750,6 +750,7 @@ pub fn handle_refund_response(
             .unwrap_or_default(),
         refund_status: status,
         status_code: http_code,
+        refund_arn: None,
     };
 
     Ok(RouterDataV2 {
@@ -795,6 +796,7 @@ pub fn handle_rsync_response(
             .unwrap_or_default(),
         refund_status: status,
         status_code: http_code,
+        refund_arn: None,
     };
 
     Ok(RouterDataV2 {

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -769,7 +769,7 @@ impl TryFrom<ResponseRouterData<MollieRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: item.response.status.to_refund_status(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -788,7 +788,7 @@ impl TryFrom<ResponseRouterData<MollieRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: item.response.status.to_refund_status(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie/transformers.rs
@@ -769,6 +769,7 @@ impl TryFrom<ResponseRouterData<MollieRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: item.response.status.to_refund_status(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -787,6 +788,7 @@ impl TryFrom<ResponseRouterData<MollieRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: item.response.status.to_refund_status(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -1097,6 +1097,7 @@ impl<F> TryFrom<ResponseRouterData<MultisafepayRefundResponse, Self>>
                 connector_refund_id: item.response.data.refund_id.to_string(),
                 refund_status: refund_status.into(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1123,6 +1124,7 @@ impl TryFrom<ResponseRouterData<MultisafepayRefundResponse, Self>>
                 connector_refund_id: item.response.data.refund_id.to_string(),
                 refund_status: refund_status.into(),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -1097,7 +1097,7 @@ impl<F> TryFrom<ResponseRouterData<MultisafepayRefundResponse, Self>>
                 connector_refund_id: item.response.data.refund_id.to_string(),
                 refund_status: refund_status.into(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1124,7 +1124,7 @@ impl TryFrom<ResponseRouterData<MultisafepayRefundResponse, Self>>
                 connector_refund_id: item.response.data.refund_id.to_string(),
                 refund_status: refund_status.into(),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -667,7 +667,7 @@ impl<F> TryFrom<ResponseRouterData<NexinetsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -686,7 +686,7 @@ impl<F> TryFrom<ResponseRouterData<NexinetsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -667,6 +667,7 @@ impl<F> TryFrom<ResponseRouterData<NexinetsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -685,6 +686,7 @@ impl<F> TryFrom<ResponseRouterData<NexinetsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id,
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -856,6 +856,7 @@ impl TryFrom<ResponseRouterData<NexixpayRefundResponse, Self>>
                 connector_refund_id: item.response.operation_id.clone(),
                 refund_status: RefundStatus::Pending, // CRITICAL: NOT Success!
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -1078,6 +1079,7 @@ impl TryFrom<ResponseRouterData<NexixpayRSyncResponse, Self>>
                 connector_refund_id: item.response.operation_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -856,7 +856,7 @@ impl TryFrom<ResponseRouterData<NexixpayRefundResponse, Self>>
                 connector_refund_id: item.response.operation_id.clone(),
                 refund_status: RefundStatus::Pending, // CRITICAL: NOT Success!
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -1079,7 +1079,7 @@ impl TryFrom<ResponseRouterData<NexixpayRSyncResponse, Self>>
                 connector_refund_id: item.response.operation_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1120,7 +1120,7 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
                 connector_refund_id: response.orderid.clone(),
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status,
@@ -1206,7 +1206,7 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
                 connector_refund_id,
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1120,6 +1120,7 @@ impl TryFrom<ResponseRouterData<StandardResponse, Self>>
                 connector_refund_id: response.orderid.clone(),
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status,
@@ -1205,6 +1206,7 @@ impl TryFrom<ResponseRouterData<SyncResponse, Self>>
                 connector_refund_id,
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status,

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -968,7 +968,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.result.transaction.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
         Ok(Self {
@@ -1037,7 +1037,7 @@ impl<F> TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: noon_transaction.id.to_owned(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -968,6 +968,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.result.transaction.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
         Ok(Self {
@@ -1036,6 +1037,7 @@ impl<F> TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: noon_transaction.id.to_owned(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -1374,6 +1374,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetRefundResponse, Self>>
                         connector_refund_id: refund_id,
                         refund_status: common_enums::RefundStatus::from(transaction_status),
                         status_code: item.http_code,
+                        refund_arn: None,
                     }),
                     ..item.router_data
                 })
@@ -1732,6 +1733,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetRefundSyncResponse, Self>>
                         connector_refund_id: refund_id,
                         refund_status: common_enums::RefundStatus::from(transaction_status),
                         status_code: item.http_code,
+                        refund_arn: None,
                     }),
                     ..item.router_data
                 })

--- a/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet/transformers.rs
@@ -1374,7 +1374,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetRefundResponse, Self>>
                         connector_refund_id: refund_id,
                         refund_status: common_enums::RefundStatus::from(transaction_status),
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..item.router_data
                 })
@@ -1733,7 +1733,7 @@ impl<F> TryFrom<ResponseRouterData<NovalnetRefundSyncResponse, Self>>
                         connector_refund_id: refund_id,
                         refund_status: common_enums::RefundStatus::from(transaction_status),
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     }),
                     ..item.router_data
                 })

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -1701,7 +1701,7 @@ impl TryFrom<ResponseRouterData<NuveiRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1783,7 +1783,7 @@ impl TryFrom<ResponseRouterData<NuveiRefundSyncResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -1701,6 +1701,7 @@ impl TryFrom<ResponseRouterData<NuveiRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -1782,6 +1783,7 @@ impl TryFrom<ResponseRouterData<NuveiRefundSyncResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -975,7 +975,7 @@ impl TryFrom<ResponseRouterData<PayboxRefundResponse, Self>>
                     connector_refund_id: item.response.paybox_order_id.clone(),
                     refund_status: RefundStatus::Success,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 }),
                 resource_common_data: RefundFlowData {
                     status: RefundStatus::Success,
@@ -1092,7 +1092,7 @@ impl TryFrom<ResponseRouterData<PayboxRSyncResponse, Self>>
                 connector_refund_id: item.response.paybox_order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -975,6 +975,7 @@ impl TryFrom<ResponseRouterData<PayboxRefundResponse, Self>>
                     connector_refund_id: item.response.paybox_order_id.clone(),
                     refund_status: RefundStatus::Success,
                     status_code: item.http_code,
+                    refund_arn: None,
                 }),
                 resource_common_data: RefundFlowData {
                     status: RefundStatus::Success,
@@ -1091,6 +1092,7 @@ impl TryFrom<ResponseRouterData<PayboxRSyncResponse, Self>>
                 connector_refund_id: item.response.paybox_order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,

--- a/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
@@ -920,7 +920,7 @@ impl TryFrom<ResponseRouterData<PayconexRefundResponse, Self>>
                 })?,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
         };
         Ok(Self {
@@ -981,7 +981,7 @@ impl TryFrom<ResponseRouterData<PayconexRefundSyncResponse, Self>>
                     .unwrap_or_else(|| item.router_data.request.connector_refund_id.clone()),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
@@ -920,6 +920,7 @@ impl TryFrom<ResponseRouterData<PayconexRefundResponse, Self>>
                 })?,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
         };
         Ok(Self {
@@ -980,6 +981,7 @@ impl TryFrom<ResponseRouterData<PayconexRefundSyncResponse, Self>>
                     .unwrap_or_else(|| item.router_data.request.connector_refund_id.clone()),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
         };
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -957,7 +957,7 @@ impl TryFrom<ResponseRouterData<PayloadRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -990,7 +990,7 @@ impl TryFrom<ResponseRouterData<PayloadRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payload/transformers.rs
@@ -957,6 +957,7 @@ impl TryFrom<ResponseRouterData<PayloadRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -989,6 +990,7 @@ impl TryFrom<ResponseRouterData<PayloadRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.to_string(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/payme/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payme/transformers.rs
@@ -797,7 +797,7 @@ impl TryFrom<ResponseRouterData<PaymeRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             };
 
             Ok(Self {
@@ -900,7 +900,7 @@ impl TryFrom<ResponseRouterData<PaymeRSyncResponse, Self>>
             connector_refund_id: transaction_item.payme_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/payme/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payme/transformers.rs
@@ -797,6 +797,7 @@ impl TryFrom<ResponseRouterData<PaymeRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             };
 
             Ok(Self {
@@ -899,6 +900,7 @@ impl TryFrom<ResponseRouterData<PaymeRSyncResponse, Self>>
             connector_refund_id: transaction_item.payme_transaction_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -3438,7 +3438,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -3466,7 +3466,7 @@ impl TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -3438,6 +3438,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -3465,6 +3466,7 @@ impl TryFrom<ResponseRouterData<RefundSyncResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status: common_enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -2643,7 +2643,7 @@ impl TryFrom<ResponseRouterData<PaysafeRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -2663,7 +2663,7 @@ impl TryFrom<ResponseRouterData<PaysafeRSyncResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -2643,6 +2643,7 @@ impl TryFrom<ResponseRouterData<PaysafeRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -2662,6 +2663,7 @@ impl TryFrom<ResponseRouterData<PaysafeRSyncResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status: enums::RefundStatus::from(item.response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/payu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payu/transformers.rs
@@ -1777,7 +1777,7 @@ impl TryFrom<ResponseRouterData<PayuRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1930,7 +1930,7 @@ impl TryFrom<ResponseRouterData<PayuRefundSyncResponse, Self>>
                                 connector_refund_id,
                                 refund_status,
                                 status_code: item.http_code,
-                                refund_arn: None,
+                                acquirer_reference_number: None,
                             }),
                             resource_common_data: RefundFlowData {
                                 status: refund_status,
@@ -1948,7 +1948,7 @@ impl TryFrom<ResponseRouterData<PayuRefundSyncResponse, Self>>
                                 connector_refund_id,
                                 refund_status: RefundStatus::Pending,
                                 status_code: item.http_code,
-                                refund_arn: None,
+                                acquirer_reference_number: None,
                             }),
                             resource_common_data: RefundFlowData {
                                 status: RefundStatus::Pending,

--- a/crates/integrations/connector-integration/src/connectors/payu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payu/transformers.rs
@@ -1777,6 +1777,7 @@ impl TryFrom<ResponseRouterData<PayuRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
@@ -1929,6 +1930,7 @@ impl TryFrom<ResponseRouterData<PayuRefundSyncResponse, Self>>
                                 connector_refund_id,
                                 refund_status,
                                 status_code: item.http_code,
+                                refund_arn: None,
                             }),
                             resource_common_data: RefundFlowData {
                                 status: refund_status,
@@ -1946,6 +1948,7 @@ impl TryFrom<ResponseRouterData<PayuRefundSyncResponse, Self>>
                                 connector_refund_id,
                                 refund_status: RefundStatus::Pending,
                                 status_code: item.http_code,
+                                refund_arn: None,
                             }),
                             resource_common_data: RefundFlowData {
                                 status: RefundStatus::Pending,

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -661,7 +661,7 @@ impl TryFrom<ResponseRouterData<responses::PeachpaymentsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -683,7 +683,7 @@ impl TryFrom<ResponseRouterData<responses::PeachpaymentsRefundSyncResponse, Self
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -661,6 +661,7 @@ impl TryFrom<ResponseRouterData<responses::PeachpaymentsRefundResponse, Self>>
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -682,6 +683,7 @@ impl TryFrom<ResponseRouterData<responses::PeachpaymentsRefundSyncResponse, Self
                 connector_refund_id: item.response.transaction_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
@@ -1907,6 +1907,7 @@ impl TryFrom<ResponseRouterData<PhonepeRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             });
             Ok(router_data)
         } else {
@@ -2177,6 +2178,7 @@ impl TryFrom<ResponseRouterData<PhonepeRefundSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             });
             Ok(router_data)
         } else {

--- a/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
@@ -1907,7 +1907,7 @@ impl TryFrom<ResponseRouterData<PhonepeRefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             });
             Ok(router_data)
         } else {
@@ -2178,7 +2178,7 @@ impl TryFrom<ResponseRouterData<PhonepeRefundSyncResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             });
             Ok(router_data)
         } else {

--- a/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
@@ -1087,7 +1087,7 @@ impl<F> TryFrom<ResponseRouterData<PinelabsOnlineRefundResponse, Self>>
                     connector_refund_id: connector_refund_id.unwrap_or_default(),
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 });
 
                 Ok(Self {
@@ -1140,7 +1140,7 @@ impl TryFrom<ResponseRouterData<PinelabsOnlineRSyncResponse, Self>>
                     connector_refund_id: connector_refund_id.unwrap_or_default(),
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 });
 
                 Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
@@ -1087,6 +1087,7 @@ impl<F> TryFrom<ResponseRouterData<PinelabsOnlineRefundResponse, Self>>
                     connector_refund_id: connector_refund_id.unwrap_or_default(),
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 });
 
                 Ok(Self {
@@ -1139,6 +1140,7 @@ impl TryFrom<ResponseRouterData<PinelabsOnlineRSyncResponse, Self>>
                     connector_refund_id: connector_refund_id.unwrap_or_default(),
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 });
 
                 Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
@@ -649,7 +649,7 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
                 connector_refund_id: item.response.internal_reference.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.status.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -706,7 +706,7 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
                 connector_refund_id: item.response.internal_reference.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.status.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
@@ -649,6 +649,7 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
                 connector_refund_id: item.response.internal_reference.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.status.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -705,6 +706,7 @@ impl<F> TryFrom<ResponseRouterData<PlacetopayRefundResponse, Self>>
                 connector_refund_id: item.response.internal_reference.to_string(),
                 refund_status: common_enums::RefundStatus::from(item.response.status.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -735,7 +735,7 @@ impl<F> TryFrom<ResponseRouterData<PowertranzRefundResponse, Self>>
                 connector_refund_id: response.transaction_identifier.clone(),
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })
@@ -770,7 +770,7 @@ impl<F> TryFrom<ResponseRouterData<PowertranzRSyncResponse, Self>>
                 connector_refund_id: response.transaction_identifier.clone(),
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -735,6 +735,7 @@ impl<F> TryFrom<ResponseRouterData<PowertranzRefundResponse, Self>>
                 connector_refund_id: response.transaction_identifier.clone(),
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
             ..router_data
         })
@@ -769,6 +770,7 @@ impl<F> TryFrom<ResponseRouterData<PowertranzRSyncResponse, Self>>
                 connector_refund_id: response.transaction_identifier.clone(),
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -942,7 +942,7 @@ impl<F, Req, T> TryFrom<ResponseRouterData<PproRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -1000,7 +1000,7 @@ impl TryFrom<ResponseRouterData<PproRSyncResponse, Self>>
             connector_refund_id: connector_refund_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -942,6 +942,7 @@ impl<F, Req, T> TryFrom<ResponseRouterData<PproRefundResponse, Self>>
                 connector_refund_id: item.response.id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -999,6 +1000,7 @@ impl TryFrom<ResponseRouterData<PproRSyncResponse, Self>>
             connector_refund_id: connector_refund_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
@@ -547,6 +547,7 @@ impl TryFrom<ResponseRouterData<QwikcilverCancelRedeemResponse, Self>>
                 connector_refund_id: body.transaction_id.to_string(),
                 refund_status: CANCEL_REDEEM_SUCCESS_STATUS,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             _ => Err(error_response_from_qc(
                 (&body).into(),

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
@@ -547,7 +547,7 @@ impl TryFrom<ResponseRouterData<QwikcilverCancelRedeemResponse, Self>>
                 connector_refund_id: body.transaction_id.to_string(),
                 refund_status: CANCEL_REDEEM_SUCCESS_STATUS,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             _ => Err(error_response_from_qc(
                 (&body).into(),

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -705,7 +705,7 @@ impl<F, T> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -705,6 +705,7 @@ impl<F, T> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
@@ -832,6 +832,7 @@ impl ForeignTryFrom<(RazorpayRefundResponse, Self, u16)>
             connector_refund_id: response.id,
             refund_status: status,
             status_code: http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -859,6 +860,7 @@ impl ForeignTryFrom<(RazorpayRefundResponse, Self, u16)>
             connector_refund_id: response.id,
             refund_status: status,
             status_code: http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
@@ -832,7 +832,7 @@ impl ForeignTryFrom<(RazorpayRefundResponse, Self, u16)>
             connector_refund_id: response.id,
             refund_status: status,
             status_code: http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -860,7 +860,7 @@ impl ForeignTryFrom<(RazorpayRefundResponse, Self, u16)>
             connector_refund_id: response.id,
             refund_status: status,
             status_code: http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
@@ -513,7 +513,7 @@ impl
             connector_refund_id: response.id,
             refund_status: status,
             status_code: _status_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -557,7 +557,7 @@ impl
             connector_refund_id: response.id,
             refund_status: status,
             status_code: _status_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
@@ -513,6 +513,7 @@ impl
             connector_refund_id: response.id,
             refund_status: status,
             status_code: _status_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -556,6 +557,7 @@ impl
             connector_refund_id: response.id,
             refund_status: status,
             status_code: _status_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -2043,6 +2043,7 @@ impl TryFrom<ResponseRouterData<responses::RedsysResponse, Self>>
                     connector_refund_id: response_data.ds_order,
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 })
             }
             responses::RedsysResponse::RedsysErrorResponse(ref err) => {
@@ -2100,12 +2101,14 @@ impl TryFrom<ResponseRouterData<responses::RedsysSyncResponse, Self>>
                             connector_refund_id: latest_response.ds_order,
                             refund_status,
                             status_code: item.http_code,
+                            refund_arn: None,
                         })
                     } else {
                         Ok(RefundsResponseData {
                             connector_refund_id: latest_response.ds_order,
                             refund_status: common_enums::RefundStatus::Pending,
                             status_code: item.http_code,
+                            refund_arn: None,
                         })
                     }
                 } else {

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -2043,7 +2043,7 @@ impl TryFrom<ResponseRouterData<responses::RedsysResponse, Self>>
                     connector_refund_id: response_data.ds_order,
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 })
             }
             responses::RedsysResponse::RedsysErrorResponse(ref err) => {
@@ -2101,14 +2101,14 @@ impl TryFrom<ResponseRouterData<responses::RedsysSyncResponse, Self>>
                             connector_refund_id: latest_response.ds_order,
                             refund_status,
                             status_code: item.http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         })
                     } else {
                         Ok(RefundsResponseData {
                             connector_refund_id: latest_response.ds_order,
                             refund_status: common_enums::RefundStatus::Pending,
                             status_code: item.http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         })
                     }
                 } else {

--- a/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
@@ -857,6 +857,7 @@ impl<F> TryFrom<ResponseRouterData<RevolutRefundResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -885,6 +886,7 @@ impl<F> TryFrom<ResponseRouterData<RevolutRefundResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
@@ -857,7 +857,7 @@ impl<F> TryFrom<ResponseRouterData<RevolutRefundResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -886,7 +886,7 @@ impl<F> TryFrom<ResponseRouterData<RevolutRefundResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
@@ -826,6 +826,7 @@ impl TryFrom<ResponseRouterData<Revolv3RefundResponse, Self>>
                 connector_refund_id: item.response.invoice.invoice_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -882,6 +883,7 @@ impl TryFrom<ResponseRouterData<Revolv3RefundSyncResponse, Self>>
                 connector_refund_id: item.response.invoice_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolv3/transformers.rs
@@ -826,7 +826,7 @@ impl TryFrom<ResponseRouterData<Revolv3RefundResponse, Self>>
                 connector_refund_id: item.response.invoice.invoice_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -883,7 +883,7 @@ impl TryFrom<ResponseRouterData<Revolv3RefundSyncResponse, Self>>
                 connector_refund_id: item.response.invoice_id.to_string(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -767,6 +767,7 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -793,6 +794,7 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -767,7 +767,7 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -794,7 +794,7 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
@@ -739,6 +739,7 @@ impl TryFrom<ResponseRouterData<SilverflowRefundResponse, Self>>
                 connector_refund_id: item.response.key,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -800,6 +801,7 @@ impl TryFrom<ResponseRouterData<SilverflowRefundSyncResponse, Self>>
                 connector_refund_id: item.response.key,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
@@ -739,7 +739,7 @@ impl TryFrom<ResponseRouterData<SilverflowRefundResponse, Self>>
                 connector_refund_id: item.response.key,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -801,7 +801,7 @@ impl TryFrom<ResponseRouterData<SilverflowRefundSyncResponse, Self>>
                 connector_refund_id: item.response.key,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -661,6 +661,7 @@ impl TryFrom<ResponseRouterData<StaxPaymentResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -692,6 +693,7 @@ impl TryFrom<ResponseRouterData<StaxPaymentResponse, Self>>
                 connector_refund_id: response.id.clone(), // Top-level ID is the refund ID
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -661,7 +661,7 @@ impl TryFrom<ResponseRouterData<StaxPaymentResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -693,7 +693,7 @@ impl TryFrom<ResponseRouterData<StaxPaymentResponse, Self>>
                 connector_refund_id: response.id.clone(), // Top-level ID is the refund ID
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -4897,6 +4897,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 
@@ -4958,6 +4959,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -4897,7 +4897,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 
@@ -4959,7 +4959,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: item.response.id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         };
 

--- a/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
@@ -485,7 +485,7 @@ impl TryFrom<ResponseRouterData<TamaraRSyncResponse, Self>>
                 connector_refund_id: item.response.order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data.clone()
         })
@@ -773,7 +773,7 @@ impl TryFrom<ResponseRouterData<TamaraRefundResponse, Self>>
                 connector_refund_id: item.response.refund_id,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
@@ -485,6 +485,7 @@ impl TryFrom<ResponseRouterData<TamaraRSyncResponse, Self>>
                 connector_refund_id: item.response.order_id.clone(),
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data.clone()
         })
@@ -772,6 +773,7 @@ impl TryFrom<ResponseRouterData<TamaraRefundResponse, Self>>
                 connector_refund_id: item.response.refund_id,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/truelayer/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/truelayer/transformers.rs
@@ -773,7 +773,7 @@ impl TryFrom<ResponseRouterData<TruelayerRefundResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::Pending,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })
@@ -842,7 +842,7 @@ impl TryFrom<ResponseRouterData<TruelayerRsyncResponse, Self>>
                         connector_refund_id: rsync_response.id,
                         refund_status: status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 };
 
@@ -885,7 +885,7 @@ impl TryFrom<ResponseRouterData<TruelayerRsyncResponse, Self>>
                         })?,
                         refund_status: status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 };
 

--- a/crates/integrations/connector-integration/src/connectors/truelayer/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/truelayer/transformers.rs
@@ -773,6 +773,7 @@ impl TryFrom<ResponseRouterData<TruelayerRefundResponse, Self>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::Pending,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })
@@ -841,6 +842,7 @@ impl TryFrom<ResponseRouterData<TruelayerRsyncResponse, Self>>
                         connector_refund_id: rsync_response.id,
                         refund_status: status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 };
 
@@ -883,6 +885,7 @@ impl TryFrom<ResponseRouterData<TruelayerRsyncResponse, Self>>
                         })?,
                         refund_status: status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 };
 

--- a/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
@@ -685,7 +685,7 @@ impl TryFrom<ResponseRouterData<TrustlyRefundResponse, Self>>
                     connector_refund_id: response.result.data.orderid,
                     refund_status: common_enums::RefundStatus::from(response.result.data.result),
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 }),
                 ..item.router_data
             }),

--- a/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
@@ -685,6 +685,7 @@ impl TryFrom<ResponseRouterData<TrustlyRefundResponse, Self>>
                     connector_refund_id: response.result.data.orderid,
                     refund_status: common_enums::RefundStatus::from(response.result.data.result),
                     status_code: item.http_code,
+                    refund_arn: None,
                 }),
                 ..item.router_data
             }),

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -1998,6 +1998,7 @@ fn handle_cards_refund_response(
         connector_refund_id: response.instance_id,
         refund_status,
         status_code,
+        refund_arn: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2046,6 +2047,7 @@ pub fn handle_webhooks_refund_response(
         },
         refund_status,
         status_code,
+        refund_arn: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2095,6 +2097,7 @@ pub fn handle_webhooks_refund_response_incoming_webhook(
             .ok_or_else(|| report!(WebhookError::WebhookProcessingFailed))?,
         refund_status,
         status_code,
+        refund_arn: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2123,6 +2126,7 @@ fn handle_bank_redirects_refund_response(
         connector_refund_id: response.payment_request_id.to_string(),
         refund_status,
         status_code,
+        refund_arn: None,
     };
     (error, refund_response_data)
 }
@@ -2164,6 +2168,7 @@ fn handle_bank_redirects_refund_sync_response(
         connector_refund_id: response.payment_information.references.payment_request_id,
         refund_status,
         status_code,
+        refund_arn: None,
     };
     (error, refund_response_data)
 }
@@ -2192,6 +2197,7 @@ fn handle_bank_redirects_refund_sync_error_response(
         connector_refund_id: "".to_string(),
         refund_status: enums::RefundStatus::Failure,
         status_code,
+        refund_arn: None,
     };
     (error, refund_response_data)
 }

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -1998,7 +1998,7 @@ fn handle_cards_refund_response(
         connector_refund_id: response.instance_id,
         refund_status,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2047,7 +2047,7 @@ pub fn handle_webhooks_refund_response(
         },
         refund_status,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2097,7 +2097,7 @@ pub fn handle_webhooks_refund_response_incoming_webhook(
             .ok_or_else(|| report!(WebhookError::WebhookProcessingFailed))?,
         refund_status,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     Ok((error, refund_response_data))
 }
@@ -2126,7 +2126,7 @@ fn handle_bank_redirects_refund_response(
         connector_refund_id: response.payment_request_id.to_string(),
         refund_status,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     (error, refund_response_data)
 }
@@ -2168,7 +2168,7 @@ fn handle_bank_redirects_refund_sync_response(
         connector_refund_id: response.payment_information.references.payment_request_id,
         refund_status,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     (error, refund_response_data)
 }
@@ -2197,7 +2197,7 @@ fn handle_bank_redirects_refund_sync_error_response(
         connector_refund_id: "".to_string(),
         refund_status: enums::RefundStatus::Failure,
         status_code,
-        refund_arn: None,
+        acquirer_reference_number: None,
     };
     (error, refund_response_data)
 }

--- a/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
@@ -1376,6 +1376,7 @@ impl TryFrom<ResponseRouterData<TrustpaymentsRSyncResponse, Self>>
             connector_refund_id: record.transactionreference.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -1417,6 +1418,7 @@ impl TryFrom<ResponseRouterData<TrustpaymentsRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
@@ -1376,7 +1376,7 @@ impl TryFrom<ResponseRouterData<TrustpaymentsRSyncResponse, Self>>
             connector_refund_id: record.transactionreference.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1418,7 +1418,7 @@ impl TryFrom<ResponseRouterData<TrustpaymentsRefundResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -974,6 +974,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: return_response.transaction_id,
                 refund_status: common_enums::enums::RefundStatus::from(return_response.status),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             TsysResponseTypes::ErrorResponse(error_response) => {
                 Err(get_error_response(&error_response, item.http_code))
@@ -1043,6 +1044,7 @@ impl TryFrom<ResponseRouterData<TsysRSyncResponse, Self>>
                     search_response.transaction_details,
                 ),
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             SearchResponseTypes::ErrorResponse(error_response) => {
                 Err(get_error_response(&error_response, item.http_code))

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -974,7 +974,7 @@ impl TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: return_response.transaction_id,
                 refund_status: common_enums::enums::RefundStatus::from(return_response.status),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             TsysResponseTypes::ErrorResponse(error_response) => {
                 Err(get_error_response(&error_response, item.http_code))
@@ -1044,7 +1044,7 @@ impl TryFrom<ResponseRouterData<TsysRSyncResponse, Self>>
                     search_response.transaction_details,
                 ),
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             SearchResponseTypes::ErrorResponse(error_response) => {
                 Err(get_error_response(&error_response, item.http_code))

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -2981,7 +2981,7 @@ impl TryFrom<ResponseRouterData<TsysTransitReturnResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -3117,7 +3117,7 @@ impl TryFrom<ResponseRouterData<TsysTransitTransactionInquiryResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -3246,7 +3246,7 @@ impl TryFrom<ResponseRouterData<TsysTransitVoidPostRefundResponse, Self>>
                 connector_refund_id,
                 refund_status: void_post_refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -2981,6 +2981,7 @@ impl TryFrom<ResponseRouterData<TsysTransitReturnResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -3116,6 +3117,7 @@ impl TryFrom<ResponseRouterData<TsysTransitTransactionInquiryResponse, Self>>
             connector_refund_id,
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -3244,6 +3246,7 @@ impl TryFrom<ResponseRouterData<TsysTransitVoidPostRefundResponse, Self>>
                 connector_refund_id,
                 refund_status: void_post_refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..router_data.clone()
         })

--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -2067,7 +2067,7 @@ impl TryFrom<ResponseRouterData<TwocTwopPacoNonUiResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })
@@ -2342,7 +2342,7 @@ impl TryFrom<ResponseRouterData<TwocTwopPacoInquiryResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -2067,6 +2067,7 @@ impl TryFrom<ResponseRouterData<TwocTwopPacoNonUiResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
             ..router_data
         })
@@ -2341,6 +2342,7 @@ impl TryFrom<ResponseRouterData<TwocTwopPacoInquiryResponse, Self>>
                 connector_refund_id,
                 refund_status,
                 status_code: http_code,
+                refund_arn: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
@@ -695,6 +695,7 @@ impl<F> TryFrom<RefundsResponseRouterData<F, RefundResponse>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::Pending, //We get Refund Status only by Webhooks
                 status_code: item.http_code,
+                refund_arn: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
@@ -695,7 +695,7 @@ impl<F> TryFrom<RefundsResponseRouterData<F, RefundResponse>>
                 connector_refund_id: item.response.id.to_string(),
                 refund_status: common_enums::RefundStatus::Pending, //We get Refund Status only by Webhooks
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..item.router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
@@ -1509,6 +1509,7 @@ impl TryFrom<ResponseRouterData<WellsfargoPaymentsResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         } else {
             // Build error response using helper function
@@ -1597,6 +1598,7 @@ impl TryFrom<ResponseRouterData<WellsfargoRSyncResponse, Self>>
                         connector_refund_id: response.id.clone(),
                         refund_status: status,
                         status_code: item.http_code,
+                        refund_arn: None,
                     })
                 }
             }

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
@@ -1509,7 +1509,7 @@ impl TryFrom<ResponseRouterData<WellsfargoPaymentsResponse, Self>>
                 connector_refund_id: response.id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         } else {
             // Build error response using helper function
@@ -1598,7 +1598,7 @@ impl TryFrom<ResponseRouterData<WellsfargoRSyncResponse, Self>>
                         connector_refund_id: response.id.clone(),
                         refund_status: status,
                         status_code: item.http_code,
-                        refund_arn: None,
+                        acquirer_reference_number: None,
                     })
                 }
             }

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -1210,7 +1210,7 @@ impl<F> TryFrom<ResponseRouterData<WorldpayPaymentsResponse, Self>>
             connector_refund_id: item.router_data.request.refund_id.clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(Self {
@@ -1240,7 +1240,7 @@ impl<F> TryFrom<ResponseRouterData<WorldpayEventResponse, Self>>
                 .clone(),
             refund_status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         });
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -1210,6 +1210,7 @@ impl<F> TryFrom<ResponseRouterData<WorldpayPaymentsResponse, Self>>
             connector_refund_id: item.router_data.request.refund_id.clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(Self {
@@ -1239,6 +1240,7 @@ impl<F> TryFrom<ResponseRouterData<WorldpayEventResponse, Self>>
                 .clone(),
             refund_status,
             status_code: item.http_code,
+            refund_arn: None,
         });
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
@@ -2087,7 +2087,7 @@ impl TryFrom<ResponseRouterData<CnpOnlineResponse, Self>>
                 connector_refund_id: credit_response.cnp_txn_id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             };
 
             Ok(Self {
@@ -2143,7 +2143,7 @@ impl TryFrom<ResponseRouterData<VantivSyncResponse, Self>>
                 .unwrap_or_else(|| "unknown".to_string()),
             refund_status: status,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
@@ -2087,6 +2087,7 @@ impl TryFrom<ResponseRouterData<CnpOnlineResponse, Self>>
                 connector_refund_id: credit_response.cnp_txn_id.clone(),
                 refund_status: status,
                 status_code: item.http_code,
+                refund_arn: None,
             };
 
             Ok(Self {
@@ -2142,6 +2143,7 @@ impl TryFrom<ResponseRouterData<VantivSyncResponse, Self>>
                 .unwrap_or_else(|| "unknown".to_string()),
             refund_status: status,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -1037,7 +1037,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRefundResponse, Self>>
             connector_refund_id: refund_received.order_code.clone(),
             refund_status: RefundStatus::Pending,
             status_code: item.http_code,
-            refund_arn: None,
+            acquirer_reference_number: None,
         };
 
         Ok(Self {
@@ -1092,7 +1092,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                             connector_refund_id: order_status.order_code.clone(),
                             refund_status: RefundStatus::Pending,
                             status_code: item.http_code,
-                            refund_arn: None,
+                            acquirer_reference_number: None,
                         };
 
                         return Ok(Self {
@@ -1137,7 +1137,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                     connector_refund_id: order_status.order_code.clone(),
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 };
 
                 Ok(Self {
@@ -1173,7 +1173,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                     connector_refund_id: order_code,
                     refund_status,
                     status_code: item.http_code,
-                    refund_arn: None,
+                    acquirer_reference_number: None,
                 };
 
                 Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -1037,6 +1037,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRefundResponse, Self>>
             connector_refund_id: refund_received.order_code.clone(),
             refund_status: RefundStatus::Pending,
             status_code: item.http_code,
+            refund_arn: None,
         };
 
         Ok(Self {
@@ -1091,6 +1092,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                             connector_refund_id: order_status.order_code.clone(),
                             refund_status: RefundStatus::Pending,
                             status_code: item.http_code,
+                            refund_arn: None,
                         };
 
                         return Ok(Self {
@@ -1135,6 +1137,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                     connector_refund_id: order_status.order_code.clone(),
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 };
 
                 Ok(Self {
@@ -1170,6 +1173,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlRsyncResponse, Self>>
                     connector_refund_id: order_code,
                     refund_status,
                     status_code: item.http_code,
+                    refund_arn: None,
                 };
 
                 Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
@@ -820,7 +820,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: common_enums::RefundStatus::from(response.status),
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             request: RefundsData {
                 integrity_object: response_integrity_object,
@@ -856,7 +856,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: common_enums::RefundStatus::from(response.status),
                 status_code: http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/xendit/transformers.rs
@@ -820,6 +820,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: common_enums::RefundStatus::from(response.status),
                 status_code: http_code,
+                refund_arn: None,
             }),
             request: RefundsData {
                 integrity_object: response_integrity_object,
@@ -855,6 +856,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
                 connector_refund_id: response.id,
                 refund_status: common_enums::RefundStatus::from(response.status),
                 status_code: http_code,
+                refund_arn: None,
             }),
             ..router_data
         })

--- a/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
@@ -1320,7 +1320,7 @@ impl<F> TryFrom<ResponseRouterData<ZiftRefundResponse, Self>>
                     })?,
                 refund_status,
                 status_code: item.http_code,
-                refund_arn: None,
+                acquirer_reference_number: None,
             })
         } else {
             Err(ErrorResponse {

--- a/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
@@ -1320,6 +1320,7 @@ impl<F> TryFrom<ResponseRouterData<ZiftRefundResponse, Self>>
                     })?,
                 refund_status,
                 status_code: item.http_code,
+                refund_arn: None,
             })
         } else {
             Err(ErrorResponse {

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2556,7 +2556,7 @@ pub struct RefundsResponseData {
     pub connector_refund_id: String,
     pub refund_status: common_enums::RefundStatus,
     pub status_code: u16,
-    pub refund_arn: Option<String>,
+    pub acquirer_reference_number: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2556,6 +2556,7 @@ pub struct RefundsResponseData {
     pub connector_refund_id: String,
     pub refund_status: common_enums::RefundStatus,
     pub status_code: u16,
+    pub refund_arn: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8638,7 +8638,10 @@ pub fn generate_refund_sync_response(
                 response_headers,
                 state: None,
                 raw_connector_request,
-                acquirer_reference_number: None,
+                acquirer_reference_number: response
+                    .refund_arn
+                    .clone()
+                    .map(hyperswitch_masking::Secret::new),
                 state_metadata: None,
             })
         }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8639,7 +8639,7 @@ pub fn generate_refund_sync_response(
                 state: None,
                 raw_connector_request,
                 acquirer_reference_number: response
-                    .refund_arn
+                    .acquirer_reference_number
                     .clone()
                     .map(hyperswitch_masking::Secret::new),
                 state_metadata: None,


### PR DESCRIPTION
## Description
Maps Glomopay's `utr` (Unique Transaction Reference) field from the RSync (list-refunds) response to `refund_arn` → `acquirer_reference_number`, so merchants can see the bank-level refund reference. Also enforces HTTPS on the Glomopay callback URL — local euler setups send `http://`, which Glomopay rejects; non-HTTPS URLs are substituted with `https://google.com` as a placeholder (production URLs are always HTTPS so this is a no-op there).

## Changes

- `crates/types-traits/domain_types/src/connector_types.rs` — added `refund_arn: Option<String>` to `RefundsResponseData`
- `crates/types-traits/domain_types/src/types.rs` — wired `refund_arn` → `acquirer_reference_number` in `generate_refund_sync_response`
- `crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs` — added `utr: Option<String>` to `GlomopayRefundSyncItem`; RSync transformer now sets `refund_arn = entry.utr.clone()`; added HTTPS callback URL fallback in Authorize
- All other connector `transformers.rs` files — mechanical `refund_arn: None` addition required by Rust's exhaustive struct initialization

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

All 4 flows tested manually against Glomopay sandbox.

<details>
<summary>1. Composite Authorize - 3DS Card Payment</summary><br>

```
curl --location 'http://localhost:8011/composite/payments/authorize' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Glomopay":{"api_key":"<REDACTED>"}}}' \
--header 'x-merchant-id: azharamin' \
--header 'x-tenant-id: JUSPAY' \
--header 'x-connector: glomopay' \
--header 'x-reference-id: GLOMO_REF_1785849062' \
--data-raw '{
    "merchant_transaction_id": "GLOMO_TXN_1785849062",
    "amount": {"minor_amount": 5000, "currency": "USD"},
    "payment_method": {
      "payment_method": {
        "card": {
          "card_number": "4111111111111111",
          "card_exp_month": "12",
          "card_exp_year": "2030",
          "card_cvc": "123",
          "card_holder_name": "Test User"
        }
      }
    },
    "capture_method": "AUTOMATIC",
    "auth_type": "THREE_DS",
    "address": {
      "billing_address": {
        "first_name": "Test",
        "last_name": "User",
        "line1": "123 Test St",
        "city": "Mumbai",
        "state": "Maharashtra",
        "zip_code": "400001",
        "country_alpha2_code": "IN"
      }
    },
    "customer": {
      "email": "test@example.com",
      "name": "Test User",
      "phone_number": "9999999999"
    },
    "return_url": "https://example.com/return",
    "merchant_order_id": "GLOMO_TXN_1785849062",
    "order_details": [],
    "test_mode": false
  }'
```

Response

```json
{
    "create_customer_response": {
        "merchant_customer_id": "cust_6a50ffd3lacrd",
        "connector_customer_id": "cust_6a50ffd3lacrd",
        "status_code": 200
    },
    "authorize_response": {
        "merchant_transaction_id": "GLOMO_TXN_1785849062",
        "connector_transaction_id": "payt_6a71e512NKqRz",
        "status": "AUTHENTICATION_PENDING",
        "status_code": 201,
        "redirection_data": {
            "form_type": {
                "Uri": {
                    "uri": "https://payments.glomopay.com?paymentId=payt_6a71e512NKqRz&authToken=test_68524ee8SJbU1RqT&redirectUrl=https%3A%2F%2Fexample.com%2Freturn"
                }
            }
        }
    },
    "create_order_response": {
        "connector_order_id": "order_6a71e512arqo7",
        "status": "PENDING",
        "status_code": 200
    },
    "composite_status": "COMPLETED"
}
```

</details>

<details>
<summary>2. Payment Sync (PSync)</summary><br>

```
curl --location 'http://localhost:8011/composite/payments/get' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Glomopay":{"api_key":"<REDACTED>"}}}' \
--header 'x-merchant-id: azharamin' \
--header 'x-tenant-id: JUSPAY' \
--header 'x-connector: glomopay' \
--header 'x-reference-id: GLOMO_REF_1785849062' \
--data-raw '{
    "connector_transaction_id": "payt_6a71e512NKqRz",
    "merchant_transaction_id": "GLOMO_TXN_1785849062",
    "amount": {"minor_amount": 5000, "currency": "USD"}
}'
```

Response

```json
{
    "get_response": {
        "connector_transaction_id": "payt_6a71e512NKqRz",
        "merchant_transaction_id": "GLOMO_TXN_1785849062",
        "status": "AUTHENTICATION_PENDING",
        "status_code": 200,
        "amount": {
            "minor_amount": 5000,
            "currency": "USD"
        }
    }
}
```

</details>

<details>
<summary>3. Refund</summary><br>

```
curl --location 'http://localhost:8011/composite/refunds/refund' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Glomopay":{"api_key":"<REDACTED>"}}}' \
--header 'x-merchant-id: azharamin' \
--header 'x-tenant-id: JUSPAY' \
--header 'x-connector: glomopay' \
--header 'x-reference-id: GLOMO_REF_1785849062' \
--data-raw '{
    "connector_transaction_id": "payt_6a71e512NKqRz",
    "merchant_refund_id": "GLOMO_REFUND_1785849062",
    "payment_amount": 5000,
    "refund_amount": {"minor_amount": 5000, "currency": "USD"},
    "reason": "Requested By Customer"
}'
```

Response

```json
{
    "refund_response": {
        "merchant_refund_id": "GLOMO_REFUND_1785849062",
        "connector_refund_id": "refund_6a71e775EMY8g",
        "status": "REFUND_SUCCESS",
        "status_code": 201,
        "connector_transaction_id": "payt_6a71e512NKqRz"
    }
}
```

</details>

<details>
<summary>4. Refund Sync (RSync) — acquirer_reference_number populated from utr</summary><br>

```
curl --location 'http://localhost:8011/composite/refunds/get' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Glomopay":{"api_key":"<REDACTED>"}}}' \
--header 'x-merchant-id: azharamin' \
--header 'x-tenant-id: JUSPAY' \
--header 'x-connector: glomopay' \
--header 'x-reference-id: GLOMO_REFUND_1785849062' \
--data-raw '{
    "connector_refund_id": "refund_6a71e775EMY8g",
    "connector_transaction_id": "payt_6a71e512NKqRz",
    "merchant_refund_id": "GLOMO_REFUND_1785849062",
    "payment_amount": 5000,
    "refund_amount": {"minor_amount": 5000, "currency": "USD"}
}'
```

Response

```json
{
    "refund_response": {
        "merchant_refund_id": "GLOMO_REFUND_1785849062",
        "connector_refund_id": "refund_6a71e775EMY8g",
        "status": "REFUND_SUCCESS",
        "status_code": 200,
        "connector_transaction_id": "payt_6a71e512NKqRz",
        "acquirer_reference_number": "MOCK-refund_6a71e775EMY8g"
    }
}
```

`acquirer_reference_number` is populated from Glomopay's `utr` field in the list-refunds response — the key change this PR introduces.

</details>
