### PR TITLE
docs(grace): require superposition URL registration + URL patching for new connectors

### DIFF
--- a/.skills/new-connector/SKILL.md
+++ b/.skills/new-connector/SKILL.md
@@ -59,10 +59,11 @@ These rules apply to ALL subagents. Include them in every subagent prompt.
 - Check `references/utility-functions.md` before implementing custom helpers
 - No `unwrap()`, no fields hardcoded to `None`, no unnecessary `.clone()`
 - Auth data accessed via `req.connector_config` (NOT `connector_auth_type`)
-- ALWAYS register connector base URLs in `config/superposition.toml` (dimension enum + sandbox &
-  production `connector_base_url` overrides) AND add the connector to `Connectors::apply` in
-  `crates/types-traits/domain_types/src/types.rs` for dynamic URL patching. The scaffold script
-  does NOT do this — it is a mandatory manual step.
+- Connector base URLs MUST be registered in `config/superposition.toml` (dimension enum + sandbox &
+  production `connector_base_url` overrides) AND the connector wired into
+  `Connectors::patch_connector_urls` in `crates/types-traits/domain_types/src/types.rs` for dynamic
+  URL patching. The scaffold script (`add_connector.sh`) now does this automatically — verify it
+  landed, and pass `--production-url` when the live URL differs from the sandbox base URL.
 
 ---
 
@@ -108,18 +109,19 @@ Do NOT attempt to infer API details from any other source. A tech spec is mandat
 
 > **Subagent prompt:** `references/subagent-prompts.md` → Subagent 2
 
-**Inputs:** connector_name, base_url, auth_method, amount_type (from Step 1)
+**Inputs:** connector_name, base_url, production_base_url (optional), auth_method, amount_type (from Step 1)
 
 **What it does:**
 - Runs `scripts/add_connector.sh {connector_name} {base_url} --force -y`
+  (add `--production-url {production_base_url}` when the live URL differs from the sandbox base URL)
 - Verifies `cargo build --package connector-integration` passes
 - Checks UCS conventions (RouterDataV2, generic struct, domain_types imports)
 - Sets up `create_amount_converter_wrapper!` macro
 - Implements `ConnectorCommon` trait (id, content_type, base_url, auth_header, error_response)
 - Adds required trait markers (ConnectorServiceTrait, SourceVerification, BodyDecoding)
-- Registers connector base URLs in `config/superposition.toml` (dimension enum + sandbox/production
-  overrides) and adds the URL-patching match arm in `types.rs` `Connectors::apply` (scaffold script
-  does NOT do this)
+- The scaffold script auto-registers the connector's base URLs in `config/superposition.toml`
+  (dimension enum + sandbox/production overrides) and adds the URL-patching arm in `types.rs`
+  `Connectors::patch_connector_urls` — the subagent verifies both landed
 
 **Outputs:** scaffold created, superposition URLs registered + URL patching wired, build passing, files list
 

--- a/.skills/new-connector/SKILL.md
+++ b/.skills/new-connector/SKILL.md
@@ -44,6 +44,8 @@ code, run tests, or review quality yourself. Spawn subagents and coordinate thei
 | Enum definitions | `crates/common/common_enums/src/enums.rs` |
 | Domain utilities | `crates/types-traits/domain_types/src/utils.rs` |
 | Macro definitions | `crates/integrations/connector-integration/src/connectors/macros/` |
+| Superposition URLs | `config/superposition.toml` |
+| URL patching (`Connectors::apply`) | `crates/types-traits/domain_types/src/types.rs` |
 
 ## Critical Conventions
 
@@ -57,6 +59,10 @@ These rules apply to ALL subagents. Include them in every subagent prompt.
 - Check `references/utility-functions.md` before implementing custom helpers
 - No `unwrap()`, no fields hardcoded to `None`, no unnecessary `.clone()`
 - Auth data accessed via `req.connector_config` (NOT `connector_auth_type`)
+- ALWAYS register connector base URLs in `config/superposition.toml` (dimension enum + sandbox &
+  production `connector_base_url` overrides) AND add the connector to `Connectors::apply` in
+  `crates/types-traits/domain_types/src/types.rs` for dynamic URL patching. The scaffold script
+  does NOT do this — it is a mandatory manual step.
 
 ---
 
@@ -111,8 +117,11 @@ Do NOT attempt to infer API details from any other source. A tech spec is mandat
 - Sets up `create_amount_converter_wrapper!` macro
 - Implements `ConnectorCommon` trait (id, content_type, base_url, auth_header, error_response)
 - Adds required trait markers (ConnectorServiceTrait, SourceVerification, BodyDecoding)
+- Registers connector base URLs in `config/superposition.toml` (dimension enum + sandbox/production
+  overrides) and adds the URL-patching match arm in `types.rs` `Connectors::apply` (scaffold script
+  does NOT do this)
 
