### PR TITLE
fix(events): serialize connector payloads as JSON text

### DIFF
--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -472,6 +472,18 @@ impl EventStage {
 pub struct KafkaTopicConfig {
     pub topic: String,
     pub partition_key_field: String,
+    #[serde(default)]
+    pub payload_format: EventPayloadFormat,
+}
+
+#[derive(
+    Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, config_patch_derive::Patch,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EventPayloadFormat {
+    #[default]
+    Json,
+    JsonString,
 }
 
 /// Configuration for events system
@@ -614,7 +626,27 @@ pub(crate) fn process_event_with_config(
         }
     }
 
+    if config.topic_config(&event.stage).payload_format == EventPayloadFormat::JsonString {
+        stringify_event_payloads(&mut result);
+    }
+
     Ok(result)
+}
+
+fn stringify_event_payloads(result: &mut serde_json::Value) {
+    let Some(obj) = result.as_object_mut() else {
+        return;
+    };
+
+    for field in ["request_data", "response_data"] {
+        let Some(value) = obj.get_mut(field) else {
+            continue;
+        };
+
+        if !value.is_null() && !value.is_string() {
+            *value = serde_json::Value::String(value.to_string());
+        }
+    }
 }
 
 pub(crate) fn extract_from_request(

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -638,7 +638,7 @@ fn stringify_event_payloads(result: &mut serde_json::Value) {
         return;
     };
 
-    for field in ["request_data", "response_data"] {
+    for field in ["request_data", "response_data", "error"] {
         let Some(value) = obj.get_mut(field) else {
             continue;
         };


### PR DESCRIPTION
## What

- Serialize final `request_data` and `response_data` values as JSON text before Kafka publication.
- Keep both fields structured while configured transformations and extractions run.
- Preserve existing null behavior.

## Why

These payloads can contain any Serde JSON value, including objects, arrays, and scalar values. Emitting one JSON-text layer gives downstream consumers a consistent wire representation.

## Rollout dependency

**Deploy the backward-compatible Vector change before deploying this UCS change.**

- Infra PR: [hyperswitch-infra #3420](https://bitbucket.juspay.net/projects/HYP/repos/hyperswitch-infra/pull-requests/3420)
- Tracking issue: [hyperswitch-cloud #22554](https://github.com/juspay/hyperswitch-cloud/issues/22554)

The Vector change accepts both the current structured payloads and the new JSON-text payloads, preventing merchant-facing Prism audit logs from being double encoded during a rolling deployment.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p ucs_common_utils`