### PR TITLE
fix(framework): Add Gcash to PaymentMethodType to PaymentMethod Mapping

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8742,6 +8742,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodType> for PaymentMeth
             grpc_api_types::payments::PaymentMethodType::QwikcilverWallet => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::Skrill => Ok(Self::Wallet),
             grpc_api_types::payments::PaymentMethodType::GrabPay => Ok(Self::Wallet),
+            grpc_api_types::payments::PaymentMethodType::Gcash => Ok(Self::Wallet),
 
             grpc_api_types::payments::PaymentMethodType::UpiCollect => Ok(Self::Upi),
             grpc_api_types::payments::PaymentMethodType::UpiIntent => Ok(Self::Upi),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add Gcash to PaymentMethodType to PaymentMethod Mapping

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Earlier the refunds were failing with the below error : Invalid data format: payment_method_type. This payment method type cannot be mapped to a high-level category

This is because of missing mapping of Gcash.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Complete a payment
2. Refund for Dlocal (Gcash): 

Request:

```

curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_VZiFyyIr3ysG38QSE8tKkXmPHvUqb9AenOZ7PKroSyqpkLjk5JLBg1nBl9jfjfO2' \
--data '{
    "payment_id": "pay_j6qwv1u44BlSkKErSjRQ",
    "amount": 100,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "all_keys_required": true
}'

```

Response:

```

{
    "refund_id": "ref_svnoMiBlAMcIEG1Vu6hU",
    "payment_id": "pay_j6qwv1u44BlSkKErSjRQ",
    "amount": 100,
    "currency": "PHP",
    "status": "failed",
    "reason": "Customer returned product",
    "metadata": null,
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2026-08-14T08:00:21.220Z",
    "updated_at": "2026-08-14T08:00:21.959Z",
    "connector": "dlocal",
    "profile_id": "pro_J9UurJpIif1UKKGQt1gD",
    "merchant_connector_id": "mca_jdk57GPxewi8t3eRmtxD",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "raw_connector_response": null,
    "connector_refund_id": "REF-1454629-x1l7tiol-248blo00n17pd2-4d4satcjgrvc"
}

```

This resulted in failure because of issue at connectors end. Have raised it with dlocal team