-**Outputs:** scaffold created, build passing, files list
+**Outputs:** scaffold created, superposition URLs registered + URL patching wired, build passing, files list
 
 **Gate:** Build must pass before proceeding.
 

--- a/.skills/new-connector/references/subagent-prompts.md
+++ b/.skills/new-connector/references/subagent-prompts.md
@@ -54,8 +54,8 @@ Output format:
 
 ## Subagent 2: Foundation Setup
 
-**Inputs**: connector_name, base_url
-**Outputs**: scaffold created, build passes, convention check results
+**Inputs**: connector_name, base_url, production_base_url
+**Outputs**: scaffold created, superposition URLs registered + URL patching wired, build passes, convention check results
 
 ```
 Set up the foundation for the {ConnectorName} connector.
@@ -95,11 +95,43 @@ Set up the foundation for the {ConnectorName} connector.
    - SourceVerification
    - BodyDecoding
 
-8. Verify: cargo build --package connector-integration
+8. Register connector base URLs in superposition + enable dynamic URL patching (MANDATORY).
+   The scaffold script does NOT do this. You MUST make BOTH edits below, or the connector
+   ships without dynamic URL patching from superposition.
+   Naming: superposition enum value / _context_ / patched.<field> use snake_case
+   ({connector_name}); ConnectorEnum::<Variant> uses PascalCase ({ConnectorName}).
+
+   a. config/superposition.toml
+      - Add "{connector_name}" to the `connector` dimension enum under [dimensions].
+      - Append override blocks at the END of the file (sandbox default + production):
+
+        # {ConnectorName}
+        [[overrides]]
+        _context_ = { connector = "{connector_name}" }
+        connector_base_url = "{sandbox_base_url}"
+
+        # {ConnectorName} Production
+        [[overrides]]
+        _context_ = { connector = "{connector_name}", environment = "production" }
+        connector_base_url = "{production_base_url}"
+
+   b. crates/types-traits/domain_types/src/types.rs  ->  Connectors::apply()
+      - Add a match arm BEFORE the `_ =>` fallback:
+
+        ConnectorEnum::{ConnectorName} => {
+            patched.{connector_name}.apply(params_patch);
+        }
+
+      - Add "{connector_name}" to the "Supported connectors:" list in the `_ =>` error message.
+
+9. Verify: cargo build --package connector-integration
 
 Output:
   STATUS: SUCCESS | FAILED
   FILES_CREATED: [list of files]
+  FILES_MODIFIED: [config/superposition.toml, crates/types-traits/domain_types/src/types.rs, ...]
+  SUPERPOSITION_URLS_REGISTERED: YES | NO
+  URL_PATCHING_WIRED: YES | NO
   BUILD: PASS | FAIL
   CONVENTION_VIOLATIONS: [none] or [list]
 ```

--- a/.skills/new-connector/references/subagent-prompts.md
+++ b/.skills/new-connector/references/subagent-prompts.md
@@ -63,6 +63,10 @@ Set up the foundation for the {ConnectorName} connector.
 1. Run the scaffold script:
    .skills/new-connector/scripts/add_connector.sh {connector_name} {base_url} --force -y
 
+   If the production base URL differs from the sandbox {base_url}, pass it too so the
+   superposition production override is correct:
+   .skills/new-connector/scripts/add_connector.sh {connector_name} {base_url} --production-url {production_base_url} --force -y
+
    If the script doesn't exist there, also check:
    grace/rulesbook/codegen/add_connector.sh
 
@@ -95,15 +99,14 @@ Set up the foundation for the {ConnectorName} connector.
    - SourceVerification
    - BodyDecoding
 
-8. Register connector base URLs in superposition + enable dynamic URL patching (MANDATORY).
-   The scaffold script does NOT do this. You MUST make BOTH edits below, or the connector
-   ships without dynamic URL patching from superposition.
+8. VERIFY superposition URL registration + dynamic URL patching (the scaffold script in step 1
+   now does BOTH of these automatically — confirm they landed; do them by hand only if missing).
    Naming: superposition enum value / _context_ / patched.<field> use snake_case
    ({connector_name}); ConnectorEnum::<Variant> uses PascalCase ({ConnectorName}).
 
    a. config/superposition.toml
-      - Add "{connector_name}" to the `connector` dimension enum under [dimensions].
-      - Append override blocks at the END of the file (sandbox default + production):
+      - "{connector_name}" is in the `connector` dimension enum under [dimensions].
+      - Override blocks exist at the END of the file (sandbox default + production):
 
         # {ConnectorName}
         [[overrides]]
@@ -115,14 +118,17 @@ Set up the foundation for the {ConnectorName} connector.
         _context_ = { connector = "{connector_name}", environment = "production" }
         connector_base_url = "{production_base_url}"
 
