### PR TITLE
fix(clippy): drop two useless format! calls failing CI

### DIFF
--- a/crates/common/common_utils/src/crypto.rs
+++ b/crates/common/common_utils/src/crypto.rs
@@ -904,10 +904,7 @@ mod crypto_tests {
     fn test_md5_digest() {
         let message = "abcdefghijklmnopqrstuvwxyz".as_bytes();
         assert_eq!(
-            format!(
-                "{}",
-                hex::encode(super::Md5.generate_digest(message).expect("Digest"))
-            ),
+            hex::encode(super::Md5.generate_digest(message).expect("Digest")),
             "c3fcd3d76192e4007dfb496cca67e13b"
         );
     }

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -1401,7 +1401,7 @@ pub async fn call_connector_api(
             };
             info_log(
                 "REQUEST_FAILURE",
-                &json!(format!("Unable to send request to connector.",)),
+                &json!("Unable to send request to connector."),
             );
             report!(api_error)
         })


### PR DESCRIPTION
## Description

Two `clippy::useless_format` sites — `format!` with no interpolation:

- `crates/common/common_utils/src/crypto.rs` — `hex::encode` already returns a `String`.
- `crates/common/external-services/src/service.rs` — `format!` on a string literal.

Both are pre-existing and unchanged; clippy 1.98 tightened the lint.

## Motivation and Context

CI fails on every branch:

```
error: useless use of `format!`
    = note: `-D clippy::useless-format` implied by `-D warnings`
error: could not compile `external-services` (lib test) due to 1 previous error
Error: Process completed with exit code 101.
```

Fixed on `main` so it clears for all open branches at once rather than being duplicated into unrelated feature PRs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

Ran CI's clippy step verbatim, including its env (`.github/workflows/ci.yml:167-169`):

```shell
RUSTFLAGS="-D warnings" cargo +stable clippy --all-features --all-targets --profile release-fast
```

Passes with exit 0. Both lints were reproducible before the change and gone after.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
