### PR TITLE
fix(connectors): [tsys_transit] send NTID in merchant initiated nitd transactions

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/cof_phase.rs
@@ -4,14 +4,7 @@
 //! actually distinguish:
 //!   • `NoCof`           — single-shot transaction
 //!   • `CitSetup`        — first-time CIT that stores the card
-//!   • `CitUsingStored`  — CIT re-using a stored card (consumer is present
-//!                          but the card was already on file)
 //!   • `Mit(MitKind)`    — merchant-initiated transaction
-//!
-//! The `CitUsingStored` vs `Mit` distinction is critical for the cert:
-//! the MOTO step-5 "25.50 Visa COF" row is a CIT-using-stored, and TSYS
-//! rejects it if we send `cardOnFile` / `cardOnFileTransactionIdentifier`
-//! (those are MIT-only).
 
 use common_enums::{FutureUsage, MitCategory};
 use domain_types::connector_types::{MandateIds, MandateReferenceId};
@@ -40,8 +33,6 @@ pub enum CofPhase {
     NoCof,
     /// CIT that stores the card on file for future MIT use.
     CitSetup { intended_kind: MitIntent },
-    /// CIT that re-uses a card already on file.
-    CitUsingStored,
     /// Merchant-initiated transaction.
     Mit(MitKind),
 }
@@ -69,20 +60,6 @@ impl CofPhase {
             });
 
         if has_mandate {
-            // A stored credential is being replayed. It is merchant-initiated
-            // ONLY when an explicit `mit_category` is set; otherwise the
-            // consumer is present and re-using the stored card
-            // (CitUsingStored — cert MOTO step-5 25.50 Visa / 29.75 MC COF).
-            //
-            // NOTE: `off_session` alone does NOT imply MIT here. Hyperswitch
-            // sets `off_session=true` for ANY stored-credential replay,
-            // including the consumer-present CIT-using-stored rows, so keying
-            // MIT off `off_session` misclassifies those CITs as MITs
-            // (M101/cardOnFileTransactionIdentifier instead of C101).
-            let is_mit = mit_category.is_some();
-            if !is_mit {
-                return Self::CitUsingStored;
-            }
             let kind = match mit_category {
                 Some(MitCategory::Recurring) => MitKind::Recurring,
                 Some(MitCategory::Installment) => MitKind::Installment,
@@ -114,16 +91,11 @@ impl CofPhase {
         matches!(self, Self::CitSetup { .. })
     }
 
-    pub fn is_cit_using_stored(self) -> bool {
-        matches!(self, Self::CitUsingStored)
-    }
-
     pub fn is_mit(self) -> bool {
         matches!(self, Self::Mit(_))
     }
 
     /// True for any flow that has stored credentials in play (CitSetup,
-    /// CitUsingStored or any MIT). Useful for cardDataInputMode gating.
     pub fn involves_stored_credential(self) -> bool {
         !self.is_no_cof()
     }

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/profile/mod.rs
@@ -9,7 +9,7 @@
 //! Axes:
 //!   • `acceptance`       — channel + recurring classification
 //!   • `card_family`      — Visa / MC / AMEX / Discover-like
-//!   • `cof_phase`        — NoCof / CitSetup / CitUsingStored / Mit(kind)
+//!   • `cof_phase`        — NoCof / CitSetup / Mit(kind)
 //!   • `commercial_level` — None / L2 / L3
 //!   • `three_ds`         — None / Present
 //!   • `capture`          — Auto / Manual

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/card_input_mode.rs
@@ -53,7 +53,7 @@ pub fn card_data_input_mode(
     // 4. MIT (any kind) OR CIT-using-stored — both replay a stored
     //    credential, so both carry the STORED_ON_FILE input mode (cert MOTO
     //    25.50 Visa / 29.75 MC CIT-using-stored rows use this too).
-    if profile.cof_phase.is_mit() || profile.cof_phase.is_cit_using_stored() {
+    if profile.cof_phase.is_mit() {
         return MerchantInitiatedTransactionCardCredentialStoredOnFile;
     }
 

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/cof_mit.rs
@@ -84,7 +84,6 @@ pub fn cit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMcCitStatu
             MitIntent::Recurring => C102,
             MitIntent::Installment => C104,
         }),
-        CofPhase::CitUsingStored => Some(C101),
         CofPhase::NoCof | CofPhase::Mit(_) => None,
     }
 }
