### PR TITLE
fix(core): add ali_pay_hk to payment method type conversions

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -2626,6 +2626,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMeth
                 Ok(PaymentMethodType::WeChatPay)
             }
             grpc_api_types::payments::PaymentMethodType::AliPay => Ok(PaymentMethodType::AliPay),
+            grpc_api_types::payments::PaymentMethodType::AliPayHk => Ok(PaymentMethodType::AliPayHk),
             grpc_api_types::payments::PaymentMethodType::Gcash => Ok(PaymentMethodType::Gcash),
             grpc_api_types::payments::PaymentMethodType::Cashapp => Ok(PaymentMethodType::Cashapp),
             grpc_api_types::payments::PaymentMethodType::SepaBankTransfer => {
@@ -8452,6 +8453,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMeth
             grpc_api_types::payments::PaymentMethodType::PayPal => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::WeChatPay => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::AliPay => Ok(Self::Wallet),
+            grpc_api_types::payments::PaymentMethodType::AliPayHk => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::Cashapp => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::RevolutPay => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::MbWay => Ok(Self::Wallet),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -2626,7 +2626,9 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMeth
                 Ok(PaymentMethodType::WeChatPay)
             }
             grpc_api_types::payments::PaymentMethodType::AliPay => Ok(PaymentMethodType::AliPay),
-            grpc_api_types::payments::PaymentMethodType::AliPayHk => Ok(PaymentMethodType::AliPayHk),
+            grpc_api_types::payments::PaymentMethodType::AliPayHk => {
+                Ok(PaymentMethodType::AliPayHk)
+            }
             grpc_api_types::payments::PaymentMethodType::Gcash => Ok(PaymentMethodType::Gcash),
             grpc_api_types::payments::PaymentMethodType::Cashapp => Ok(PaymentMethodType::Cashapp),
             grpc_api_types::payments::PaymentMethodType::SepaBankTransfer => {


### PR DESCRIPTION
## Description

Adds the missing `AliPayHk` match arms in the gRPC to domain payment method type conversions in `crates/types-traits/domain_types/src/types.rs`. The gRPC enum already defines `ALI_PAY_HK` (proto enum value 6) and the domain enum already has the `AliPayHk` variant, but the conversion impls fell through to the catch-all `_` arm, returning `InvalidDataFormat: "This payment method type is not yet supported"` (UCS_400).

## Motivation and Context

Production shadow-mode PSync calls for Adyen wallet `ali_pay_hk` payments were failing with:

```
UCS error: InvalidArgument - Invalid data format: payment_method_type. This payment method type is not yet supported
```

The payment itself succeeds on the hyperswitch side (status `charged`), but the UCS shadow execution fails before reaching the connector, producing diffs. This blocks `ali_pay_hk` for all connectors, not just Adyen, because the conversion fails at the gRPC boundary. The Adyen connector transformer already fully supports `AliPayHk` (request enum `alipay_hk`, supported PMT list, `WalletData::AliPayHkRedirect` mapping).

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

`cargo check -p domain_types` passes cleanly.

Manual verification of the failure path: a production payment (adyen, wallet, ali_pay_hk, HKD) was charged on the HS side while UCS shadow PSync returned `UCS_400 InvalidArgument - Invalid data format: payment_method_type. This payment method type is not yet supported` from `ForeignTryFrom<grpc PaymentMethodType>`. With these arms added, `ALI_PAY_HK` converts to `PaymentMethodType::AliPayHk` / `PaymentMethod::Wallet` instead of hitting the catch-all.
