### PR TITLE
refactor(deps): make log_utils optional and fix default log format visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "build_info"
 version = "0.1.0"
-source = "git+https://github.com/juspay/framework-libs-rs?rev=76613f5d0c72fd3d26a3403ae859c2a7545e8dd2#76613f5d0c72fd3d26a3403ae859c2a7545e8dd2"
+source = "git+https://github.com/juspay/framework-libs-rs?rev=3cdcc24b461917b29641942b04f3aef8110b1adf#3cdcc24b461917b29641942b04f3aef8110b1adf"
 dependencies = [
  "cargo_metadata 0.23.1",
  "vergen-gix",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "log_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/framework-libs-rs?rev=76613f5d0c72fd3d26a3403ae859c2a7545e8dd2#76613f5d0c72fd3d26a3403ae859c2a7545e8dd2"
+source = "git+https://github.com/juspay/framework-libs-rs?rev=3cdcc24b461917b29641942b04f3aef8110b1adf#3cdcc24b461917b29641942b04f3aef8110b1adf"
 dependencies = [
  "gethostname 1.1.0",
  "rustc-hash 2.1.3",

--- a/crates/common/common_utils/Cargo.toml
+++ b/crates/common/common_utils/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 rdkafka = { version = "0.36", optional = true }
 tracing-kafka = { path = "../tracing-kafka", optional = true }
 tracing = { workspace = true }
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "log_utils", features = ["tracing", "tracing-storage-api"] }
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "log_utils", features = ["tracing", "tracing-storage-api"], optional = true }
 once_cell = "1.19"
 chrono = "0.4.31"
 
@@ -50,10 +50,11 @@ josekit = "0.8.7"
 # Optional features
 [features]
 default = []
+logging = ["dep:log_utils"]
 kafka = ["dep:rdkafka", "dep:tracing-kafka"]
 async_ext = ["dep:async-trait", "dep:futures"]
 superposition = ["dep:superposition_core", "dep:superposition_types"]
-log-transformations = []
+log-transformations = ["logging"]
 
 [dependencies.async-trait]
 version = "0.1.74"

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -698,16 +698,20 @@ pub fn maskable_headers_to_json<'a>(
 /// All reserved-key filtering happens **outside** the span lock to avoid
 /// deadlocks (the storage layer logs a warning for reserved keys, which would
 /// re-enter the subscriber).
