### PR TITLE
fix(maya): return merchant transaction id in webhook event reference

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/maya.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya.rs
@@ -278,6 +278,26 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(EventType::from(body.status))
     }
 
+    fn get_webhook_event_reference(
+        &self,
+        request: RequestDetails,
+    ) -> Result<Option<WebhookResourceReference>, error_stack::Report<errors::WebhookError>> {
+        let body: MayaWebhookBody = request
+            .body
+            .parse_struct("MayaWebhookBody")
+            .change_context(errors::WebhookError::WebhookResourceObjectNotFound)?;
+
+        Ok(Some(WebhookResourceReference::Payment(
+            PaymentWebhookReference {
+                // Maya's payment `id` is the connector transaction id.
+                connector_transaction_id: Some(body.id),
+                // `requestReferenceNumber` is the merchant-assigned reference we
+                // sent when creating the payment, echoed back by Maya.
+                merchant_transaction_id: body.request_reference_number,
+            },
+        )))
+    }
+
     fn process_payment_webhook(
         &self,
         request: RequestDetails,


### PR DESCRIPTION
## Summary

Maya's `IncomingWebhook` implementation never overrode `get_webhook_event_reference`, so it fell through to the trait default (`Ok(None)`). As a result the `/events/parse` (`EventService::ParseEvent`) response always came back with an empty `reference`, and the **merchant transaction id** (`requestReferenceNumber`) was never surfaced to callers.

This PR implements `get_webhook_event_reference` for Maya, mapping:
- Maya payment `id` → `connector_transaction_id`
- `requestReferenceNumber` (merchant reference we send at payment creation, echoed back by Maya) → `merchant_transaction_id`

No other flow is affected — `process_payment_webhook` already set `connector_request_reference_id` from the same field.

## Changes
- `crates/integrations/connector-integration/src/connectors/maya.rs`: add `get_webhook_event_reference` to the `IncomingWebhook` impl.

## Testing

Ran the server locally in HTTP mode and replayed real Maya `PAYMENT_SUCCESS` webhook payloads (taken from the Maya webhook test sheet) through `POST /events/parse` with `x-connector: maya` and `x-auth: NoKey`.

### Before (merchant transaction id missing)

**Request**
```
POST /events/parse
x-connector: maya
x-auth: NoKey
```
```json
{
  "request_details": {
    "method": "HTTP_METHOD_POST",
    "uri": "/webhooks/maya",
    "headers": {},
    "body": "<bytes of {\"id\":\"8a797136-4150-4e49-a070-21fd883d068e\",\"status\":\"PAYMENT_SUCCESS\",\"requestReferenceNumber\":\"azharamin-1785317544-1\"}>"
  }
}
```
**Response**
```json
{ "event_type": "PAYMENT_INTENT_SUCCESS" }
```
`reference` (and therefore `merchant_transaction_id`) was absent.

### After (this PR)

**Request** — real Maya success webhook (order `1785317544`)
```json
{
  "id": "8a797136-4150-4e49-a070-21fd883d068e",
  "isPaid": true,
  "status": "PAYMENT_SUCCESS",
  "amount": "11",
  "currency": "PHP",
  "canVoid": true,
  "canRefund": true,
  "receiptNumber": "621009660577",
  "metadata": { "order_id": "1785317544" },
  "requestReferenceNumber": "azharamin-1785317544-1"
}
```
**Response**
```json
{
  "reference": {
    "resource": {
      "Payment": {
        "connector_transaction_id": "8a797136-4150-4e49-a070-21fd883d068e",
        "merchant_transaction_id": "azharamin-1785317544-1"
      }
    }
  },
  "event_type": "PAYMENT_INTENT_SUCCESS"
}
```

### Additional cases verified

| Case | `status` | `requestReferenceNumber` | `connector_transaction_id` | `merchant_transaction_id` | `event_type` |
|---|---|---|---|---|---|
| Success #2 (order 1785322267) | `PAYMENT_SUCCESS` | `azharamin-1785322267-1` | `ee7651ca-6657-4fd6-bb2c-379a86c8c892` | `azharamin-1785322267-1` | `PAYMENT_INTENT_SUCCESS` |
| Failure (order 1785494308) | `PAYMENT_FAILED` | `azharamin-1785494308-1` | `f6af22ce-10d1-4ad3-9456-4005804809b4` | `azharamin-1785494308-1` | `PAYMENT_INTENT_FAILURE` |
| Missing reference | `PENDING_TOKEN` | `null` | `72a47851-8091-4fff-995c-7ac6489ff27a` | *(omitted, no error)* | `PAYMENT_INTENT_PROCESSING` |

The extracted `merchant_transaction_id` matches the `txn_id` Euler records for each order (e.g. `azharamin-1785317544-1`).
