### PR TITLE
feat(connector): Plaid Link token native app identifier support

### DIFF
--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -74,6 +74,8 @@ mod tests {
                     country_codes,
                     locale: None,
                     permissions: None,
+                    browser_info: None,
+                    native_app_identifier: None,
                 },
                 response: Err(ErrorResponse::default()),
             }
@@ -167,6 +169,76 @@ mod tests {
 
             let result = integration.build_request_v2(&req);
             assert!(result.is_err(), "expected error for empty country_codes");
+        }
+
+        fn make_req_with_platform(
+            os_type: Option<&str>,
+            native_app_identifier: Option<&str>,
+        ) -> RouterDataV2<
+            ClientAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ClientAuthenticationTokenRequestData,
+            PaymentsResponseData,
+        > {
+            let mut req = make_req(Some("My App"), Some(customer()), vec![CountryAlpha2::US]);
+            req.request.browser_info =
+                os_type.map(
+                    |os| domain_types::router_request_types::BrowserInformation {
+                        os_type: Some(os.to_owned()),
+                        ..Default::default()
+                    },
+                );
+            req.request.native_app_identifier = native_app_identifier.map(str::to_owned);
+            req
+        }
+
+        fn link_token_body(
+            req: &RouterDataV2<
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            >,
+        ) -> serde_json::Value {
+            let connector = Plaid::<DefaultPCIHolder>::new();
+            let integration: BoxedConnectorIntegrationV2<
+                '_,
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            > = connector.get_connector_integration_v2();
+
+            let request = integration.build_request_v2(req).unwrap();
+            request
+                .as_ref()
+                .map(|r| match r.body.as_ref() {
+                    Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
+                    _ => json!({}),
+                })
+                .unwrap()
+        }
+
+        #[test]
+        fn test_build_request_android_sends_package_name() {
+            let req = make_req_with_platform(Some("Android"), Some("com.merchant.app"));
+            let body = link_token_body(&req);
+            assert_eq!(body["android_package_name"], "com.merchant.app");
+            assert!(
+                body.get("redirect_uri").is_none(),
+                "redirect_uri must be omitted for Android"
+            );
+        }
+
+        #[test]
+        fn test_build_request_ios_sends_redirect_uri() {
+            let req = make_req_with_platform(Some("iOS"), Some("https://merchant.example/oauth"));
+            let body = link_token_body(&req);
+            assert_eq!(body["redirect_uri"], "https://merchant.example/oauth");
+            assert!(
+                body.get("android_package_name").is_none(),
+                "android_package_name must be omitted for non-Android"
+            );
         }
     }
 

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -74,7 +74,6 @@ mod tests {
                     country_codes,
                     locale: None,
                     permissions: None,
-                    browser_info: None,
                     native_app_identifier: None,
                 },
                 response: Err(ErrorResponse::default()),