@@ -92,10 +91,6 @@ pub fn cit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMcCitStatu
 /// `mitStatusIndicator`.
 pub fn mit_status_indicator(profile: &TxProfile) -> Option<TsysTransitMitIndicator> {
     use TsysTransitMitIndicator::*;
-    // CIT-using-stored never sends MIT status (use citStatusIndicator).
-    if matches!(profile.cof_phase, CofPhase::CitUsingStored) {
-        return None;
-    }
     let CofPhase::Mit(kind) = profile.cof_phase else {
         return None;
     };

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/rules/tests.rs
@@ -311,47 +311,6 @@ fn mit_uses_stored_on_file_marker() {
 }
 
 #[test]
-fn cit_using_stored_uses_stored_on_file_marker() {
-    // TSYS_MOTO_V2 rows 161/162 (25.50 Visa / 29.75 MC CIT-using-stored) carry
-    // the STORED_ON_FILE input mode, same as an MIT.
-    let p = profile(
-        AcceptanceProfile::MotoPhone,
-        CardFamily::Mastercard,
-        CofPhase::CitUsingStored,
-        CommercialLevel::None,
-        CaptureKind::Auto,
-    );
-    let block = AcceptanceProfile::MotoPhone.terminal_data();
-    assert!(matches!(
-        card_input_mode::card_data_input_mode(&p, &block, false),
-        TsysTransitCardDataInputMode::MerchantInitiatedTransactionCardCredentialStoredOnFile
-    ));
-}
-
-#[test]
-fn derive_stored_replay_off_session_without_mit_category_is_cit_using_stored() {
-    // Hyperswitch sends off_session=true for EVERY stored-credential replay,
-    // including consumer-present CIT-using-stored (cert MOTO 25.50 Visa /
-    // 29.75 MC). Without an explicit mit_category it must resolve to
-    // CIT-using-stored (→ C101, no NTID), NOT an MIT (M101).
-    let mandate = domain_types::connector_types::MandateIds {
-        mandate_id: None,
-        mandate_reference_id: Some(
-            domain_types::connector_types::MandateReferenceId::NetworkMandateId(
-                domain_types::connector_types::NetworkMandateIdRef {
-                    network_transaction_id: "VTL1".to_string(),
-                    transaction_link_id: None,
-                },
-            ),
-        ),
-    };
-    assert_eq!(
-        CofPhase::derive(Some(&mandate), None, None, Some(true)),
-        CofPhase::CitUsingStored
-    );
-}
-
-#[test]
 fn derive_stored_replay_with_mit_category_is_mit() {
     let mandate = domain_types::connector_types::MandateIds {
         mandate_id: None,
@@ -594,22 +553,6 @@ fn card_on_file_is_y_on_visa_cit_setup() {
 }
 
 #[test]
-fn card_on_file_is_none_on_visa_cit_using_stored() {
-    // Cert: "cardOnFile tag must not be sent on the 25.50 Visa card on
-    // file transaction in step 5 as this tag is a Merchant initiated
-    // transaction (MIT) only and this test case is a Consumer initiated
-    // transaction (CIT)."
-    let p = profile(
-        AcceptanceProfile::MotoPhone,
-        CardFamily::Visa,
-        CofPhase::CitUsingStored,
-        CommercialLevel::None,
-        CaptureKind::Auto,
-    );
-    assert!(cof_mit::card_on_file(&p).is_none());
-}
-
-#[test]
 fn card_on_file_is_sent_on_visa_mit() {
     // Cert step 9: "cardOnFile tag must not be sent on the 25.50 Visa card on
     // file transaction." cardOnFile is a storage marker for CIT-setup only; a
@@ -712,26 +655,6 @@ fn card_on_file_none_on_discover_family_unscheduled_mit() {
 }
 
 #[test]
-fn cit_status_indicator_c101_on_mastercard_cit_using_stored() {
-    // Cert: "mitStatusIndicator tag must not be sent on the 29.75
-    // Mastercard transaction in step 5 as this test case is a Card on
-    // File CIT and not MIT. The citStatusIndicator tag will need to be
-    // sent on this test case with a value of 'C101'."
-    let p = profile(
-        AcceptanceProfile::MotoPhone,
-        CardFamily::Mastercard,
-        CofPhase::CitUsingStored,
-        CommercialLevel::None,
-        CaptureKind::Auto,
-    );
-    assert!(matches!(
-        cof_mit::cit_status_indicator(&p),
-        Some(TsysTransitMcCitStatusIndicator::C101)
-    ));
-    assert!(cof_mit::mit_status_indicator(&p).is_none());
-}
-
-#[test]
 fn cit_status_indicator_c101_on_mastercard_cit_setup() {
     // Cert: "citStatusIndicator tag must be sent on the 2.00 Mastercard
     // transaction in step 5 with a value of C101 as this transaction
@@ -785,23 +708,6 @@ fn mit_status_u_on_discover_unscheduled_mit() {
     assert!(matches!(
         cof_mit::mit_status_indicator(&p),
         Some(TsysTransitMitIndicator::U)
-    ));
-}
-
-#[test]
-fn should_not_send_cof_txn_id_on_cit_using_stored() {
-    // Cert: "cardOnFileTransactionIdentifier tag must not be sent on
-    // the 25.50 Visa card on file transaction in step 5 as this tag is
-    // a Merchant initiated transaction (MIT) only..."
-    let p = profile(
-        AcceptanceProfile::MotoPhone,
-        CardFamily::Visa,
-        CofPhase::CitUsingStored,
-        CommercialLevel::None,
-        CaptureKind::Auto,
-    );
-    assert!(!cof_mit::should_send_card_on_file_transaction_identifier(
-        &p
     ));
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We haven’t been sending the NTID in MIT flows when mit_category is not provided. Since the merchant isn’t sending mit_category in their MIT requests, it should default to unscheduled, but this case is currently not handled. This PR handles it

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Create an MIT payment with Visa

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_nEynku8kVmL1RCM34iamAMPxJG2ynaODxYqZKw8E1AWfk7K6jWcGhzkDOoTt6kUW' \
--data '{
    "amount": 107000,
    "currency": "USD",
    "off_session": true,
    "confirm": true,
    "capture_method": "automatic",
    "recurring_details": {
        "type": "payment_method_id",
        "data": "pm_Hvec8rhDX2aYTpR8ec6F"
    },
    "payment_channel": "telephone_order",
    "payment_method": "card",
    
    "customer_id":  "234386", 
    "mit_category": "unscheduled",

    
    
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "13.232.74.226"
    }
    

    
}'
```

Response

```
{
    "payment_id": "pay_TTJY1lA6D9li4AWGnHhV",
    "merchant_id": "postman_merchant_GHAction_122",
    "status": "succeeded",
    "amount": 107000,
    "net_amount": 107000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 107000,
    "processor_merchant_id": "postman_merchant_GHAction_122",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fYTJlSzE5MEZEUXNEQWI1Q2FiTmMscHVibGlzaGFibGVfa2V5PXBrX2Rldl9hZTQzZGJkOWRlOTU0OTY1Yjg3ZWM3NjFiMDUxNzU1MixjbGllbnRfc2VjcmV0PXBheV9UVEpZMWxBNkQ5bGk0QVdHbkhoVl9zZWNyZXRfUXIycTFZUUxtdEZ4NDJ2VEhKdkYsY3VzdG9tZXJfaWQ9MjM0Mzg2LGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzX0xWenlkYm5SaFQzY0liMVdsYzJGLHBheW1lbnRfaWQ9cGF5X1RUSlkxbEE2RDlsaTRBV0duSGhW",
    "connector": "tsys_transit",
    "state_metadata": null,
    "client_secret": "pay_TTJY1lA6D9li4AWGnHhV_secret_Qr2q1YQLmtFx42vTHJvF",
    "created": "2026-08-20T11:38:58.887Z",
    "modified_at": "2026-08-20T11:39:03.844Z",
    "connector_customer_id": null,
    "currency": "USD",
    "customer_id": "234386",
    "customer": {
        "id": "234386",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": true,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": "DEBIT",
            "card_network": "Visa",
            "card_issuer": "CONOTOXIA SP Z O.O.",
            "card_issuing_country": "POLAND",
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "28",
            "card_holder_name": "John Doe",
            "payment_checks": null,
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "86495623",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "86495623",
    "payment_link": null,
    "profile_id": "pro_a2eK190FDQsDAb5CabNc",
    "surcharge_details": null,
    "applied_offer": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_EtHnz6Ea4kJbOerd7k24",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-20T11:53:58.887Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "13.232.74.226",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": "telephone_order",
    "payment_method_id": "pm_Hvec8rhDX2aYTpR8ec6F",
    "network_transaction_id": "000000001834206",
    "network_transaction_link_id": null,
    "payment_method_status": "active",
    "updated": "2026-08-20T11:39:03.844Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "saved_card",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": true,
    "mit_category": "unscheduled",
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_Hvec8rhDX2aYTpR8ec6F",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": "000000001830177",
        "network_transaction_link_id": null,
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

Mastercard MIT 

```
<?xml version="1.0" encoding="UTF-8"?>
<Sale><deviceID>*****</deviceID><transactionKey>*****</transactionKey><cardDataSource>PHONE</cardDataSource><transactionAmount>1070.00</transactionAmount><cardNumber>5146315000000055</cardNumber><expirationDate>12/28</expirationDate><mitStatusIndicator>M101</mitStatusIndicator><addressLine1>123 Main St</addressLine1><zip>10001</zip><externalReferenceID>payfk13T2epsrWPZmOSfCkm1</externalReferenceID><terminalCapability>KEYED_ENTRY_ONLY</terminalCapability><terminalOperatingEnvironment>ON_MERCHANT_PREMISES_ATTENDED</terminalOperatingEnvironment><cardholderAuthenticationMethod>NOT_AUTHENTICATED</cardholderAuthenticationMethod><terminalAuthenticationCapability>NO_CAPABILITY</terminalAuthenticationCapability><terminalOutputCapability>DISPLAY_ONLY</terminalOutputCapability><maxPinLength>NOT_SUPPORTED</maxPinLength><terminalCardCaptureCapability>NO_CAPABILITY</terminalCardCaptureCapability><cardholderPresentDetail>CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION</cardholderPresentDetail><cardPresentDetail>CARD_NOT_PRESENT</cardPresentDetail><cardDataInputMode>MERCHANT_INITIATED_TRANSACTION_CARD_CREDENTIAL_STORED_ON_FILE</cardDataInputMode><cardholderAuthenticationEntity>NOT_AUTHENTICATED</cardholderAuthenticationEntity><cardDataOutputCapability>NONE</cardDataOutputCapability><developerID>*****</developerID><authorizationIndicator>FINAL</authorizationIndicator></Sale>
```

Sanity : 
1. Refund - succeeded
2.  Manual Capture - Psync - MIT 