### PR TITLE
feat(webhooks): add merchant_transaction_id to RefundEventReference and MandateEventReference

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -900,6 +900,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     connector_refund_id: Some(notif.psp_reference),
                     merchant_refund_id: Some(notif.merchant_reference),
                     connector_transaction_id: notif.original_reference,
+                    merchant_transaction_id: None,
                 })
             }
             // Dispute events: psp_reference is the dispute ID; original_reference is the parent payment.

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -2170,6 +2170,7 @@ pub(super) fn get_finix_webhook_reference(
                         connector_refund_id: Some(transfer.id),
                         merchant_refund_id: None,
                         connector_transaction_id: None,
+                        merchant_transaction_id: None,
                     },
                 ))),
                 // finix platform fee ignored (HS: Err(WebhookEventTypeNotFound))

--- a/crates/integrations/connector-integration/src/connectors/fiuu.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu.rs
@@ -935,6 +935,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     merchant_refund_id: None,
                     // txn_id is the connector ID of the original payment.
                     connector_transaction_id: Some(r.txn_id),
+                    merchant_transaction_id: None,
                 })
             }
         };

--- a/crates/integrations/connector-integration/src/connectors/givepayments.rs
+++ b/crates/integrations/connector-integration/src/connectors/givepayments.rs
@@ -188,6 +188,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     connector_refund_id: Some(response_data.id),
                     merchant_refund_id: response_data.external_reference,
                     connector_transaction_id: None,
+                    merchant_transaction_id: None,
                 })
             }
         };

--- a/crates/integrations/connector-integration/src/connectors/glomopay.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay.rs
@@ -577,6 +577,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         connector_refund_id: Some(payload.data.id),
                         merchant_refund_id: None,
                         connector_transaction_id: payload.data.payment_id,
+                        merchant_transaction_id: None,
                     },
                 )))
             }

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
@@ -201,6 +201,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     connector_refund_id: Some(webhook_body.psp_reference.clone()),
                     merchant_refund_id: Some(webhook_body.psp_reference),
                     connector_transaction_id: webhook_body.original_reference,
+                    merchant_transaction_id: None,
                 })
             }
         };

--- a/crates/integrations/connector-integration/src/connectors/nmi.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi.rs
@@ -211,6 +211,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     connector_refund_id: None,
                     merchant_refund_id: Some(reference_body.event_body.order_id),
                     connector_transaction_id: None,
+                    merchant_transaction_id: None,
                 },
             ))),
             // HS maps `credit` to `WebhooksNotImplemented`.

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -4096,6 +4096,7 @@ pub(crate) fn get_webhook_reference(
                 connector_refund_id,
                 merchant_refund_id,
                 connector_transaction_id: event_object.payment_intent.clone(),
+                merchant_transaction_id: None,
             })
         }
     };

--- a/crates/integrations/connector-integration/src/connectors/truelayer.rs
+++ b/crates/integrations/connector-integration/src/connectors/truelayer.rs
@@ -803,6 +803,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         connector_refund_id: webhook_body.refund_id,
                         merchant_refund_id: None,
                         connector_transaction_id: Some(webhook_body.payment_id.clone()),
+                        merchant_transaction_id: None,
                     },
                 )
             }

--- a/crates/integrations/connector-integration/src/connectors/trustly.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly.rs
@@ -320,6 +320,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         connector_refund_id: Some(webhook_body.params.data.orderid.clone()),
                         merchant_refund_id: None,
                         connector_transaction_id: Some(webhook_body.params.data.orderid.clone()),
+                        merchant_transaction_id: None,
                     },
                 )
             }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2822,6 +2822,8 @@ pub struct RefundWebhookReference {
     pub merchant_refund_id: Option<String>,
     /// PSP-assigned ID of the original payment this refund belongs to.
     pub connector_transaction_id: Option<String>,
+    /// Caller-assigned order / invoice ID echoed back by the connector.
+    pub merchant_transaction_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -2836,6 +2838,8 @@ pub struct DisputeWebhookReference {
 pub struct MandateWebhookReference {
     /// PSP-assigned mandate ID.
     pub connector_mandate_id: Option<String>,
+    /// Caller-assigned order / invoice ID echoed back by the connector.
+    pub merchant_transaction_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -17817,11 +17817,13 @@ impl From<connector_types::WebhookResourceReference> for grpc_api_types::payment
                 connector_refund_id,
                 merchant_refund_id,
                 connector_transaction_id,
+                merchant_transaction_id,
             }) => EventReference {
                 resource: Some(event_reference::Resource::Refund(RefundEventReference {
                     connector_refund_id,
                     merchant_refund_id,
                     connector_transaction_id,
+                    merchant_transaction_id,
                 })),
             },
             WebhookResourceReference::Dispute(DisputeWebhookReference {
@@ -17835,9 +17837,11 @@ impl From<connector_types::WebhookResourceReference> for grpc_api_types::payment
             },
             WebhookResourceReference::Mandate(MandateWebhookReference {
                 connector_mandate_id,
+                merchant_transaction_id,
             }) => EventReference {
                 resource: Some(event_reference::Resource::Mandate(MandateEventReference {
                     connector_mandate_id,
+                    merchant_transaction_id,
                 })),
             },
             WebhookResourceReference::Payout(PayoutWebhookReference {

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -4011,6 +4011,7 @@ message RefundEventReference {
   optional string connector_refund_id      = 1;
   optional string merchant_refund_id       = 2;
   optional string connector_transaction_id = 3;  // Parent payment ID, if present.
+  optional string merchant_transaction_id  = 4;
 }
 
 // IDs extracted from a dispute webhook.
@@ -4025,6 +4026,7 @@ message DisputeEventReference {
 // IDs extracted from a mandate webhook.
 message MandateEventReference {
   optional string connector_mandate_id = 1;
+  optional string merchant_transaction_id = 2;
 }
 
 // IDs extracted from a payout webhook.


### PR DESCRIPTION
## Summary
- `PaymentEventReference` already carried `merchant_transaction_id`; this extends the same optional string field to `RefundEventReference` (tag 4) and `MandateEventReference` (tag 2) so all three event reference types are consistent.
- Wires the field through the core `WebhookResourceReference` -> `EventReference` mapping in `domain_types`.
- Connectors default the new field to `None` for now; no connector currently constructs `MandateWebhookReference`, so only `RefundWebhookReference` construction sites needed updating (adyen, finix, fiuu, givepayments, glomopay, imerchantsolutions, nmi, stripe, truelayer, trustly).

## Test plan
- [x] `cargo check -p domain_types -p connector-integration -p grpc-api-types` passes