@@ -169,82 +168,6 @@ mod tests {
 
             let result = integration.build_request_v2(&req);
             assert!(result.is_err(), "expected error for empty country_codes");
-        }
-
-        fn make_req_with_platform(
-            os_type: Option<&str>,
-            native_app_identifier: Option<&str>,
-        ) -> RouterDataV2<
-            ClientAuthenticationToken,
-            MerchantAuthenticationFlowData,
-            ClientAuthenticationTokenRequestData,
-            PaymentsResponseData,
-        > {
-            let mut req = make_req(Some("My App"), Some(customer()), vec![CountryAlpha2::US]);
-            req.request.browser_info =
-                os_type.map(
-                    |os| domain_types::router_request_types::BrowserInformation {
-                        os_type: Some(os.to_owned()),
-                        ..Default::default()
-                    },
-                );
-            req.request.native_app_identifier = native_app_identifier.map(str::to_owned);
-            req
-        }
-
-        fn link_token_body(
-            req: &RouterDataV2<
-                ClientAuthenticationToken,
-                MerchantAuthenticationFlowData,
-                ClientAuthenticationTokenRequestData,
-                PaymentsResponseData,
-            >,
-        ) -> serde_json::Value {
-            let connector = Plaid::<DefaultPCIHolder>::new();
-            let integration: BoxedConnectorIntegrationV2<
-                '_,
-                ClientAuthenticationToken,
-                MerchantAuthenticationFlowData,
-                ClientAuthenticationTokenRequestData,
-                PaymentsResponseData,
-            > = connector.get_connector_integration_v2();
-
-            let request = integration.build_request_v2(req).unwrap();
-            request
-                .as_ref()
-                .map(|r| match r.body.as_ref() {
-                    Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
-                    _ => json!({}),
-                })
-                .unwrap()
-        }
-
-        #[test]
-        fn test_build_request_android_sends_package_name() {
-            let req = make_req_with_platform(Some("Android"), Some("com.merchant.app"));
-            let body = link_token_body(&req);
-            assert_eq!(
-                body.get("android_package_name").and_then(|v| v.as_str()),
-                Some("com.merchant.app")
-            );
-            assert!(
-                body.get("redirect_uri").is_none(),
-                "redirect_uri must be omitted for Android"
-            );
-        }
-
-        #[test]
-        fn test_build_request_ios_sends_redirect_uri() {
-            let req = make_req_with_platform(Some("iOS"), Some("https://merchant.example/oauth"));
-            let body = link_token_body(&req);
-            assert_eq!(
-                body.get("redirect_uri").and_then(|v| v.as_str()),
-                Some("https://merchant.example/oauth")
-            );
-            assert!(
-                body.get("android_package_name").is_none(),
-                "android_package_name must be omitted for non-Android"
-            );
         }
     }
 

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -223,7 +223,10 @@ mod tests {
         fn test_build_request_android_sends_package_name() {
             let req = make_req_with_platform(Some("Android"), Some("com.merchant.app"));
             let body = link_token_body(&req);
-            assert_eq!(body["android_package_name"], "com.merchant.app");
+            assert_eq!(
+                body.get("android_package_name").and_then(|v| v.as_str()),
+                Some("com.merchant.app")
+            );
             assert!(
                 body.get("redirect_uri").is_none(),
                 "redirect_uri must be omitted for Android"
@@ -234,7 +237,10 @@ mod tests {
         fn test_build_request_ios_sends_redirect_uri() {
             let req = make_req_with_platform(Some("iOS"), Some("https://merchant.example/oauth"));
             let body = link_token_body(&req);
-            assert_eq!(body["redirect_uri"], "https://merchant.example/oauth");
+            assert_eq!(
+                body.get("redirect_uri").and_then(|v| v.as_str()),
+                Some("https://merchant.example/oauth")
+            );
             assert!(
                 body.get("android_package_name").is_none(),
                 "android_package_name must be omitted for non-Android"

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
@@ -196,27 +196,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }));
         }
 
-        // Plaid's Link token needs a platform-specific "return target":
-        // - Android: `android_package_name` (redirect_uri must be blank)
-        // - iOS / web / unknown: `redirect_uri` (an https URI)
-        // The client platform is derived from `browser_info.os_type`; the generic
-        // `native_app_identifier` carries the platform-appropriate value.
-        let is_android = req
-            .browser_info
-            .as_ref()
-            .and_then(|browser_info| browser_info.os_type.as_deref())
-            .map(|os_type| os_type.eq_ignore_ascii_case("android"))
-            .unwrap_or(false);
-
-        let (redirect_uri, android_package_name) = if is_android {
-            (None, req.native_app_identifier.clone())
-        } else {
-            (
-                item.router_data.resource_common_data.return_url.clone(),
-                None,
-            )
-        };
-
+        // Plaid's Link token "return target": web/iOS merchants send a return
+        // URL (-> redirect_uri), native-app merchants send a native app
+        // identifier (-> android_package_name). We forward whatever was
+        // provided without asserting mutual exclusivity.
         Ok(Self {
             client_id: auth.client_id,
             secret: auth.secret,
@@ -225,8 +208,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             products: vec!["auth".to_owned()],
             country_codes,
             language: req.locale.clone(),
-            redirect_uri,
-            android_package_name,
+            redirect_uri: item.router_data.resource_common_data.return_url.clone(),
+            android_package_name: req.native_app_identifier.clone(),
             webhook: req.webhook_url.clone(),
         })
     }

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
@@ -85,6 +85,8 @@ pub struct PlaidLinkTokenRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redirect_uri: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub android_package_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook: Option<String>,
 }
 
@@ -194,6 +196,27 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }));
         }
 
