### PR TITLE
feat(framework): Add missing connector error code mapping

### DIFF
--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -222,15 +222,20 @@ impl ToGrpcStatus for ConnectorError {
 
         match self {
             Self::ConnectorErrorResponse(error_response) => match error_response.status_code {
-                400 => Status::with_details(tonic::Code::InvalidArgument, msg, buf.into()),
+                400 | 402 | 405 | 406 | 407 | 410..=428 | 431..=499 => {
+                    Status::with_details(tonic::Code::InvalidArgument, msg, buf.into())
+                }
                 401 => Status::with_details(tonic::Code::Unauthenticated, msg, buf.into()),
                 403 => Status::with_details(tonic::Code::PermissionDenied, msg, buf.into()),
                 404 => Status::with_details(tonic::Code::NotFound, msg, buf.into()),
+                408 | 504 => Status::with_details(tonic::Code::DeadlineExceeded, msg, buf.into()),
+                409 => Status::with_details(tonic::Code::Aborted, msg, buf.into()),
                 429 => Status::with_details(tonic::Code::ResourceExhausted, msg, buf.into()),
-                500 => Status::with_details(tonic::Code::Internal, msg, buf.into()),
+                500 | 502 | 505..=599 => {
+                    Status::with_details(tonic::Code::Internal, msg, buf.into())
+                }
                 501 => Status::with_details(tonic::Code::Unimplemented, msg, buf.into()),
                 503 => Status::with_details(tonic::Code::Unavailable, msg, buf.into()),
-                504 => Status::with_details(tonic::Code::DeadlineExceeded, msg, buf.into()),
                 _ => Status::with_details(tonic::Code::Unknown, msg, buf.into()),
             },
             Self::ResponseDeserializationFailed { .. }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add missing connector error code mapping
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing Results:-

1. Response Handling Failed:-
```json
{
    "error": {
        "type": "api",
        "message": "Something went wrong",
        "code": "HE_00"
    }
}
```

<img width="1223" height="203" alt="Image" src="https://github.com/user-attachments/assets/ac0fe99a-d83d-456b-bd68-2a12c936a719" />

<img width="1041" height="200" alt="Image" src="https://github.com/user-attachments/assets/698130ad-f163-4666-85fd-c67e7a6044ab" />

2. NotImplemented:-
```json
{
    "error": {
        "type": "invalid_request",
        "message": "This feature is not implemented: Selected payment method through finix is not implemented",
        "code": "IR_00"
    }
}
```

UCS 4xx:-

```json
{
    "error": {
        "type": "invalid_request",
        "message": "Payment failed during authorization with connector. Retry payment",
        "code": "CE_01",
        "data": {
            "code": "UCS_400",
            "message": "Missing required field: either billing.email/customer_email or billing.phone",
            "status_code": 400
        }
    }
}
```
