### PR TITLE
ci: require create_all_prerequisites! for newly added connectors

### DIFF
--- a/.github/scripts/check-new-connector-flow-declaration.sh
+++ b/.github/scripts/check-new-connector-flow-declaration.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# New connectors must declare their flows through create_all_prerequisites!.
+#
+# check_connector_specs derives flow -> suite coverage from the macro's api:
+# list, and prints [SKIP] for a connector that has no macro. A new connector
+# without one therefore gets no flow coverage at all: nothing checks that the
+# flows it implements appear in its specs.json. Requiring the macro is what
+# brings the connector under that check.
+#
+# Scoped to connectors that did not exist at the PR's base commit. Existing
+# connectors are left alone: some hand-write a flow because the macro cannot
+# express it — two flows sharing a request or response type collide on the
+# marker structs it emits, and a flow whose response type is decided at runtime
+# does not fit the single ResponseBody a Bridge carries. Scoping to new code
+# keeps this enforceable without an exception list.
+#
+# Inputs:
+#   NEW_CONNECTORS  comma-separated connector names added in this PR
+#
+# Exit status: 0 unless a new connector is missing the macro or declares no flows.
+
+set -uo pipefail
+
+# Payment connectors only. check_connector_specs draws its universe from this
+# directory alone, and every payout flow maps to None in flow_to_suites, so the
+# macro buys no coverage there — 7 of the 9 payout connectors do not use it.
+SRC_ROOT=crates/integrations/connector-integration/src/connectors
+
+failures=0
+
+if [[ -z "${NEW_CONNECTORS:-}" ]]; then
+  echo "No newly added connectors."
+  exit 0
+fi
+
+IFS=',' read -ra CONNECTORS <<< "${NEW_CONNECTORS}"
+
+for name in "${CONNECTORS[@]}"; do
+  [[ -n "${name}" ]] || continue
+
+  # Names reach this script from paths in the diff, so keep them to the shape a
+  # connector name can have before they are used to build a path.
+  if [[ ! "${name}" =~ ^[a-z0-9_]+$ ]]; then
+    echo "::error::Not a valid connector name: '${name}'"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # Names are extracted from paths, and "connectors/" also matches inside
+  # "payout_connectors/", so a payout or authenticator connector can arrive
+  # here. Those live outside this rule; skip rather than fail. A payment
+  # connector with a spec directory and no source is already caught by
+  # check_connector_specs' phase 1 parity check.
+  src="${SRC_ROOT}/${name}.rs"
+  if [[ ! -f "${src}" ]]; then
+    echo "Skipping '${name}': no ${src} (not a payment connector)"
+    continue
+  fi
+
+  if ! grep -q 'macros::create_all_prerequisites!(' "${src}"; then
+    echo "::error::New connector '${name}' does not use create_all_prerequisites! in ${src}. check_connector_specs derives flow -> suite coverage from the macro's api: list and skips connectors that have none, so this connector's flows would never be checked against its specs.json. Declare them through the macro."
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # An empty api: [] satisfies a presence check while declaring nothing.
+  if ! grep -Pzoq 'macros::create_all_prerequisites!\((?s).*?api:\s*\[\s*\(' "${src}"; then
+    echo "::error::New connector '${name}' calls create_all_prerequisites! with an empty api: [] in ${src}. Declare at least one flow."
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "::error::${failures} new connector(s) failed the flow-declaration check"
+  exit 1
+fi
+
+echo "All newly added connectors declare their flows through create_all_prerequisites!."
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       any-rs: ${{ steps.filter.outputs.any-rs }}
       ci: ${{ steps.filter.outputs.ci }}
       connector-names: ${{ steps.connector-names.outputs.list }}
+      new-connectors: ${{ steps.new-connectors.outputs.list }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -123,6 +124,39 @@ jobs:
             sort -u | paste -sd ',' -)
           echo "list=$names" >> $GITHUB_OUTPUT
           echo "Changed connectors: $names"
+
+      - name: Detect newly added connectors
+        id: new-connectors
+        if: steps.connector-names.outputs.list != ''
+        shell: bash
+        env:
+          # Read through the environment, never interpolated into the script:
+          # these derive from paths in the diff, which a fork PR controls.
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+          CHANGED_CONNECTORS: ${{ steps.connector-names.outputs.list }}
+        run: |
+          new_list=""
+          # No usable base to compare against: merge_group carries neither
+          # field, and the first push of a branch reports all zeros. Treating
+          # that as "everything is new" would fail the run for connectors the
+          # change never added, so report nothing instead.
+          if [[ -z "${BASE_REF}" || "${BASE_REF}" =~ ^0+$ ]] \
+            || ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
+            echo "No base commit available (BASE_REF='${BASE_REF}') — skipping detection"
+          else
+            IFS=',' read -ra CONNECTORS <<< "${CHANGED_CONNECTORS}"
+            for c in "${CONNECTORS[@]}"; do
+              spec_dir="crates/internal/integration-tests/src/connector_specs/$c"
+              # New if its spec directory does not exist on the base branch as
+              # of this event, so a connector someone else added is not
+              # attributed to this change.
+              if ! git cat-file -e "${BASE_REF}:${spec_dir}" 2>/dev/null; then
+                new_list="${new_list}${new_list:+,}${c}"
+              fi
+            done
+          fi
+          echo "list=$new_list" >> $GITHUB_OUTPUT
+          echo "Newly added connectors: $new_list"
 
   # ── Fast Checks ───────────────────────────────────────────────────────────
 
