### PR TITLE
fix(maya): capture missing response fields + surface raw connector response

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/maya.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya.rs
@@ -17,7 +17,7 @@ use domain_types::{
     types::Connectors,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeInterface, Maskable};
+use hyperswitch_masking::{ExposeInterface, Maskable, Secret};
 use interfaces::{
     api::ConnectorCommon, connector_integration_v2::ConnectorIntegrationV2, connector_types,
     decode::BodyDecoding,
@@ -213,7 +213,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
             network_advice_code: None,
             network_error_message: None,
             typed_connector_response: typed,
-            raw_connector_response: None,
+            raw_connector_response: Some(Secret::new(
+                String::from_utf8_lossy(&res.response).to_string(),
+            )),
             raw_connector_request: None,
             typed_connector_request: None,
         })
@@ -634,7 +636,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     fn process_redirect_response(
         &self,
         _request: &RequestDetails,
-        _connector_feature_data: Option<&hyperswitch_masking::Secret<String>>,
+        _connector_feature_data: Option<&Secret<String>>,
     ) -> CustomResult<RedirectDetailsResponse, errors::IntegrationError> {
         // Maya is a redirect-only connector. The redirect body carries no
         // meaningful payment state; final status is confirmed via PSync or

--- a/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
@@ -571,17 +571,6 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
             _ => None,
         };
 
-        // Operational fields Maya returns that have no typed slot on the payments
-        // response are surfaced verbatim through `connector_metadata`.
-        let connector_metadata = serde_json::json!({
-            "isPaid": payment.is_paid,
-            "canVoid": payment.can_void,
-            "canRefund": payment.can_refund,
-            "canCapture": payment.can_capture,
-            "createdAt": payment.created_at.clone(),
-            "updatedAt": payment.updated_at.clone(),
-        });
-
         let settlement_status = maya_settlement_status(payment.can_void, payment.can_refund);
 
         let status = common_enums::AttemptStatus::from(payment.status.clone());
@@ -607,7 +596,7 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
                 resource_id,
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: Some(connector_metadata),
+                connector_metadata: None,
                 network_txn_id: None,
                 connector_response_reference_id: Some(connector_response_reference_id),
                 incremental_authorization_allowed: None,

--- a/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
@@ -1,4 +1,7 @@
-use common_utils::{types::FloatMajorUnit, Method};
+use common_utils::{
+    types::{AmountConvertor, FloatMajorUnit, StringMajorUnit, StringMajorUnitForConnector},
+    Method,
+};
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund, Void},
     connector_types::{
@@ -10,6 +13,7 @@ use domain_types::{
     payment_method_data::{PaymentMethodData, PaymentMethodDataTypes, WalletData},
     router_data::ConnectorSpecificConfig,
     router_data_v2::RouterDataV2,
+    router_request_types::{PaymentSynIntegrityObject, RefundIntegrityObject},
     router_response_types::RedirectForm,
 };
 use error_stack::ResultExt;
@@ -251,6 +255,27 @@ pub struct MayaWebhookBody {
     pub can_void: Option<bool>,
     #[serde(default)]
     pub can_refund: Option<bool>,
+    /// Whether Maya has captured funds for this payment. Present on the
+    /// payment-inquiry response but not on every webhook event, so optional.
+    #[serde(default)]
+    pub can_capture: Option<bool>,
+    /// Whether the payment has been paid. Returned by the payment-inquiry
+    /// endpoint; absent on some webhook events, so optional.
+    #[serde(default)]
+    pub is_paid: Option<bool>,
+    /// Processed amount returned by Maya. The API reference documents this as a
+    /// JSON number, but Maya's live payment response actually serializes it as a
+    /// decimal string (e.g. `"100"`), so it is modeled as `StringMajorUnit` and
+    /// fed through the money framework into the PSync integrity check.
+    #[serde(default)]
+    pub amount: Option<StringMajorUnit>,
+    /// ISO 4217 currency echoed by Maya on the payment object.
+    #[serde(default)]
+    pub currency: Option<common_enums::Currency>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
 }
@@ -534,6 +559,33 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
 
         let payment = item.response;
 
+        // Maya returns the processed amount/currency on the payment object. Run them
+        // through the money framework and hand them to the PSync integrity check,
+        // but only when both are present (Maya omits them for e.g. expired payments).
+        let integrity_object = match (payment.amount.clone(), payment.currency) {
+            (Some(amount), Some(currency)) => {
+                let amount = StringMajorUnitForConnector
+                    .convert_back(amount, currency)
+                    .change_context(crate::utils::response_handling_fail_for_connector(
+                        item.http_code,
+                        "maya",
+                    ))?;
+                Some(PaymentSynIntegrityObject { amount, currency })
+            }
+            _ => None,
+        };
+
+        // Operational fields Maya returns that have no typed slot on the payments
+        // response are surfaced verbatim through `connector_metadata`.
+        let connector_metadata = serde_json::json!({
+            "isPaid": payment.is_paid,
+            "canVoid": payment.can_void,
+            "canRefund": payment.can_refund,
+            "canCapture": payment.can_capture,
+            "createdAt": payment.created_at.clone(),
+            "updatedAt": payment.updated_at.clone(),
+        });
+
         let settlement_status = maya_settlement_status(payment.can_void, payment.can_refund);
 
         let status = common_enums::AttemptStatus::from(payment.status.clone());
@@ -559,7 +611,7 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
                 resource_id,
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
+                connector_metadata: Some(connector_metadata),
                 network_txn_id: None,
                 connector_response_reference_id: Some(connector_response_reference_id),
                 incremental_authorization_allowed: None,
@@ -567,6 +619,10 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
                 splits: None,
                 status_code: item.http_code,
             }),