-   b. crates/types-traits/domain_types/src/types.rs  ->  Connectors::apply()
-      - Add a match arm BEFORE the `_ =>` fallback:
+      - If you did NOT pass --production-url, the production override reuses {base_url}; fix it if
+        the connector has a distinct live URL.
+
+   b. crates/types-traits/domain_types/src/types.rs  ->  Connectors::patch_connector_urls()
+      - A match arm exists BEFORE the `_ =>` fallback:
 
         ConnectorEnum::{ConnectorName} => {
             patched.{connector_name}.apply(params_patch);
         }
 
-      - Add "{connector_name}" to the "Supported connectors:" list in the `_ =>` error message.
+      - "{connector_name}" is in the "Supported connectors:" list in the `_ =>` error message.
 
 9. Verify: cargo build --package connector-integration
 

--- a/grace/grace-workspace/packages/core/src/checkpoints/scaffold.ts
+++ b/grace/grace-workspace/packages/core/src/checkpoints/scaffold.ts
@@ -53,31 +53,42 @@ export const scaffoldCheckpoint: Checkpoint = {
       );
     }
 
-    // Resolve baseUrl from the broadest set of locations the wizard / hand-
+    // Resolve URLs from the broadest set of locations the wizard / hand-
     // crafted task JSON might populate. Previously only the two top-level
     // fields were checked, which caused asiapay's first E2E run to silently
     // skip the scaffold step because the URL was buried in connectorDocs.
+    //
+    // NOTE on the task schema (see TaskDefinition in types.ts):
+    //   task.sandboxUrl → sandbox/test base URL
+    //   task.baseUrl    → PRODUCTION base URL
+    // add_connector.sh's positional arg is the sandbox/default base_url, and the
+    // production URL is passed via --production-url so the superposition production
+    // override (used for live-mode testing) points at the real live host.
     const spec = (task as { integrationSpec?: { baseUrl?: string; sandboxUrl?: string } })
       .integrationSpec;
     const docs = (task as { connectorDocs?: Array<{ urls?: Array<{ url?: string }> }> })
       .connectorDocs;
     const docUrls = (task as { connectorDocUrls?: string[] }).connectorDocUrls;
-    const baseUrl =
+    const productionUrl =
       task.baseUrl?.trim() ||
+      spec?.baseUrl?.trim();
+    const baseUrl =
       task.sandboxUrl?.trim() ||
-      spec?.baseUrl?.trim() ||
       spec?.sandboxUrl?.trim() ||
       docs?.[0]?.urls?.[0]?.url?.trim() ||
-      docUrls?.[0]?.trim();
+      docUrls?.[0]?.trim() ||
+      productionUrl; // last resort: reuse production so we still scaffold
     if (!baseUrl) {
       ctx.log(
-        "[scaffold] No baseUrl/sandboxUrl on task (checked task.baseUrl, " +
-          "task.sandboxUrl, integrationSpec.baseUrl/sandboxUrl, connectorDocs[0], " +
+        "[scaffold] No sandbox/base URL on task (checked task.sandboxUrl, " +
+          "task.baseUrl, integrationSpec.sandboxUrl/baseUrl, connectorDocs[0], " +
           "connectorDocUrls[0]) — skipping add_connector.sh",
         "warn",
       );
       return { passed: true, output: "no baseUrl to scaffold" };
     }
+    // Only pass --production-url when we actually have a distinct live URL.
+    const passProductionUrl = Boolean(productionUrl && productionUrl !== baseUrl);
 
     const projectRoot = task.projectRoot;
     const scriptPath = path.join(
@@ -94,8 +105,15 @@ export const scaffoldCheckpoint: Checkpoint = {
       };
     }
 
+    // <connector> <base_url> [--production-url <url>] --force -y
+    const scriptArgs = [connector, baseUrl];
+    if (passProductionUrl) {
+      scriptArgs.push("--production-url", productionUrl!);
+    }
+    scriptArgs.push("--force", "-y");
+
     ctx.log(
-      `[scaffold] Running add_connector.sh ${connector} ${baseUrl} --force -y`,
+      `[scaffold] Running add_connector.sh ${scriptArgs.join(" ")}`,
       "info"
     );
 
