### PR TITLE
fix(connector): [fiuu] revert hardcoded Failure status on error arm

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -1393,10 +1393,6 @@ where
                     network_decline_code: None,
                     network_error_message: None,
                 }),
-                resource_common_data: PaymentFlowData {
-                    status: common_enums::AttemptStatus::Failure,
-                    ..router_data.resource_common_data
-                },
                 ..router_data
             }),
             FiuuPaymentsResponse::PaymentResponse(data) => match data.txn_data.request_data {


### PR DESCRIPTION
## Summary

Reverts the hardcoded `AttemptStatus::Failure` override that prism #482 (merged 2026-02-06) added to the `FiuuPaymentsResponse::Error` arm of the Fiuu Authorize transformer, and aligns UCS with Hyperswitch's untouched-status behavior.

## Why

The shadow-validation pipeline reports a genuine `router.valueDiff:status` for **fiuu / authorize** wallet payments (merchants `my_edge_gi`, `my_edge_gt`; payment method apple_pay / google_pay):

```
router.valueDiff:status = { "hyperswitch": "pending", "ucs": "failure" }
```

- **UCS (this repo):** the `FiuuPaymentsResponse::Error` arm hard-writes `status: AttemptStatus::Failure` into `resource_common_data` (added by prism #482).
- **Hyperswitch (ground truth):** the Fiuu connector leaves the status untouched on this path — `FiuuPaymentsResponse::Error(error) => Ok(Self { response: Err(ErrorResponse { attempt_status: None, ... }), ..item.data })` — and hyperswitch #13253 (merged 2026-07-15) additionally preserves the *previous* status on Fiuu error paths. The final DB attempt status is derived by the Hyperswitch core from `attempt_status` + `status_code`, never from the connector's `router_data.status` field.

So the override produces a constant validation diff without any DB-behavior change on the Hyperswitch side.

## Change

Remove the `resource_common_data: PaymentFlowData { status: common_enums::AttemptStatus::Failure, ..router_data.resource_common_data }` block from the `FiuuPaymentsResponse::Error` arm, leaving `response: Err(...)` + `..router_data`. Success arms (QR / redirect AuthenticationPending) are untouched.