+        // Plaid's Link token needs a platform-specific "return target":
+        // - Android: `android_package_name` (redirect_uri must be blank)
+        // - iOS / web / unknown: `redirect_uri` (an https URI)
+        // The client platform is derived from `browser_info.os_type`; the generic
+        // `native_app_identifier` carries the platform-appropriate value.
+        let is_android = req
+            .browser_info
+            .as_ref()
+            .and_then(|browser_info| browser_info.os_type.as_deref())
+            .map(|os_type| os_type.eq_ignore_ascii_case("android"))
+            .unwrap_or(false);
+
+        let (redirect_uri, android_package_name) = if is_android {
+            (None, req.native_app_identifier.clone())
+        } else {
+            (
+                item.router_data.resource_common_data.return_url.clone(),
+                None,
+            )
+        };
+
         Ok(Self {
             client_id: auth.client_id,
             secret: auth.secret,
@@ -202,7 +225,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             products: vec!["auth".to_owned()],
             country_codes,
             language: req.locale.clone(),
-            redirect_uri: item.router_data.resource_common_data.return_url.clone(),
+            redirect_uri,
+            android_package_name,
             webhook: req.webhook_url.clone(),
         })
     }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2403,9 +2403,9 @@ pub struct ClientAuthenticationTokenRequestData {
     /// Connector-specific permissions for client authentication token
     /// e.g., ["PMT_POST_Create_Single"] for GlobalPay hosted fields
     pub permissions: Option<Vec<String>>,
-    /// Customer's browser / device information (used e.g. for platform detection)
-    pub browser_info: Option<BrowserInformation>,
-    /// Platform-specific target for returning to the client app after the hosted flow completes.
+    /// Native app identifier for returning to the client app after the hosted
+    /// flow completes (e.g. an Android package name). Sent instead of a return
+    /// URL when the merchant integrates from a native app.
     pub native_app_identifier: Option<String>,
 }
 

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2403,6 +2403,10 @@ pub struct ClientAuthenticationTokenRequestData {
     /// Connector-specific permissions for client authentication token
     /// e.g., ["PMT_POST_Create_Single"] for GlobalPay hosted fields
     pub permissions: Option<Vec<String>>,
+    /// Customer's browser / device information (used e.g. for platform detection)
+    pub browser_info: Option<BrowserInformation>,
+    /// Platform-specific target for returning to the client app after the hosted flow completes.
+    pub native_app_identifier: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11302,6 +11302,11 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     .map(CustomerInfo::foreign_try_from)
                     .transpose()?;
 
+                let browser_info = value
+                    .browser_info
+                    .map(BrowserInformation::foreign_try_from)
+                    .transpose()?;
+
                 Ok(Self {
                     amount: common_utils::types::MinorUnit::new(0),
                     currency: common_enums::Currency::USD,
@@ -11315,6 +11320,8 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     country_codes,
                     locale: auth_ctx.locale,
                     permissions,
+                    browser_info,
+                    native_app_identifier: auth_ctx.native_app_identifier,
                 })
             }
             Some(DomainContext::Payment(payment_ctx)) => {
@@ -11368,6 +11375,8 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     webhook_url: None,
                     country_codes: vec![],
                     locale: None,
+                    browser_info: None,
+                    native_app_identifier: None,
                 })
             }
             _ => Err(report!(IntegrationError::InvalidDataFormat {

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11302,11 +11302,6 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     .map(CustomerInfo::foreign_try_from)
                     .transpose()?;
 
-                let browser_info = value
-                    .browser_info
-                    .map(BrowserInformation::foreign_try_from)
-                    .transpose()?;
-
                 Ok(Self {
                     amount: common_utils::types::MinorUnit::new(0),
                     currency: common_enums::Currency::USD,
@@ -11320,7 +11315,6 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     country_codes,
                     locale: auth_ctx.locale,
                     permissions,
-                    browser_info,
                     native_app_identifier: auth_ctx.native_app_identifier,
                 })
             }
@@ -11375,7 +11369,6 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     webhook_url: None,
                     country_codes: vec![],
                     locale: None,
-                    browser_info: None,
                     native_app_identifier: None,
                 })
             }

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3080,9 +3080,6 @@ message MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest {
   // Connector-specific permissions for client authentication token
   // e.g., ["PMT_POST_Create_Single"] for GlobalPay hosted fields
   optional Permissions permissions = 7;
-
-  // Customer's browser / device information.
-  optional BrowserInformation browser_info = 9;
 }
 
 // Payment-specific context for client authentication token creation
