### PR TITLE
fix(log): decode _DOT_ in target paths and add dev log field config

### DIFF
--- a/crates/common/common_utils/src/consts.rs
+++ b/crates/common/common_utils/src/consts.rs
@@ -34,9 +34,17 @@ pub const MIN_GLOBAL_ID_LENGTH: u8 = 32;
 /// Encoded dot separator used in prod infra config keys (e.g. `request_DOT_body`).
 pub const DOT_ENCODED: &str = "_DOT_";
 
-/// Decode `_DOT_` back to `.` in field names from prod config.
+/// Lowercase variant of [`DOT_ENCODED`] for case-insensitive matching.
+/// The `config` crate lowercases all TOML keys at parse time, so runtime
+/// values contain `_dot_` instead of `_DOT_`.
+pub const DOT_ENCODED_LOWER: &str = "_dot_";
+
+/// Decode `_DOT_` back to `.` in field names from config.
+///
+/// Lowercases the input first so that both `_DOT_` (source TOML) and `_dot_`
+/// (lowercased by the `config` crate) are matched.
 pub fn decode_dot(s: &str) -> String {
-    s.replace(DOT_ENCODED, ".")
+    s.to_lowercase().replace(DOT_ENCODED_LOWER, ".")
 }
 
 // =============================================================================

--- a/crates/common/common_utils/src/events.rs
+++ b/crates/common/common_utils/src/events.rs
@@ -547,7 +547,8 @@ impl CompiledLogFields {
         let rules = raw
             .iter()
             .filter_map(|(target_path, field_entry)| {
-                let segments: Vec<String> = target_path.split('.').map(String::from).collect();
+                let decoded_target = crate::consts::decode_dot(target_path);
+                let segments: Vec<String> = decoded_target.split('.').map(String::from).collect();
                 let root_key = segments.first()?.clone();
                 let entry = match field_entry {
                     LogFieldEntry::Source { source } => {


### PR DESCRIPTION
## Summary
- **Bug fix**: `decode_dot` only matched uppercase `_DOT_`, but the `config` crate lowercases all TOML keys to `_dot_` at runtime. This caused target paths like `api_details_DOT_url` to appear as flat keys (`api_details_dot_url`) instead of nested JSON (`api_details.url`). Fix makes `decode_dot` case-insensitive.
- **Bug fix**: Target paths in `CompiledLogFields::compile()` were not being decoded with `decode_dot` at all — only source fields were. Added `decode_dot` on target paths before splitting by `.`.
- **Config**: Switch dev log format from `default` to `json` (pretty-printed) and add comprehensive `[log.fields]` config for both incoming and outgoing golden log lines.
- **Dev convenience**: Map `LogFormat::Json` to `PrettyJson` output for readable local development logs.

## Test plan
- [x] Built and ran server locally with `development.toml`
- [x] Sent authorize request via `grpcurl` to `localhost:8000`
- [x] Verified outgoing logs show nested `api_details.url`, `api_details.method`, etc. instead of flat `api_details_dot_url`
- [x] Verified incoming logs show nested `message.latency`, `message.res_code`, etc.