### PR TITLE
refactor(connector): use cancellation reason in VoidPostRefund flow

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -33,6 +33,7 @@ use super::{super::macros::GetSoapXml, profile::TxProfile, rules, TsysTransitRou
 use crate::types::ResponseRouterData;
 
 const POS_ACCEPTANCE_DEVICE_TYPE: &str = "0";
+const DEFAULT_CANCELLATION_REASON: &str = "POST_AUTH_USER_DECLINE";
 
 #[derive(Debug, Serialize, Clone, Copy)]
 #[serde(rename_all = "UPPERCASE")]
@@ -3136,7 +3137,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         // arbitrary caller-supplied cancellation_reason (free text) is rejected
         // with "The value of element 'voidReason' is not valid." Ignore the
         // request value and always send a valid connector default.
-        let void_reason = "RETURN_REVERSAL".to_string();
+        let void_reason = router_data
+            .request
+            .cancellation_reason
+            .clone()
+            .unwrap_or_else(|| DEFAULT_CANCELLATION_REASON.to_string());
 
         Ok(Self {
             device_id: auth.device_id,


### PR DESCRIPTION
## Description
use cancellation reason in VoidPostRefund flow, instead of hardcoding it.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
test cases are here - https://github.com/juspay/hyperswitch/pull/13610