### PR TITLE
fix(ci): require specs.json for connector-name detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
                ! echo ",${payment_touched}," | grep -q ",${name},"; then
               payment_touched="${payment_touched}${payment_touched:+,}${name}"
             fi
-          done < <(names_in_dir crates/internal/integration-tests/src/connector_specs crates/internal/integration-tests/src/connector_specs)
+          done < <(find crates/internal/integration-tests/src/connector_specs -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -u)
 
           # authenticator/payout/surcharge connectors have no connector_specs/
           # entry, so names_in_dir's specs.json check does not apply here —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,17 @@ jobs:
             exit 1
           fi
 
-          # Enumerate real directories instead of grepping diff paths, so a
-          # name can only ever be one that actually exists.
+          # Enumerate real directories instead of grepping diff paths, and
+          # require a specs.json so a shared, non-connector module in the same
+          # directory is never counted as a connector.
           names_in_dir() {
             local dir="$1"
+            local specs_root="$2"
             [ -d "${dir}" ] || return 0
             find "${dir}" -mindepth 1 -maxdepth 1 \( -type d -o -name '*.rs' \) -exec basename {} \; | \
-              sed 's|\.rs$||' | sort -u
+              sed 's|\.rs$||' | sort -u | while IFS= read -r name; do
+                [ -f "${specs_root}/${name}/specs.json" ] && echo "${name}"
+              done
           }
 
           touched_under() {
@@ -172,7 +176,7 @@ jobs:
             if touched_under "crates/integrations/connector-integration/src/connectors" "${name}"; then
               payment_touched="${payment_touched}${payment_touched:+,}${name}"
             fi
-          done < <(names_in_dir crates/integrations/connector-integration/src/connectors)
+          done < <(names_in_dir crates/integrations/connector-integration/src/connectors crates/internal/integration-tests/src/connector_specs)
 
           # A connector's specs.json/override.json can change without any of
           # its own Rust files changing, so specs-only edits need their own
@@ -183,8 +187,11 @@ jobs:
                ! echo ",${payment_touched}," | grep -q ",${name},"; then
               payment_touched="${payment_touched}${payment_touched:+,}${name}"
             fi
-          done < <(names_in_dir crates/internal/integration-tests/src/connector_specs)
+          done < <(names_in_dir crates/internal/integration-tests/src/connector_specs crates/internal/integration-tests/src/connector_specs)
 
+          # authenticator/payout/surcharge connectors have no connector_specs/
+          # entry, so names_in_dir's specs.json check does not apply here —
+          # every name under these directories is used as-is.
           other_touched=""
           for dir in authenticator_connectors payout_connectors surcharge_connectors; do
             while IFS= read -r name; do
@@ -192,7 +199,7 @@ jobs:
               if touched_under "crates/integrations/connector-integration/src/${dir}" "${name}"; then
                 other_touched="${other_touched}${other_touched:+,}${name}"
               fi
-            done < <(names_in_dir "crates/integrations/connector-integration/src/${dir}")
+            done < <(find "crates/integrations/connector-integration/src/${dir}" -mindepth 1 -maxdepth 1 \( -type d -o -name '*.rs' \) -exec basename {} \; 2>/dev/null | sed 's|\.rs$||' | sort -u)
           done
 
           # Taking a connector off the alpha list is what starts certifying it,


### PR DESCRIPTION
## Problem

\`names_in_dir()\` (added in #2086, refined in #2197) treats every directory or top-level \`.rs\` file under \`connectors/\` as a payment connector. Several real Rust modules there are not connectors — \`macros.rs\`, \`sanlam_common/\`, \`juspay_upi_stack/\` — and get swept in the same way. Any PR touching one of them fails CI:

\`\`\`
Error: New connector 'sanlam_common' has no specs.json
\`\`\`

Seen live on PR #2196 (\`sanlam_common\`) and earlier on \`macros.rs\`.

## Fix

Require a matching \`connector_specs/<name>/specs.json\` before counting a name as a payment connector — the one fact true of every real connector and false for every shared module, rather than naming individual files to exclude.

\`authenticator_connectors/\`, \`payout_connectors/\`, \`surcharge_connectors/\` have no \`connector_specs/\` entries at all, so they keep the original unfiltered enumeration — unaffected by this change.

## Verification

Checked against the current tree:
- Resulting payment-connector list has exact parity with \`connector_specs/\` in both directions (nothing in one list missing from the other).
- \`macros\`, \`sanlam_common\`, \`juspay_upi_stack\` excluded.
- All 107 real connectors included.
- \`authenticator_connectors\`/\`payout_connectors\`/\`surcharge_connectors\` enumeration unchanged.