### PR TITLE
feat(composite): support merchant_transaction_id as order id for connectors that treat order and transaction as same entity

### DIFF
--- a/crates/internal/composite-service/src/payments.rs
+++ b/crates/internal/composite-service/src/payments.rs
@@ -560,6 +560,7 @@ where
             );
 
         let should_execute_create_order = connector_data.connector.should_do_order_create();
+        let merchant_order_id_source = connector_data.connector.merchant_order_id_source();
 
         let create_order_response = match should_execute_create_order {
             true => {
@@ -570,6 +571,7 @@ where
                 let create_order_payload = PaymentServiceCreateOrderRequest::foreign_from((
                     payload,
                     create_customer_response,
+                    merchant_order_id_source,
                 ));
                 let mut create_order_request = tonic::Request::new(create_order_payload);
                 *create_order_request.metadata_mut() = metadata.clone();

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -152,8 +152,12 @@ impl
         });
 
         let merchant_order_id = match merchant_order_id_source {
-            interfaces::connector_types::MerchantOrderIdSource::OrderId => item.merchant_order_id.clone(),
-            interfaces::connector_types::MerchantOrderIdSource::TransactionId => item.merchant_transaction_id.clone(),
+            interfaces::connector_types::MerchantOrderIdSource::OrderId => {
+                item.merchant_order_id.clone()
+            }
+            interfaces::connector_types::MerchantOrderIdSource::TransactionId => {
+                item.merchant_transaction_id.clone()
+            }
         };
 
         Self {

--- a/crates/internal/composite-service/src/transformers.rs
+++ b/crates/internal/composite-service/src/transformers.rs
@@ -120,22 +120,6 @@ impl ForeignFrom<(&CompositeAuthorizeRequest, &ConnectorEnum)>
     }
 }
 
-impl ForeignFrom<&CompositeAuthorizeRequest> for PaymentServiceCreateOrderRequest {
-    fn foreign_from(item: &CompositeAuthorizeRequest) -> Self {
-        Self {
-            merchant_order_id: item.merchant_order_id.clone(),
-            amount: item.amount,
-            webhook_url: item.webhook_url.clone(),
-            metadata: item.metadata.clone(),
-            connector_feature_data: item.connector_feature_data.clone(),
-            state: item.state.clone(),
-            test_mode: item.test_mode,
-            payment_method_type: None,
-            order_details: item.order_details.clone(),
-        }
-    }
-}
-
 // Tuple variant: threads the freshly-created connector_customer_id from
 // `create_customer_response` into the outgoing state. Required for connectors
 // that do not cache the connector-side customer id externally (e.g. Glomopay),
@@ -145,12 +129,14 @@ impl
     ForeignFrom<(
         &CompositeAuthorizeRequest,
         Option<&CustomerServiceCreateResponse>,
+        interfaces::connector_types::MerchantOrderIdSource,
     )> for PaymentServiceCreateOrderRequest
 {
     fn foreign_from(
-        (item, create_customer_response): (
+        (item, create_customer_response, merchant_order_id_source): (
             &CompositeAuthorizeRequest,
             Option<&CustomerServiceCreateResponse>,
+            interfaces::connector_types::MerchantOrderIdSource,
         ),
     ) -> Self {
         let connector_customer_id_from_req = item
@@ -165,8 +151,13 @@ impl
             connector_customer_id,
         });
 
+        let merchant_order_id = match merchant_order_id_source {
+            interfaces::connector_types::MerchantOrderIdSource::OrderId => item.merchant_order_id.clone(),
+            interfaces::connector_types::MerchantOrderIdSource::TransactionId => item.merchant_transaction_id.clone(),
+        };
+
         Self {
-            merchant_order_id: item.merchant_order_id.clone(),
+            merchant_order_id,
             amount: item.amount,
             webhook_url: item.webhook_url.clone(),
             metadata: item.metadata.clone(),

--- a/crates/types-traits/interfaces/src/connector_types.rs
+++ b/crates/types-traits/interfaces/src/connector_types.rs
@@ -91,6 +91,18 @@ pub enum RedirectState {
     RedirectWithoutParams,
 }
 
+/// Describes which merchant-side identifier a connector uses as its order reference.
+/// Some connectors do not distinguish between order and transaction and expect
+/// merchant_transaction_id wherever an order identifier is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MerchantOrderIdSource {
+    /// Connector uses merchant_order_id (default)
+    OrderId,
+    /// Connector treats order and transaction as the same entity;
+    /// merchant_transaction_id is used wherever an order identifier is needed
+    TransactionId,
+}
+
 pub trait ConnectorServiceTrait<T: PaymentMethodDataTypes>:
     ConnectorCommon
     + ValidationTrait
@@ -270,6 +282,13 @@ pub trait ValidationTrait: ConnectorCommon {
     /// after VerifyRedirectResponse in the composite flow.
     fn requires_authorize_post_redirect(&self) -> bool {
         false
+    }
+
+    /// Returns which merchant identifier this connector uses as its order reference.
+    /// Connectors that treat order and transaction as the same entity should return
+    /// `MerchantOrderIdSource::TransactionId`.
+    fn merchant_order_id_source(&self) -> MerchantOrderIdSource {
+        MerchantOrderIdSource::OrderId
     }
 }
 


### PR DESCRIPTION
## Problem

Some connectors do not distinguish between an order and a transaction — they are the same entity. For these connectors, `merchant_transaction_id` (not `merchant_order_id`) must be used as the order identifier when calling `CreateOrder`. Previously there was no mechanism to express this at the connector level.

## Solution

Introduce `MerchantOrderIdSource` enum in `ValidationTrait`:

```rust
pub enum MerchantOrderIdSource {
    OrderId,       // default
    TransactionId, // connector treats order = transaction
}

fn merchant_order_id_source(&self) -> MerchantOrderIdSource {
    MerchantOrderIdSource::OrderId
}
```

Connectors that require `merchant_transaction_id` as their order reference override this to return `MerchantOrderIdSource::TransactionId`.

At the composite layer, `create_order` resolves the correct ID and passes it into the `ForeignFrom` transform, which sets `merchant_order_id` accordingly before dispatching to the granular service.

## Key design decisions

- **No proto change** — `PaymentServiceCreateOrderRequest` keeps only `merchant_order_id`; the mapping is transparent to the granular connector layer
- **Connector declares intent once** — `merchant_order_id_source()` is a single override point on `ValidationTrait`, reusable by any flow that needs to resolve an order identifier
- **No `mut` at call site** — resolution happens inside the `ForeignFrom` impl, keeping `payments.rs` clean

## Files changed

| File | Change |
|---|---|
| `interfaces/src/connector_types.rs` | Add `MerchantOrderIdSource` enum and `merchant_order_id_source()` to `ValidationTrait` |
| `composite-service/src/transformers.rs` | Tuple `ForeignFrom` takes `MerchantOrderIdSource`; resolves `merchant_order_id` from the correct source. Remove unused simple `ForeignFrom<&CompositeAuthorizeRequest>` impl |
| `composite-service/src/payments.rs` | Call `merchant_order_id_source()` and pass result into `foreign_from` |