### PR TITLE
fix(superposition): temporarily remove kount from superposition config

### DIFF
--- a/config/superposition.toml
+++ b/config/superposition.toml
@@ -85,7 +85,7 @@ api_tags_tags_psync = { value = "", schema = { type = "string" } }
 environment = { position = 1, schema = { type = "string", enum = ["sandbox", "development", "production"] } }
 
 # Connector dimension - determines which payment processor URLs to use
-connector = { position = 2, schema = { type = "string", enum = ["glomopay", "stripe", "adyen", "paypal", "razorpay", "checkout", "braintree", "worldpay", "cybersource", "payme", "bluesnap", "fiserv", "trustpay", "volt", "hipay", "xendit", "phonepe", "cashfree", "payu", "paytm", "dlocal", "rapyd", "aci", "nuvei", "forte", "authorizedotnet", "elavon", "bamboraapac", "billwerk", "paysafe", "worldpayvantiv", "worldpayxml", "tsys", "tsys_transit", "bankofamerica", "powertranz", "revolut", "airwallex", "bambora", "shift4", "multisafepay", "iatapay", "jpmorgan", "nmi", "nexixpay", "authipay", "stax", "trustpayments", "fiservemea", "datatrans", "silverflow", "celero", "globalpay", "razorpayv2", "fiuu", "payload", "cashtocode", "novalnet", "nexinets", "noon", "mifinity", "calida", "cryptopay", "helcim", "placetopay", "barclaycard", "gigadat", "loonio", "mollie", "absa_sanlam", "truelayer", "trustly", "twoc_twop_paco", "zift", "revolv3", "fiservcommercehub", "finix", "wellsfargo", "imerchantsolutions", "qwikcilver", "flywire", "kount", "plaid"] } }
+connector = { position = 2, schema = { type = "string", enum = ["glomopay", "stripe", "adyen", "paypal", "razorpay", "checkout", "braintree", "worldpay", "cybersource", "payme", "bluesnap", "fiserv", "trustpay", "volt", "hipay", "xendit", "phonepe", "cashfree", "payu", "paytm", "dlocal", "rapyd", "aci", "nuvei", "forte", "authorizedotnet", "elavon", "bamboraapac", "billwerk", "paysafe", "worldpayvantiv", "worldpayxml", "tsys", "tsys_transit", "bankofamerica", "powertranz", "revolut", "airwallex", "bambora", "shift4", "multisafepay", "iatapay", "jpmorgan", "nmi", "nexixpay", "authipay", "stax", "trustpayments", "fiservemea", "datatrans", "silverflow", "celero", "globalpay", "razorpayv2", "fiuu", "payload", "cashtocode", "novalnet", "nexinets", "noon", "mifinity", "calida", "cryptopay", "helcim", "placetopay", "barclaycard", "gigadat", "loonio", "mollie", "absa_sanlam", "truelayer", "trustly", "twoc_twop_paco", "zift", "revolv3", "fiservcommercehub", "finix", "wellsfargo", "imerchantsolutions", "qwikcilver", "flywire", "plaid"] } }
 
 # ============================================================================
 # Development Environment Overrides
@@ -555,12 +555,6 @@ connector_base_url = "https://api.trustly.com/v1/"
 _context_ = { connector = "twoc_twop_paco" }
 connector_base_url = "https://core.demo-paco.2c2p.com"
 
-# Kount (FRM) — sandbox
-[[overrides]]
-_context_ = { connector = "kount" }
-connector_base_url = "https://api-sandbox.kount.com"
-connector_secondary_base_url = "https://login.kount.com"
-
 # Plaid (Authenticator) — sandbox
 [[overrides]]
 _context_ = { connector = "plaid" }
@@ -890,12 +884,6 @@ connector_base_url = "https://api.trustly.com/v1/"
 [[overrides]]
 _context_ = { connector = "twoc_twop_paco", environment = "production" }
 connector_base_url = "https://core.paco.2c2p.com"
-
-# Kount (FRM) Production
-[[overrides]]
-_context_ = { connector = "kount", environment = "production" }
-connector_base_url = "https://api.kount.com"
-connector_secondary_base_url = "https://login.kount.com"
 
 # Plaid (Authenticator) — production
 [[overrides]]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes kount from config/superposition.toml — drops it from the [dimensions].connector enum and removes both the sandbox and production [[overrides]] blocks that set its connector_base_url / connector_secondary_base_url.

### Why

Kount is currently integrated as both a Payment connector (used for the pre-authenticate / create-server-authentication-token flow) and an FRM connector (used for pre-risk-check and notify). Because it's dimensioned in superposition as a single connector = "kount" context without distinguishing which taxonomy is resolving it, URL patching fails — the resolved superposition URL isn't reliably applied to the right connector variant depending on which flow (ConnectorEnum::Kount vs FrmConnectorEnum::Kount) is doing the lookup.

This is a temporary removal to stop the URL-patching failures. Kount will fall back to its static base_url / secondary_base_url values in config/{development,sandbox,production}.toml, which are unaffected by this change.

### Fix-forward

This should be reverted once Kount is correctly classified as an FRM-only connector in the pre-authenticate flow, so that superposition can unambiguously resolve its URLs under a single connector taxonomy.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Verified Kount api call using x-env header
<img width="1726" height="296" alt="Screenshot 2026-08-12 at 6 25 12 PM" src="https://github.com/user-attachments/assets/5b7594e4-abcc-4612-b3f0-1b00e4d82d0c" />