+#[cfg(feature = "logging")]
 pub fn record_json_fields_on_span(fields: Vec<(&'static str, serde_json::Value)>) {
+    // Filter reserved keys and log fields outside the span lock to avoid deadlocks
+    // (tracing::info!/warn! re-enters the subscriber).
     let fields: Vec<_> = fields
         .into_iter()
-        .filter(|(key, _)| {
+        .filter(|(key, value)| {
             if log_utils::Storage::is_reserved(key) {
                 tracing::warn!(
                     "Span field `{key}` is reserved by the logging infrastructure, skipping"
                 );
                 false
             } else {
+                tracing::info!(%value, "{key}");
                 true
             }
         })

--- a/crates/common/external-services/Cargo.toml
+++ b/crates/common/external-services/Cargo.toml
@@ -47,6 +47,7 @@ domain_types = { path = "../../types-traits/domain_types" }
 interfaces = { path = "../../types-traits/interfaces" }
 common_utils = { path = "../common_utils", package = "ucs_common_utils", features = [
     "async_ext",
+    "logging",
 ] }
 common_enums = { path = "../common_enums", package = "ucs_common_enums" }
 hyperswitch_masking = { version = "0.0.1", default-features = false, features = [
@@ -59,7 +60,7 @@ injector = { git = "https://github.com/juspay/hyperswitch", tag = "2026.06.18.0"
 connector_request_kafka = { path = "../connector_request_kafka", optional = true }
 url = "2.5.0"
 chrono = "0.4.31"
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "log_utils", features = [
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "log_utils", features = [
     "tracing",
     "tracing-storage-api",
 ] }

--- a/crates/common/tracing-kafka/Cargo.toml
+++ b/crates/common/tracing-kafka/Cargo.toml
@@ -11,7 +11,7 @@ rdkafka = "0.36"
 serde_json = { workspace = true }
 tokio = "1.0"
 thiserror = { workspace = true }
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "log_utils", features = ["tracing"] }
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "log_utils", features = ["tracing"] }
 
 # Optional dependencies for metrics
 prometheus = { version = "0.13", optional = true }

--- a/crates/common/ucs_env/Cargo.toml
+++ b/crates/common/ucs_env/Cargo.toml
@@ -49,16 +49,16 @@ tokio = { version = "1.48.0", features = [
 tonic = { workspace = true }
 tonic-reflection = "0.14.0"
 http = "1.2.0"
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "log_utils", features = [
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "log_utils", features = [
     "tracing",
 ] }
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "build_info", features = [
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "build_info", features = [
     "cargo-workspace",
     "framework-libs-members-env",
 ] }
 
 [build-dependencies]
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "build_info", features = [
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "build_info", features = [
     "cargo-workspace-build",
     "vergen-gix-build",
     "framework-libs-members-env",

--- a/crates/grpc-server/grpc-server/Cargo.toml
+++ b/crates/grpc-server/grpc-server/Cargo.toml
@@ -15,6 +15,7 @@ cards = { path = "../../types-traits/cards", package = "ucs_cards" }
 common_enums = { path = "../../common/common_enums", package = "ucs_common_enums" }
 common_utils = { path = "../../common/common_utils", package = "ucs_common_utils", features = [
     "superposition",
+    "logging",
 ] }
 composite-service = { path = "../../internal/composite-service" }
 config_patch_derive = { path = "../../common/config_patch_derive" }
@@ -66,11 +67,11 @@ prost-types = "0.14"
 rustc-hash = "2.0"
 gethostname = "0.5.0"
 once_cell = "1.19.0"
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "log_utils", features = [
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "log_utils", features = [
     "tracing",
     "tracing-storage-api",
 ] }
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "build_info", features = [
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "build_info", features = [
     "cargo-workspace",
     "framework-libs-members-env",
 ] }
@@ -78,7 +79,7 @@ uuid = { workspace = true }
 chrono = "0.4.31"
 
 [build-dependencies]
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "76613f5d0c72fd3d26a3403ae859c2a7545e8dd2", package = "build_info", features = [
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", package = "build_info", features = [
     "cargo-workspace-build",
     "vergen-gix-build",
     "framework-libs-members-env",


### PR DESCRIPTION
## Summary
- Make `log_utils` an optional dependency behind a `logging` feature flag in `ucs_common_utils`, so external consumers (e.g. hyperswitch importing `sdk/rust`) don't transitively pull it in and break MSRV
- Log fields via `tracing::info!` inside `record_json_fields_on_span` so `request.body`, `response.body`, headers etc. appear in default/human-readable log format (not just JSON)
- Update `framework-libs-rs` rev to `3cdcc24b` across all crates

## Changes
- `common_utils/Cargo.toml` — `log_utils` made optional, new `logging` feature, `log-transformations` implies `logging`
- `common_utils/src/events.rs` — `record_json_fields_on_span` gated behind `#[cfg(feature = "logging")]`, added `tracing::info!` per field
- `external-services/Cargo.toml` — enabled `logging` feature on `common_utils`
- `grpc-server/Cargo.toml` — enabled `logging` feature on `common_utils`
- All `framework-libs-rs` refs updated to latest rev

## Test plan
- [ ] `cargo check -p ucs_common_utils` (without `logging`) — verifies `log_utils` not required
- [ ] `cargo check -p grpc-server` — verifies server crates compile with `logging` enabled
- [ ] Run server with `log_format = "default"` and make a connector call — verify `request.body` and `response.body` appear in log output