### PR TITLE
fix(ci): derive connector names from real directories, not diff-path regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,8 @@ jobs:
             exit 1
           fi
 
-          # Names come from real directory listings, not from pattern-matching
-          # diff paths, so a name can only ever be one that actually exists.
-          #
-          # Regression certification (below) only covers payment connectors —
-          # connector_specs/ has no authenticator/payout/surcharge entries —
-          # so only payment names feed it. The other three types are kept
-          # separately, for nextest scoping only (see "Run Tests").
+          # Enumerate real directories instead of grepping diff paths, so a
+          # name can only ever be one that actually exists.
           names_in_dir() {
             local dir="$1"
             [ -d "${dir}" ] || return 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
       any-rs: ${{ steps.filter.outputs.any-rs }}
       ci: ${{ steps.filter.outputs.ci }}
       certification-inputs: ${{ steps.filter.outputs.certification-inputs }}
-      connector-names: ${{ steps.connector-names.outputs.list }}
-      all-connector-names: ${{ steps.connector-names.outputs.all-list }}
+      payment-connector-names: ${{ steps.payment-connector-names.outputs.list }}
+      all-connector-names: ${{ steps.payment-connector-names.outputs.all-list }}
       new-connectors: ${{ steps.new-connectors.outputs.list }}
       spec-modified-connectors: ${{ steps.spec-modified-connectors.outputs.list }}
     steps:
@@ -128,8 +128,8 @@ jobs:
               # Shared connector code: no connector name in the path, so nothing
               # would be selected. `*` stops at the slash, sparing connectors/.
               - 'crates/integrations/connector-integration/src/*.rs'
-      - name: Extract changed connector names
-        id: connector-names
+      - name: Extract changed payment connector names
+        id: payment-connector-names
         if: steps.filter.outputs.connector == 'true'
         shell: bash
         # Expressions reach bash through the environment, never spliced into the
@@ -231,10 +231,10 @@ jobs:
 
       - name: Detect newly added connectors
         id: new-connectors
-        if: steps.connector-names.outputs.list != ''
+        if: steps.payment-connector-names.outputs.list != ''
         shell: bash
         env:
-          CHANGED_LIST: ${{ steps.connector-names.outputs.list }}
+          CHANGED_LIST: ${{ steps.payment-connector-names.outputs.list }}
           # merge_group has no pull_request and no `before` — it diffs a
           # synthetic batch commit, so its own base_sha (the target branch's
           # tip before the queued batch) is the only correct base here.
@@ -262,10 +262,10 @@ jobs:
 
       - name: Detect connectors with a modified specs.json or override.json
         id: spec-modified-connectors
-        if: steps.connector-names.outputs.list != ''
+        if: steps.payment-connector-names.outputs.list != ''
         shell: bash
         env:
-          CHANGED_LIST: ${{ steps.connector-names.outputs.list }}
+          CHANGED_LIST: ${{ steps.payment-connector-names.outputs.list }}
           # merge_group has no pull_request and no `before` — it diffs a
           # synthetic batch commit, so its own base_sha (the target branch's
           # tip before the queued batch) is the only correct base here.
@@ -837,7 +837,7 @@ jobs:
         env:
           # Git facts only. Which suites and scenarios each connector runs is the
           # framework's to derive from that connector's own specs.json.
-          CHANGED_CONNECTORS: ${{ needs.changes.outputs.connector-names }}
+          CHANGED_CONNECTORS: ${{ needs.changes.outputs.payment-connector-names }}
           NEW_CONNECTORS: ${{ needs.changes.outputs.new-connectors }}
           SPEC_MODIFIED_CONNECTORS: ${{ needs.changes.outputs.spec-modified-connectors }}
           SHARED_CHANGED: ${{ needs.changes.outputs.rust-core == 'true' || needs.changes.outputs.proto == 'true' || needs.changes.outputs.certification-inputs == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
       any-rs: ${{ steps.filter.outputs.any-rs }}
       ci: ${{ steps.filter.outputs.ci }}
       certification-inputs: ${{ steps.filter.outputs.certification-inputs }}
-      payment-connector-names: ${{ steps.payment-connector-names.outputs.list }}
-      all-connector-names: ${{ steps.payment-connector-names.outputs.all-list }}
+      payment-connector-names: ${{ steps.connector-names.outputs.list }}
+      all-connector-names: ${{ steps.connector-names.outputs.all-list }}
       new-connectors: ${{ steps.new-connectors.outputs.list }}
       spec-modified-connectors: ${{ steps.spec-modified-connectors.outputs.list }}
     steps:
@@ -129,7 +129,7 @@ jobs:
               # would be selected. `*` stops at the slash, sparing connectors/.
               - 'crates/integrations/connector-integration/src/*.rs'
       - name: Extract changed payment connector names
-        id: payment-connector-names
+        id: connector-names
         if: steps.filter.outputs.connector == 'true'
         shell: bash
         # Expressions reach bash through the environment, never spliced into the
@@ -231,10 +231,10 @@ jobs:
 
       - name: Detect newly added connectors
         id: new-connectors
-        if: steps.payment-connector-names.outputs.list != ''
+        if: steps.connector-names.outputs.list != ''
         shell: bash
         env:
-          CHANGED_LIST: ${{ steps.payment-connector-names.outputs.list }}
+          CHANGED_LIST: ${{ steps.connector-names.outputs.list }}
           # merge_group has no pull_request and no `before` — it diffs a
           # synthetic batch commit, so its own base_sha (the target branch's
           # tip before the queued batch) is the only correct base here.
@@ -262,10 +262,10 @@ jobs:
 
       - name: Detect connectors with a modified specs.json or override.json
         id: spec-modified-connectors
-        if: steps.payment-connector-names.outputs.list != ''
+        if: steps.connector-names.outputs.list != ''
         shell: bash
         env:
-          CHANGED_LIST: ${{ steps.payment-connector-names.outputs.list }}
+          CHANGED_LIST: ${{ steps.connector-names.outputs.list }}
           # merge_group has no pull_request and no `before` — it diffs a
           # synthetic batch commit, so its own base_sha (the target branch's
           # tip before the queued batch) is the only correct base here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
       certification-inputs: ${{ steps.filter.outputs.certification-inputs }}
       connector-names: ${{ steps.connector-names.outputs.list }}
+      all-connector-names: ${{ steps.connector-names.outputs.all-list }}
       new-connectors: ${{ steps.new-connectors.outputs.list }}
       spec-modified-connectors: ${{ steps.spec-modified-connectors.outputs.list }}
     steps:
@@ -149,11 +150,62 @@ jobs:
             exit 1
           fi
 
-          touched=$(echo "${CONNECTOR_FILES}" | \
-            jq -r '.[]' | \
-            grep -oE '(connectors|connector_specs)/[^/]+' | \
-            sed 's|^connectors/||;s|^connector_specs/||;s|\.rs$||' | \
-            grep -v -E '^(alpha_connectors|live_connectors)\.json$')
+          # Names come from real directory listings, never from pattern-matching
+          # diff paths: a regex on "connectors/<name>" also matches inside an
+          # unrelated sibling directory that merely ends with that word, e.g.
+          # authenticator_connectors/plaid/ — inventing a "plaid" connector that
+          # has no specs.json and never did, and failing the newly-added-connector
+          # check for a PR that never touched a real connector. Enumerating each
+          # root's actual children makes an invented name structurally impossible.
+          #
+          # Regression certification (below) only understands payment connectors
+          # today — connector_specs/ has no authenticator/payout/surcharge
+          # entries — so only payment names feed it. The other three are kept
+          # separately, for nextest scoping only (see "Run Tests"), so a PR that
+          # touches only e.g. authenticator_connectors/ still gets a fast, scoped
+          # run instead of falling back to the full suite.
+          names_in_dir() {
+            local dir="$1"
+            [ -d "${dir}" ] || return 0
+            find "${dir}" -mindepth 1 -maxdepth 1 \( -type d -o -name '*.rs' \) -exec basename {} \; | \
+              sed 's|\.rs$||' | sort -u
+          }
+
+          touched_under() {
+            local dir_prefix="$1"
+            local name="$2"
+            echo "${CONNECTOR_FILES}" | jq -r '.[]' | \
+              grep -qE "^${dir_prefix}/${name}(\.rs)?(/|$)"
+          }
+
+          payment_touched=""
+          while IFS= read -r name; do
+            [ -n "${name}" ] || continue
+            if touched_under "crates/integrations/connector-integration/src/connectors" "${name}"; then
+              payment_touched="${payment_touched}${payment_touched:+,}${name}"
+            fi
+          done < <(names_in_dir crates/integrations/connector-integration/src/connectors)
+
+          # A connector's specs.json/override.json can change without any of its
+          # own Rust files changing, so specs-only edits need their own pass
+          # against the same real, known list — not a path-shape guess either.
+          while IFS= read -r name; do
+            [ -n "${name}" ] || continue
+            if touched_under "crates/internal/integration-tests/src/connector_specs" "${name}" && \
+               ! echo ",${payment_touched}," | grep -q ",${name},"; then
+              payment_touched="${payment_touched}${payment_touched:+,}${name}"
+            fi
+          done < <(names_in_dir crates/internal/integration-tests/src/connector_specs)
+
+          other_touched=""
+          for dir in authenticator_connectors payout_connectors surcharge_connectors; do
+            while IFS= read -r name; do
+              [ -n "${name}" ] || continue
+              if touched_under "crates/integrations/connector-integration/src/${dir}" "${name}"; then
+                other_touched="${other_touched}${other_touched:+,}${name}"
+              fi
+            done < <(names_in_dir "crates/integrations/connector-integration/src/${dir}")
+          done
 
           # Taking a connector off the alpha list is what starts certifying it,
           # but the edit touches only that shared file. Names present at the
@@ -175,9 +227,14 @@ jobs:
               <(jq -r '.connectors | keys[]' "$live"))
           fi
 
-          names=$(printf '%s\n%s\n%s\n' "$touched" "$promoted" "$newly_live" | sed '/^$/d' | sort -u | paste -sd ',' -)
-          echo "list=$names" >> $GITHUB_OUTPUT
-          echo "Changed connectors: $names"
+          payment_names=$(printf '%s\n%s\n%s\n' "$(echo "$payment_touched" | tr ',' '\n')" "$promoted" "$newly_live" | sed '/^$/d' | sort -u | paste -sd ',' -)
+          other_names=$(echo "$other_touched" | tr ',' '\n' | sed '/^$/d' | sort -u | paste -sd ',' -)
+          all_names=$(printf '%s\n%s\n' "$(echo "$payment_names" | tr ',' '\n')" "$(echo "$other_names" | tr ',' '\n')" | sed '/^$/d' | sort -u | paste -sd ',' -)
+
+          echo "list=$payment_names" >> $GITHUB_OUTPUT
+          echo "all-list=$all_names" >> $GITHUB_OUTPUT
+          echo "Changed payment connectors (drives regression + nextest scoping): $payment_names"
+          echo "Changed non-payment connectors (drives nextest scoping only): $other_names"
 
       - name: Detect newly added connectors
         id: new-connectors
@@ -705,7 +762,11 @@ jobs:
           # Debug test binaries overflow the 2 MiB default thread stack.
           RUST_MIN_STACK: "8388608"
         run: |
-          CONNECTOR_NAMES="${{ needs.changes.outputs.connector-names }}"
+          # All real, touched connector names (payment + authenticator + payout
+          # + surcharge) — nextest scoping only needs a Rust test-name filter,
+          # not certification, so the non-payment types are fine here even
+          # though they don't feed the regression pipeline below.
+          CONNECTOR_NAMES="${{ needs.changes.outputs.all-connector-names }}"
           CORE_CHANGED="${{ needs.changes.outputs.rust-core }}"
           PROTO_CHANGED="${{ needs.changes.outputs.proto }}"
           CI_CHANGED="${{ needs.changes.outputs.ci }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,20 +150,13 @@ jobs:
             exit 1
           fi
 
-          # Names come from real directory listings, never from pattern-matching
-          # diff paths: a regex on "connectors/<name>" also matches inside an
-          # unrelated sibling directory that merely ends with that word, e.g.
-          # authenticator_connectors/plaid/ — inventing a "plaid" connector that
-          # has no specs.json and never did, and failing the newly-added-connector
-          # check for a PR that never touched a real connector. Enumerating each
-          # root's actual children makes an invented name structurally impossible.
+          # Names come from real directory listings, not from pattern-matching
+          # diff paths, so a name can only ever be one that actually exists.
           #
-          # Regression certification (below) only understands payment connectors
-          # today — connector_specs/ has no authenticator/payout/surcharge
-          # entries — so only payment names feed it. The other three are kept
-          # separately, for nextest scoping only (see "Run Tests"), so a PR that
-          # touches only e.g. authenticator_connectors/ still gets a fast, scoped
-          # run instead of falling back to the full suite.
+          # Regression certification (below) only covers payment connectors —
+          # connector_specs/ has no authenticator/payout/surcharge entries —
+          # so only payment names feed it. The other three types are kept
+          # separately, for nextest scoping only (see "Run Tests").
           names_in_dir() {
             local dir="$1"
             [ -d "${dir}" ] || return 0
@@ -186,9 +179,9 @@ jobs:
             fi
           done < <(names_in_dir crates/integrations/connector-integration/src/connectors)
 
-          # A connector's specs.json/override.json can change without any of its
-          # own Rust files changing, so specs-only edits need their own pass
-          # against the same real, known list — not a path-shape guess either.
+          # A connector's specs.json/override.json can change without any of
+          # its own Rust files changing, so specs-only edits need their own
+          # pass against the same real, known list.
           while IFS= read -r name; do
             [ -n "${name}" ] || continue
             if touched_under "crates/internal/integration-tests/src/connector_specs" "${name}" && \
@@ -762,10 +755,8 @@ jobs:
           # Debug test binaries overflow the 2 MiB default thread stack.
           RUST_MIN_STACK: "8388608"
         run: |
-          # All real, touched connector names (payment + authenticator + payout
-          # + surcharge) — nextest scoping only needs a Rust test-name filter,
-          # not certification, so the non-payment types are fine here even
-          # though they don't feed the regression pipeline below.
+          # Includes non-payment connector types too — this only scopes a
+          # Rust test-name filter, not certification.
           CONNECTOR_NAMES="${{ needs.changes.outputs.all-connector-names }}"
           CORE_CHANGED="${{ needs.changes.outputs.rust-core }}"
           PROTO_CHANGED="${{ needs.changes.outputs.proto }}"


### PR DESCRIPTION
## What broke

PR #2188's merge-queue run failed with `New connector 'plaid' has no specs.json` even though it never touched a payment connector — it only modified `crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs`, a pre-existing authenticator test file (a modification, not a new file: `index 1177e19d1c..9e183e7936`, no `new file mode`).

## Root cause

The "Extract changed connector names" step (introduced in #2086) derives connector names from an unanchored regex:

```bash
grep -oE '(connectors|connector_specs)/[^/]+'
```

This matches the *substring* `connectors/plaid` inside `authenticator_connectors/plaid/test.rs` — an unrelated sibling directory that merely ends with the word "connectors". It invents a phantom connector name, `plaid`, that has no `connector_specs/plaid/` directory and never has. `verify-new-connectors.sh` then correctly (given the bad input) reports it as a new connector with no certification data, and hard-fails.

Confirmed via `git log -S` that this exact unanchored pattern was introduced by #2086 (`75079740f`) — it did not exist on `main` before.

## Fix

Replace path-pattern matching with real directory enumeration. The only names that can legitimately exist are the actual children of `connectors/` and `connector_specs/` — walk those directories directly, then check whether any touched file falls under that specific, already-known-real name's own path. An invented name like `plaid` is now structurally impossible to produce, not merely excluded by a pattern rule.

Two lists come out of this:

- **Payment connector names** — from `connectors/` and `connector_specs/`. Feeds both nextest scoping and the full regression pipeline (`new-connectors`, `spec-modified-connectors`, `verify-new-connectors.sh`, `certify-connectors.sh`), exactly as before, just fed clean input.
- **All connector names** (payment + `authenticator_connectors/` + `payout_connectors/` + `surcharge_connectors/`) — feeds nextest's test-name scoping only. Regression certification stays payment-only, since `connector_specs/` has no authenticator/payout/surcharge entries today — there's nothing for it to certify against. This also restores (and now correctly generalizes) the pre-#2086 behavior where a PR touching only e.g. `authenticator_connectors/` got a fast, scoped nextest run instead of falling back to the full suite.

## Verification

Ran the extraction logic standalone against a synthetic file list covering all four connector-type directories plus a nonexistent name:

```
payment_touched=stripe,adyen
other_touched=plaid
```

`plaid` never reaches the payment list (and thus never reaches `verify-new-connectors.sh`); a made-up `payout_connectors/foo/` path with no real `foo` directory produces nothing at all, in either list.

`actionlint` reports no new issues beyond pre-existing style-only shellcheck infos already present elsewhere in the file.

## Scope

This is scoped to the extraction bug only. The `connector` path filter that decides whether this whole pipeline runs at all (`crates/integrations/**`) is left unchanged — narrowing it would change what triggers certification-binary builds for authenticator/payout/surcharge changes, which is a separate design decision, not a defect this bug fix needs to make.

Not applied to #2086 (already merged) or bundled with unrelated connector-certification work — raised standalone per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)