### PR TITLE
ci(docker): publish a latest image tag and document running the server image

### DIFF
--- a/.github/workflows/docker-to-ghcr-publish.yml
+++ b/.github/workflows/docker-to-ghcr-publish.yml
@@ -182,6 +182,7 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           if [[ "${REF_NAME}" =~ ^20[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
             docker buildx imagetools create --tag "ghcr.io/${REPO}:latest" "ghcr.io/${REPO}:${VERSION}"
             echo "Moved latest to ghcr.io/${REPO}:${VERSION}"

--- a/.github/workflows/docker-to-ghcr-publish.yml
+++ b/.github/workflows/docker-to-ghcr-publish.yml
@@ -159,21 +159,6 @@ jobs:
             "ghcr.io/${REPO}:${VERSION}-linux-arm64"
           echo "Successfully created manifest: ghcr.io/${REPO}:${VERSION}"
 
-      # `latest` follows nightly CalVer tags only. Hotfix tags are cut from
-      # older release branches and branch dispatches build unreleased code, so
-      # neither may move it backwards.
-      - name: Tag latest
-        if: ${{ github.ref_type == 'tag' }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ "${REF_NAME}" =~ ^20[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
-            docker buildx imagetools create --tag "ghcr.io/${REPO}:latest" "ghcr.io/${REPO}:${VERSION}"
-            echo "Moved latest to ghcr.io/${REPO}:${VERSION}"
-          else
-            echo "Tag '${REF_NAME}' is not a nightly tag - leaving latest unchanged."
-          fi
-
       - name: Get manifest digest
         id: digest
         run: |
@@ -188,3 +173,18 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
+
+      # `latest` follows nightly CalVer tags only. Hotfix tags are cut from
+      # older release branches and branch dispatches build unreleased code, so
+      # neither may move it backwards.
+      - name: Tag latest
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" =~ ^20[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
+            docker buildx imagetools create --tag "ghcr.io/${REPO}:latest" "ghcr.io/${REPO}:${VERSION}"
+            echo "Moved latest to ghcr.io/${REPO}:${VERSION}"
+          else
+            echo "Tag '${REF_NAME}' is not a nightly tag - leaving latest unchanged."
+          fi

--- a/.github/workflows/docker-to-ghcr-publish.yml
+++ b/.github/workflows/docker-to-ghcr-publish.yml
@@ -159,6 +159,21 @@ jobs:
             "ghcr.io/${REPO}:${VERSION}-linux-arm64"
           echo "Successfully created manifest: ghcr.io/${REPO}:${VERSION}"
 
+      # `latest` follows nightly CalVer tags only. Hotfix tags are cut from
+      # older release branches and branch dispatches build unreleased code, so
+      # neither may move it backwards.
+      - name: Tag latest
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" =~ ^20[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
+            docker buildx imagetools create --tag "ghcr.io/${REPO}:latest" "ghcr.io/${REPO}:${VERSION}"
+            echo "Moved latest to ghcr.io/${REPO}:${VERSION}"
+          else
+            echo "Tag '${REF_NAME}' is not a nightly tag - leaving latest unchanged."
+          fi
+
       - name: Get manifest digest
         id: digest
         run: |

--- a/README.md
+++ b/README.md
@@ -258,16 +258,18 @@ docker run --rm -p 8000:8000 ghcr.io/juspay/hyperswitch-prism:latest
 
 `--rm` deletes the container once it exits — leave it out if you want to read the logs afterwards.
 
-Server reflection is enabled, so [`grpcurl`](https://github.com/fullstorydev/grpcurl) works without local `.proto` files:
+The server registers its own descriptors, so [`grpcurl`](https://github.com/fullstorydev/grpcurl) needs no local `.proto` files — it can list the services and print the exact request schema:
 
 ```bash
 grpcurl -plaintext localhost:8000 grpc.health.v1.Health/Check
 # { "status": "SERVING" }
 
 grpcurl -plaintext localhost:8000 list
+grpcurl -plaintext localhost:8000 describe types.PaymentService.Authorize
+grpcurl -plaintext localhost:8000 describe types.PaymentServiceAuthorizeRequest
 ```
 
-Connector credentials are sent per request as gRPC metadata (`x-connector`, `x-auth`, `x-api-key`, ...) — the server keeps nothing. See [setup.md](./setup.md) for a complete authorize request and troubleshooting.
+Connector credentials are sent per request as gRPC metadata (`x-connector`, `x-auth`, `x-api-key`, ...) — the server keeps nothing. The proto definitions are in [`crates/types-traits/grpc-api-types/proto`](./crates/types-traits/grpc-api-types/proto).
 
 ### Configuration
 
@@ -306,12 +308,6 @@ docker run --rm -p 8000:8000 \
 ```
 
 The endpoint must be an OTLP gRPC receiver (port 4317), not an HTTP one. Both paths are independent — enabling OTLP does not turn off the `/metrics` endpoint.
-
-### Building the image yourself
-
-```bash
-docker build -t hyperswitch-prism:local .
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,53 @@ Ready-made integrations for popular platforms.
 
 ---
 
+## 🐳 Running the gRPC Server (Docker)
+
+Prism also runs as a standalone gRPC server. Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every nightly tag — [browse the available tags](https://github.com/juspay/hyperswitch-prism/pkgs/container/hyperswitch-prism). There is no `latest` tag, so pick a dated one.
+
+```bash
+# gRPC on 8000, Prometheus metrics on 8080
+docker run --rm -p 8000:8000 -p 8080:8080 \
+  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+```
+
+Server reflection is enabled, so [`grpcurl`](https://github.com/fullstorydev/grpcurl) works without local `.proto` files:
+
+```bash
+grpcurl -plaintext localhost:8000 grpc.health.v1.Health/Check
+# { "status": "SERVING" }
+
+grpcurl -plaintext localhost:8000 list
+```
+
+Connector credentials are sent per request as gRPC metadata (`x-connector`, `x-auth`, `x-api-key`, ...) — the server keeps nothing. See [setup.md](./setup.md) for a complete authorize request and troubleshooting.
+
+### Configuration
+
+The image ships `development.toml` (default), `sandbox.toml` and `production.toml`. Pick one with `CS__COMMON__ENVIRONMENT`:
+
+```bash
+docker run --rm -p 8000:8000 -p 8080:8080 \
+  -e CS__COMMON__ENVIRONMENT=sandbox \
+  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+```
+
+Individual keys are overridden with `CS__<SECTION>__<KEY>` environment variables, for example `CS__SERVER__PORT=9000`. To supply a config of your own, mount it over the one in the image:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v "$(pwd)/my-config.toml:/app/config/development.toml:ro" \
+  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+```
+
+### Building the image yourself
+
+```bash
+docker build -t hyperswitch-prism:local .
+```
+
+---
+
 ## 🛠️ Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -256,8 +256,6 @@ Prism also runs as a standalone gRPC server. Multi-arch images (`linux/amd64`, `
 docker run --rm -p 8000:8000 ghcr.io/juspay/hyperswitch-prism:latest
 ```
 
-`--rm` deletes the container once it exits — leave it out if you want to read the logs afterwards.
-
 The server registers its own descriptors, so [`grpcurl`](https://github.com/fullstorydev/grpcurl) needs no local `.proto` files — it can list the services and print the exact request schema:
 
 ```bash
@@ -269,7 +267,7 @@ grpcurl -plaintext localhost:8000 describe types.PaymentService.Authorize
 grpcurl -plaintext localhost:8000 describe types.PaymentServiceAuthorizeRequest
 ```
 
-Connector credentials are sent per request as gRPC metadata (`x-connector`, `x-auth`, `x-api-key`, ...) — the server keeps nothing. The proto definitions are in [`crates/types-traits/grpc-api-types/proto`](./crates/types-traits/grpc-api-types/proto).
+Connector credentials are sent per request in the `x-connector-config` metadata header, as JSON of the form `{"config":{"Stripe":{"api_key":"sk_test_..."}}}` — it selects the connector and carries its credentials, and the server keeps neither. The proto definitions are in [`crates/types-traits/grpc-api-types/proto`](./crates/types-traits/grpc-api-types/proto).
 
 ### Configuration
 
@@ -291,23 +289,12 @@ docker run --rm -p 8000:8000 \
 
 ### Metrics
 
-Prometheus metrics are always served on port `8080`. Publish that port as well if you want to scrape them:
+Prometheus metrics are served on port `8080`. Publish that port as well if you want to scrape them:
 
 ```bash
 docker run --rm -p 8000:8000 -p 8080:8080 ghcr.io/juspay/hyperswitch-prism:latest
 curl localhost:8080/metrics
 ```
-
-The same instruments can be pushed to an OpenTelemetry collector over OTLP/gRPC instead. That pipeline is compiled into the image but disabled in every config it ships with, so turn it on explicitly:
-
-```bash
-docker run --rm -p 8000:8000 \
-  -e CS__METRICS__OTEL__ENABLED=true \
-  -e CS__METRICS__OTEL__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
-  ghcr.io/juspay/hyperswitch-prism:latest
-```
-
-The endpoint must be an OTLP gRPC receiver (port 4317), not an HTTP one. Both paths are independent — enabling OTLP does not turn off the `/metrics` endpoint.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,21 @@ docker run --rm -p 8000:8000 -p 8080:8080 ghcr.io/juspay/hyperswitch-prism:lates
 curl localhost:8080/metrics
 ```
 
+The endpoint is empty until the server has handled its first request.
+
+The image is also built with the OTLP push pipeline compiled in, disabled by default.
+Enable it to push metrics to an OpenTelemetry collector over gRPC:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e CS__METRICS__OTEL__ENABLED=true \
+  -e CS__METRICS__OTEL__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
+  ghcr.io/juspay/hyperswitch-prism:latest
+```
+
+The endpoint must be an OTLP gRPC receiver (default port `4317`). Enabling this does
+not affect the Prometheus endpoint above.
+
 ---
 
 ## 🛠️ Development

--- a/README.md
+++ b/README.md
@@ -250,13 +250,13 @@ Ready-made integrations for popular platforms.
 
 ## 🐳 Running the gRPC Server (Docker)
 
-Prism also runs as a standalone gRPC server. Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every nightly tag — [browse the available tags](https://github.com/juspay/hyperswitch-prism/pkgs/container/hyperswitch-prism). There is no `latest` tag, so pick a dated one.
+Prism also runs as a standalone gRPC server. Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every nightly tag — [browse the available tags](https://github.com/juspay/hyperswitch-prism/pkgs/container/hyperswitch-prism). `latest` follows the most recent nightly; pin a dated tag for anything you need to reproduce.
 
 ```bash
-# gRPC on 8000, Prometheus metrics on 8080
-docker run --rm -p 8000:8000 -p 8080:8080 \
-  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+docker run --rm -p 8000:8000 ghcr.io/juspay/hyperswitch-prism:latest
 ```
+
+`--rm` deletes the container once it exits — leave it out if you want to read the logs afterwards.
 
 Server reflection is enabled, so [`grpcurl`](https://github.com/fullstorydev/grpcurl) works without local `.proto` files:
 
@@ -274,9 +274,9 @@ Connector credentials are sent per request as gRPC metadata (`x-connector`, `x-a
 The image ships `development.toml` (default), `sandbox.toml` and `production.toml`. Pick one with `CS__COMMON__ENVIRONMENT`:
 
 ```bash
-docker run --rm -p 8000:8000 -p 8080:8080 \
+docker run --rm -p 8000:8000 \
   -e CS__COMMON__ENVIRONMENT=sandbox \
-  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+  ghcr.io/juspay/hyperswitch-prism:latest
 ```
 
 Individual keys are overridden with `CS__<SECTION>__<KEY>` environment variables, for example `CS__SERVER__PORT=9000`. To supply a config of your own, mount it over the one in the image:
@@ -284,8 +284,28 @@ Individual keys are overridden with `CS__<SECTION>__<KEY>` environment variables
 ```bash
 docker run --rm -p 8000:8000 \
   -v "$(pwd)/my-config.toml:/app/config/development.toml:ro" \
-  ghcr.io/juspay/hyperswitch-prism:2026.08.25.0
+  ghcr.io/juspay/hyperswitch-prism:latest
 ```
+
+### Metrics
+
+Prometheus metrics are always served on port `8080`. Publish that port as well if you want to scrape them:
+
+```bash
+docker run --rm -p 8000:8000 -p 8080:8080 ghcr.io/juspay/hyperswitch-prism:latest
+curl localhost:8080/metrics
+```
+
+The same instruments can be pushed to an OpenTelemetry collector over OTLP/gRPC instead. That pipeline is compiled into the image but disabled in every config it ships with, so turn it on explicitly:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e CS__METRICS__OTEL__ENABLED=true \
+  -e CS__METRICS__OTEL__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
+  ghcr.io/juspay/hyperswitch-prism:latest
+```
+
+The endpoint must be an OTLP gRPC receiver (port 4317), not an HTTP one. Both paths are independent — enabling OTLP does not turn off the `/metrics` endpoint.
 
 ### Building the image yourself
 


### PR DESCRIPTION
## Description

The gRPC server is already published to GHCR on every nightly tag, but the README never said so — the only container instructions live in `setup.md` and describe a local `docker build`. This adds a **Running the gRPC Server (Docker)** section to the README, and publishes a `latest` tag so the first command in it is the one people actually type.

**CI** (`docker-to-ghcr-publish.yml`): `create-manifest` now also points `latest` at the freshly created manifest. It is guarded so only nightly CalVer tags move it — hotfix tags are cut from older release branches and a `workflow_dispatch` builds an unreleased branch, so neither may drag `latest` backwards.

**README**: pull/run, health check, configuration, metrics, and a local build.

- `ghcr.io/juspay/hyperswitch-prism`, multi-arch (`linux/amd64`, `linux/arm64`); `latest` for a quick start, dated tags to pin
- ports: gRPC `8000`; Prometheus metrics `8080`, called out separately rather than in the headline command since it is only needed if you scrape it
- OTLP push documented alongside it: the pipeline is compiled into the image but disabled in every config the image ships with, so it needs `CS__METRICS__OTEL__ENABLED=true` plus an endpoint
- `grpcurl` health check and `list` (server reflection is on, so no local `.proto` files are needed)
- config selection via `CS__COMMON__ENVIRONMENT`, per-key overrides via `CS__<SECTION>__<KEY>`, and mounting a custom config file

Open question for reviewers: `latest` currently follows nightly CalVer tags. Now that stable `vX.Y.Z` tags build images too, you may prefer `latest` to follow those instead — happy to switch, though `latest` would then not exist until the next stable tag.

## How did you test it?

Every command in the new section was run against the published image `ghcr.io/juspay/hyperswitch-prism:2026.08.25.0`:

- anonymous `docker pull` (no `docker login` needed — the package is public)
- `docker run -p 8000:8000 -p 8080:8080` → `grpc.health.v1.Health/Check` returns `{"status": "SERVING"}`; `/metrics` returns `200` with populated `GRPC_SERVER_REQUESTS_TOTAL` / `GRPC_SERVER_REQUEST_LATENCY` series
- `-e CS__COMMON__ENVIRONMENT=sandbox` → boots and serves
- `-e CS__SERVER__PORT=9001` → serves on the overridden port
- `-e CS__METRICS__OTEL__ENABLED=true -e CS__METRICS__OTEL__OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317` → logs `OTLP metrics push pipeline initialised, endpoint: Some("http://otel-collector:4317")`
- config mounted over `/app/config/development.toml` → serves on the port set in the mounted file
- the platform claim was checked against the live OCI index, not just the build matrix: `linux/amd64` + `linux/arm64` (the two `unknown/unknown` entries are provenance attestations)

The `latest` step itself cannot run until this lands on a tag build. Note that `latest` will therefore not resolve until the next nightly tag after merge; the README links the packages page for dated tags in the meantime.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all` (n/a — no Rust changes)
- [x] I addressed lints thrown by `cargo clippy` (n/a — no Rust changes)
- [x] I reviewed the submitted code
