### PR TITLE
fix(core): allow Authorize without payment_method on the 3DS return leg

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -889,14 +889,25 @@ impl PaymentService for Payments {
                 // Convert proto request to intermediate type
                 let payload: AuthorizationRequest = proto_payload.clone().into();
 
-                let payment_method_data_action = PaymentMethodDataAction::get_payment_method_data_action(proto_payload.payment_method.clone().ok_or(ucs_env::error::GrpcError::from(IntegrationError::MissingRequiredField { field_name: "payment_method", context: domain_types::errors::IntegrationErrorContext::default() }))?)
-                    .map_err(|err| {
-                        tracing::error!("PAYMENT_AUTHORIZE_FLOW: failed to get payment method data action - error: {:?}", err);
-                        ucs_env::error::GrpcError::from(IntegrationError::InvalidDataFormat { field_name: "payment_method", context: domain_types::errors::IntegrationErrorContext::default() })
-                    })?;
+                // `payment_method` is required for an ordinary authorization, but not for the
+                // second leg of a redirect-based one: connectors that finalise 3DS through
+                // Authorize are re-invoked after the ACS posts back to `TermUrl`, and the
+                // caller no longer holds the raw instrument at that point. That leg is
+                // identified by `redirection_response`, exactly as the connectors themselves
+                // identify it (`request.redirect_response.is_some()`), and it is the only case
+                // in which an absent `payment_method` is accepted.
+                let payment_method_data_action = match proto_payload.payment_method.clone() {
+                    Some(payment_method) => Some(PaymentMethodDataAction::get_payment_method_data_action(payment_method)
+                        .map_err(|err| {
+                            tracing::error!("PAYMENT_AUTHORIZE_FLOW: failed to get payment method data action - error: {:?}", err);
+                            ucs_env::error::GrpcError::from(IntegrationError::InvalidDataFormat { field_name: "payment_method", context: domain_types::errors::IntegrationErrorContext::default() })
+                        })?),
+                    None if proto_payload.redirection_response.is_some() => None,
+                    None => Err(ucs_env::error::GrpcError::from(IntegrationError::MissingRequiredField { field_name: "payment_method", context: domain_types::errors::IntegrationErrorContext::default() }))?,
+                };
 
                 let authorize_response = match payment_method_data_action {
-                    PaymentMethodDataAction::CardProxy(proxy_card_details) => {
+                    Some(PaymentMethodDataAction::CardProxy(proxy_card_details)) => {
                         let token_data = proxy_card_details.to_token_data();
                         let payment_method_data = payment_method_data::PaymentMethodData::Card(payment_method_data::Card::<VaultTokenHolder>::foreign_try_from(proxy_card_details).map_err(|err| {
                             tracing::error!("PAYMENT_AUTHORIZE_FLOW: failed to get payment method data action - error: {:?}", err);
@@ -917,7 +928,7 @@ impl PaymentService for Payments {
                         ))
                         .await?
                     }
-                    PaymentMethodDataAction::Card(card_details) => {
+                    Some(PaymentMethodDataAction::Card(card_details)) => {
                         tracing::info!("REGULAR: Processing regular payment authorization (no injector)");
                         let payment_method_data = payment_method_data::PaymentMethodData::Card(payment_method_data::Card::<DefaultPCIHolder>::foreign_try_from(card_details).map_err(|err| {
                             tracing::error!("PAYMENT_AUTHORIZE_FLOW: failed to get payment method data action - error: {:?}", err);
@@ -938,7 +949,7 @@ impl PaymentService for Payments {
                         ))
                         .await?
                     }
-                    PaymentMethodDataAction::Default => {
+                    Some(PaymentMethodDataAction::Default) => {
                         let payment_method_data = payment_method_data::PaymentMethodData::convert_to_domain_model_for_non_card_payment_methods(proto_payload.payment_method.clone().ok_or(ucs_env::error::GrpcError::from(IntegrationError::MissingRequiredField { field_name: "payment_method", context: domain_types::errors::IntegrationErrorContext::default() }))?)
                             .map_err(|err| {
                                 tracing::error!("Failed to convert payment method data: {:?}", err);
@@ -959,7 +970,7 @@ impl PaymentService for Payments {
                         ))
                         .await?
                     }
-                    PaymentMethodDataAction::CardWithNoCvc(card_details) => {
+                    Some(PaymentMethodDataAction::CardWithNoCvc(card_details)) => {
                         tracing::info!("REGULAR: Processing payment authorization with CardWithNoCvc");
                         let payment_method_data = payment_method_data::PaymentMethodData::CardWithNoCvc(
                             payment_method_data::CardWithNoCvc::foreign_try_from(card_details).map_err(|err| {
@@ -978,6 +989,27 @@ impl PaymentService for Payments {
                             &metadata_payload.request_id,
                             None,
                             payment_method_data,
+                        ))
+                        .await?
+                    }
+                    // Redirect-return leg: no instrument was sent (guarded above by
+                    // `redirection_response` being present). The connector finalises from the
+                    // redirect payload and its own transaction reference; connectors that
+                    // cannot do so reject `NoInstrumentAfterRedirect` rather than mistaking it
+                    // for a payable instrument.
+                    None => {
+                        tracing::info!("REDIRECT_COMPLETION: authorization re-entered after redirect without payment method data");
+                        Box::pin(self.process_authorization_internal::<DefaultPCIHolder>(
+                            &config,
+                            payload,
+                            metadata_payload.connector.clone(),
+                            metadata_payload.connector_config.clone(),
+                            metadata,
+                            &metadata_payload,
+                            &service_name,
+                            &metadata_payload.request_id,
+                            None,
+                            payment_method_data::PaymentMethodData::NoInstrumentAfterRedirect,
                         ))
                         .await?
                     }

--- a/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci/transformers.rs
@@ -762,7 +762,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Aci"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -3905,11 +3905,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
                 | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
                 | PaymentMethodData::CardWithNoCvc(_)
-                | PaymentMethodData::MobilePayment(_) => Err(IntegrationError::NotImplemented(
-                    ("payment method").into(),
-                    Default::default(),
-                )
-                .into()),
+                | PaymentMethodData::MobilePayment(_)
+                | PaymentMethodData::NoInstrumentAfterRedirect => Err(
+                    IntegrationError::NotImplemented(("payment method").into(), Default::default())
+                        .into(),
+                ),
             },
         }
     }
@@ -6525,7 +6525,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 | PaymentMethodData::NetworkToken(_)
                 | PaymentMethodData::CardWithNoCvc(_)
                 | PaymentMethodData::MobilePayment(_)
-                | PaymentMethodData::PaymentMethodToken(_) => Err(
+                | PaymentMethodData::PaymentMethodToken(_)
+                | PaymentMethodData::NoInstrumentAfterRedirect => Err(
                     IntegrationError::NotImplemented(("payment method").into(), Default::default())
                         .into(),
                 ),

--- a/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bambora/transformers.rs
@@ -298,7 +298,8 @@ impl<T: PaymentMethodDataTypes>
             | PaymentMethodData::MobilePayment(_)
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 return Err(IntegrationError::NotSupported {
                     message: "Selected payment method".to_string(),
                     connector: "bambora",

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica/transformers.rs
@@ -767,7 +767,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     domain_types::utils::get_unimplemented_payment_method_error_message(
                         "Bank of America",
@@ -2061,7 +2062,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("BankOfAmerica"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -157,6 +157,7 @@ fn payment_method_data_label<T: PaymentMethodDataTypes>(
         PaymentMethodData::NetworkToken(_) => "network_token",
         PaymentMethodData::CardWithNoCvc(_) => "card_with_no_cvc",
         PaymentMethodData::MobilePayment(_) => "mobile_payment",
+        PaymentMethodData::NoInstrumentAfterRedirect => "no_instrument_after_redirect",
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -240,7 +240,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("billwerk"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree/transformers.rs
@@ -633,7 +633,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("braintree"),
                     connector: "Braintree",
@@ -1647,7 +1648,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("braintree"),
                     connector: "Braintree",
@@ -2684,7 +2686,8 @@ fn get_braintree_redirect_form<
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 return Err(ConnectorError::unexpected_response_error_http_status_unknown().into());
             }
         },
@@ -3014,7 +3017,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("braintree"),
                     connector: "Braintree",
@@ -3375,7 +3379,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("braintree"),
                     connector: "Braintree",

--- a/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
@@ -111,7 +111,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: get_unimplemented_payment_method_error_message("CryptoPay"),
                     connector: "Cryptopay",

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -347,7 +347,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 | PaymentMethodData::PaymentMethodToken(_)
                 | PaymentMethodData::NetworkToken(_)
                 | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-                | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+                | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+                | PaymentMethodData::NoInstrumentAfterRedirect => {
                     Err(error_stack::report!(IntegrationError::NotSupported {
                         message:
                             domain_types::utils::get_unimplemented_payment_method_error_message(
@@ -2604,7 +2605,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::Voucher(_)
             | PaymentMethodData::GiftCard(_)
             | PaymentMethodData::OpenBanking(_)
-            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: domain_types::utils::get_unimplemented_payment_method_error_message(
                         "Cybersource",
@@ -2710,7 +2712,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Cybersource"),
                     connector: "Cybersource",
@@ -3747,7 +3750,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Cybersource"),
                     Default::default(),
@@ -4036,7 +4040,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Cybersource"),
                     Default::default(),
@@ -5138,7 +5143,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 | PaymentMethodData::GiftCard(_)
                 | PaymentMethodData::OpenBanking(_)
                 | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-                | PaymentMethodData::PaymentMethodToken(_) => {
+                | PaymentMethodData::PaymentMethodToken(_)
+                | PaymentMethodData::NoInstrumentAfterRedirect => {
                     Err(IntegrationError::NotImplemented(
                         utils::get_unimplemented_payment_method_error_message("Cybersource"),
                         Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/datatrans/transformers.rs
@@ -789,7 +789,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::CardWithNoCvc(_)
             | PaymentMethodData::MobilePayment(_)
             | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     UNSUPPORTED_PAYMENT_METHOD_ERROR.to_string(),
                     datatrans_context(

--- a/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal/transformers.rs
@@ -454,7 +454,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     crate::utils::get_unimplemented_payment_method_error_message("Dlocal"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv/transformers.rs
@@ -549,7 +549,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("fiserv"),
                     Default::default()

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -691,7 +691,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("fiuu"),
                     Default::default(),
@@ -1062,7 +1063,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("fiuu"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/forte/transformers.rs
@@ -352,7 +352,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(utils::get_unimplemented_payment_method_error_message("Forte") , Default::default()))?
             }
         }

--- a/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/givepayments/transformers.rs
@@ -447,7 +447,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::MobilePayment(_)
             | PaymentMethodData::PaymentMethodToken(_)
-            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(errors::IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Givepayments"),
                     errors::IntegrationErrorContext {

--- a/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay/transformers.rs
@@ -598,7 +598,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     "Payment method not supported for tokenization".to_string(),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -632,7 +632,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::CardWithNoCvc(_)
             | PaymentMethodData::MobilePayment(_)
             | PaymentMethodData::PaymentMethodToken(_)
-            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(errors::IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Imerchantsolutions"),
                     errors::IntegrationErrorContext {

--- a/crates/integrations/connector-integration/src/connectors/loonio/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/loonio/transformers.rs
@@ -250,10 +250,13 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardWithNoCvc(_)
-            | PaymentMethodData::MobilePayment(_) => Err(IntegrationError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("Loonio"),
-                Default::default(),
-            ))?,
+            | PaymentMethodData::MobilePayment(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
+                Err(IntegrationError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Loonio"),
+                    Default::default(),
+                ))?
+            }
         }
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/mifinity/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/mifinity/transformers.rs
@@ -260,7 +260,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Mifinity"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -174,13 +174,12 @@ fn get_order_type_from_payment_method<T: PaymentMethodDataTypes>(
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::NetworkToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
-            Err(IntegrationError::NotImplemented(
-                crate::utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                Default::default(),
-            ))
-            .attach_printable("Payment method not supported")?
-        }
+        | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+        | PaymentMethodData::NoInstrumentAfterRedirect => Err(IntegrationError::NotImplemented(
+            crate::utils::get_unimplemented_payment_method_error_message("multisafepay"),
+            Default::default(),
+        ))
+        .attach_printable("Payment method not supported")?,
     };
 
     Ok(payment_type)
@@ -374,13 +373,12 @@ fn get_gateway_from_payment_method<T: PaymentMethodDataTypes>(
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::NetworkToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
-            Err(IntegrationError::NotImplemented(
-                crate::utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                Default::default(),
-            ))
-            .attach_printable("Payment method not supported")?
-        }
+        | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+        | PaymentMethodData::NoInstrumentAfterRedirect => Err(IntegrationError::NotImplemented(
+            crate::utils::get_unimplemented_payment_method_error_message("multisafepay"),
+            Default::default(),
+        ))
+        .attach_printable("Payment method not supported")?,
     };
 
     Ok(gateway)

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -774,12 +774,11 @@ fn get_payment_details_and_product<
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::NetworkToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
-            Err(IntegrationError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("nexinets"),
-                Default::default(),
-            ))?
-        }
+        | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+        | PaymentMethodData::NoInstrumentAfterRedirect => Err(IntegrationError::NotImplemented(
+            utils::get_unimplemented_payment_method_error_message("nexinets"),
+            Default::default(),
+        ))?,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -392,7 +392,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Noon"),
                     connector: "Noon",
@@ -1313,7 +1314,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     | PaymentMethodData::PaymentMethodToken(_)
                     | PaymentMethodData::NetworkToken(_)
                     | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-                    | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+                    | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+                    | PaymentMethodData::NoInstrumentAfterRedirect => {
                         Err(error_stack::report!(IntegrationError::NotSupported {
                             message: utils::get_unimplemented_payment_method_error_message("Noon"),
                             connector: "Noon",

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -1654,7 +1654,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Paypal"),
                     connector: "Paypal",
@@ -3212,7 +3213,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardWithNoCvc(_)
-            | PaymentMethodData::MobilePayment(_) => {
+            | PaymentMethodData::MobilePayment(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Paypal"),
                     connector: "Paypal",

--- a/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/placetopay/transformers.rs
@@ -211,7 +211,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Placetopay"),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
@@ -574,7 +574,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 | PaymentMethodData::NetworkToken(_)
                 | PaymentMethodData::CardWithNoCvc(_)
                 | PaymentMethodData::MobilePayment(_)
-                | PaymentMethodData::OpenBanking(_)) => {
+                | PaymentMethodData::OpenBanking(_)
+                | PaymentMethodData::NoInstrumentAfterRedirect) => {
                     return Err(IntegrationError::NotImplemented(
                         format!("Payment Method {pm:?} not supported for Razorpay"),
                         Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -287,6 +287,7 @@ where
             | Some(PaymentMethodData::CardDetailsForNetworkTransactionId(_))
             | Some(PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_))
             | Some(PaymentMethodData::CardWithNoCvc(_))
+            | Some(PaymentMethodData::NoInstrumentAfterRedirect)
             | None => Err(IntegrationError::NotImplemented(
                 domain_types::utils::get_unimplemented_payment_method_error_message("redsys"),
                 Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/sanlam_common/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/sanlam_common/transformers.rs
@@ -278,7 +278,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: get_unimplemented_payment_method_error_message("AbsaSanlam"),
                     connector: "AbsaSanlam",

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -1109,7 +1109,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     "Only card and ACH bank debit tokenization are supported for Stax".to_string(),
                     Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -1606,13 +1606,12 @@ fn create_stripe_payment_method<
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::NetworkToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
-            Err(IntegrationError::NotImplemented(
-                get_unimplemented_payment_method_error_message("stripe"),
-                Default::default(),
-            )
-            .into())
-        }
+        | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+        | PaymentMethodData::NoInstrumentAfterRedirect => Err(IntegrationError::NotImplemented(
+            get_unimplemented_payment_method_error_message("stripe"),
+            Default::default(),
+        )
+        .into()),
     }
 }
 
@@ -5224,7 +5223,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(IntegrationError::NotImplemented(
                     get_unimplemented_payment_method_error_message("stripe"),
                     Default::default(),
@@ -5623,6 +5623,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(
                             _,
                         )
+                        | PaymentMethodData::NoInstrumentAfterRedirect
                         | PaymentMethodData::Card(_) => Err(IntegrationError::NotImplemented(
                             "Network tokenization for payment method".to_string(),
                             Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly/transformers.rs
@@ -426,7 +426,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardWithNoCvc(_)
-            | PaymentMethodData::MobilePayment(_) => Err(error_stack::report!(
+            | PaymentMethodData::MobilePayment(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => Err(error_stack::report!(
                 errors::IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Trustly"),
                     connector: "Trustly",

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -1840,7 +1840,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("trustpay"),
                     connector: "trustpay",

--- a/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/volt/transformers.rs
@@ -300,7 +300,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             | PaymentMethodData::PaymentMethodToken(_)
             | PaymentMethodData::NetworkToken(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-            | PaymentMethodData::CardDetailsForNetworkTransactionId(_) => {
+            | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
                 Err(error_stack::report!(IntegrationError::NotSupported {
                     message: utils::get_unimplemented_payment_method_error_message("Volt"),
                     connector: "Volt",

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo/transformers.rs
@@ -621,11 +621,14 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             | PaymentMethodData::OpenBanking(_)
             | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
             | PaymentMethodData::CardWithNoCvc(_)
-            | PaymentMethodData::MobilePayment(_) => Err(IntegrationError::NotSupported {
-                message: "Payment method".to_string(),
-                connector: "Wellsfargo",
-                context: Default::default(),
-            })?,
+            | PaymentMethodData::MobilePayment(_)
+            | PaymentMethodData::NoInstrumentAfterRedirect => {
+                Err(IntegrationError::NotSupported {
+                    message: "Payment method".to_string(),
+                    connector: "Wellsfargo",
+                    context: Default::default(),
+                })?
+            }
         };
 
         // Get amount and currency - amount is in minor units (cents)

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -260,7 +260,8 @@ fn fetch_payment_instrument<
         | PaymentMethodData::OpenBanking(_)
         | PaymentMethodData::PaymentMethodToken(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)
-        | PaymentMethodData::NetworkToken(_) => Err(IntegrationError::NotImplemented(utils::get_unimplemented_payment_method_error_message("worldpay") , Default::default())
+        | PaymentMethodData::NetworkToken(_)
+        | PaymentMethodData::NoInstrumentAfterRedirect => Err(IntegrationError::NotImplemented(utils::get_unimplemented_payment_method_error_message("worldpay") , Default::default())
         .into())
 }
 }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -4056,6 +4056,7 @@ impl<T: PaymentMethodDataTypes> From<PaymentMethodData<T>> for PaymentMethodData
         match pm_data {
             PaymentMethodData::Card(_) => Self::Card,
             PaymentMethodData::CardWithNoCvc(_) => Self::CardWithNoCvc,
+            PaymentMethodData::NoInstrumentAfterRedirect => Self::NoInstrumentAfterRedirect,
             PaymentMethodData::CardRedirect(card_redirect_data) => match card_redirect_data {
                 payment_method_data::CardRedirectData::Knet {} => Self::Knet,
                 payment_method_data::CardRedirectData::Benefit {} => Self::Benefit,

--- a/crates/types-traits/domain_types/src/payment_method_data.rs
+++ b/crates/types-traits/domain_types/src/payment_method_data.rs
@@ -383,6 +383,17 @@ pub enum PaymentMethodData<T: PaymentMethodDataTypes> {
     OpenBanking(OpenBankingData),
     NetworkToken(NetworkTokenData),
     MobilePayment(MobilePaymentData),
+    /// No raw payment instrument accompanies this request.
+    ///
+    /// Emitted only for the second leg of a redirect-based authorization (e.g. the 3DS
+    /// return leg): the customer has come back from the ACS/hosted page and the caller no
+    /// longer holds the card or wallet details, so the connector must finalise the payment
+    /// from the redirect payload plus its own transaction reference instead.
+    ///
+    /// A connector that cannot finalise without an instrument should reject this variant
+    /// (the usual `_ => NotImplemented` arm already does), never treat it as a fallback for
+    /// an ordinary authorization.
+    NoInstrumentAfterRedirect,
 }
 
 impl<T: PaymentMethodDataTypes> PaymentMethodData<T> {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -4487,6 +4487,28 @@ impl<
             )?),
         };
 
+        // The redirect-return leg of an authorization carries no instrument, so there is no
+        // payment method type to derive from it. Every other authorization still requires one.
+        let payment_method_type = match value.payment_method.clone() {
+            Some(payment_method) => <Option<PaymentMethodType>>::foreign_try_from(payment_method)?,
+            None if matches!(
+                payment_method_data,
+                PaymentMethodData::NoInstrumentAfterRedirect
+            ) =>
+            {
+                None
+            }
+            None => {
+                return Err(report!(IntegrationError::InvalidDataFormat {
+                    field_name: "unknown",
+                    context: IntegrationErrorContext {
+                        additional_context: Some("Payment method data is required".to_string()),
+                        ..Default::default()
+                    },
+                }));
+            }
+        };
+
         Ok(Self {
             authentication_data,
             capture_method: Some(CaptureMethod::foreign_try_from(value.capture_method)?),
@@ -4501,17 +4523,7 @@ impl<
                 .cloned()
                 .map(BrowserInformation::foreign_try_from)
                 .transpose()?,
-            payment_method_type: <Option<PaymentMethodType>>::foreign_try_from(
-                value.payment_method.clone().ok_or_else(|| {
-                    IntegrationError::InvalidDataFormat {
-                        field_name: "unknown",
-                        context: IntegrationErrorContext {
-                            additional_context: Some("Payment method data is required".to_string()),
-                            ..Default::default()
-                        },
-                    }
-                })?,
-            )?,
+            payment_method_type,
             minor_amount: common_utils::types::MinorUnit::new(amount.minor_amount),
             email,
             customer_document_details,
@@ -13188,6 +13200,9 @@ pub enum PaymentMethodDataType {
     QwikcilverWalletDirect,
     Skrill,
     CardWithNoCvc,
+    /// Companion of [`PaymentMethodData::NoInstrumentAfterRedirect`]: the redirect-return leg
+    /// carries no instrument, so it matches no mandate-capable payment method data type.
+    NoInstrumentAfterRedirect,
 }
 
 impl ForeignTryFrom<String> for Secret<time::Date> {


### PR DESCRIPTION
## Problem

`PaymentService::authorize` required `payment_method` unconditionally:

```rust
proto_payload.payment_method.clone().ok_or(MissingRequiredField { field_name: "payment_method" })?
```

Connectors that finalise 3-D Secure **through the Authorize flow** — Ilixium, NMI, Airwallex,
Nexixpay and others that key off `request.redirect_response.is_some()` — are re-invoked after
the ACS posts back to `TermUrl`. At that point the caller no longer holds the raw instrument, so
Hyperswitch sends `payment_method_data: None` and omits the proto field (it is optional in both
the proto and Hyperswitch's `CompleteAuthorizeData`).

UCS therefore rejected the completion call with `InvalidArgument: Missing required field:
payment_method` **before any connector code ran**, making 3DS completion impossible for every
connector that uses this pattern.

## Fix

`payment_method` is now required only when the call is *not* a redirect-return leg. The leg is
identified by `redirection_response`, the same signal the connectors themselves already use.
A plain authorize with no `payment_method` is still rejected exactly as before.

`PaymentsAuthorizeData::payment_method_data` is not optional, so the absent instrument is
modelled explicitly as a new `PaymentMethodData::NoInstrumentAfterRedirect` variant rather than
substituted with a default (e.g. `MandatePayment`) that a connector could mistake for a payable
instrument.

Adding the variant is compiler-enforced: all 51 existing matches on `PaymentMethodData` now
handle it through their **existing unsupported-payment-method rejection arm**, so no connector's
behaviour changes and a connector that later wants to accept this leg has to opt in deliberately.
That accounts for the file count — the connector diffs are one added pattern alternative each.

`PaymentsAuthorizeData::foreign_try_from` derived `payment_method_type` from the same field and
had the same unconditional gate; it now returns `None` for the instrument-less leg only (matched
on `NoInstrumentAfterRedirect`), and errors as before otherwise.

## Verification

Driven end to end against a mock Ilixium server (Hyperswitch → UCS → mock):

- **3DS**: `POST /payments` → `requires_customer_action` → ACS challenge → complete-authorize →
  mock received `POST /platform/ili/direct/threedcomplete` (merchant digest verified) → HS
  payment status `succeeded`. This call was rejected with `InvalidArgument` before the fix.
- **Direct gRPC**: `PaymentService/Authorize` with `payment_method` omitted and
  `redirection_response` present now reaches the connector and returns `CHARGED`.
- **No-3DS regression**: unchanged, payment `succeeded`.
- **Validation preserved**: `Authorize` with no `payment_method` and no `redirection_response`
  still fails with `InvalidArgument: Missing required field: payment_method`.

`cargo check --workspace --all-targets`, `cargo fmt --all` and `cargo clippy` on the touched
crates are clean.

## Context

Found while integrating the Ilixium connector (#2125). Raised separately because it is a
core-flow change that unblocks 3DS completion for every UCS connector using this pattern, not
just Ilixium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
