### PR TITLE
feat(config): add euler golden-line log.fields mappings to production and development configs

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -16,6 +16,55 @@ brokers = ["localhost:9092"]
 topic = "connector-service-logs"
 buffer_limit = 100000
 
+# Euler golden-line field mapping (feature `log-transformations`), unified per-direction map.
+# { source = "span_field" } reads a span storage field; { value = "literal" } injects a constant.
+# Dotted target keys build the nested `api_details` object (renamed to euler `message` downstream).
+# Disabled by default in development; enable to test log transformation locally.
+[log.fields]
+enabled = false
+
+[log.fields.incoming]
+"x-request-id" = { source = "request_id" }
+"udf_order_id" = { source = "merchant_order_id" }
+"udf_customer_id" = { source = "customer_id" }
+"udf_txn_uuid" = { source = "merchant_transaction_id" }
+"entity" = { source = "flow" }
+"resp_code" = { source = "res_code" }
+"category" = { value = "INCOMING_API" }
+"schema_version" = { value = "V2" }
+"tag" = { value = "euler_logs" }
+"tenant_name" = { source = "tenant_id" }
+"latency" = { source = "latency_ms" }
+"api_details.url" = { source = "uri" }
+"api_details.method" = { source = "action" }
+"api_details.res_code" = { source = "res_code" }
+"api_details.req_body" = { source = "request_body" }
+"api_details.res_body" = { source = "response_body" }
+"api_details.error" = { source = "error_message" }
+"api_details.latency" = { source = "latency_ms" }
+"api_details.api_tag" = { source = "flow" }
+"api_details.req_type" = { value = "INTERNAL" }
+
+[log.fields.outgoing]
+"x-request-id" = { source = "request_id" }
+"entity" = { source = "flow" }
+"resp_code" = { source = "response.status_code" }
+"category" = { value = "OUTGOING_API" }
+"schema_version" = { value = "V2" }
+"tag" = { value = "euler_logs" }
+"tenant_name" = { source = "tenant_id" }
+"api_details.url" = { source = "request.url" }
+"api_details.method" = { source = "request.method" }
+"api_details.req_headers" = { source = "request.headers" }
+"api_details.req_body" = { source = "request.body" }
+"api_details.res_body" = { source = "response.body" }
+"api_details.res_headers" = { source = "response.headers" }
+"api_details.res_code" = { source = "response.status_code" }
+"api_details.error" = { source = "response.error_message" }
+"api_details.latency" = { source = "latency_ms" }
+"api_details.api_tag" = { source = "flow" }
+"api_details.req_type" = { value = "EXTERNAL" }
+
 [server]
 host = "0.0.0.0"
 port = 8000

--- a/config/production.toml
+++ b/config/production.toml
@@ -8,6 +8,59 @@ enabled = true
 level = "TRACE"
 log_format = "default"
 
+# Euler golden-line field mapping (feature `log-transformations`), unified per-direction map.
+# { source = "span_field" } reads a span storage field; { value = "literal" } injects a constant.
+# Dotted target keys build the nested `api_details` object (renamed to euler `message` downstream).
+# Patchable per-request via `x-config-override` (merge semantics).
+[log.fields]
+enabled = true
+
+[log.fields.incoming]
+"x-request-id" = { source = "request_id" }
+"udf_order_id" = { source = "merchant_order_id" }
+"udf_customer_id" = { source = "customer_id" }
+"udf_txn_uuid" = { source = "merchant_transaction_id" }
+"entity" = { source = "flow" }
+"resp_code" = { source = "res_code" }
+"category" = { value = "INCOMING_API" }
+"schema_version" = { value = "V2" }
+"tag" = { value = "euler_logs" }
+# euler sends the tenant NAME as x-tenant-id (span `tenant_id`); relabel it to `tenant_name`.
+# euler overrides the real `tenant_id` (uuid) per-request via x-config-override.
+"tenant_name" = { source = "tenant_id" }
+"latency" = { source = "latency_ms" }
+"api_details.url" = { source = "uri" }
+"api_details.method" = { source = "action" }
+"api_details.res_code" = { source = "res_code" }
+"api_details.req_body" = { source = "request_body" }
+"api_details.res_body" = { source = "response_body" }
+"api_details.error" = { source = "error_message" }
+"api_details.latency" = { source = "latency_ms" }
+"api_details.api_tag" = { source = "flow" }
+# req_type is a fixed per-direction constant (UCS is always called internally by euler).
+"api_details.req_type" = { value = "INTERNAL" }
+
+[log.fields.outgoing]
+"x-request-id" = { source = "request_id" }
+"entity" = { source = "flow" }
+"resp_code" = { source = "response.status_code" }
+"category" = { value = "OUTGOING_API" }
+"schema_version" = { value = "V2" }
+"tag" = { value = "euler_logs" }
+"tenant_name" = { source = "tenant_id" }
+"api_details.url" = { source = "request.url" }
+"api_details.method" = { source = "request.method" }
+"api_details.req_headers" = { source = "request.headers" }
+"api_details.req_body" = { source = "request.body" }
+"api_details.res_body" = { source = "response.body" }
+"api_details.res_headers" = { source = "response.headers" }
+"api_details.res_code" = { source = "response.status_code" }
+"api_details.error" = { source = "response.error_message" }
+"api_details.latency" = { source = "latency_ms" }
+"api_details.api_tag" = { source = "flow" }
+# req_type is a fixed per-direction constant (UCS→connector is always external).
+"api_details.req_type" = { value = "EXTERNAL" }
+
 [server]
 host = "0.0.0.0"
 port = 8000


### PR DESCRIPTION
## Summary

- Adds `[log.fields]` sections to `config/production.toml` and `config/development.toml` to wire UCS span storage fields into euler's golden log line schema
- Follows the same pattern as hyperswitch-infra PR #3253 (`euler_production_http.toml` / `euler_sandbox_http.toml`)
- Required for UCS logs to flow through euler's log pipeline (LP → Kafka → sessionizer → ClickHouse) with the correct schema

### Changes

**`config/production.toml`** — `enabled = true`
- `[log.fields.incoming]`: maps `x-request-id`, `udf_order_id`, `udf_customer_id`, `udf_txn_uuid`, `entity`, `resp_code`, `category`, `schema_version`, `tag`, `tenant_name`, `latency`, and all `api_details.*` fields (url, method, req_body, res_body, res_code, error, latency, api_tag, req_type=INTERNAL)
- `[log.fields.outgoing]`: maps the same top-level fields plus `api_details.req_headers`, `api_details.res_headers` (sourced from `request.headers` / `response.headers` already recorded in span storage by `service.rs`); `api_details.req_type=EXTERNAL`

**`config/development.toml`** — same structure, `enabled = false` (opt-in for local testing)

### Notes

- `req_headers` / `res_headers` for **outgoing** only — incoming calls are gRPC from euler with no HTTP headers
- `tenant_name` sources from span field `tenant_id` (euler sends the tenant NAME in `x-tenant-id`); euler will override the real `tenant_id` UUID per-request via `x-config-override`
- `x-parent-api-tag` is euler-side forwarding (not yet deployed); no UCS change needed
- Requires `log-transformations` Cargo feature at build time (already used in euler overlay image)