+            request: PaymentsSyncData {
+                integrity_object,
+                ..item.router_data.request
+            },
             resource_common_data: PaymentFlowData {
                 status,
                 settlement_status,
@@ -658,6 +714,14 @@ pub struct MayaRefundResponse {
     pub status: MayaRefundStatus,
     #[serde(default)]
     pub reason: Option<String>,
+    /// Refunded amount echoed by Maya. Unlike the payment object's numeric
+    /// `amount`, Maya's refund response serializes it as a JSON string, so it is
+    /// modeled as `StringMajorUnit` and fed through the money framework.
+    #[serde(default)]
+    pub amount: Option<StringMajorUnit>,
+    /// ISO 4217 currency echoed by Maya on the refund response.
+    #[serde(default)]
+    pub currency: Option<common_enums::Currency>,
     #[serde(default)]
     pub request_reference_number: Option<String>,
     #[serde(default)]
@@ -734,6 +798,24 @@ impl TryFrom<ResponseRouterData<MayaRefundResponse, Self>>
             reason: None,
         };
 
+        // Feed Maya's echoed refund amount/currency through the money framework into
+        // the refund integrity check, but only when Maya returns both.
+        let integrity_object = match (item.response.amount.clone(), item.response.currency) {
+            (Some(amount), Some(currency)) => {
+                let refund_amount = StringMajorUnitForConnector
+                    .convert_back(amount, currency)
+                    .change_context(crate::utils::response_handling_fail_for_connector(
+                        item.http_code,
+                        "maya",
+                    ))?;
+                Some(RefundIntegrityObject {
+                    refund_amount,
+                    currency,
+                })
+            }
+            _ => None,
+        };
+
         Ok(Self {
             response: Ok(RefundsResponseData {
                 connector_refund_id: item.response.id,
@@ -741,6 +823,10 @@ impl TryFrom<ResponseRouterData<MayaRefundResponse, Self>>
                 status_code: item.http_code,
                 acquirer_reference_number: None,
             }),
+            request: RefundsData {
+                integrity_object,
+                ..item.router_data.request
+            },
             resource_common_data: RefundFlowData {
                 raw_connector_status: Some(raw_connector_status),
                 ..item.router_data.resource_common_data

--- a/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
@@ -502,6 +502,8 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MayaPaymentsResponse,
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(item: ResponseRouterData<MayaPaymentsResponse, Self>) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+
         let redirect_url = Url::parse(&item.response.redirect_url).change_context(
             ConnectorError::response_deserialization_failed_with_context(
                 item.http_code,
@@ -538,6 +540,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<MayaPaymentsResponse,
             resource_common_data: PaymentFlowData {
                 status,
                 raw_connector_status: None,
+                raw_connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -551,6 +554,8 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(item: ResponseRouterData<MayaWebhookBody, Self>) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+
         let connector_request_reference_id = item
             .router_data
             .resource_common_data
@@ -627,6 +632,7 @@ impl TryFrom<ResponseRouterData<MayaWebhookBody, Self>>
                 status,
                 settlement_status,
                 raw_connector_status: Some(raw_connector_status),
+                raw_connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -640,6 +646,8 @@ impl TryFrom<ResponseRouterData<MayaVoidResponse, Self>>
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(item: ResponseRouterData<MayaVoidResponse, Self>) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+
         let status = common_enums::AttemptStatus::from(item.response.status.clone());
         let void_id = item.response.id;
         let payment_id = item.response.payment;
@@ -664,6 +672,7 @@ impl TryFrom<ResponseRouterData<MayaVoidResponse, Self>>
                     message: None,
                     reason: None,
                 }),
+                raw_connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -790,6 +799,8 @@ impl TryFrom<ResponseRouterData<MayaRefundResponse, Self>>
     type Error = error_stack::Report<ConnectorError>;
 
     fn try_from(item: ResponseRouterData<MayaRefundResponse, Self>) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+
         let refund_status = common_enums::RefundStatus::from(item.response.status.clone());
 
         let raw_connector_status = RawConnectorStatus {
@@ -829,6 +840,7 @@ impl TryFrom<ResponseRouterData<MayaRefundResponse, Self>>
             },
             resource_common_data: RefundFlowData {
                 raw_connector_status: Some(raw_connector_status),
+                raw_connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -844,6 +856,8 @@ impl TryFrom<ResponseRouterData<MayaRefundSyncResponse, Self>>
     fn try_from(
         item: ResponseRouterData<MayaRefundSyncResponse, Self>,
     ) -> Result<Self, Self::Error> {
+        let raw_connector_response = serde_json::to_string(&item.response).ok().map(Secret::new);
+
         let refund_status = common_enums::RefundStatus::from(item.response.status.clone());
 
         let raw_connector_status = RawConnectorStatus {
@@ -861,6 +875,7 @@ impl TryFrom<ResponseRouterData<MayaRefundSyncResponse, Self>>
             }),
             resource_common_data: RefundFlowData {
                 raw_connector_status: Some(raw_connector_status),
+                raw_connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data

--- a/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya/transformers.rs
@@ -17,7 +17,7 @@ use domain_types::{
     router_response_types::RedirectForm,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{PeekInterface, Secret};
+use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -90,8 +90,6 @@ pub struct MayaPaymentsRequest {
     pub total_amount: MayaTotalAmount,
     pub redirect_url: MayaRedirectUrl,
     pub request_reference_number: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<String>,
 }
 
 /// `totalAmount` object carried by most Maya request bodies (`value` + `currency`,
@@ -471,12 +469,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             },
         )?;
 
-        let user_id = router_data
-            .request
-            .email
-            .clone()
-            .map(|email| email.peek().to_string());
-
         Ok(Self {
             total_amount: MayaTotalAmount {
                 value,
@@ -491,7 +483,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .resource_common_data
                 .connector_request_reference_id
                 .clone(),
-            user_id,
         })
     }
 }


### PR DESCRIPTION
## Description

Two related connector-response improvements for the **Maya** connector (one commit each):

**1. Capture missing PSync & refund response fields via the money framework**
Maya's payment-inquiry (PSync) and refund responses returned fields the connector was neither deserializing nor handing back, so they were dropped from the emitted response.
- **PSync** (`MayaWebhookBody`): add `isPaid`, `amount`, `currency`, `canCapture`, `createdAt`, `updatedAt`. `amount` is modeled as `StringMajorUnit` (Maya serializes it as a JSON **string** `"100"`, despite the API reference documenting a number), run through `AmountConvertor::convert_back` and surfaced via `PaymentSynIntegrityObject`. The non-money flags/timestamps go through `connector_metadata`.
- **Refund** (`MayaRefundResponse`): add `amount` (also a string) + `currency` → `RefundIntegrityObject`.
- RSync's integrity object is identity-based, so its amount is modeled/consumed but not wired to an amount check.

**2. Surface raw connector response on all flows**
Populate `raw_connector_response` in connector code for Authorize / PSync / Void / Refund / RSync (mirrors flywire/kount and Maya's existing webhook path), plus the error path (`get_error_response`). This captures the raw response independent of the `return_raw_connector_data` config flag (off in development).

3. Removed user_id from request 
No need to pass user_id , since it is optional and not needed for current implementation.

## Motivation and Context

The connector was silently dropping response data Maya returns. Because the emitted response body is re-serialized from the typed structs, any unmodeled field never reached the caller — losing amount/currency (needed for money-framework integrity verification) and operational flags (`isPaid`, `canVoid`, `canRefund`, `canCapture`) as well as the raw connector payload. This models those fields and routes amount/currency through the money framework so PSync/refund amounts are verified against intent, and makes the raw connector response available on every flow.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

(No proto/contract change — the response fields already exist; they are now populated. No config changes committed.)

## How did you test it?
