### PR TITLE
docs(grace): add OrcaRouter as an alternative AI provider

### DIFF
--- a/grace/.env.example
+++ b/grace/.env.example
@@ -11,6 +11,14 @@ AI_VISION_MODEL_ID=openai/glm-46-fp8
 AI_MAX_TOKENS=32768
 AI_TEMPERATURE=0.7
 
+# Alternative: route through the OrcaRouter gateway
+# (model id repeats the provider prefix because LiteLLM forwards the model id
+# to the OpenAI-compatible endpoint after stripping its own leading prefix)
+# AI_API_KEY=sk-orca-...
+# AI_BASE_URL=https://api.orcarouter.ai/v1
+# AI_MODEL_ID=openai/openai/gpt-4o
+# AI_VISION_MODEL_ID=openai/openai/gpt-4o
+
 # Firecrawl API Key (Required for web scraping)
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
 

--- a/grace/setup.md
+++ b/grace/setup.md
@@ -76,6 +76,20 @@ AI_BASE_URL=https://api.anthropic.com/v1
 AI_MODEL_ID=anthropic/claude-sonnet-4-20250514
 ```
 
+### Using OrcaRouter
+
+```env
+AI_API_KEY=sk-orca-...
+AI_BASE_URL=https://api.orcarouter.ai/v1
+AI_MODEL_ID=openai/openai/gpt-4o
+AI_VISION_MODEL_ID=openai/openai/gpt-4o
+```
+
+> **Note:** OrcaRouter model ids carry their own provider prefix (e.g.
+> `openai/gpt-4o`). Because Grace routes through LiteLLM, the leading `openai/`
+> is repeated so LiteLLM forwards the full `openai/gpt-4o` id to OrcaRouter.
+> Get a key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
+
 ### For URL Scraping
 
 Set one of:


### PR DESCRIPTION
## Description

Documents [OrcaRouter](https://www.orcarouter.ai) as an alternative AI provider
for the Grace code-generation CLI, alongside the existing GRID / OpenAI /
Anthropic provider examples in the API-key configuration section of the setup
guide. OrcaRouter is an OpenAI-compatible model routing gateway that exposes
200+ models from OpenAI, Anthropic, Google, DeepSeek and others behind a single
endpoint and API key. It also provides gateway-level security controls for AI
agents.

I'm an engineer on the OrcaRouter team.

## Motivation and Context

`grace/setup.md` section 3 already lists named provider configs for GRID,
OpenAI and Anthropic. Adding an OrcaRouter entry gives users another one-line
option for routing Grace's LLM calls, with no code changes required.

Note on the model id: OrcaRouter model ids carry their own provider prefix
(e.g. `openai/gpt-4o`). Because Grace routes through LiteLLM, the leading
`openai/` is repeated (`openai/openai/gpt-4o`) so LiteLLM strips only its own
router prefix and forwards the full `openai/gpt-4o` id to OrcaRouter.

### Additional Changes
- [ ] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables
  - `grace/.env.example`: adds a commented OrcaRouter gateway alternative block
    (documentation/example only, no runtime behavior change)

## How did you test it?

- Live API: `litellm.completion(model="openai/openai/gpt-4o",
  api_base="https://api.orcarouter.ai/v1", ...)` returns a valid completion
  (HTTP 200) against the real OrcaRouter API; the Anthropic-protocol path
  (`anthropic/anthropic/claude-sonnet-4.6` against `/v1/messages`) also returns
  200.
- Verified `openai/orcarouter/auto` auto-routing is NOT used as the documented
  default because its upstream pool can return empty responses on short probes;
  a pinned model id (`openai/gpt-4o`) is documented instead.