@@ -418,6 +452,13 @@ jobs:
 
       - name: Run Connector Specs Coverage Check
         run: cargo run --all-features --bin check_connector_specs
+
+      - name: Check new connectors declare flows through the macro
+        if: needs.changes.outputs.new-connectors != ''
+        shell: bash
+        env:
+          NEW_CONNECTORS: ${{ needs.changes.outputs.new-connectors }}
+        run: .github/scripts/check-new-connector-flow-declaration.sh
 
       - name: Run Superposition Config Validation
         run: cargo test -p grpc-server --all-features --test test_superposition_config


### PR DESCRIPTION
## What

A connector added in a PR must declare its flows through `create_all_prerequisites!`. Existing connectors are untouched.

## Why

`check_connector_specs` derives flow → suite coverage from the macro's `api:` list. A connector without the macro is not partially checked — it is skipped outright:

```rust
println!("[SKIP] {connector}  (no create_all_prerequisites! macro)");
```

So a new connector that hand-writes its `ConnectorIntegrationV2` impls gets **no flow coverage at all**: nothing verifies that the flows it implements appear in its `specs.json`. Requiring the macro is what brings the connector under the existing check. Two connectors are in that state on `main` today — `razorpay` and `razorpayv2` — and neither has ever been flow-checked.

## Why it is scoped to new connectors

The macro cannot express every flow. `impl_templating_mixed!` emits one marker struct per request type and one per response type, and keys the `BridgeRequestResponse` impl on that pair — the flow is not part of the key. So two flows sharing *either* type do not compile:

```
error[E0428]: the name `CnpOnlineResponseTemplating` is defined multiple times
error[E0119]: conflicting implementations of trait `BridgeRequestResponse`
```

That this is structural rather than a matter of style is measurable: of the 102 connectors with a non-empty `api:` list, **zero** reuse a request or response type across two entries. It is the only shape that compiles. `worldpayvantiv` is the clearest case — `CnpOnlineResponse` is returned by Authorize, Capture, Void, VoidPC, Refund and IncrementalAuthorization, so only one of them can be declared.

Separately, a flow whose response type is chosen at runtime — `braintree` `Authorize` branches on `is_auto_capture()` — does not fit the single `ResponseBody` a `Bridge` carries.

Widening the rule would mean changing those connectors first. Scoping it to new code keeps it enforceable with no exception list for a future author to add themselves to.

## Blast radius

Three connectors on `main` would not satisfy the rule today — `itaubank` (empty `api: []`), `razorpay`, `razorpayv2` (no macro). None is newly added, so none is affected.

Both recently added connectors pass:

| connector | macro | flows in `api:` |
|---|---|---|
| `ilixium` | yes | 7 |
| `worldpayraft` (#2138) | yes | 5 |

## Scope: payment connectors only

`check_connector_specs` draws its universe from `connectors/` alone, and every payout flow maps to `None` in `flow_to_suites`, so the macro buys no coverage outside that directory — 7 of the 9 payout connectors do not use it.

This matters because connector names are extracted from paths, and `connectors/` also matches inside `payout_connectors/`. `santander`, `deutschebank` (payout) and `plaid` have no spec directory, so they are reported as newly added on any edit; a name with no `connectors/<name>.rs` is therefore skipped rather than failed. A payment connector with a spec directory and no source file is already caught by phase 1 parity.

## Robustness

- rejects an empty `api: []`, which satisfies a presence check while declaring nothing
- detection reports nothing when there is no base commit — `merge_group` carries neither `pull_request.base.sha` nor `event.before`, and a branch's first push reports all zeros; treating that as "everything is new" would fail the run for connectors the change never added
- connector names are passed through `env:` rather than interpolated into the script, and validated against `^[a-z0-9_]+$`

## Note for reviewers

This PR changes no connector files, so `new-connectors` is empty and the new step is skipped on its own run. It is exercised by the next PR that adds a connector. Behaviour was verified locally against every connector in the tree.

## Cost

One `grep` per newly added connector, in the existing Compilation Check job. No new job, no build, no credentials.
