### PR TITLE
fix(ucs): record res_code as integer and populate response body/headers on error path in outgoing golden log

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -476,25 +476,17 @@ where
 
                     if let Some(evt) = event {
                         evt.set_error_response(&error_response);
+                        let mut json_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
                         if let Some(error_data) = &evt.error {
-                            record_json_fields_on_span(vec![(
-                                "response.body",
-                                error_data.inner().clone(),
-                            )]);
+                            json_fields.push(("response.body", error_data.inner().clone()));
                         }
-                    }
-                    if let Some(response_headers) = &body.headers {
-                        let headers_json: serde_json::Value = response_headers
-                            .iter()
-                            .map(|(k, v)| {
-                                (
-                                    k.as_str().to_string(),
-                                    serde_json::Value::String(v.to_str().unwrap_or("").to_string()),
-                                )
-                            })
-                            .collect::<serde_json::Map<_, _>>()
-                            .into();
-                        record_json_fields_on_span(vec![("response.headers", headers_json)]);
+                        // Use event headers (already masked) — consistent with success path
+                        if let Ok(headers_json) = serde_json::to_value(&evt.headers) {
+                            json_fields.push(("response.headers", headers_json));
+                        }
+                        if !json_fields.is_empty() {
+                            record_json_fields_on_span(json_fields);
+                        }
                     }
                     tracing::Span::current().record(
                         "response.error_message",

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -477,7 +477,10 @@ where
                     if let Some(evt) = event.as_deref_mut() {
                         evt.set_error_response(&error_response);
                         if let Some(error_data) = &evt.error {
-                            record_json_fields_on_span(vec![("response.body", error_data.inner().clone())]);
+                            record_json_fields_on_span(vec![(
+                                "response.body",
+                                error_data.inner().clone(),
+                            )]);
                         }
                     }
                     if let Some(response_headers) = &body.headers {
@@ -501,7 +504,8 @@ where
                         "response.status_code",
                         tracing::field::display(error_response.status_code),
                     );
-                    tracing::Span::current().record("res_code", u64::from(error_response.status_code));
+                    tracing::Span::current()
+                        .record("res_code", u64::from(error_response.status_code));
                     // Additive: record the connector flow outcome (FlowStatus) so a
                     // decline is visible even though the gRPC call "succeeded".
                     #[cfg(feature = "otel")]

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -374,6 +374,7 @@ where
                     let status_code = body.status_code;
                     tracing::Span::current()
                         .record("status_code", tracing::field::display(status_code));
+                    tracing::Span::current().record("res_code", u64::from(status_code));
 
                     if all_keys_required.unwrap_or(true) && return_raw {
                         let raw_response_string = strip_bom_and_convert_to_string(&body.response);
@@ -473,8 +474,24 @@ where
                         }
                     }
 
-                    if let Some(evt) = event {
+                    if let Some(evt) = event.as_deref_mut() {
                         evt.set_error_response(&error_response);
+                        if let Some(error_data) = &evt.error {
+                            record_json_fields_on_span(vec![("response.body", error_data.inner().clone())]);
+                        }
+                    }
+                    if let Some(response_headers) = &body.headers {
+                        let headers_json: serde_json::Value = response_headers
+                            .iter()
+                            .map(|(k, v)| {
+                                (
+                                    k.as_str().to_string(),
+                                    serde_json::Value::String(v.to_str().unwrap_or("").to_string()),
+                                )
+                            })
+                            .collect::<serde_json::Map<_, _>>()
+                            .into();
+                        record_json_fields_on_span(vec![("response.headers", headers_json)]);
                     }
                     tracing::Span::current().record(
                         "response.error_message",
@@ -484,6 +501,7 @@ where
                         "response.status_code",
                         tracing::field::display(error_response.status_code),
                     );
+                    tracing::Span::current().record("res_code", u64::from(error_response.status_code));
                     // Additive: record the connector flow outcome (FlowStatus) so a
                     // decline is visible even though the gRPC call "succeeded".
                     #[cfg(feature = "otel")]
@@ -602,6 +620,7 @@ pub struct EventProcessingParams<'a> {
         response.headers = Empty,
         response.error_message = Empty,
         response.status_code = Empty,
+        res_code = Empty,
         message_ = "Golden Log Line (outgoing)",
         // `latency` is the pre-existing human-readable string; `latency_ms` is the same
         // duration as a plain number of milliseconds, for numeric downstream consumers.

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -474,7 +474,7 @@ where
                         }
                     }
 
-                    if let Some(evt) = event.as_deref_mut() {
+                    if let Some(evt) = event {
                         evt.set_error_response(&error_response);
                         if let Some(error_data) = &evt.error {
                             record_json_fields_on_span(vec![(


### PR DESCRIPTION
## Summary

Fixes three gaps in UCS outgoing golden log lines so they match the euler `OutgoingLogEntry` schema:

- **`res_code` as integer**: Euler expects `res_code :: Int`. Previously only `response.status_code` was recorded, via `tracing::field::display()` which stores as a `String`. Added a dedicated `res_code` span field recorded via `u64::from(status_code)` which routes through `record_u64` in the tracing subscriber → stored as `serde_json::Number` → integer in log output. Applied on both success and error paths.

- **`response.body` on error path**: Was only emitted on success. Changed the event borrow from a consuming move to `as_deref_mut()` so the event is accessible after `set_error_response`, then recorded `evt.error` (which `set_error_response` populates) as `response.body`.

- **`response.headers` on error path**: Was only emitted on success. Now recorded from `body.headers: Option<http::HeaderMap>` available in the `Err(body)` arm, inline-converted to `serde_json::Value::Object`.

## Test plan

- [ ] Deploy to staging, trigger connector calls that succeed (2xx) and fail (4xx/5xx)
- [ ] In Kibana, filter for `message_: "Golden Log Line (outgoing)"` and verify `res_code` is an integer (not a string)
- [ ] Verify `response.body` and `response.headers` are present on error-path golden log lines
- [ ] Confirm Unified LogViewer / LP ingests the updated format correctly