@@ -3106,7 +3103,9 @@ message AuthenticatorClientAuthenticationContext {
   optional Customer customer = 5;           // User/customer context
   optional string metadata = 6;             // Additional provider-specific config as JSON
 
-  // Platform-specific target for returning control to the client app after the hosted flow completes.
+  // Native app identifier for returning control to the client app after the
+  // hosted flow completes (e.g. an Android package name). Sent by merchants
+  // integrating from a native app instead of return_url.
   optional string native_app_identifier = 7;
 }
 

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3080,6 +3080,9 @@ message MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest {
   // Connector-specific permissions for client authentication token
   // e.g., ["PMT_POST_Create_Single"] for GlobalPay hosted fields
   optional Permissions permissions = 7;
+
+  // Customer's browser / device information.
+  optional BrowserInformation browser_info = 9;
 }
 
 // Payment-specific context for client authentication token creation
@@ -3102,6 +3105,9 @@ message AuthenticatorClientAuthenticationContext {
   optional string locale = 4;               // Locale/language preference (e.g., "en", "es", "en-US")
   optional Customer customer = 5;           // User/customer context
   optional string metadata = 6;             // Additional provider-specific config as JSON
+
+  // Platform-specific target for returning control to the client app after the hosted flow completes.
+  optional string native_app_identifier = 7;
 }
 
 // Response message for SDK session


### PR DESCRIPTION
## What

Plaid's `/link/token/create` accepts two mutually-exclusive "return targets" for handing control back to the client after the hosted Link flow:

- **web / iOS** → `redirect_uri` (an `https://` URI)
- **native app (Android)** → `android_package_name`

The `ClientAuthenticationToken` flow could only ever produce `redirect_uri` (from `return_url`); there was no way for a merchant integrating from a native app to pass a package name.

This adds a `native_app_identifier` field. The merchant sends **either** `return_url` **or** `native_app_identifier`; the connector forwards whatever is present and does not enforce or check mutual exclusivity.

## Changes

- **proto** (`payment.proto`)
  - `AuthenticatorClientAuthenticationContext`: `optional string native_app_identifier = 7;` — native app identifier (e.g. an Android package name), sent instead of `return_url` for native-app integrations. Optional and additive → wire-compatible.
- **domain** (`connector_types.rs`, `types.rs`): thread `native_app_identifier` onto `ClientAuthenticationTokenRequestData`.
- **plaid** (`transformers.rs`): `PlaidLinkTokenRequest` gains `android_package_name`; the request builder maps `return_url` → `redirect_uri` and `native_app_identifier` → `android_package_name` directly, with no platform detection.

## Notes

- No `browser_info` / OS-type inspection — the merchant chooses which field to send.
- `return_url` is not overloaded to carry the package name.

## Testing

```
curl --location 'http://localhost:8011/payments/client_authentication_token' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Plaid":{"client_id":"-","secret":"-","client_name":"-"}}}' \
--header 'x-merchant-id: test_merchant' \
--header 'x-tenant-id: public' \
--header 'x-request-id: req-plaid-flow1-001' \
--data-raw '{
    "merchant_client_session_id": "session_plaid_001",
    "domain_context": {
      "Authenticator": {
        "country_codes": ["US"],
        "locale": "en",
        "native_app_identifier": "com.merchant.app",
        "customer": {
          "id": "customer_001",
          "name": "Jane Doe",
          "email": "jane@example.com",
          "phone_number": "1234"
        }
      }
    }
  }'
```
Connector Request
```
{"client_id": String("*** alloc::string::String ***"), "secret": String("*** alloc::string::String ***"), "client_name": String("test_app"), "user": Object {"client_user_id": String("customer_001"), "legal_name": String("*** alloc::string::String ***"), "email_address": String("****@example.com"), "phone_number": String("*** alloc::string::String ***")}, "products": Array [String("auth")], "country_codes": Array [String("US")], "language": String("en"), "android_package_name": String("com.merchant.app")}
```

Send `return_url` instead of `native_app_identifier` to get `redirect_uri` in the connector request.
