### PR TITLE
feat(config): use Superposition local provider with file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,222 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding 2.3.2",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding 2.3.2",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time 0.3.55",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +850,16 @@ name = "base64-serde"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c6d128af408d8ebd08331f0331cf2cf20d19e6c44a7aec58791641ecc8c0b5"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -926,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bytestring"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1845,6 +2090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,12 +2423,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg 1.5.0",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3367,7 +3642,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serial_test",
- "superposition_core",
  "tempfile",
  "thiserror 1.0.69",
  "time 0.3.55",
@@ -3736,6 +4010,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
+ "log 0.4.29",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3751,6 +4026,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4105,6 +4381,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,6 +4744,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,6 +5066,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "modifier"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,6 +5237,33 @@ name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log 0.4.29",
+ "mio 1.1.1",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5090,6 +5459,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
+name = "open-feature"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1ef07989b00b697d9e597e66509e2b0e7a1c889d8925fffe5408703215d72b"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "log 0.4.29",
+ "mockall",
+ "time 0.3.55",
+ "tokio",
+ "typed-builder",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5233,6 +5617,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -5635,6 +6025,32 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -6611,12 +7027,25 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6654,6 +7083,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7346,8 +7776,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superposition_core"
-version = "0.101.0"
-source = "git+https://github.com/juspay/superposition?branch=main#89d64d28ce250020af4495560ce825510a61f07c"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e780565fc6f86d37dd034461f78bb3759d4aa0c622cc6dc5960a6e40b1660caa"
 dependencies = [
  "bigdecimal",
  "blake3",
@@ -7366,8 +7797,9 @@ dependencies = [
 
 [[package]]
 name = "superposition_derives"
-version = "0.101.0"
-source = "git+https://github.com/juspay/superposition?branch=main#89d64d28ce250020af4495560ce825510a61f07c"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e794835b098ec8677f2004b7252cdf3ea73c110e1b28afbd99ac9092657b46d0"
 dependencies = [
  "proc-macro-crate",
  "quote",
@@ -7375,9 +7807,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "superposition_provider"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b877bf8fa5882cd96775d7f587834ccde3d219f50df7819abddc2510001981"
+dependencies = [
+ "async-trait",
+ "aws-smithy-types",
+ "chrono",
+ "derive_more 0.99.20",
+ "log 0.4.29",
+ "notify",
+ "open-feature",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "superposition_core",
+ "superposition_sdk",
+ "superposition_types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
+name = "superposition_sdk"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c898b9823da19b0bd226510cb81416214d0d9087cadd9ef4f59c853b2b38e14"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "tracing",
+]
+
+[[package]]
 name = "superposition_types"
-version = "0.101.0"
-source = "git+https://github.com/juspay/superposition?branch=main#89d64d28ce250020af4495560ce825510a61f07c"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3372446c445a958859c6eda19f25f888d50d3c9f00427591ef032ffd64af89f"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -7607,6 +8083,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -8265,6 +8747,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8352,8 +8854,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "strum 0.26.3",
- "superposition_core",
- "superposition_types",
+ "superposition_provider",
  "thiserror 1.0.69",
  "time 0.3.55",
  "tonic 0.14.5",
@@ -8842,6 +9343,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-resolver = "2"
+exclude = [
+  "examples/example-rs",
+  "examples/example-tui",
+  "examples/example-cli",
+]
 members = [
   "crates/types-traits/grpc-api-types",
   "crates/integrations/connector-integration",
@@ -23,19 +27,14 @@ members = [
   "crates/ffi/ffi",
   "crates/internal/uniffi-bindgen",
   "crates/internal/field-probe",
-  "crates/internal/integration-tests"
+  "crates/internal/integration-tests",
 ]
-exclude = [
-  "examples/example-rs",
-  "examples/example-tui",
-  "examples/example-cli"
-]
-
+resolver = "2"
 
 [profile.release]
-strip = true
-lto = "thin"
 codegen-units = 1
+lto = "thin"
+strip = true
 
 # UniFFI bindgen needs metadata symbols (UNIFFI_META_*) in the cdylib to generate
 # Python/Kotlin bindings. Stripping removes them. Keep symbols for the ffi crate.
@@ -50,11 +49,11 @@ strip = "none"
 # incremental: reuse codegen artefacts for unchanged crates across rebuilds.
 # Use --release only for dist.
 [profile.release-fast]
-inherits = "release"
-opt-level = 1
-lto = false
-codegen-units = 16
-incremental = true  # reuse codegen from unchanged crates on partial rebuilds
+codegen-units = 16 
+incremental = true # reuse codegen from unchanged crates on partial rebuilds
+inherits = "release" 
+lto = false 
+opt-level = 1 
 
 [profile.release-fast.package.ffi]
 strip = "none"
@@ -66,25 +65,24 @@ strip = "none"
 # NOT listed here (incompatible versions in use across the workspace):
 #   http        — 0.2.12 (ffi/domain_types) vs 1.3.1 (grpc-api-types/external-services)
 #   error-stack — 0.4.1 (ffi/domain_types)  vs 0.5.0 (grpc-api-types) — both compiled today
-tonic       = "0.14"
-tonic-build = "0.14"
-prost       = "0.14"
+bytes = "1"
+prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-serde       = { version = "1.0.228", features = ["derive"] }
-serde_json  = "1.0.107"
-thiserror   = "1"
-tracing     = "0.1"
-bytes       = "1"
+serde = {version = "1.0.228", features = ["derive"]}
+serde_json = "1.0.107"
+superposition_provider = "=0.116.0"
+thiserror = "1"
+tonic = "0.14"
+tonic-build = "0.14"
 tonic-prost = "0.14"
-superposition_core = { git = "https://github.com/juspay/superposition", branch = "main" }
+tracing = "0.1"
 uuid = "=1.20.0"
 vergen = "=9.0.6"
 
-
 [workspace.lints.rust]
+rust_2018_idioms = {level = "warn", priority = -1}# Remove priority once https://github.com/rust-lang/rust-clippy/pull/12827 is available in stable clippy
 unsafe_code = "forbid"
-rust_2018_idioms = { level = "warn", priority = -1 } # Remove priority once https://github.com/rust-lang/rust-clippy/pull/12827 is available in stable clippy
 unused_qualifications = "warn"
 # missing_debug_implementations = "warn"
 # missing_docs = "warn"

--- a/crates/common/common_utils/Cargo.toml
+++ b/crates/common/common_utils/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 common_enums = { path = "../common_enums", package = "ucs_common_enums" }
-superposition_core = { git = "https://github.com/juspay/superposition", branch = "main", optional = true }
-superposition_types = { git = "https://github.com/juspay/superposition", branch = "main", optional = true }
+superposition_provider = { workspace = true, optional = true }
 config_patch_derive = { path = "../config_patch_derive" }
 anyhow = "1.0"
 rdkafka = { version = "0.36", optional = true }
@@ -52,7 +51,7 @@ josekit = "0.8.7"
 default = []
 kafka = ["dep:rdkafka", "dep:tracing-kafka"]
 async_ext = ["dep:async-trait", "dep:futures"]
-superposition = ["dep:superposition_core", "dep:superposition_types"]
+superposition = ["dep:superposition_provider"]
 log-transformations = []
 
 [dependencies.async-trait]

--- a/crates/common/common_utils/src/superposition_config.rs
+++ b/crates/common/common_utils/src/superposition_config.rs
@@ -1,12 +1,15 @@
 //! Superposition configuration wrapper for connector-service
 //!
-//! This module provides a thin wrapper around `superposition_core::Config`
+//! This module provides a thin wrapper around Superposition's local provider
 //! for loading and resolving configuration based on dimensions (connector, environment).
 
+use std::{fmt, path::PathBuf};
+
 use serde_json::{Map, Value};
-use std::collections::HashMap;
-use superposition_core::{eval_config, ConfigFormat, MergeStrategy, TomlFormat};
-use superposition_types::DetailedConfig;
+use superposition_provider::{
+    data_source::file::FileDataSource, traits::AllFeatureProvider, EvaluationContext,
+    LocalResolutionProvider, RefreshStrategy, WatchStrategy,
+};
 
 use crate::consts::{
     CONFIG_KEY_CONNECTOR_BASE_URL, CONFIG_KEY_CONNECTOR_BASE_URL_BANK_REDIRECTS,
@@ -17,28 +20,26 @@ use crate::consts::{
 /// Error type for superposition configuration operations
 #[derive(Debug, thiserror::Error)]
 pub enum SuperpositionConfigError {
-    /// Failed to read the configuration file
-    #[error("Failed to read superposition config file '{path}': {source}")]
-    FileReadError {
-        path: String,
-        source: std::io::Error,
-    },
-    /// Failed to parse the TOML configuration
-    #[error("Failed to parse superposition.toml: {0}")]
-    ParseError(String),
-    /// Failed to resolve configuration for given context
-    #[error("Failed to resolve configuration: {0}")]
+    #[error("Failed to initialize superposition local provider: {0}")]
+    InitializationError(String),
+    #[error("Failed to resolve superposition configuration: {0}")]
     ResolutionError(String),
 }
 
-/// Parsed and cached representation of superposition.toml
-#[derive(Debug, Clone)]
+/// Local provider backed by superposition.toml.
+#[derive(Clone)]
 pub struct SuperpositionConfig {
-    config: DetailedConfig,
+    provider: LocalResolutionProvider,
+}
+
+impl fmt::Debug for SuperpositionConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SuperpositionConfig")
+    }
 }
 
 impl SuperpositionConfig {
-    /// Load and parse superposition.toml from the given path.
+    /// Load superposition.toml and watch it for changes.
     ///
     /// # Arguments
     /// * `path` - Path to the superposition.toml file
@@ -48,19 +49,22 @@ impl SuperpositionConfig {
     ///
     /// # Example
     /// ```ignore
-    /// let config = SuperpositionConfig::from_file("config/superposition.toml")?;
+    /// let config = SuperpositionConfig::from_file("config/superposition.toml").await?;
     /// ```
-    pub fn from_file(path: &str) -> Result<Self, SuperpositionConfigError> {
-        let contents =
-            std::fs::read_to_string(path).map_err(|e| SuperpositionConfigError::FileReadError {
-                path: path.to_string(),
-                source: e,
-            })?;
+    pub async fn from_file(path: &str) -> Result<Self, SuperpositionConfigError> {
+        let source = FileDataSource::new(PathBuf::from(path))
+            .map_err(SuperpositionConfigError::InitializationError)?;
+        let provider = LocalResolutionProvider::new(
+            Box::new(source),
+            None,
+            RefreshStrategy::Watch(WatchStrategy::default()),
+        );
+        provider
+            .init(EvaluationContext::default())
+            .await
+            .map_err(|error| SuperpositionConfigError::InitializationError(error.to_string()))?;
 
-        let config = TomlFormat::parse_into_detailed(&contents)
-            .map_err(|e| SuperpositionConfigError::ParseError(e.to_string()))?;
-
-        Ok(Self { config })
+        Ok(Self { provider })
     }
 
     /// Resolve the flat key-value map for given dimensions.
@@ -70,56 +74,33 @@ impl SuperpositionConfig {
     /// * `environment` - The environment name (e.g., "production", "sandbox", "development")
     ///
     /// # Returns
-    /// A HashMap of configuration keys to their resolved values.
+    /// A map of configuration keys to their resolved values.
     ///
     /// # Example
     /// ```ignore
-    /// let resolved = config.resolve("stripe", "production")?;
+    /// let resolved = config.resolve("stripe", "production").await?;
     /// let base_url = resolved.get("connector_base_url").and_then(|v| v.as_str());
     /// ```
-    pub fn resolve(
+    pub async fn resolve(
         &self,
         connector: &str,
         environment: &str,
-    ) -> Result<HashMap<String, Value>, SuperpositionConfigError> {
-        let mut dims: Map<String, Value> = Map::new();
-        dims.insert(
-            DIMENSION_CONNECTOR.to_string(),
-            Value::String(connector.to_string()),
-        );
-        dims.insert(
-            DIMENSION_ENVIRONMENT.to_string(),
-            Value::String(environment.to_string()),
-        );
+    ) -> Result<Map<String, Value>, SuperpositionConfigError> {
+        let context = EvaluationContext::default()
+            .with_custom_field(DIMENSION_CONNECTOR, connector)
+            .with_custom_field(DIMENSION_ENVIRONMENT, environment);
 
-        // Convert DefaultConfigsWithSchema to Map<String, Value> by extracting the value field
-        let default_configs: Map<String, Value> = self
-            .config
-            .default_configs
-            .clone()
-            .into_inner()
-            .into_iter()
-            .map(|(k, v)| (k, v.value))
-            .collect();
-
-        eval_config(
-            default_configs,
-            &self.config.contexts,
-            &self.config.overrides,
-            &self.config.dimensions,
-            &dims,
-            MergeStrategy::MERGE,
-            None,
-        )
-        .map(|m| m.into_iter().collect())
-        .map_err(SuperpositionConfigError::ResolutionError)
+        self.provider
+            .resolve_all_features(context)
+            .await
+            .map_err(|error| SuperpositionConfigError::ResolutionError(error.to_string()))
     }
 }
 
 /// Helper function to extract a string value from the resolved configuration.
 ///
 /// Returns `Some(String)` if the key exists and the value is a string, `None` otherwise.
-pub fn get_string(resolved: &HashMap<String, Value>, key: &str) -> Option<String> {
+pub fn get_string(resolved: &Map<String, Value>, key: &str) -> Option<String> {
     resolved
         .get(key)
         .and_then(|v| v.as_str())
@@ -129,10 +110,7 @@ pub fn get_string(resolved: &HashMap<String, Value>, key: &str) -> Option<String
 /// Helper function to extract an optional non-empty string from the resolved configuration.
 ///
 /// Returns `Some(String)` if the key exists, is a string, and is non-empty; `None` otherwise.
-pub fn get_optional_nonempty_string(
-    resolved: &HashMap<String, Value>,
-    key: &str,
-) -> Option<String> {
+pub fn get_optional_nonempty_string(resolved: &Map<String, Value>, key: &str) -> Option<String> {
     get_string(resolved, key).filter(|s| !s.is_empty())
 }
 
@@ -161,10 +139,10 @@ pub struct ConnectorUrls {
 ///
 /// # Example
 /// ```ignore
-/// let resolved = config.resolve("stripe", Some("production"))?;
+/// let resolved = config.resolve("stripe", "production").await?;
 /// let urls = get_connector_urls(&resolved);
 /// ```
-pub fn get_connector_urls(resolved: &HashMap<String, Value>) -> ConnectorUrls {
+pub fn get_connector_urls(resolved: &Map<String, Value>) -> ConnectorUrls {
     ConnectorUrls {
         base_url: get_optional_nonempty_string(resolved, CONFIG_KEY_CONNECTOR_BASE_URL),
         dispute_base_url: get_optional_nonempty_string(
@@ -189,13 +167,13 @@ mod tests {
 
     #[test]
     fn test_get_string_returns_none_for_missing_key() {
-        let resolved = HashMap::new();
+        let resolved = Map::new();
         assert_eq!(get_string(&resolved, "missing_key"), None);
     }
 
     #[test]
     fn test_get_string_returns_some_for_value() {
-        let mut resolved = HashMap::new();
+        let mut resolved = Map::new();
         resolved.insert(
             "connector_base_url".to_string(),
             Value::String("https://api.example.com/".to_string()),
@@ -208,14 +186,14 @@ mod tests {
 
     #[test]
     fn test_get_optional_nonempty_string_returns_none_for_empty() {
-        let mut resolved = HashMap::new();
+        let mut resolved = Map::new();
         resolved.insert("key".to_string(), Value::String("".to_string()));
         assert_eq!(get_optional_nonempty_string(&resolved, "key"), None);
     }
 
     #[test]
     fn test_get_optional_nonempty_string_returns_some_for_value() {
-        let mut resolved = HashMap::new();
+        let mut resolved = Map::new();
         resolved.insert("key".to_string(), Value::String("value".to_string()));
         assert_eq!(
             get_optional_nonempty_string(&resolved, "key"),

--- a/crates/common/ucs_env/src/configs.rs
+++ b/crates/common/ucs_env/src/configs.rs
@@ -52,7 +52,7 @@ pub struct Config {
     #[serde(default)]
     pub runtime_metadata: RuntimeMetadata,
     /// Superposition configuration for connector URL resolution
-    /// This is loaded at startup from config/superposition.toml
+    /// This is loaded at startup and watches config/superposition.toml for changes.
     #[serde(skip)]
     #[patch(ignore)]
     pub superposition_config: Option<Arc<SuperpositionConfig>>,

--- a/crates/grpc-server/grpc-server/Cargo.toml
+++ b/crates/grpc-server/grpc-server/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 # First-party dependencies
 grpc-api-types = { path = "../../types-traits/grpc-api-types" }
-superposition_core = { workspace = true }
 connector-integration = { path = "../../integrations/connector-integration" }
 external-services = { path = "../../common/external-services" }
 domain_types = { path = "../../types-traits/domain_types" }

--- a/crates/grpc-server/grpc-server/src/main.rs
+++ b/crates/grpc-server/grpc-server/src/main.rs
@@ -24,15 +24,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         [ucs_env::service_name!(), "grpc_server", "tower_http"],
     );
 
-    // Load superposition.toml for connector URL resolution
+    // Load and watch superposition.toml for connector URL resolution.
     let superposition_config_path = format!(
         "{}/config/superposition.toml",
         configs::workspace_path().display()
     );
-    match SuperpositionConfig::from_file(&superposition_config_path) {
+    match SuperpositionConfig::from_file(&superposition_config_path).await {
         Ok(sp_config) => {
             tracing::info!(
-                "Successfully loaded superposition.toml from {}",
+                "Successfully loaded and watching superposition.toml from {}",
                 superposition_config_path
             );
             config.superposition_config = Some(Arc::new(sp_config));

--- a/crates/grpc-server/grpc-server/src/server/disputes.rs
+++ b/crates/grpc-server/grpc-server/src/server/disputes.rs
@@ -150,6 +150,7 @@ impl DisputeService for Disputes {
                         &connector_config,
                         environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     let dispute_flow_data =
@@ -391,6 +392,7 @@ impl DisputeService for Disputes {
                         &connector_config,
                         environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     let dispute_flow_data =

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -517,6 +517,7 @@ impl Payments {
             &connector_config,
             metadata_payload.environment.as_deref(),
         )
+        .await
         .map_err(|e| {
             tracing::error!("Failed to resolve connector overrides: {:?}", e);
             e.to_grpc_error()
@@ -659,6 +660,7 @@ impl Payments {
             &metadata_payload.connector_config,
             metadata_payload.environment.as_deref(),
         )
+        .await
         .to_grpc_error()?;
 
         // Create common request data
@@ -1058,6 +1060,7 @@ impl PaymentService for Payments {
                         &metadata_payload.connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     // Create common request data
@@ -1262,6 +1265,7 @@ impl PaymentService for Payments {
                         &metadata_payload.connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     let temp_payment_flow_data = PaymentFlowData::foreign_try_from((
@@ -1548,6 +1552,7 @@ impl PaymentService for Payments {
                         &metadata_payload.connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     let temp_payment_flow_data = PaymentFlowData::foreign_try_from((
@@ -2561,6 +2566,7 @@ impl PaymentMethod {
             &connector_config,
             metadata_payload.environment.as_deref(),
         )
+        .await
         .to_grpc_error()?;
 
         // Create payment flow data
@@ -3226,6 +3232,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     // Create merchant authentication flow data
@@ -3341,6 +3348,7 @@ impl MerchantAuthenticationService for MerchantAuthentication {
                         connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     // Create minimal merchant auth flow data for access token generation
@@ -3470,6 +3478,7 @@ impl RecurringPaymentService for RecurringPayments {
                         &metadata_payload.connector_config,
                         metadata_payload.environment.as_deref(),
                     )
+                    .await
                     .to_grpc_error()?;
 
                     // Create payment flow data

--- a/crates/grpc-server/grpc-server/src/utils.rs
+++ b/crates/grpc-server/grpc-server/src/utils.rs
@@ -96,7 +96,7 @@ pub fn validate_environment(environment: &str) -> Result<Env, String> {
 /// This is the **single entry point** for connector URL resolution. All flows must call this
 /// instead of `connectors_with_connector_config_overrides` directly so that both override
 /// sources are always applied consistently.
-pub fn apply_url_overrides(
+pub async fn apply_url_overrides(
     config: &configs::Config,
     connector: &connector_types::ConnectorVariant,
     connector_config: &ConnectorSpecificConfig,
@@ -122,7 +122,9 @@ pub fn apply_url_overrides(
                 config.superposition_config.as_ref().map(|arc| arc.as_ref()),
                 &connector_name,
                 env,
-            ) {
+            )
+            .await
+            {
                 Some(urls) => {
                     tracing::info!("resolved URLs from superposition for environment: {}", env);
                     let patch_result = match connector {
@@ -186,8 +188,8 @@ pub fn apply_url_overrides(
 /// # Static vs Dynamic Config
 /// - **Static config**: Connector URLs defined in TOML files (development.toml, sandbox.toml, production.toml)
 ///   that are loaded at application startup and remain constant for the deployment environment.
-/// - **Dynamic config**: URLs resolved at runtime from the Superposition service, which can vary per-request
-///   based on the `x-environment` header, allowing different URLs for the same connector across requests.
+/// - **Dynamic config**: URLs resolved at runtime by Superposition's local provider, which watches
+///   `superposition.toml` and varies values per request based on the `x-environment` header.
 ///
 /// # Note
 /// This function does NOT validate the environment. Call `validate_environment()` first if you need
@@ -204,7 +206,7 @@ pub fn apply_url_overrides(
 ///     environment,
 /// );
 /// ```
-pub fn resolve_connector_urls(
+pub async fn resolve_connector_urls(
     superposition_config: Option<&SuperpositionConfig>,
     connector_name: &str,
     environment: &str,
@@ -214,7 +216,7 @@ pub fn resolve_connector_urls(
     let environment_lower = environment.to_lowercase();
     let connector_str = connector_name.to_lowercase();
 
-    match config.resolve(&connector_str, &environment_lower) {
+    match config.resolve(&connector_str, &environment_lower).await {
         Ok(resolved) => {
             let urls = get_connector_urls(&resolved);
             if urls.base_url.is_none() {
@@ -703,6 +705,7 @@ macro_rules! implement_connector_operation {
                     &connector_config,
                     metadata_payload.environment.as_deref(),
                 )
+                .await
                 .to_grpc_error()?;
 
             // Create common request data (shared by both the direct and proxy paths;
@@ -1054,6 +1057,7 @@ macro_rules! implement_connector_operation {
                     &connector_config,
                     metadata_payload.environment.as_deref(),
                 )
+                .await
                 .to_grpc_error()?;
 
             // Create common request data

--- a/crates/grpc-server/grpc-server/tests/test_superposition_config.rs
+++ b/crates/grpc-server/grpc-server/tests/test_superposition_config.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::panic)]
 
+use std::{fs, time::Duration};
+
 use common_utils::SuperpositionConfig;
+use tokio::time::{sleep, timeout};
 use ucs_env::configs;
 
 /// `config/superposition.toml` is validated against its own `[dimensions]` schema at parse
@@ -11,17 +14,75 @@ use ucs_env::configs;
 /// file, which silently disables superposition URL overrides for every connector at
 /// runtime (falls back to static config with no fatal error). This test exists so that
 /// class of mistake fails CI instead of degrading production silently.
-#[test]
-fn superposition_toml_parses_successfully() {
+#[tokio::test]
+async fn superposition_toml_loads_and_resolves_successfully() {
     let path = format!(
         "{}/config/superposition.toml",
         configs::workspace_path().display()
     );
-    SuperpositionConfig::from_file(&path).unwrap_or_else(|e| {
-        panic!(
-            "config/superposition.toml failed to parse: {e}\n\
+    let config = SuperpositionConfig::from_file(&path)
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "config/superposition.toml failed to parse: {e}\n\
              Check that every `_context_` value used in an [[overrides]] block is present \
              in the corresponding dimension's `enum` list under [dimensions]."
-        )
-    });
+            )
+        });
+    let resolved = config.resolve("stripe", "sandbox").await.unwrap();
+    assert_eq!(
+        resolved
+            .get("connector_base_url")
+            .and_then(|url| url.as_str()),
+        Some("https://api.stripe.com/")
+    );
+}
+
+#[tokio::test]
+async fn superposition_toml_file_changes_are_reloaded() {
+    let source_path = configs::workspace_path().join("config/superposition.toml");
+    let temp_path = std::env::temp_dir().join(format!(
+        "prism-superposition-watch-{}.toml",
+        std::process::id()
+    ));
+    fs::copy(&source_path, &temp_path).unwrap();
+
+    let config = SuperpositionConfig::from_file(temp_path.to_str().unwrap())
+        .await
+        .unwrap();
+    let initial = config.resolve("stripe", "sandbox").await.unwrap();
+    assert_eq!(
+        initial
+            .get("connector_base_url")
+            .and_then(|url| url.as_str()),
+        Some("https://api.stripe.com/")
+    );
+    sleep(Duration::from_millis(100)).await;
+
+    let contents = fs::read_to_string(&temp_path).unwrap();
+    let updated = contents.replacen(
+        "connector_base_url = \"https://api.stripe.com/\"",
+        "connector_base_url = \"https://updated.stripe.test/\"",
+        1,
+    );
+    assert_ne!(contents, updated);
+    fs::write(&temp_path, updated).unwrap();
+
+    let refreshed = timeout(Duration::from_secs(5), async {
+        loop {
+            let resolved = config.resolve("stripe", "sandbox").await.unwrap();
+            if resolved
+                .get("connector_base_url")
+                .and_then(|url| url.as_str())
+                == Some("https://updated.stripe.test/")
+            {
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    let _ = fs::remove_file(temp_path);
+    refreshed.expect("superposition config was not refreshed after the file changed");
 }


### PR DESCRIPTION
## Description

Replaces Prism’s custom Superposition TOML parsing and resolution logic with Superposition’s `LocalResolutionProvider`.

The provider loads configuration from the existing TOML file and uses `RefreshStrategy::Watch`, allowing configuration changes to be picked up at runtime without restarting the gRPC server.

## Changes

- Added `superposition_provider` version `0.116.0`.
- Configured `FileDataSource` for the existing Superposition TOML file.
- Replaced custom resolution logic with `LocalResolutionProvider`.
- Updated configuration resolution to use the provider’s async API.
- Added tests covering:
  - Initial TOML loading and context-based resolution.
  - Automatic resolution updates after the TOML file changes.

## Testing

```bash
LIBRARY_PATH=/opt/homebrew/opt/libpq/lib \
cargo test -p grpc-server \
  --test test_superposition_config \
  -- --nocapture