### PR TITLE
feat(connector): [GRABPAY] fall back to HMAC one-time-charge status api

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/grabpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay.rs
@@ -831,10 +831,14 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         connector_feature_data
             .and_then(|data| serde_json::from_str::<serde_json::Value>(data.peek()).ok())
             .map(|feature_data| {
-                feature_data
-                    .get("code")
-                    .and_then(serde_json::Value::as_str)
-                    .is_some()
+                // `code` comes from the browser redirect; `o_auth_code` is recovered
+                // via the HMAC one-time-charge status inquiry (missed redirect).
+                ["code", "o_auth_code"].iter().any(|key| {
+                    feature_data
+                        .get(key)
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|value| !value.is_empty())
+                })
             })
             .unwrap_or(false)
     }

--- a/crates/integrations/connector-integration/src/connectors/grabpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay.rs
@@ -203,34 +203,42 @@ pub(crate) fn oauth_endpoint(base_url: &str, path: &str) -> String {
         .unwrap_or_else(|| format!("{base_url}{path}"))
 }
 
-/// Builds GrabPay's canonical signing string:
-/// `{method}\n{content_type}\n{date}\n{path}\n{base64(sha256(body))}\n`.
-/// Per Grab's merchant SDK (`GenerateHmac`), the body digest is an empty string
-/// for GET requests; otherwise it is `base64(sha256(body))`.
+/// The body digest in Grab's HMAC canonical string for OUTBOUND requests,
+/// per the reference SDK: GET requests sign the empty string, all other
+/// methods sign `base64(sha256(body))`.
+/// NOTE: webhook verification must not use this — Grab always includes the
+/// body digest in webhook signatures, so verification of inbound webhooks
+/// needs the hashed body regardless of method.
+fn grabpay_outbound_hmac_body_digest(
+    method: &str,
+    body: &[u8],
+) -> CustomResult<String, IntegrationError> {
+    use common_utils::crypto::GenerateDigest;
+
+    if method.eq_ignore_ascii_case("GET") {
+        return Ok(String::new());
+    }
+
+    let digest = crypto::Sha256.generate_digest(body).change_context(
+        IntegrationError::RequestEncodingFailed {
+            context: grabpay_integration_context(
+                "GrabPay HMAC signing failed to hash request body",
+            ),
+        },
+    )?;
+    Ok(BASE64_ENGINE.encode(digest))
+}
+
+/// Formats the Grab HMAC canonical string:
+/// `{method}\n{content_type}\n{date}\n{path}\n{body_digest}\n`.
 fn grabpay_hmac_signing_string(
     method: &str,
     content_type: &str,
     path: &str,
-    body: &[u8],
+    body_digest: &str,
     date: &str,
-) -> CustomResult<String, IntegrationError> {
-    use common_utils::crypto::GenerateDigest;
-
-    let body_digest = if method.eq_ignore_ascii_case("GET") {
-        String::new()
-    } else {
-        let digest = crypto::Sha256.generate_digest(body).change_context(
-            IntegrationError::RequestEncodingFailed {
-                context: grabpay_integration_context(
-                    "GrabPay HMAC signing failed to hash request body",
-                ),
-            },
-        )?;
-        BASE64_ENGINE.encode(digest)
-    };
-    Ok(format!(
-        "{method}\n{content_type}\n{date}\n{path}\n{body_digest}\n"
-    ))
+) -> String {
+    format!("{method}\n{content_type}\n{date}\n{path}\n{body_digest}\n")
 }
 
 fn build_hmac_authorization(
@@ -243,7 +251,9 @@ fn build_hmac_authorization(
 ) -> CustomResult<String, IntegrationError> {
     use common_utils::crypto::SignMessage;
 
-    let signing_string = grabpay_hmac_signing_string(method, content_type, path, body, date)?;
+    let body_digest = grabpay_outbound_hmac_body_digest(method, body)?;
+    let signing_string =
+        grabpay_hmac_signing_string(method, content_type, path, &body_digest, date);
     let signature = crypto::HmacSha256
         .sign_message(
             auth.partner_secret.peek().as_bytes(),
@@ -890,9 +900,19 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             Ok(signature) => signature,
             Err(_) => return Ok(false),
         };
+        // Verification of an inbound webhook must compute Grab's signature
+        // exactly as Grab constructed it: digest of the raw body — unlike
+        // OUTBOUND GET requests, which Grab signs with an empty digest (see
+        // `grabpay_outbound_hmac_body_digest`).
+        let body_digest = {
+            use common_utils::crypto::GenerateDigest;
+            crypto::Sha256
+                .generate_digest(&request.body)
+                .map(|digest| BASE64_ENGINE.encode(digest))
+                .change_context(WebhookError::WebhookSourceVerificationFailed)?
+        };
         let signing_string =
-            grabpay_hmac_signing_string(&method, content_type, &path, &request.body, date)
-                .change_context(WebhookError::WebhookSourceVerificationFailed)?;
+            grabpay_hmac_signing_string(&method, content_type, &path, &body_digest, date);
 
         crypto::HmacSha256
             .verify_signature(

--- a/crates/integrations/connector-integration/src/connectors/grabpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay.rs
@@ -60,6 +60,8 @@ const CONTENT_TYPE: &str = "application/json";
 const CHARGE_INIT_PATH: &str = "/charge/init";
 const CHARGE_COMPLETE_PATH: &str = "/charge/complete";
 const CHARGE_STATUS_PREFIX: &str = "/charge";
+// Grab's second charge-status inquiry: HMAC partner auth (no OAuth token needed).
+const OTC_CHARGE_STATUS_PREFIX: &str = "/one-time-charge";
 const REFUND_PATH: &str = "/refund";
 const OAUTH_TOKEN_PATH: &str = "/grabid/v1/oauth2/token";
 pub(crate) const GRABPAY_DOC_URL: &str =
@@ -203,6 +205,8 @@ pub(crate) fn oauth_endpoint(base_url: &str, path: &str) -> String {
 
 /// Builds GrabPay's canonical signing string:
 /// `{method}\n{content_type}\n{date}\n{path}\n{base64(sha256(body))}\n`.
+/// Per Grab's merchant SDK (`GenerateHmac`), the body digest is an empty string
+/// for GET requests; otherwise it is `base64(sha256(body))`.
 fn grabpay_hmac_signing_string(
     method: &str,
     content_type: &str,
@@ -212,16 +216,20 @@ fn grabpay_hmac_signing_string(
 ) -> CustomResult<String, IntegrationError> {
     use common_utils::crypto::GenerateDigest;
 
-    let body_digest = crypto::Sha256.generate_digest(body).change_context(
-        IntegrationError::RequestEncodingFailed {
-            context: grabpay_integration_context(
-                "GrabPay HMAC signing failed to hash request body",
-            ),
-        },
-    )?;
-    let encoded_body_digest = BASE64_ENGINE.encode(body_digest);
+    let body_digest = if method.eq_ignore_ascii_case("GET") {
+        String::new()
+    } else {
+        let digest = crypto::Sha256.generate_digest(body).change_context(
+            IntegrationError::RequestEncodingFailed {
+                context: grabpay_integration_context(
+                    "GrabPay HMAC signing failed to hash request body",
+                ),
+            },
+        )?;
+        BASE64_ENGINE.encode(digest)
+    };
     Ok(format!(
-        "{method}\n{content_type}\n{date}\n{path}\n{encoded_body_digest}\n"
+        "{method}\n{content_type}\n{date}\n{path}\n{body_digest}\n"
     ))
 }
 
@@ -348,6 +356,25 @@ fn session_token_from_connector_feature_data(
         .or_else(|| metadata.get("access_token"))
         .and_then(serde_json::Value::as_str)
         .map(ToOwned::to_owned)
+}
+
+/// Resolves the GrabPay OAuth session/access token for a PSync call, from the
+/// typed state first and `connector_feature_data` second. Empty tokens are
+/// treated as absent (Grab's SDK rejects `len(token) == 0`). `None` means the
+/// caller must fall back to the HMAC-signed `/one-time-charge/{id}/status` API.
+fn psync_access_token(
+    req: &RouterDataV2<PSync, PaymentFlowData, PaymentsSyncData, PaymentsResponseData>,
+) -> Option<String> {
+    req.resource_common_data
+        .get_access_token()
+        .ok()
+        .filter(|token| !token.is_empty())
+        .or_else(|| {
+            session_token_from_connector_feature_data(
+                req.resource_common_data.connector_feature_data.as_ref(),
+            )
+            .filter(|token| !token.is_empty())
+        })
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> ConnectorCommon
@@ -590,14 +617,29 @@ macros::macro_connector_implementation!(
                     ),
                 },
             )?;
-            let access_token = req.resource_common_data.get_access_token().or_else(|err| {
-                session_token_from_connector_feature_data(
-                    req.resource_common_data.connector_feature_data.as_ref(),
-                )
-                .ok_or(err)
-            })?;
 
-            self.build_pop_headers(&auth, &access_token)
+            match psync_access_token(req) {
+                Some(access_token) => self.build_pop_headers(&auth, &access_token),
+                None => {
+                    // Fallback: no OAuth session token is available (e.g. after a
+                    // restart). Grab's `/one-time-charge/{id}/status` inquiry is
+                    // HMAC-signed with the partner credentials instead of the PoP
+                    // token, so it works without one. The path passed to the HMAC
+                    // canonical string must include the query string.
+                    let request_path = url::Url::parse(&self.get_url(req)?)
+                        .change_context(IntegrationError::RequestEncodingFailed {
+                            context: grabpay_integration_context(
+                                "GrabPay PSync failed to parse the one-time-charge status URL for HMAC path",
+                            ),
+                        })
+                        .map(|parsed| match parsed.query() {
+                            Some(query) => format!("{}?{}", parsed.path(), query),
+                            None => parsed.path().to_string(),
+                        })?;
+
+                    self.build_hmac_headers(&auth, "GET", &request_path, &[])
+                }
+            }
         }
 
         fn get_url(
@@ -609,9 +651,15 @@ macros::macro_connector_implementation!(
                 .connector_request_reference_id
                 .clone();
             grabpay::validate_partner_tx_id(&partner_tx_id)?;
+            let path_prefix = if psync_access_token(req).is_some() {
+                CHARGE_STATUS_PREFIX
+            } else {
+                OTC_CHARGE_STATUS_PREFIX
+            };
             Ok(format!(
-                "{}{CHARGE_STATUS_PREFIX}/{}/status?currency={}",
+                "{}{}/{}/status?currency={}",
                 self.connector_base_url_payments(req),
+                path_prefix,
                 partner_tx_id,
                 req.request.currency,
             ))

--- a/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
@@ -638,16 +638,21 @@ impl
 
         // Prefer the redirect-derived code; fall back to the codes recovered
         // from the one-time-charge status inquiry (HMAC-fallback PSync).
-        let code = feature_data
-            .code
-            .clone()
-            .or_else(|| feature_data.o_auth_code.clone())
+        // Ignore empty strings: `code` may carry an empty-JSON-string default
+        // ("") from upstream plumbing, which must not shadow the fallback.
+        let code_from_redirect = feature_data.code.as_deref().filter(|code| !code.is_empty());
+        let code = code_from_redirect
+            .or(feature_data
+                .o_auth_code
+                .as_deref()
+                .filter(|code| !code.is_empty()))
+            .map(str::to_string)
             .ok_or_else(missing_oauth_code_error)?;
 
         // The state check is OAuth CSRF protection for browser-redirect
         // flows. When the code was recovered via the OTC status inquiry
         // (HMAC-authenticated server-to-server, no redirect), skip it.
-        if feature_data.code.is_some() {
+        if code_from_redirect.is_some() {
             validate_callback_state(&feature_data)?;
         }
 

--- a/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
@@ -194,6 +194,11 @@ pub struct GrabpayConnectorFeatureData {
     pub state: Option<Secret<String>>,
     pub callback_state: Option<String>,
     pub code: Option<String>,
+    /// GrabID authorization code recovered via the one-time-charge status
+    /// inquiry (HMAC-authenticated server-to-server), as opposed to `code`
+    /// which arrives via the browser redirect. Its presence signals that the
+    /// CSRF state check does not apply.
+    pub o_auth_code: Option<String>,
     pub nonce: Option<String>,
     pub code_verifier: Option<Secret<String>>,
     pub redirect_uri: Option<String>,
@@ -231,6 +236,10 @@ pub struct GrabpayChargeCompleteResponse {
     #[serde(rename = "txStatus")]
     pub tx_status: GrabpayPaymentStatus,
     pub reason: Option<String>,
+    // Only Grab's `/one-time-charge/{id}/status` inquiry returns this; the
+    // `/charge/complete` and `/charge/{id}/status` responses do not.
+    #[serde(rename = "oAuthCode", skip_serializing_if = "Option::is_none")]
+    pub o_auth_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -627,11 +636,20 @@ impl
                 .as_ref(),
         )?;
 
+        // Prefer the redirect-derived code; fall back to the codes recovered
+        // from the one-time-charge status inquiry (HMAC-fallback PSync).
         let code = feature_data
             .code
             .clone()
+            .or_else(|| feature_data.o_auth_code.clone())
             .ok_or_else(missing_oauth_code_error)?;
-        validate_callback_state(&feature_data)?;
+
+        // The state check is OAuth CSRF protection for browser-redirect
+        // flows. When the code was recovered via the OTC status inquiry
+        // (HMAC-authenticated server-to-server, no redirect), skip it.
+        if feature_data.code.is_some() {
+            validate_callback_state(&feature_data)?;
+        }
 
         Ok(Self {
             grant_type: AUTHORIZATION_CODE_GRANT.to_string(),
@@ -1352,6 +1370,7 @@ fn parse_connector_feature_data(
             state: None,
             callback_state: None,
             code: None,
+            o_auth_code: None,
             nonce: None,
             code_verifier: None,
             redirect_uri: None,
@@ -1419,13 +1438,36 @@ fn build_complete_connector_feature_data(
         );
     }
 
-    // Strip OAuth-only fields that are dead after the token exchange completes.
-    metadata.remove("code_verifier");
-    metadata.remove("nonce");
-    metadata.remove("state");
-    metadata.remove("code");
-    metadata.remove("callback_state");
-    metadata.remove("redirect_uri");
+    // Grab's `/one-time-charge/{id}/status` inquiry returns the GrabID
+    // authorization code after user consent — crucial in the HMAC-fallback
+    // PSync path where the redirect callback was missed. Persist it under
+    // `o_auth_code` (not `code`) so the token-exchange transformer can tell
+    // it apart from a redirect-derived code and skip the CSRF state check.
+    // Grab returns `"oAuthCode": ""` when consent is pending; skip empties.
+    if let Some(code) = response
+        .o_auth_code
+        .as_deref()
+        .filter(|code| !code.is_empty())
+    {
+        metadata.insert("o_auth_code".to_string(), serde_json::json!(code));
+    }
+
+    // Strip OAuth-only fields that are dead once the token exchange has
+    // completed — detected by a session token being passed in or already
+    // persisted in metadata. Before authorization (HMAC-fallback PSync)
+    // the exchange is still pending, so the fields — and the recovered
+    // `o_auth_code` above — are kept redeemable. Order matters: this strip
+    // runs after the `o_auth_code` insert so a pre-existing session token
+    // always wins.
+    if session_token.is_some() || metadata.get("session_token").is_some() {
+        metadata.remove("code_verifier");
+        metadata.remove("nonce");
+        metadata.remove("state");
+        metadata.remove("code");
+        metadata.remove("o_auth_code");
+        metadata.remove("callback_state");
+        metadata.remove("redirect_uri");
+    }
 
     connector_metadata
 }

--- a/data/field_probe/grabpay.json
+++ b/data/field_probe/grabpay.json
@@ -3535,8 +3535,26 @@
     },
     "get": {
       "default": {
-        "status": "error",
-        "error": "Stuck on field: access_token — Missing required field: access_token"
+        "status": "supported",
+        "proto_request": {
+          "merchant_transaction_id": "probe_merchant_txn_001",
+          "connector_transaction_id": "probe_connector_txn_001",
+          "amount": {
+            "minor_amount": 1000,
+            "currency": "USD"
+          }
+        },
+        "sample": {
+          "url": "https://partner-api.grab.com/grabpay/partner/v2/one-time-charge/probe_merchant_txn_001/status?currency=USD",
+          "method": "Get",
+          "headers": {
+            "authorization": "probe_key:cHJvYmVfa2V5OnByb2JlX3NlY3JldA==",
+            "content-type": "application/json",
+            "date": "2020-01-01T00:00:00+00:00",
+            "via": "HyperSwitch"
+          },
+          "body": null
+        }
       }
     },
     "handle_event": {

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -182,7 +182,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Givepayments](connectors/givepayments.md) | ✓ | ⚠ | ⚠ | x | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ✓ | x | x | x | x | x | x | x | x | x | ⚠ | x | x | x | x | x | x | ⚠ | x | x | ✓ | ✓ | x |
 | [Globalpay](connectors/globalpay.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Glomopay](connectors/glomopay.md) | ✓ | x | x | ⚠ | ? | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ? | ✓ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | x | x | x | ⚠ | x | x | ✓ | ✓ | x |
-| [Grabpay](connectors/grabpay.md) | ? | x | ⚠ | x | ⚠ | ? | ⚠ | ✓ | x | ? | x | ? | x | ⚠ | x | ? | x | ⚠ | ⚠ | x | x | x | x | x | ⚠ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
+| [Grabpay](connectors/grabpay.md) | ✓ | x | ⚠ | x | ⚠ | ? | ⚠ | ✓ | x | ? | x | ? | x | ⚠ | x | ? | x | ⚠ | ⚠ | x | x | x | x | x | ⚠ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
 | [Helcim](connectors/helcim.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Hipay](connectors/hipay.md) | ✓ | ✓ | x | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | x | ✓ | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x | ⚠ | x | ⚠ | ⚠ | ⚠ | x |
 | [Hyperpg](connectors/hyperpg.md) | ✓ | ⚠ | x | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |

--- a/docs-generated/connectors/grabpay.md
+++ b/docs-generated/connectors/grabpay.md
@@ -139,13 +139,20 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/grabpay/grabpay.py#L67) · [JavaScript](../../examples/grabpay/grabpay.js) · [Kotlin](../../examples/grabpay/grabpay.kt#L74) · [Rust](../../examples/grabpay/grabpay.rs#L112)
+**Examples:** [Python](../../examples/grabpay/grabpay.py#L77) · [JavaScript](../../examples/grabpay/grabpay.js) · [Kotlin](../../examples/grabpay/grabpay.kt#L85) · [Rust](../../examples/grabpay/grabpay.rs#L124)
+
+### Get Payment Status
+
+Retrieve current payment status from the connector.
+
+**Examples:** [Python](../../examples/grabpay/grabpay.py#L96) · [JavaScript](../../examples/grabpay/grabpay.js) · [Kotlin](../../examples/grabpay/grabpay.kt#L101) · [Rust](../../examples/grabpay/grabpay.rs#L140)
 
 ## API Reference
 
 | Flow (Service.RPC) | Category | gRPC Request Message |
 |--------------------|----------|----------------------|
 | [PaymentService.Authorize](#paymentserviceauthorize) | Payments | `PaymentServiceAuthorizeRequest` |
+| [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [EventService.HandleEvent](#eventservicehandleevent) | Events | `EventServiceHandleRequest` |
 | [EventService.ParseEvent](#eventserviceparseevent) | Events | `EventServiceParseRequest` |
 | [PaymentService.VerifyRedirectResponse](#paymentserviceverifyredirectresponse) | Payments | `PaymentServiceVerifyRedirectResponseRequest` |
@@ -450,7 +457,18 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/grabpay/grabpay.py) · [TypeScript](../../examples/grabpay/grabpay.ts#L108) · [Kotlin](../../examples/grabpay/grabpay.kt#L89) · [Rust](../../examples/grabpay/grabpay.rs)
+**Examples:** [Python](../../examples/grabpay/grabpay.py) · [TypeScript](../../examples/grabpay/grabpay.ts#L141) · [Kotlin](../../examples/grabpay/grabpay.kt#L119) · [Rust](../../examples/grabpay/grabpay.rs)
+
+#### PaymentService.Get
+
+Retrieve current payment status from the payment processor. Enables synchronization between your system and payment processors for accurate state tracking.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceGetRequest` |
+| **Response** | `PaymentServiceGetResponse` |
+
+**Examples:** [Python](../../examples/grabpay/grabpay.py) · [TypeScript](../../examples/grabpay/grabpay.ts#L150) · [Kotlin](../../examples/grabpay/grabpay.kt#L131) · [Rust](../../examples/grabpay/grabpay.rs)
 
 #### PaymentService.VerifyRedirectResponse
 
@@ -461,4 +479,4 @@ Verify and process redirect responses from 3D Secure or other external flows. Va
 | **Request** | `PaymentServiceVerifyRedirectResponseRequest` |
 | **Response** | `PaymentServiceVerifyRedirectResponseResponse` |
 
-**Examples:** [Python](../../examples/grabpay/grabpay.py) · [TypeScript](../../examples/grabpay/grabpay.ts#L135) · [Kotlin](../../examples/grabpay/grabpay.kt#L132) · [Rust](../../examples/grabpay/grabpay.rs)
+**Examples:** [Python](../../examples/grabpay/grabpay.py) · [TypeScript](../../examples/grabpay/grabpay.ts#L177) · [Kotlin](../../examples/grabpay/grabpay.kt#L170) · [Rust](../../examples/grabpay/grabpay.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -353,9 +353,9 @@ examples_python: examples/glomopay/glomopay.py
 ## Grabpay
 connector_id: grabpay
 doc: docs/connectors/grabpay.md
-scenarios: checkout_autocapture
+scenarios: checkout_autocapture, get_payment
 payment_methods: Ach, AchBankTransfer, Affirm, Afterpay, Alfamart, AliPayRedirect, AmazonPayRedirect, ApplePay, ApplePayDecrypted, ApplePayThirdPartySdk, Bacs, BacsBankTransfer, BancontactCard, BcaBankTransfer, Becs, BillDeskRedirect, Bizum, Blik, Bluecode, BniVaBankTransfer, Boleto, BriVaBankTransfer, Card, CashappQr, CashfreeRedirect, CimbVaBankTransfer, ClassicReward, Dana, DanamonVaBankTransfer, EVoucher, EaseBuzzRedirect, Efecty, Eft, Eps, FamilyMart, GCash, Giropay, GoPay, GooglePay, GooglePayDecrypted, GooglePayThirdPartySdk, Ideal, Indomaret, IndonesianBankTransfer, InstantBankTransfer, InstantBankTransferFinland, InstantBankTransferPoland, Interac, KakaoPay, Klarna, Lawson, LazyPayRedirect, LocalBankRedirect, LocalBankTransfer, MandiriVaBankTransfer, MbWay, Mifinity, MiniStop, Momo, MultibancoBankTransfer, Netbanking, OnlineBankingCzechRepublic, OnlineBankingFinland, OnlineBankingFpx, OnlineBankingPoland, OnlineBankingSlovakia, OnlineBankingThailand, OpenBanking, OpenBankingUk, Oxxo, PagoEfectivo, PayEasy, PaySafeCard, PayURedirect, PaypalRedirect, PaypalSdk, PermataBankTransfer, PhonePeRedirect, Pix, Przelewy24, Pse, RedCompra, RedPagos, RevolutPay, SamsungPay, Satispay, Seicomart, Sepa, SepaBankTransfer, SepaGuaranteedDebit, SevenEleven, Skrill, Sofort, Swish, TouchNGo, Trustly, Twint, UpiCollect, UpiIntent, UpiQr, Vipps, WeChatPayQr, Wero
-flows: authorize, handle_event, parse_event, verify_redirect
+flows: authorize, get, handle_event, parse_event, verify_redirect
 examples_python: examples/grabpay/grabpay.py
 
 ## Helcim

--- a/examples/grabpay/grabpay.kt
+++ b/examples/grabpay/grabpay.kt
@@ -22,7 +22,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.GrabpayConfig
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "parse_event")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "get", "parse_event")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -69,6 +69,17 @@ private fun buildAuthorizeRequest(captureMethodStr: String): PaymentServiceAutho
     }.build()
 }
 
+private fun buildGetRequest(connectorTransactionIdStr: String): PaymentServiceGetRequest {
+    return PaymentServiceGetRequest.newBuilder().apply {
+        merchantTransactionId = "probe_merchant_txn_001"  // Identification.
+        connectorTransactionId = connectorTransactionIdStr
+        amountBuilder.apply {  // Amount Information.
+            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
+            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
+    }.build()
+}
+
 // Scenario: One-step Payment (Authorize + Capture)
 // Simple payment that authorizes and captures in one call. Use for immediate charges.
 fun processCheckoutAutocapture(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
@@ -85,6 +96,25 @@ fun processCheckoutAutocapture(txnId: String, config: ConnectorConfig = _default
     return mapOf("status" to authorizeResponse.status.name, "transactionId" to authorizeResponse.connectorTransactionId, "error" to authorizeResponse.error)
 }
 
+// Scenario: Get Payment Status
+// Retrieve current payment status from the connector.
+fun processGetPayment(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
+    val paymentClient = PaymentClient(config)
+
+    // Step 1: Authorize — reserve funds on the payment method
+    val authorizeResponse = paymentClient.authorize(buildAuthorizeRequest("MANUAL"))
+
+    when (authorizeResponse.status.name) {
+        "FAILED"  -> throw RuntimeException("Payment failed: ${authorizeResponse.error.unifiedDetails.message}")
+        "PENDING" -> return mapOf("status" to "PENDING")  // await webhook before proceeding
+    }
+
+    // Step 2: Get — retrieve current payment status from the connector
+    val getResponse = paymentClient.get(buildGetRequest(authorizeResponse.connectorTransactionId ?: ""))
+
+    return mapOf("status" to getResponse.status.name, "transactionId" to getResponse.connectorTransactionId, "error" to getResponse.error)
+}
+
 // Flow: PaymentService.Authorize (Card)
 fun authorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val client = PaymentClient(config)
@@ -95,6 +125,14 @@ fun authorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
         "PENDING" -> println("Pending — await webhook before proceeding")
         else      -> println("Authorized: ${response.connectorTransactionId}")
     }
+}
+
+// Flow: PaymentService.Get
+fun get(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = buildGetRequest("probe_connector_txn_001")
+    val response = client.get(request)
+    println("Status: ${response.status.name}")
 }
 
 // Flow: EventService.HandleEvent
@@ -144,10 +182,12 @@ fun main(args: Array<String>) {
     val flow = args.firstOrNull() ?: "processCheckoutAutocapture"
     when (flow) {
         "processCheckoutAutocapture" -> processCheckoutAutocapture(txnId)
+        "processGetPayment" -> processGetPayment(txnId)
         "authorize" -> authorize(txnId)
+        "get" -> get(txnId)
         "handleEvent" -> handleEvent(txnId)
         "parseEvent" -> parseEvent(txnId)
         "verifyRedirect" -> verifyRedirect(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, authorize, handleEvent, parseEvent, verifyRedirect")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processGetPayment, authorize, get, handleEvent, parseEvent, verifyRedirect")
     }
 }

--- a/examples/grabpay/grabpay.py
+++ b/examples/grabpay/grabpay.py
@@ -11,7 +11,7 @@ from payments import PaymentClient
 from payments import EventClient
 from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "parse_event"]
+SUPPORTED_FLOWS = ["authorize", "get", "parse_event"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -55,6 +55,16 @@ def _build_authorize_request(capture_method: str):
         session_token="probe_session_token",  # Session and Token Information.
     )
 
+def _build_get_request(connector_transaction_id: str):
+    return payment_pb2.PaymentServiceGetRequest(
+        merchant_transaction_id="probe_merchant_txn_001",  # Identification.
+        connector_transaction_id=connector_transaction_id,
+        amount=payment_pb2.Money(  # Amount Information.
+            minor_amount=1000,  # Amount in minor units (e.g., 1000 = $10.00).
+            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
+        ),
+    )
+
 def _build_parse_event_request():
     return payment_pb2.EventServiceParseRequest(
         request_details=payment_pb2.RequestDetails(
@@ -83,6 +93,28 @@ async def process_checkout_autocapture(merchant_transaction_id: str, config: sdk
     return {"status": getattr(authorize_response, "status", ""), "transaction_id": getattr(authorize_response, "connector_transaction_id", ""), "error": getattr(authorize_response, "error", None)}
 
 
+async def process_get_payment(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Get Payment Status
+
+    Retrieve current payment status from the connector.
+    """
+    payment_client = PaymentClient(config)
+
+    # Step 1: Authorize — reserve funds on the payment method
+    authorize_response = await payment_client.authorize(_build_authorize_request("MANUAL"))
+
+    if authorize_response.status == "FAILED":
+        raise RuntimeError(f"Payment failed: {authorize_response.error}")
+    if authorize_response.status == "PENDING":
+        # Awaiting async confirmation — handle via webhook
+        return {"status": "pending", "transaction_id": authorize_response.connector_transaction_id}
+
+    # Step 2: Get — retrieve current payment status from the connector
+    get_response = await payment_client.get(_build_get_request(authorize_response.connector_transaction_id))
+
+    return {"status": getattr(get_response, "status", ""), "transaction_id": getattr(get_response, "connector_transaction_id", ""), "error": getattr(get_response, "error", None)}
+
+
 async def process_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: PaymentService.Authorize (Card)"""
     payment_client = PaymentClient(config)
@@ -90,6 +122,15 @@ async def process_authorize(merchant_transaction_id: str, config: sdk_config_pb2
     authorize_response = await payment_client.authorize(_build_authorize_request("AUTOMATIC"))
 
     return {"status": authorize_response.status, "transaction_id": authorize_response.connector_transaction_id}
+
+
+async def process_get(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.Get"""
+    payment_client = PaymentClient(config)
+
+    get_response = await payment_client.get(_build_get_request("probe_connector_txn_001"))
+
+    return {"status": get_response.status}
 
 
 async def process_parse_event(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/grabpay/grabpay.rs
+++ b/examples/grabpay/grabpay.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 #[allow(dead_code)]
-pub const SUPPORTED_FLOWS: &[&str] = &["authorize", "parse_event"];
+pub const SUPPORTED_FLOWS: &[&str] = &["authorize", "get", "parse_event"];
 
 #[allow(dead_code)]
 fn build_client() -> ConnectorClient {
@@ -87,6 +87,19 @@ pub fn build_authorize_request(capture_method: &str) -> PaymentServiceAuthorizeR
     }
 }
 
+pub fn build_get_request(connector_transaction_id: &str) -> PaymentServiceGetRequest {
+    PaymentServiceGetRequest {
+        merchant_transaction_id: Some("probe_merchant_txn_001".to_string()), // Identification.
+        connector_transaction_id: connector_transaction_id.to_string(),
+        amount: Some(Money {
+            // Amount Information.
+            minor_amount: 1000, // Amount in minor units (e.g., 1000 = $10.00).
+            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
+        }),
+        ..Default::default()
+    }
+}
+
 #[allow(dead_code)]
 pub fn build_handle_event_request() -> EventServiceHandleRequest {
     EventServiceHandleRequest {
@@ -151,6 +164,43 @@ pub async fn process_checkout_autocapture(
     ))
 }
 
+// Scenario: Get Payment Status
+// Retrieve current payment status from the connector.
+#[allow(dead_code)]
+pub async fn process_get_payment(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Step 1: Authorize — reserve funds on the payment method
+    let authorize_response = client
+        .authorize(build_authorize_request("MANUAL"), &HashMap::new(), None)
+        .await?;
+
+    match authorize_response.status() {
+        PaymentStatus::Failure | PaymentStatus::AuthorizationFailed => {
+            return Err(format!("Payment failed: {:?}", authorize_response.error).into())
+        }
+        PaymentStatus::Pending => return Ok("pending — awaiting webhook".to_string()),
+        _ => {}
+    }
+
+    // Step 2: Get — retrieve current payment status from the connector
+    let get_response = client
+        .get(
+            build_get_request(
+                authorize_response
+                    .connector_transaction_id
+                    .as_deref()
+                    .unwrap_or(""),
+            ),
+            &HashMap::new(),
+            None,
+        )
+        .await?;
+
+    Ok(format!("Status: {:?}", get_response.status()))
+}
+
 // Flow: PaymentService.Authorize (Card)
 #[allow(dead_code)]
 pub async fn process_authorize(
@@ -172,6 +222,22 @@ pub async fn process_authorize(
     }
 }
 
+// Flow: PaymentService.Get
+#[allow(dead_code)]
+pub async fn process_get(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client
+        .get(
+            build_get_request("probe_connector_txn_001"),
+            &HashMap::new(),
+            None,
+        )
+        .await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 // Flow: EventService.ParseEvent
 #[allow(dead_code)]
 pub async fn process_parse_event(
@@ -191,10 +257,12 @@ async fn main() {
         .unwrap_or_else(|| "process_checkout_autocapture".to_string());
     let result: Result<String, Box<dyn std::error::Error>> = match flow.as_str() {
         "process_checkout_autocapture" => process_checkout_autocapture(&client, "order_001").await,
+        "process_get_payment" => process_get_payment(&client, "order_001").await,
         "process_authorize" => process_authorize(&client, "txn_001").await,
+        "process_get" => process_get(&client, "txn_001").await,
         "process_parse_event" => process_parse_event(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_authorize, process_parse_event", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_get_payment, process_authorize, process_get, process_parse_event", flow);
             return;
         }
     };

--- a/examples/grabpay/grabpay.ts
+++ b/examples/grabpay/grabpay.ts
@@ -7,7 +7,7 @@
 
 import { PaymentClient, EventClient, types } from 'hyperswitch-prism';
 const { Environment, AuthenticationType, CaptureMethod, Currency, HttpMethod } = types;
-export const SUPPORTED_FLOWS = ["authorize", "parse_event"];
+export const SUPPORTED_FLOWS = ["authorize", "get", "parse_event"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -50,6 +50,17 @@ function _buildAuthorizeRequest(captureMethod: types.CaptureMethod): types.IPaym
         "authType": AuthenticationType.NO_THREE_DS,  // Authentication Details.
         "returnUrl": "https://example.com/return",  // URLs for Redirection and Webhooks.
         "sessionToken": "probe_session_token"  // Session and Token Information.
+    };
+}
+
+function _buildGetRequest(connectorTransactionId: string): types.IPaymentServiceGetRequest {
+    return {
+        "merchantTransactionId": "probe_merchant_txn_001",  // Identification.
+        "connectorTransactionId": connectorTransactionId,
+        "amount": {  // Amount Information.
+            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
+            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
+        }
     };
 }
 
@@ -104,6 +115,28 @@ async function processCheckoutAutocapture(merchantTransactionId: string, config:
     return { status: authorizeResponse.status, transactionId: authorizeResponse.connectorTransactionId!, error: authorizeResponse.error } as any;
 }
 
+// Get Payment Status
+// Retrieve current payment status from the connector.
+async function processGetPayment(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    // Step 1: Authorize — reserve funds on the payment method
+    const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.MANUAL));
+
+    if (authorizeResponse.status === types.PaymentStatus.FAILURE) {
+        throw new Error(`Payment failed: ${JSON.stringify(authorizeResponse.error)}`);
+    }
+    if (authorizeResponse.status === types.PaymentStatus.PENDING) {
+        // Awaiting async confirmation — handle via webhook
+        return { status: 'pending', connectorTransactionId: authorizeResponse.connectorTransactionId };
+    }
+
+    // Step 2: Get — retrieve current payment status from the connector
+    const getResponse = await paymentClient.get(_buildGetRequest(authorizeResponse.connectorTransactionId!));
+
+    return { status: getResponse.status, transactionId: getResponse.connectorTransactionId!, error: getResponse.error } as any;
+}
+
 // Flow: PaymentService.Authorize (Card)
 async function authorize(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -111,6 +144,15 @@ async function authorize(merchantTransactionId: string, config: types.IConnector
     const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.AUTOMATIC));
 
     return authorizeResponse;
+}
+
+// Flow: PaymentService.Get
+async function get(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const getResponse = await paymentClient.get(_buildGetRequest('probe_connector_txn_001'));
+
+    return getResponse;
 }
 
 // Flow: EventService.HandleEvent
@@ -143,7 +185,7 @@ async function verifyRedirect(merchantTransactionId: string, config: types.IConn
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, authorize, handleEvent, parseEvent, verifyRedirect, _buildAuthorizeRequest, _buildHandleEventRequest, _buildParseEventRequest, _buildVerifyRedirectRequest
+    processCheckoutAutocapture, processGetPayment, authorize, get, handleEvent, parseEvent, verifyRedirect, _buildAuthorizeRequest, _buildGetRequest, _buildHandleEventRequest, _buildParseEventRequest, _buildVerifyRedirectRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
GrabPay's one-time-charge API exposes two charge-status inquiry endpoints:

| | Get Charge Status | Get One-Time-Charge (OTC) Status |
|---|---|---|
| Path | `GET /grabpay/partner/v2/charge/{partnerTxID}/status` | `GET /grabpay/partner/v2/one-time-charge/{partnerTxID}/status` |
| Auth | OAuth PoP (`Bearer` + `X-GID-AUX-POP`, needs an access token) | Partner HMAC signature (same scheme as `/charge/init`) |
| Extra response fields | `description`, `msgID` | `oAuthCode` |

Previously PSync always used the PoP endpoint and **hard-failed** whenever the OAuth session/access token was unavailable (e.g., service restart or metadata loss between GrabID consent and the `ServerSessionAuthenticationToken` exchange), leaving such payments unreconcilable.

# Changes
1. **HMAC fallback for PSync** — PSync now resolves the access token via a shared `psync_access_token()` helper (typed state first, persisted `session_token`/`access_token` in `connector_feature_data` second, empty strings rejected). When no token is found, both `get_url` and `get_headers` consistently switch to the OTC inquiry with partner-HMAC auth; when a token exists, behavior is byte-for-byte identical to before.

2. **HMAC canonical-string correctness** — fixed to match Grab's official merchant SDK (`GenerateHmac`): body digest is an empty string for GET requests (not `base64(sha256(""))`), and the signed path now includes the query string (`?currency=...`).

3. **`oAuthCode` recovery plumbing** — the OTC inquiry returns the GrabID authorization `oAuthCode` once the customer has consented, which is the only recovery mechanism for payments whose redirect callback was missed:
   - `oAuthCode` is now modeled on `GrabpayChargeCompleteResponse`; empty values returned while consent is pending are ignored.
   - It is persisted in `connector_feature_data` under a **dedicated `o_auth_code` key** — deliberately separate from the redirect-derived `code` — so the token exchange can tell the two provenance paths apart.
   - `build_complete_connector_feature_data` no longer strips the OAuth scratch fields (`code_verifier`, `state`, `nonce`, `callback_state`, `redirect_uri`, `code`) until a session token exists; the Authorize-path strip after a completed exchange is unchanged.

4. **Token exchange accepts the recovered code** — `GrabpayServerSessionAuthenticationTokenRequest` prefers `code` (redirect) and falls back to `o_auth_code` (sync-recovered). The OAuth CSRF `validate_callback_state` check runs only when `code` is present — a browser-redirect CSRF concern that does not apply to a code fetched server-to-server over HMAC-signed partner credentials.

5. **Upstream gate fix** — `should_do_session_token` previously gated only on the `"code"` key, so the composite layer (`verify_redirect_response` → `authorize_post_redirect`) silently skipped the session-token call when the code had been recovered into `o_auth_code`. The gate now accepts either key and rejects empty-string values.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
PSync always called the PoP-authenticated `/charge/{partnerTxID}/status` endpoint, which requires the OAuth access token minted after GrabID consent; whenever that token is missing (e.g. a missed redirect or restart before the exchange), sync hard-fails and the payment can neither be reconciled nor completed. This PR falls back to GrabPay's HMAC-authenticated `/one-time-charge/{partnerTxID}/status` inquiry when no token is available — which additionally returns the issued `oAuthCode` — letting the payment be synced and its consent recovered so the normal authorize flow can proceed.


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<details>
<summary>Sync With Access Token</summary>

**Request**
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto \
  -H 'x-connector: grabpay' \
  -H 'x-connector-config: {"config":{"Grabpay":{"partner_id":"<REDACTED>","partner_secret":"<REDACTED>","client_id":"<REDACTED>","client_secret":"<REDACTED>","merchant_id":"<REDACTED>"}}}' \
  -H 'x-merchant-id: azharamin' \
  -H 'x-tenant-id: JUSPAY' \
  -H 'x-environment: production' \
  -H 'x-request-id: grabpay-psync-pop-001' \
  -H 'x-reference-id: cardbox-psync-1' \
  -d '{"merchant_transaction_id":"cardbox-psync-1","connector_transaction_id":"cardbox-psync-1","amount":{"minor_amount":50,"currency":"PHP"},"state":{"access_token":{"token":{"value":"dummy-token-for-url-check"},"token_type":"Bearer","expires_in_seconds":3600}}}' \
  localhost:8000 types.PaymentService/Get
```

**Response**
```json
ERROR:
  Code: Internal
  Message: grpc-status-details-bin mismatch: grpc-status=Unauthenticated, grpc-message="No error message", grpc-status-details-bin=message:"CONNECTOR_ERROR_RESPONSE"  1:"No error message"  3:401  5:""  6:"\n\x9d\x03{\"url\":\"https://partner-api.grab.com/grabpay/partner/v2/charge/cardbox-psync-1/status?currency=PHP\",\"method\":\"GET\",\"headers\":{\"X-GID-AUX-POP\":\"eyJ0aW1lX3NpbmNlX2Vwb2NoIjoxNzg4MzU3NDU1LCJzaWciOiJHMW10MU9PdFdrY193WlFMRXdtdWxYcGIzT2JtazNmVnJKVHQ4MktVb3NVIn0\",\"via\":\"HyperSwitch\",\"Date\":\"Wed, 02 Sep 2026 13:57:35 GMT\",\"Content-Type\":\"application/json\",\"Authorization\":\"Bearer dummy-token-for-url-check\"},\"body\":null}"
```
Url Called: https://partner-api.grab.com/grabpay/partner/v2/charge/cardbox-psync-1/status?currency=PHP
</details>

<details>
<summary>Sync Without Access Token</summary>

**Request**
```bash
grpcurl -plaintext \
  -import-path crates/types-traits/grpc-api-types/proto \
  -proto services.proto \
  -H 'x-connector: grabpay' \
  -H 'x-connector-config: {"config":{"Grabpay":{"partner_id":"<REDACTED>","partner_secret":"<REDACTED>","client_id":"<REDACTED>","client_secret":"<REDACTED>","merchant_id":"<REDACTED>"}}}' \
  -H 'x-merchant-id: azharamin' \
  -H 'x-tenant-id: JUSPAY' \
  -H 'x-environment: production' \
  -H 'x-request-id: grabpay-psync-hmac-001' \
  -H 'x-reference-id: cardbox-psync-1' \
  -d '{"merchant_transaction_id":"cardbox-psync-1","connector_transaction_id":"cardbox-psync-1","amount":{"minor_amount":50,"currency":"PHP"},"state":{}}' \
  localhost:8000 types.PaymentService/Get
```

**Response**

```json
ERROR:
  Code: Internal
  Message: grpc-status-details-bin mismatch: grpc-status=InvalidArgument, grpc-message="ServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found", grpc-status-details-bin=message:"CONNECTOR_ERROR_RESPONSE"  1:"ServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found"  3:400  4:"\n\xba\x01\n\x044090\x12XServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found\x1aXServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found\x1a\xba\x01\n\x044090\x12XServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found\x1aXServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found"  5:"\nq{\"code\":4090,\"reason\":\"ServerError: target=, reason=not_found, msg=error executing tasks: transaction_not_found\"}"  6:"\n\xd5\x02{\"url\":\"https://partner-api.grab.com/grabpay/partner/v2/one-time-charge/cardbox-psync-1/status?currency=PHP\",\"method\":\"GET\",\"headers\":{\"via\":\"HyperSwitch\",\"Authorization\":\"56b8978b-ad62-4002-ac59-17e745d55687:N4d/QPOsPScT+mzm1O7zi4WygXaMMYjWEgSuFXYJmcw=\",\"Content-Type\":\"application/json\",\"Date\":\"Wed, 02 Sep 2026 13:59:28 GMT\"},\"body\":null}"
```
Url Called: https://partner-api.grab.com/grabpay/partner/v2/one-time-charge/cardbox-psync-1/status?currency=PHP
</details>