@@ -105,7 +123,7 @@ export const scaffoldCheckpoint: Checkpoint = {
       // surfacing only the tail at the end.
       const child = spawn(
         "bash",
-        [scriptPath, connector, baseUrl, "--force", "-y"],
+        [scriptPath, ...scriptArgs],
         { cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"] }
       );
 

--- a/grace/rulesbook/codegen/.gracerules
+++ b/grace/rulesbook/codegen/.gracerules
@@ -198,13 +198,24 @@ You are the Foundation Setup Subagent. Your ONLY responsibility is to establish 
 #### STEP 2: Tech Spec Analysis
 ```bash
 # Read tech spec from grace/rulesbook/codegen/references/{connector_name}/technical_specification.md
-# Extract connector_name and base_url
+# Extract connector_name and base_url (sandbox)
+# Extract production_base_url if the connector has a distinct live URL (optional)
 # Validate tech spec completeness
 ```
 
 #### STEP 3: Execute add_connector.sh Script
 ```bash
 # Execute: ./add_connector.sh {connector_name} {base_url} --force -y
+#
+# If the production base URL differs from the sandbox {base_url}, pass it so the
+# superposition production override is correct:
+#   ./add_connector.sh {connector_name} {base_url} --production-url {production_base_url} --force -y
+#
+# NOTE: this script also auto-registers the connector's base URLs in
+# config/superposition.toml (dimension enum + sandbox/production overrides) and wires it into
+# Connectors::patch_connector_urls in crates/types-traits/domain_types/src/types.rs for dynamic
+# URL patching. When --production-url is omitted, the production override reuses {base_url}.
+#
 # This script MUST complete successfully
 # If script fails, analyze error and fix before proceeding
 ```

--- a/grace/rulesbook/codegen/add_connector.sh
+++ b/grace/rulesbook/codegen/add_connector.sh
@@ -46,6 +46,7 @@ readonly ROUTER_DATA_FILE="$CRATES_TRAITS/domain_types/src/router_data.rs"
 readonly CONFIG_FILE="$CONFIG_DIR/development.toml"
 readonly SANDBOX_CONFIG_FILE="$CONFIG_DIR/sandbox.toml"
 readonly PRODUCTION_CONFIG_FILE="$CONFIG_DIR/production.toml"
+readonly SUPERPOSITION_CONFIG_FILE="$CONFIG_DIR/superposition.toml"
 readonly FIELD_PROBE_FILE="$CRATES_INTERNAL/field-probe/src/auth.rs"
 
 # Template files
@@ -184,6 +185,7 @@ readonly COLOR_RESET='\033[0m'
 # User inputs
 CONNECTOR_NAME=""
 BASE_URL=""
+PRODUCTION_URL=""   # Optional; defaults to BASE_URL. Used for the superposition production override.
 FORCE_MODE=false
 YES_MODE=false
 
@@ -287,9 +289,11 @@ USAGE:
 
 ARGUMENTS:
     connector_name    Name of the connector (snake_case, e.g., 'my_connector')
-    base_url         Base URL for the connector API
+    base_url         Base URL for the connector API (sandbox / default)
 
 OPTIONS:
+    --production-url URL  Production base URL for the superposition production override
+                          (defaults to base_url when omitted)
     --list-flows     Show auto-detected flows from codebase
     --force          Ignore git status and force creation
     -y, --yes        Skip confirmation prompts
@@ -303,6 +307,9 @@ EXAMPLES:
 
     # Force creation with auto-confirmation
     $0 example https://api.example.com --force -y
+
+    # Provide a distinct production URL for the superposition override
+    $0 example https://sandbox.example.com --production-url https://api.example.com
 
     # List auto-detected flows
     $0 --list-flows
@@ -393,6 +400,13 @@ parse_arguments() {
     # Parse optional arguments
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --production-url)
+                if [[ $# -lt 2 ]]; then
+                    fatal_error "--production-url requires a URL argument"
+                fi
+                PRODUCTION_URL="$2"
+                shift 2
+                ;;
             --force)
                 FORCE_MODE=true
                 shift
@@ -422,6 +436,12 @@ parse_arguments() {
                 ;;
         esac
     done
+
+    # Default the production URL to the sandbox base URL when not explicitly provided
+    # (mirrors the existing behaviour of writing BASE_URL into production.toml).
+    if [[ -z "$PRODUCTION_URL" ]]; then
+        PRODUCTION_URL="$BASE_URL"
+    fi
 
     log_debug "Arguments parsed successfully"
 }
@@ -569,6 +589,7 @@ create_backup() {
         "$CONFIG_FILE"
         "$SANDBOX_CONFIG_FILE"
         "$PRODUCTION_CONFIG_FILE"
+        "$SUPERPOSITION_CONFIG_FILE"
     )
 
     local file
@@ -861,6 +882,49 @@ open(path, "w").write(content)
 PYEOF
 
     log_success "Added $NAME_SNAKE to Connectors struct in types.rs"
+}
+
+update_domain_types_apply() {
+    log_step "Updating patch_connector_urls match arm in types.rs (dynamic URL patching)"
+
+    if grep -q "ConnectorEnum::$NAME_PASCAL =>" "$DOMAIN_TYPES_TYPES_FILE" 2>/dev/null; then
+        log_warning "Skipping patch_connector_urls update - $NAME_PASCAL already exists"
+        return 0
+    fi
+
+    python3 - "$NAME_PASCAL" "$NAME_SNAKE" "$DOMAIN_TYPES_TYPES_FILE" <<'PYEOF'
+import sys
+
+pascal = sys.argv[1]
+snake = sys.argv[2]
+path = sys.argv[3]
+content = open(path).read()
+
+# Anchor on the unique fallback error inside patch_connector_urls().
+marker = "is not supported for dynamic URL patching from superposition"
+mi = content.index(marker)
+
+# Insert the new match arm just before the `_ => {` fallback of that match.
+fb = content.rindex("_ => {", 0, mi)
+line_start = content.rindex("\n", 0, fb) + 1
+indent = content[line_start:fb]  # leading whitespace of the `_ => {` line
+arm = (
+    f"{indent}ConnectorEnum::{pascal} => {{\n"
+    f"{indent}    patched.{snake}.apply(params_patch);\n"
+    f"{indent}}}\n"
+)
+content = content[:line_start] + arm + content[line_start:]
+
+# Keep the human-readable "Supported connectors:" hint in sync.
+key = "Supported connectors: "
+ki = content.index(key)
+end = content.index('"', ki)  # closing quote of the string literal
+content = content[:end] + f", {snake}" + content[end:]
+
+open(path, "w").write(content)
+PYEOF
+
+    log_success "Added ConnectorEnum::$NAME_PASCAL arm to patch_connector_urls in types.rs"
 }
 
 update_router_data() {
@@ -1200,6 +1264,57 @@ update_config() {
     log_success "All configuration files updated"
 }
 
+update_superposition_config() {
+    log_step "Updating superposition.toml (connector dimension + base-URL overrides)"
+
+    if [[ ! -f "$SUPERPOSITION_CONFIG_FILE" ]]; then
+        log_warning "superposition.toml not found, skipping superposition update"
+        return 0
+    fi
+
+    python3 - "$NAME_SNAKE" "$NAME_PASCAL" "$BASE_URL" "$PRODUCTION_URL" "$SUPERPOSITION_CONFIG_FILE" <<'PYEOF'
+import sys
+
+snake = sys.argv[1]
+pascal = sys.argv[2]
+sandbox_url = sys.argv[3]
+prod_url = sys.argv[4]
+path = sys.argv[5]
+content = open(path).read()
+
+# 1) Add the connector to the `connector` dimension enum (idempotent).
+lines = content.splitlines(keepends=True)
+for i, line in enumerate(lines):
+    if line.lstrip().startswith("connector = {") and "enum = [" in line:
+        if f'"{snake}"' not in line:
+            idx = line.rindex("]")  # closing bracket of the enum array
+            lines[i] = line[:idx].rstrip() + f', "{snake}"' + line[idx:]
+        break
+content = "".join(lines)
+
+# 2) Append sandbox (default) + production overrides at EOF (idempotent).
+ctx = f'_context_ = {{ connector = "{snake}" }}'
+if ctx not in content:
+    prefix = "" if content.endswith("\n") else "\n"
+    content += (
+        f"{prefix}\n"
+        f"# {pascal}\n"
+        f"[[overrides]]\n"
+        f'_context_ = {{ connector = "{snake}" }}\n'
+        f'connector_base_url = "{sandbox_url}"\n'
+        f"\n"
+        f"# {pascal} Production\n"
+        f"[[overrides]]\n"
+        f'_context_ = {{ connector = "{snake}", environment = "production" }}\n'
+        f'connector_base_url = "{prod_url}"\n'
+    )
+
+open(path, "w").write(content)
+PYEOF
+
+    log_success "Registered $NAME_SNAKE in superposition.toml (enum + sandbox/production overrides)"
+}
+
 update_field_probe() {
     log_step "Updating field-probe auth.rs (ConnectorEnum match arm)"
 
@@ -1325,6 +1440,9 @@ emergency_rollback() {
                     "production.toml")
                         cp "$backup_file" "$PRODUCTION_CONFIG_FILE"
                         ;;
+                    "superposition.toml")
+                        cp "$backup_file" "$SUPERPOSITION_CONFIG_FILE"
+                        ;;
                 esac
             fi
         done
@@ -1435,12 +1553,14 @@ main() {
     update_protobuf_auth
     update_domain_types
     update_domain_types_file
+    update_domain_types_apply
     update_router_data
     update_router_data_grpc_auth
     update_connectors_module
     update_integration_types
     update_default_implementations
     update_config
+    update_superposition_config
     update_field_probe
 
     # Validate and finalize

--- a/grace/rulesbook/codegen/guides/connector_integration_guide.md
+++ b/grace/rulesbook/codegen/guides/connector_integration_guide.md
@@ -171,6 +171,52 @@ impl TryFrom<&ConnectorAuthType> for ConnectorNameAuthType {
 }
 ```
 
+#### Step 2.3: Superposition URL Registration & Dynamic URL Patching (MANDATORY)
+
+> **⚠️ The scaffold script (`add_connector.sh`) does NOT do this.** It only writes `base_url`
+> into `development/sandbox/production.toml` and updates the proto enum, `ConnectorEnum`, and
+> `ConnectorSpecificConfig`. You MUST make BOTH edits below for every new connector, otherwise the
+> connector ships without dynamic URL patching from superposition. Reference: PR
+> [juspay/hyperswitch-prism#2118](https://github.com/juspay/hyperswitch-prism/pull/2118).
+
+**Naming convention** (e.g. `twoc_twop_paco` ↔ `ConnectorEnum::TwocTwopPaco`):
+- superposition enum value, `_context_ = { connector = "..." }`, and `patched.<field>` → **snake_case** (`{connector_name}`)
+- `ConnectorEnum::<Variant>` → **PascalCase** (`{ConnectorName}`)
+
+**A. `config/superposition.toml`**
+
+1. Add `"{connector_name}"` to the `connector` dimension `enum` list under `[dimensions]`.
+2. Append override blocks at the END of the file (sandbox/default + production):
+
+```toml
+# {ConnectorName}
+[[overrides]]
+_context_ = { connector = "{connector_name}" }
+connector_base_url = "{sandbox_base_url}"
+
+# {ConnectorName} Production
+[[overrides]]
+_context_ = { connector = "{connector_name}", environment = "production" }
+connector_base_url = "{production_base_url}"
+```
+
+**B. `crates/types-traits/domain_types/src/types.rs` → `Connectors::apply()`**
+
+1. Add a match arm BEFORE the `_ =>` fallback:
+
+```rust
+ConnectorEnum::{ConnectorName} => {
+    patched.{connector_name}.apply(params_patch);
+}
+```
+
+2. Add `{connector_name}` to the "Supported connectors:" list in the `_ =>` fallback error message
+   (this list is surfaced when an unsupported connector is requested for URL patching).
+
+> Connectors with extra URL fields (e.g. TrustPay uses `ConnectorParamsWithMoreUrls`) build a
+> connector-specific patch struct instead of using `params_patch` directly — mirror the nearest
+> existing arm for such cases.
+
 ### Phase 3: Flow Implementation
 
 > **📖 Pattern Reference:** For detailed implementation patterns, see:

--- a/grace/rulesbook/codegen/guides/connector_integration_guide.md
+++ b/grace/rulesbook/codegen/guides/connector_integration_guide.md
@@ -171,22 +171,27 @@ impl TryFrom<&ConnectorAuthType> for ConnectorNameAuthType {
 }
 ```
 
-#### Step 2.3: Superposition URL Registration & Dynamic URL Patching (MANDATORY)
+#### Step 2.3: Superposition URL Registration & Dynamic URL Patching
 
-> **⚠️ The scaffold script (`add_connector.sh`) does NOT do this.** It only writes `base_url`
-> into `development/sandbox/production.toml` and updates the proto enum, `ConnectorEnum`, and
-> `ConnectorSpecificConfig`. You MUST make BOTH edits below for every new connector, otherwise the
-> connector ships without dynamic URL patching from superposition. Reference: PR
-> [juspay/hyperswitch-prism#2118](https://github.com/juspay/hyperswitch-prism/pull/2118).
+> **✅ `add_connector.sh` now does this automatically** as part of scaffolding — it registers the
+> connector in `config/superposition.toml` and wires it into `patch_connector_urls` in `types.rs`.
+> This section documents what the script produces so you can **verify** it, and how to supply a
+> distinct production URL. It became automated after being a manual step (ref PR
+> [juspay/hyperswitch-prism#2118](https://github.com/juspay/hyperswitch-prism/pull/2118)).
+
+By default the script writes the single `base_url` to both the sandbox (default) and production
+overrides. When the connector has a distinct live URL, pass it explicitly:
+
+```bash
+./add_connector.sh {connector_name} {sandbox_base_url} --production-url {production_base_url}
+```
 
 **Naming convention** (e.g. `twoc_twop_paco` ↔ `ConnectorEnum::TwocTwopPaco`):
 - superposition enum value, `_context_ = { connector = "..." }`, and `patched.<field>` → **snake_case** (`{connector_name}`)
 - `ConnectorEnum::<Variant>` → **PascalCase** (`{ConnectorName}`)
 
-**A. `config/superposition.toml`**
-
-1. Add `"{connector_name}"` to the `connector` dimension `enum` list under `[dimensions]`.
-2. Append override blocks at the END of the file (sandbox/default + production):
+**A. `config/superposition.toml`** — the script adds `"{connector_name}"` to the `connector`
+dimension `enum` under `[dimensions]` and appends override blocks at the END of the file:
 
 ```toml
 # {ConnectorName}
@@ -200,9 +205,9 @@ _context_ = { connector = "{connector_name}", environment = "production" }
 connector_base_url = "{production_base_url}"
 ```
 
-**B. `crates/types-traits/domain_types/src/types.rs` → `Connectors::apply()`**
-
-1. Add a match arm BEFORE the `_ =>` fallback:
+**B. `crates/types-traits/domain_types/src/types.rs` → `Connectors::patch_connector_urls()`** — the
+script inserts a match arm BEFORE the `_ =>` fallback and adds the name to the fallback's
+"Supported connectors:" hint:
 
 ```rust
 ConnectorEnum::{ConnectorName} => {
@@ -210,12 +215,9 @@ ConnectorEnum::{ConnectorName} => {
 }
 ```
 
-2. Add `{connector_name}` to the "Supported connectors:" list in the `_ =>` fallback error message
-   (this list is surfaced when an unsupported connector is requested for URL patching).
-
-> Connectors with extra URL fields (e.g. TrustPay uses `ConnectorParamsWithMoreUrls`) build a
-> connector-specific patch struct instead of using `params_patch` directly — mirror the nearest
-> existing arm for such cases.
+> Connectors with extra URL fields (e.g. TrustPay uses `ConnectorParamsWithMoreUrls`) need a
+> connector-specific patch struct instead of `params_patch` directly — the script emits the standard
+> arm, so adjust it by hand for such cases (mirror the nearest existing arm).
 
 ### Phase 3: Flow Implementation
 

--- a/grace/rulesbook/pr-reviewer/config/path-rules.yaml
+++ b/grace/rulesbook/pr-reviewer/config/path-rules.yaml
@@ -111,11 +111,14 @@ scenarios:
       - "new connector file plus new transformers file"
       - "new pub mod or pub use in connectors.rs"
       - "new ConnectorEnum variant or convert_connector match arm"
+      - "new connector entry in config/superposition.toml or Connectors::apply match arm"
     must_read_companion_files:
       - "crates/integrations/connector-integration/src/connectors.rs"
       - "crates/integrations/connector-integration/src/default_implementations.rs"
       - "crates/integrations/connector-integration/src/types.rs"
       - "crates/types-traits/domain_types/src/connector_types.rs"
+      - "crates/types-traits/domain_types/src/types.rs"
+      - "config/superposition.toml"
       - "data/field_probe/manifest.json"
     likely_owners:
       - "@juspay/hyperswitch-prism-connectors"

--- a/grace/rulesbook/pr-reviewer/config/rubric.yaml
+++ b/grace/rulesbook/pr-reviewer/config/rubric.yaml
@@ -106,6 +106,7 @@ scenario_checklists:
       - registration points are updated when a new connector is added
       - default implementations are updated when connector-wide optional traits need registration
       - ConnectorEnum and convert_connector stay consistent with connector registry changes
+      - connector base URLs are registered in config/superposition.toml (connector dimension enum + sandbox and production connector_base_url overrides) and the connector is wired into Connectors::apply in types.rs for dynamic URL patching
       - auth, status mapping, amount conversion, and error mapping are connector-correct
       - unsupported flows are explicit rather than silently implied
       - targeted connector tests or harness scenarios exist for the changed behavior
@@ -115,6 +116,7 @@ scenario_checklists:
       - amount or currency transformation changed without regression coverage
       - webhook verification weakened or bypassed
       - auth secrets exposed in code paths, errors, or serialized values
+      - new connector missing config/superposition.toml URL overrides or not added to Connectors::apply (silently unsupported for dynamic URL patching)
 
   core_flow:
     required:

--- a/grace/rulesbook/pr-reviewer/reviewers/connector.md
+++ b/grace/rulesbook/pr-reviewer/reviewers/connector.md
@@ -37,6 +37,8 @@ For new connectors or shared plumbing changes, read and compare:
 - `crates/integrations/connector-integration/src/default_implementations.rs`
 - `crates/integrations/connector-integration/src/types.rs`
 - `crates/types-traits/domain_types/src/connector_types.rs`
+- `config/superposition.toml` (connector dimension `enum` + base-URL overrides)
+- `crates/types-traits/domain_types/src/types.rs` (`Connectors::apply` dynamic URL patching)
 
 When payment methods change, also read:
 
@@ -52,6 +54,9 @@ When webhook or source verification changes, also read:
 
 - connector registration is complete and consistent
 - `ConnectorEnum`, module exports, and `convert_connector` stay aligned
+- connector base URLs are registered in `config/superposition.toml` (connector dimension `enum` +
+  sandbox & production `connector_base_url` overrides) and the connector is wired into
+  `Connectors::apply` in `types.rs` for dynamic URL patching (added to the match, not left to `_ =>`)
 - default trait implementations are updated when a new connector needs them
 - auth headers, signatures, and request signing are connector-correct
 - URLs, methods, headers, and body encodings match the connector behavior being claimed
@@ -70,6 +75,8 @@ When webhook or source verification changes, also read:
 - auth material exposed in errors, logs, or serialized values
 - webhook verification bypassed or made optional without a strong reason
 - new connector added without all registration points updated
+- new connector missing `config/superposition.toml` URL overrides or not added to
+  `Connectors::apply` (silently unsupported for dynamic URL patching)
 - payment method support claimed in code or docs but absent in tests/specs
 
 ## Output Format

--- a/grace/rulesbook/pr-reviewer/subagents/connector-new-integration.md
+++ b/grace/rulesbook/pr-reviewer/subagents/connector-new-integration.md
@@ -13,6 +13,7 @@ Review a PR classified as `connector-new-integration`.
 - registration in `connectors.rs`
 - companion updates in `default_implementations.rs`, `types.rs`, and `ConnectorEnum` plumbing
 - connector-specific auth, URLs, status mapping, and error mapping
+- superposition URL registration (`config/superposition.toml`) and dynamic URL patching (`types.rs`)
 - proof that the PR is truly connector-scoped
 
 ## Extra Checks
@@ -21,6 +22,13 @@ Review a PR classified as `connector-new-integration`.
 - connector naming is consistent across files and branch/title when applicable
 - unsupported flows are explicit
 - no copied provider logic survives with wrong endpoints or semantics
+- **superposition URLs registered**: `config/superposition.toml` adds the connector to the
+  `connector` dimension `enum` AND has `connector_base_url` override blocks for sandbox (default)
+  and production
+- **dynamic URL patching wired**: `crates/types-traits/domain_types/src/types.rs` `Connectors::apply()`
+  has a `ConnectorEnum::<Variant>` match arm (not left to the `_ =>` fallback) and the connector is
+  added to the fallback "Supported connectors:" list. Flag a new connector that skips either edit —
+  it silently ships without dynamic URL patching. Reference: PR #2118.
 
 ## Output
 


### PR DESCRIPTION
## Description

Adds a **codegen rule** (GRACE / `new-connector` skill) and a **review point** (`pr-reviewer` skill) so every new connector always:

1. Registers its base URLs in `config/superposition.toml` — the `connector` dimension `enum` **and** `connector_base_url` `[[overrides]]` for sandbox (default) + production.
2. Is wired into `Connectors::apply` in `crates/types-traits/domain_types/src/types.rs` for **dynamic URL patching** (a `ConnectorEnum::<Variant>` match arm + the connector added to the `_ =>` fallback "Supported connectors" list).

## Motivation and Context

The scaffold script `add_connector.sh` writes `base_url` into `development/sandbox/production.toml` and updates the proto/`ConnectorEnum`/`ConnectorSpecificConfig`, but it does **not** touch `superposition.toml` or `types.rs::apply`. Those two edits were manual and easy to forget, so connectors could ship without dynamic URL patching. This was done by hand in juspay/hyperswitch-prism#2118 (grabpay, maya) — this PR turns that manual step into a documented rule and a reviewer check.

## Changes

**Codegen rule**
- `.skills/new-connector/references/subagent-prompts.md` — new Foundation (Subagent 2) step performing both edits, with snake_case/PascalCase naming note + new output fields.
- `.skills/new-connector/SKILL.md` — project-structure rows, a Critical Convention, and a Step 2 bullet.
- `grace/rulesbook/codegen/guides/connector_integration_guide.md` — new **Step 2.3: Superposition URL Registration & Dynamic URL Patching** with full snippets.

**Review point**
- `grace/rulesbook/pr-reviewer/subagents/connector-new-integration.md` — Focus + Extra Checks.
- `grace/rulesbook/pr-reviewer/reviewers/connector.md` — companion cross-checks, checklist item, red flag.
- `grace/rulesbook/pr-reviewer/config/rubric.yaml` — required checklist item + red flag.
- `grace/rulesbook/pr-reviewer/config/path-rules.yaml` — `superposition.toml` + `types.rs` companion files + diff signal.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

Docs/rules only — no Rust or runtime behavior changes.

## How did you test it?

- `grep` confirms the rule is present in all 3 codegen docs and all 4 pr-reviewer files.
- Both YAML configs parse cleanly (`yaml.safe_load`).
- Snippets verified against the real patterns in `config/superposition.toml` and `types.rs::apply` (casing + override block shape).