### PR TITLE
log response headers

### DIFF
--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "log-transformations")]
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use hyperswitch_masking::ErasedMaskSerialize;
+use hyperswitch_masking::{ErasedMaskSerialize, Maskable, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::errors::EventPublisherError;
@@ -19,6 +19,7 @@ use crate::{
     lineage,
     types::TimeRange,
 };
+use reqwest::header::HeaderMap;
 
 /// Wrapper type that enforces masked serialization for Serde values
 #[derive(Debug, Clone, Serialize)]
@@ -675,20 +676,61 @@ pub fn apply_log_fields(compiled: &CompiledLogFields) {
 /// Convert a set of headers with `Maskable` values into a `serde_json::Value` object.
 /// Normal values are preserved as-is; masked values use the standard masking format
 /// from `Maskable`'s `Debug` implementation.
-pub fn maskable_headers_to_json<'a>(
-    headers: impl IntoIterator<Item = &'a (String, hyperswitch_masking::Maskable<String>)>,
+pub trait MaskableHeadersToJson {
+    fn maskable_headers_to_json(&self, unmasked_keys: Option<&[&str]>) -> serde_json::Value;
+}
+
+fn maskable_header_values_to_json<'a>(
+    headers: impl Iterator<Item = &'a (String, Maskable<String>)>,
 ) -> serde_json::Value {
     headers
-        .into_iter()
-        .map(|(k, v)| {
-            let val = match v {
-                hyperswitch_masking::Maskable::Normal(s) => s.clone(),
-                hyperswitch_masking::Maskable::Masked(secret) => format!("{secret:?}"),
+        .map(|(key, value)| {
+            let value = match value {
+                Maskable::Normal(value) => value.clone(),
+                Maskable::Masked(secret) => format!("{secret:?}"),
             };
-            (k.clone(), serde_json::Value::String(val))
+            (key.clone(), serde_json::Value::String(value))
         })
         .collect::<serde_json::Map<String, serde_json::Value>>()
         .into()
+}
+
+impl MaskableHeadersToJson for Vec<(String, Maskable<String>)> {
+    fn maskable_headers_to_json(&self, _unmasked_keys: Option<&[&str]>) -> serde_json::Value {
+        maskable_header_values_to_json(self.iter())
+    }
+}
+
+impl MaskableHeadersToJson for HashSet<(String, Maskable<String>)> {
+    fn maskable_headers_to_json(&self, _unmasked_keys: Option<&[&str]>) -> serde_json::Value {
+        maskable_header_values_to_json(self.iter())
+    }
+}
+
+impl MaskableHeadersToJson for HeaderMap {
+    fn maskable_headers_to_json(&self, unmasked_keys: Option<&[&str]>) -> serde_json::Value {
+        self.iter()
+            .map(|(key, value)| {
+                let value = match value.to_str() {
+                    Ok(value)
+                        if unmasked_keys.is_some_and(|keys| {
+                            keys.iter()
+                                .any(|unmasked_key| key.as_str().eq_ignore_ascii_case(unmasked_key))
+                        }) =>
+                    {
+                        value.to_string()
+                    }
+                    Ok(value) => format!("{:?}", Secret::<String>::new(value.to_string())),
+                    Err(_) => format!(
+                        "{:?}",
+                        Secret::<String>::new("<non-UTF-8 header value>".to_string())
+                    ),
+                };
+                (key.to_string(), serde_json::Value::String(value))
+            })
+            .collect::<serde_json::Map<String, serde_json::Value>>()
+            .into()
+    }
 }
 
 /// Record one or more key-value pairs as structured JSON directly into the
@@ -1091,5 +1133,48 @@ mod runtime_metadata_tests {
         };
         let value = serde_json::to_value(sample_event(rm)).expect("event serializes");
         assert_eq!(value.get("version").and_then(|v| v.as_str()), Some("v"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod maskable_headers_to_json_tests {
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    use super::MaskableHeadersToJson;
+
+    #[test]
+    fn only_connector_allowlisted_headers_are_unmasked() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("req_123"));
+        headers.insert("authorization", HeaderValue::from_static("secret"));
+
+        let headers_json = headers.maskable_headers_to_json(Some(&["X-Request-Id"]));
+
+        assert_eq!(headers_json["x-request-id"], "req_123");
+        assert_ne!(headers_json["authorization"], "secret");
+    }
+
+    #[test]
+    fn non_utf8_headers_remain_masked_even_when_allowlisted() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-request-id",
+            HeaderValue::from_bytes(&[0xff]).expect("valid opaque header value"),
+        );
+
+        let headers_json = headers.maskable_headers_to_json(Some(&["x-request-id"]));
+
+        assert_ne!(headers_json["x-request-id"], "<non-UTF-8 header value>");
+    }
+
+    #[test]
+    fn no_allowlist_masks_every_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("req_123"));
+
+        let headers_json = headers.maskable_headers_to_json(None);
+
+        assert_ne!(headers_json["x-request-id"], "req_123");
     }
 }

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -7,11 +7,11 @@ use common_utils::events::apply_log_fields;
 #[cfg(feature = "injector-client")]
 use common_utils::{
     consts::{X_API_TAG, X_API_URL, X_SESSION_ID},
-    events::{maskable_headers_to_json, EventStage, MaskedSerdeValue},
+    events::{EventStage, MaskedSerdeValue},
     request::TransportType,
 };
 use common_utils::{
-    events::{record_json_fields_on_span, CompiledLogFields},
+    events::{record_json_fields_on_span, CompiledLogFields, MaskableHeadersToJson},
     ext_traits::AsyncExt,
     lineage,
     request::{Method, Request, RequestContent},
@@ -395,22 +395,25 @@ where
                         body.clone(),
                     );
 
