### PR TITLE
fix(paysafe): don't send a card accountId on wallet settle

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -1685,9 +1685,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     router_data.request.payment_method_type,
                     Some(enums::PaymentMethodType::GooglePay)
                         | Some(enums::PaymentMethodType::ApplePay)
-                ) && !router_data
-                    .request
-                    .is_customer_initiated_mandate_payment() =>
+                ) && !router_data.request.is_customer_initiated_mandate_payment() =>
             {
                 None
             }

--- a/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paysafe/transformers.rs
@@ -1670,6 +1670,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         // Match on the payment-method enum (not payment_method_data) because the settle
         // leg carries PaymentMethodData::PaymentMethodToken for cards too.
         let account_id = match router_data.resource_common_data.payment_method {
+            // A connector-tokenized wallet settle reaches this match as `Card`, because the
+            // gRPC `token` payment method maps to Card — the wallet identity survives only in
+            // `payment_method_type`. Falling through to the Card arm below resolves a
+            // card three_ds/no_three_ds account, but the Tokenize leg minted the handle on the
+            // apple_pay/google_pay account, so Paysafe rejects the settle with
+            // 5068 "Value does not correspond with the accountId in payment handle"
+            // (reproduced on sandbox with auth_type=three_ds: handle on the wallet account,
+            // settle sent card.<CUR>.three_ds). Wallets follow the rule stated above — the
+            // handle already carries its account binding, so send NO accountId. The CIT arm
+            // below still applies, since a vaulted CONVERTED handle has no binding.
+            enums::PaymentMethod::Card
+                if matches!(
+                    router_data.request.payment_method_type,
+                    Some(enums::PaymentMethodType::GooglePay)
+                        | Some(enums::PaymentMethodType::ApplePay)
+                ) && !router_data
+                    .request
+                    .is_customer_initiated_mandate_payment() =>
+            {
+                None
+            }
             enums::PaymentMethod::Card => {
                 if router_data.resource_common_data.is_three_ds() {
                     Some(account_id.get_account_id(


### PR DESCRIPTION
## Description

A connector-tokenized **wallet** settle reaches the account-resolution match in `PaysafePaymentsRequest` as `PaymentMethod::Card` — the gRPC `token` payment method maps to Card, so the wallet identity survives only in `payment_method_type`.

It therefore fell into the Card arm and resolved `card.<CURRENCY>.three_ds` / `no_three_ds`, while the Tokenize leg had minted the payment handle on the `apple_pay` / `google_pay` account. Paysafe rejects the mismatch:

```
5068 — fieldErrors: [{ "field": "accountId",
  "error": "Value does not correspond with the accountId in payment handle" }]
```

This restores the rule already documented directly above that match — *wallet settles send NO accountId, because the payment handle carries its own account binding*. The wallet CIT arm is deliberately untouched: a vaulted CONVERTED handle has no binding, so it still resolves an explicit account.

## Reproduction

Sandbox Google Pay payment with `authentication_type: three_ds` (`pay_fz979retzyGT3PRkk2GW`):

- Tokenize → handle minted on account **1002671400**, `status: PAYABLE`, `tokenType: GOOGLE_PAY`
- Settle → `POST /paymenthub/v1/payments` carried `accountId` resolved from `card.USD.three_ds` = **1003047440**
- Paysafe → `5068`, payment `FAILED`

Confirmed independently against the Paysafe API with Hyperswitch excluded: minting a handle on `1002671400` and settling with `accountId: 1003047440` returns the identical `fieldError`.

## Verification

- `cargo check -p connector-integration` passes.
- Verified directly against Paysafe that a Google Pay handle settles successfully with **no** `accountId` in the `/payments` body — USD 1.00, `authCode 149723`, `status: COMPLETED` on account `1002671400`. EUR was likewise charged earlier on `1003044460` (`authCode 727050`).

No automated test added — the behaviour is only observable in the outgoing Paysafe body for a tokenized wallet settle, which the current unit-test harness for this connector doesn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)