### PR TITLE
feat(framework): add Prop, PrivateLabel, and Dinacard card networks

### DIFF
--- a/crates/common/common_enums/src/enums.rs
+++ b/crates/common/common_enums/src/enums.rs
@@ -1614,6 +1614,12 @@ pub enum CardNetwork {
     Accel,
     #[serde(alias = "NYCE")]
     Nyce,
+    #[serde(alias = "PROP")]
+    Prop,
+    #[serde(alias = "PRIVATE LABEL")]
+    PrivateLabel,
+    #[serde(alias = "DINACARD")]
+    Dinacard,
 }
 
 impl CardNetwork {
@@ -1628,6 +1634,9 @@ impl CardNetwork {
                 | Self::Discover
                 | Self::CartesBancaires
                 | Self::UnionPay
+                | Self::Prop
+                | Self::PrivateLabel
+                | Self::Dinacard
         )
     }
 

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -1390,7 +1390,10 @@ fn get_adyen_card_network(card_network: common_enums::CardNetwork) -> Option<Car
         common_enums::CardNetwork::Accel => Some(CardBrand::Accel),
         common_enums::CardNetwork::Pulse => Some(CardBrand::Pulse),
         common_enums::CardNetwork::Nyce => Some(CardBrand::Nyce),
-        common_enums::CardNetwork::Interac => None,
+        common_enums::CardNetwork::Interac
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -1658,7 +1658,10 @@ fn get_boa_card_type(card_network: common_enums::CardNetwork) -> Option<&'static
         | common_enums::CardNetwork::Star
         | common_enums::CardNetwork::Accel
         | common_enums::CardNetwork::Pulse
-        | common_enums::CardNetwork::Nyce => None,
+        | common_enums::CardNetwork::Nyce
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -269,7 +269,10 @@ fn get_barclaycard_card_type(card_network: common_enums::CardNetwork) -> Option<
         | common_enums::CardNetwork::Star
         | common_enums::CardNetwork::Accel
         | common_enums::CardNetwork::Pulse
-        | common_enums::CardNetwork::Nyce => None,
+        | common_enums::CardNetwork::Nyce
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -4999,7 +4999,10 @@ fn get_cybersource_card_type(card_network: common_enums::CardNetwork) -> Option<
         | common_enums::CardNetwork::Star
         | common_enums::CardNetwork::Accel
         | common_enums::CardNetwork::Pulse
-        | common_enums::CardNetwork::Nyce => None,
+        | common_enums::CardNetwork::Nyce
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -203,7 +203,10 @@ fn card_network_to_gateway(network: &common_enums::CardNetwork) -> Option<Gatewa
         | common_enums::CardNetwork::Star
         | common_enums::CardNetwork::Pulse
         | common_enums::CardNetwork::Accel
-        | common_enums::CardNetwork::Nyce => None,
+        | common_enums::CardNetwork::Nyce
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/requests.rs
@@ -40,6 +40,9 @@ pub enum CardNetworkLowercase {
     Pulse,
     Accel,
     Nyce,
+    Prop,
+    PrivateLabel,
+    Dinacard,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -735,6 +735,9 @@ impl TryFrom<common_enums::CardNetwork> for requests::CardNetworkLowercase {
             common_enums::CardNetwork::Pulse => Ok(Self::Pulse),
             common_enums::CardNetwork::Accel => Ok(Self::Accel),
             common_enums::CardNetwork::Nyce => Ok(Self::Nyce),
+            common_enums::CardNetwork::Prop => Ok(Self::Prop),
+            common_enums::CardNetwork::PrivateLabel => Ok(Self::PrivateLabel),
+            common_enums::CardNetwork::Dinacard => Ok(Self::Dinacard),
         }
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -1628,7 +1628,10 @@ fn get_stripe_card_network(card_network: common_enums::CardNetwork) -> Option<St
         | common_enums::CardNetwork::Star
         | common_enums::CardNetwork::Accel
         | common_enums::CardNetwork::Pulse
-        | common_enums::CardNetwork::Nyce => None,
+        | common_enums::CardNetwork::Nyce
+        | common_enums::CardNetwork::Prop
+        | common_enums::CardNetwork::PrivateLabel
+        | common_enums::CardNetwork::Dinacard => None,
     }
 }
 

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -1050,6 +1050,9 @@ impl ForeignTryFrom<grpc_api_types::payments::CardNetwork> for CardNetwork {
             grpc_api_types::payments::CardNetwork::Pulse => Ok(Self::Pulse),
             grpc_api_types::payments::CardNetwork::Accel => Ok(Self::Accel),
             grpc_api_types::payments::CardNetwork::Nyce => Ok(Self::Nyce),
+            grpc_api_types::payments::CardNetwork::Prop => Ok(Self::Prop),
+            grpc_api_types::payments::CardNetwork::PrivateLabel => Ok(Self::PrivateLabel),
+            grpc_api_types::payments::CardNetwork::Dinacard => Ok(Self::Dinacard),
             grpc_api_types::payments::CardNetwork::Unspecified => {
                 Err(IntegrationError::InvalidDataFormat {
                     field_name: "card_network",
@@ -6226,6 +6229,9 @@ impl ForeignFrom<CardNetwork> for grpc_payment_types::CardNetwork {
             CardNetwork::Pulse => Self::Pulse,
             CardNetwork::Accel => Self::Accel,
             CardNetwork::Nyce => Self::Nyce,
+            CardNetwork::Prop => Self::Prop,
+            CardNetwork::PrivateLabel => Self::PrivateLabel,
+            CardNetwork::Dinacard => Self::Dinacard,
         }
     }
 }

--- a/crates/types-traits/grpc-api-types/proto/payment_methods.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment_methods.proto
@@ -26,6 +26,9 @@ enum CardNetwork {
   PULSE = 13;
   ACCEL = 14;
   NYCE = 15;
+  PROP = 16;
+  PRIVATE_LABEL = 17;
+  DINACARD = 18;
 }
 
 // Paysafecard - Prepaid payment method


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
dds three new `CardNetwork` variants — `Prop` (proprietary), `PrivateLabel` (store/closed-loop cards), and `Dinacard` (Serbia's national scheme) — sourced from BIN enrichment. They deserialize from the enrichment source via `PROP`, `PRIVATE LABEL`, and `DINACARD` serde aliases, and are threaded through every exhaustive `CardNetwork` match in the codebase.
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
As this is a framework support and extension of existing CardNetwork enum testing is not required. Used `cargo build` and `cargo run --bin grpc-server` to verify the build.