### PR TITLE
fix(sync): return merchant_transaction_id on failed payment sync response

### DIFF
--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8533,7 +8533,12 @@ pub fn generate_payment_sync_response(
                     &e.connector_transaction_id,
                 ),
                 connector_reference_id: None,
-                merchant_transaction_id: None,
+                merchant_transaction_id: Some(
+                    router_data_v2
+                        .resource_common_data
+                        .connector_request_reference_id
+                        .clone(),
+                ),
                 mandate_reference: None,
                 mandate_reference_details: None,
                 status: status as i32,


### PR DESCRIPTION
## Summary

The error branch of `generate_payment_sync_response` (`crates/types-traits/domain_types/src/types.rs`) hardcoded `merchant_transaction_id: None`. As a result, **a failed payment sync dropped the merchant transaction id** from the response, while the success branch correctly returns it.

Downstream integrity checks read `merchant_transaction_id` as the transaction id and compare it against the stored txn id. On a failed sync they received an empty value and the comparison failed — flagging otherwise-valid syncs as integrity failures.

## Root cause

`generate_payment_sync_response` had asymmetric behaviour across its two arms:

| Arm | `merchant_transaction_id` |
|-----|---------------------------|
| `Ok(..)` (success) | `connector_response_reference_id` ✅ |
| `Err(e)` (failure) | `None` ❌ |

The failure response still carried `amount`, `status`, `error`,
`connector_transaction_id`, `status_code` — everything **except** the merchant
transaction id.

## Fix

Echo `connector_request_reference_id` (the caller-supplied reference, i.e. the
value sent in the `x-connector-request-reference-id` header) on the error path,
mirroring the success branch. One field, connector-agnostic — applies to every
UCS connector.

```rust
// error branch
- merchant_transaction_id: None,
+ merchant_transaction_id: Some(
+     router_data_v2
+         .resource_common_data
+         .connector_request_reference_id
+         .clone(),
+ ),
```

## Testing

Verified live against a connector sandbox (twoc_twop_paco / 2C2P PACO UAT)
through the local gRPC server. Sensitive values (API key, office id, merchant
id, keys, connector config) redacted below.

Common setup:

```bash
# CONFIG = x-connector-config header, built from local UAT keys (redacted)
export CONFIG='<REDACTED_CONNECTOR_CONFIG>'   # contains <API_KEY>, <OFFICE_ID>, <MERCHANT_ID>, <KID>, PEMs
```

### Test 1 — success sync (regression): merchant_transaction_id still returned

```bash
ORDER='<CHARGED_ORDER_REF>'
grpcurl -plaintext -H "x-connector: twoc_twop_paco" \
  -H "x-connector-config: $CONFIG" \
  -H "x-connector-request-reference-id: $ORDER" -H "x-tenant-id: default" \
  -d '{ "merchant_transaction_id":"'"$ORDER"'","merchant_request_id":"<GUID>",
        "connector_transaction_id":"<CONNECTOR_TXN_ID>",
        "amount":{"minor_amount":"10000","currency":"PHP"} }' \
  localhost:8000 types.PaymentService/Get
```

Observed:
```json
{ "status":"CHARGED",
  "merchantTransactionId":"<CHARGED_ORDER_REF>",
  "amount":{"minorAmount":"10000","currency":"PHP"} }
```
✅ No regression — merchant_transaction_id present on success.

### Test 2 — failed sync (the bug): merchant_transaction_id now returned

Synced an order whose payment ended in a connector FAILURE status (declined
card), exercising the `Err(..)` branch.

```bash
ORDER='<DECLINED_ORDER_REF>'
grpcurl -plaintext -H "x-connector: twoc_twop_paco" \
  -H "x-connector-config: $CONFIG" \
  -H "x-connector-request-reference-id: $ORDER" -H "x-tenant-id: default" \
  -d '{ "merchant_transaction_id":"'"$ORDER"'","merchant_request_id":"<GUID>",
        "connector_transaction_id":"<CONNECTOR_TXN_ID>",
        "amount":{"minor_amount":"10000","currency":"PHP"} }' \
  localhost:8000 types.PaymentService/Get
```

Observed (**after** fix):
```json
{ "status":"FAILURE",
  "merchant_transaction_id":"<DECLINED_ORDER_REF>",   // was absent before the fix
  "amount":{"minorAmount":"10000","currency":"PHP"},
  "has_error":true, "status_code":200 }
```
✅ On the failure path the merchant transaction id is now populated with the
caller-supplied reference. **Before** the fix this field was `None` (absent),
which is what triggered the downstream integrity failure.

## Scope

- Single field in shared code; no connector-specific logic.
- Behaviour on the success path is unchanged.
