### PR TITLE
fix(ci): grant the test job pull-requests write so the unproven-connector comment can post

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,6 +642,12 @@ jobs:
   test:
     name: Run Tests
     needs: [changes, auto-fix]
+    # `Comment unproven connector declarations on the PR` calls issues.createComment,
+    # which the top-level `contents: read` does not grant. Scoped the same way as the
+    # PR comment in sdk-client-sanity.yml.
+    permissions:
+      contents: read
+      pull-requests: write
     # Run if rust/proto/CI files changed AND auto-fix succeeded without pushing.
     # Skip if auto-fix pushed (new CI run incoming) or if auto-fix failed.
     if: >-


### PR DESCRIPTION
## What

Adds a `permissions` block to the `test` job in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

## Why

The `Comment unproven connector declarations on the PR` step (added in #2086) calls `github.rest.issues.createComment`. `ci.yml` sets a top-level `permissions: contents: read` (line 18) and the `test` job adds no override, so the call has no write scope and fails with:

```
403 Resource not accessible by integration
```

That takes the whole **Run Tests** job red even though every test passed. On #2206 the job breakdown is:

| Step | Result |
|---|---|
| Run Tests (527 unit tests) | success |
| Verify newly added connectors' declared scenarios | success |
| Certify selected connectors (`passed=132 failed=0`) | success |
| Upload certification reports | success |
| **Comment unproven connector declarations on the PR** | **failure — 403** |

## Why it has not been seen before

The step is gated on `steps.verify-new-connectors.outputs.unproven == 'true'`, which only becomes true when a brand-new connector is declared in `alpha_connectors.json` with a no-sandbox-credentials reason. #2206 (Elavon PG) is the first PR to exercise it. Left unfixed, **every future connector merged without live sandbox proof hits the same red CI.**

## Scope choice

`pull-requests: write`, not `issues: write` — GitHub maps PR comments to the pull-requests scope, and this matches how the existing PR comment in `sdk-client-sanity.yml` is already scoped in this repo. `contents: read` is restated explicitly so declaring the block does not silently narrow or widen the job's other access.

No behaviour change to any test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAkcU35CogeVE4psCe8bfR