-                    // Log response body and headers using properly masked data from connector
-                    if let Some(evt) = event.as_deref_mut() {
-                        let mut json_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
+                    let mut json_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
 
+                    // Log response body using properly masked data from connector
+                    if let Some(evt) = event.as_deref_mut() {
                         if let Some(response_data) = &evt.response_data {
                             json_fields.push(("response.body", response_data.inner().clone()));
                         }
+                    }
 
-                        // Log response headers from event (already masked)
-                        if let Ok(headers_json) = serde_json::to_value(&evt.headers) {
-                            json_fields.push(("response.headers", headers_json));
-                        }
-
-                        if !json_fields.is_empty() {
-                            record_json_fields_on_span(json_fields);
-                        }
+                    // Log masked response headers
+                    if let Some(headers) = &body.headers {
+                        let masked_response_headers = headers.maskable_headers_to_json(Some(
+                            connector.get_unmasked_response_headers(),
+                        ));
+                        json_fields.push(("response.headers", masked_response_headers));
+                    }
+                    
+                    if !json_fields.is_empty() {
+                        record_json_fields_on_span(json_fields);
                     }
 
                     handle_response_result?
@@ -484,6 +487,16 @@ where
                         "response.status_code",
                         tracing::field::display(error_response.status_code),
                     );
+                    // Log masked response headers
+                    if let Some(headers) = &body.headers {
+                        let masked_response_headers = headers.maskable_headers_to_json(Some(
+                            connector.get_unmasked_response_headers(),
+                        ));
+                        record_json_fields_on_span(vec![(
+                            "response.headers",
+                            masked_response_headers,
+                        )]);
+                    }
                     // Additive: record the connector flow outcome (FlowStatus) so a
                     // decline is visible even though the gRPC call "succeeded".
                     #[cfg(feature = "otel")]
@@ -792,7 +805,7 @@ where
                     tracing::info!(headers=?masked_headers, "headers of connector request");
                     record_json_fields_on_span(vec![(
                         "request.headers",
-                        maskable_headers_to_json(&masked_headers),
+                        masked_headers.maskable_headers_to_json(None),
                     )]);
 
                     let masked_request = request
@@ -1023,7 +1036,7 @@ where
                     tracing::info!(headers=?masked_headers, "headers of connector request");
                     record_json_fields_on_span(vec![(
                         "request.headers",
-                        maskable_headers_to_json(&masked_headers),
+                        masked_headers.maskable_headers_to_json(None),
                     )]);
 
                     let masked_request = mask_connector_request(&record.payload);

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -411,7 +411,7 @@ where
                         ));
                         json_fields.push(("response.headers", masked_response_headers));
                     }
-                    
+
                     if !json_fields.is_empty() {
                         record_json_fields_on_span(json_fields);
                     }

--- a/crates/types-traits/interfaces/src/connector_integration_v2.rs
+++ b/crates/types-traits/interfaces/src/connector_integration_v2.rs
@@ -45,6 +45,11 @@ where
 pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     ConnectorIntegrationAnyV2<Flow, ResourceCommonData, Req, Resp> + Sync + api::ConnectorCommon
 {
+    /// Response headers that are safe to expose in logs.
+    fn get_unmasked_response_headers(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// returns a vec of tuple of header key and value
     fn get_headers(
         &self,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
### Changes
- Introduces MaskableHeadersToJson implementations for HeaderMap, Vec, and HashSet.
- Adds get_unmasked_response_headers() to ConnectorIntegrationV2.
- Allows connectors to explicitly declare response headers that are safe to log.
- Masks all headers when no allowlist is provided.
- Keeps non-UTF-8 header values masked even when allowlisted.
- Removes the old response-header serialization path and uses the new trait for success and error responses.
- Adds tests covering allowlisted, sensitive, non-UTF-8, and absent-allowlist behavior.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
