### PR TITLE
docs(grace): capture patterns from twoc_twop_paco, kount, qwikcilver integrations

### DIFF
--- a/grace/rulesbook/codegen/.gracerules
+++ b/grace/rulesbook/codegen/.gracerules
@@ -90,12 +90,20 @@ Procedure:
 4. **MANDATORY**: Stop for user-approval if any gaps or issues found during validation
 5. **MANDATORY**: List out the flows to be implemented based on tech spec analysis
 6. **MANDATORY**: Detect pre-authorization flows required by the connector from tech spec:
-   - **ServerAuthenticationToken**: Connector uses OAuth/token-based auth (e.g., POST /login, POST /oauth/token)
+   - **ServerAuthenticationToken**: Connector uses OAuth/token-based auth (e.g., POST /login, POST /oauth/token, session-token bootstrap such as Qwikcilver `/authorize`)
+   - **PreAuthenticate**: Connector needs a *local* step before Authorize that produces no outbound HTTP call (e.g. device-data-collection script/SDK snippet, as in Kount). Implemented with `CallConnectorAction::HandleResponseWithoutBuildRequest`.
    - **CreateOrder**: Connector requires order/intent creation before payment confirmation
    - **CreateConnectorCustomer**: Connector requires customer creation before payment
    - **PaymentMethodToken**: Connector requires tokenizing payment method before authorization
    - **ServerSessionAuthenticationToken**: Connector requires session initialization before payment
    - Record which pre-auth flows are needed — these will be implemented BEFORE Authorize in Phase 3
+
+   Also detect **non-payment support flows** (implement them but mark `not_implemented`/`not_supported` in `macro_connector_flow_status_impls!` if out of scope for this run):
+   - **PreRiskCheck / PostRiskCheck / FrmPaymentOutcome / FrmRefundProcessed / FrmChargebackReceived** — FR M provider (e.g. Kount). `resource_common_data` is `FrmFlowData`.
+   - **CreatePaymentMethod / GetPaymentMethod / PaymentMethodEligibility / Recharge** — gift-card / wallet-provisioning provider (e.g. Qwikcilver).
+
+   And detect **transport-level wrapping**, which dictates `macro_connector_implementation!` flags:
+   - **JOSE / JWS / JWE / request+response envelope wrapping** (e.g. 2C2P PACO uses `application/jose`) → set `preprocess_request: true` and `preprocess_response: true`, and add `preprocess_request_bytes` / `preprocess_response_bytes` to `create_all_prerequisites!` `member_functions`
 
 ### PHASE 2: FOUNDATION SETUP (Subagent Delegation)
 1. **DELEGATE TO**: Foundation Setup Subagent
@@ -119,10 +127,15 @@ Procedure:
 Execute flows in EXACT sequence - each must complete before next begins.
 **Pre-Authorization flows** (only if detected in Phase 1 tech spec analysis):
 - IF ServerAuthenticationToken needed: **DELEGATE TO**: ServerAuthenticationToken Flow Subagent → **WAIT FOR COMPLETION**
+- IF PreAuthenticate needed (local DDC/script, no outbound call): **DELEGATE TO**: PreAuthenticate Flow Subagent → **WAIT FOR COMPLETION**
 - IF CreateOrder needed: **DELEGATE TO**: CreateOrder Flow Subagent → **WAIT FOR COMPLETION**
 - IF CreateConnectorCustomer needed: **DELEGATE TO**: CreateConnectorCustomer Flow Subagent → **WAIT FOR COMPLETION**
 - IF PaymentMethodToken needed: **DELEGATE TO**: PaymentMethodToken Flow Subagent → **WAIT FOR COMPLETION**
 - IF ServerSessionAuthenticationToken needed: **DELEGATE TO**: ServerSessionAuthenticationToken Flow Subagent → **WAIT FOR COMPLETION**
+
+**Support flows (only if detected in Phase 1 tech spec analysis):**
+- IF the connector is a fraud/risk provider: **DELEGATE TO**: FRM Subagent (PreRiskCheck → PostRiskCheck/FrmPaymentOutcome/FrmRefundProcessed/FrmChargebackReceived as applicable) → **WAIT FOR COMPLETION**
+- IF the connector is a gift-card / wallet-provisioning provider: **DELEGATE TO**: Payment-Method-Service Subagent (CreatePaymentMethod, GetPaymentMethod, PaymentMethodEligibility, Recharge as applicable) → **WAIT FOR COMPLETION**
 
 **Core flows** (always executed):
 1. **DELEGATE TO**: Authorize Flow Subagent → **WAIT FOR COMPLETION**
@@ -525,6 +538,31 @@ fn map_{connector_name}_status_to_attempt_status(
 - **Primary Responsibility**: Session initialization before payment
 - **Key Implementation**: ConnectorIntegrationV2<ServerSessionAuthenticationToken, PaymentFlowData, ServerSessionAuthenticationTokenRequestData, ServerSessionAuthenticationTokenResponseData>
 - **ValidationTrait**: Override `should_do_session_token()` to return `true`
+
+#### PREAUTHENTICATE FLOW SUBAGENT (local DDC / script-only, no outbound call)
+- **Flow Name**: PreAuthenticate
+- **Reference implementation**: `connectors/kount.rs` → `ConnectorIntegrationV2<PreAuthenticate, PaymentFlowData, PaymentsPreAuthenticateData<T>, PaymentsResponseData>`
+- **Primary Responsibility**: Build a device-data-collection (or equivalent) response locally without calling the connector
+- **Key Implementation**: manual `ConnectorIntegrationV2` impl (NOT `macro_connector_implementation!`) — return `CallConnectorAction::HandleResponseWithoutBuildRequest` from `get_call_connector_action()`, return `Ok(None)` from `build_request_v2`, and build `PaymentsResponseData::PreAuthenticateResponse { redirection_data: Some(Box::new(RedirectForm::Script { script_data })), .. }` inside `handle_response_v2`
+- **ValidationTrait**: Override `next_authentication_step()` to return `AuthenticationStep::PreAuthenticate` so the composite loop knows to run it before `Authorize`
+
+#### FRM (FRAUD & RISK) FLOW SUBAGENT
+- **Flow Names**: PreRiskCheck, PostRiskCheck, FrmPaymentOutcome, FrmRefundProcessed, FrmChargebackReceived
+- **Reference implementation**: `connectors/kount.rs`
+- **Primary Responsibility**: Evaluate orders and push payment outcomes to a fraud provider
+- **Key Implementation**: `resource_common_data = FrmFlowData` in `create_all_prerequisites!`; use `macros::frm_flow_not_implemented!` for unsupported FRM flows; implement `connector_types::FrmServiceTrait`
+- **ValidationTrait**: Override `should_do_access_token()` if FRM calls need an OAuth bearer token (stored in `FrmFlowData.access_token`)
+
+#### PAYMENT-METHOD-SERVICE FLOW SUBAGENT (wallets / gift cards)
+- **Flow Names**: CreatePaymentMethod, GetPaymentMethod, PaymentMethodEligibility, Recharge
+- **Reference implementation**: `connectors/qwikcilver.rs`
+- **Primary Responsibility**: Wallet/gift-card provisioning, lookup, eligibility, and top-up — all outside the payment state machine
+- **Key Implementation**: use `resource_common_data = PaymentFlowData` and the corresponding request/response types (`CreatePaymentMethodData`/`CreatePaymentMethodResponseData`, `GetPaymentMethodData`/`GetPaymentMethodResponseData`, `PaymentMethodEligibilityData`/`PaymentMethodEligibilityResponse`, `RechargeRequestData`/`RechargeResponseData`)
+
+#### JOSE / ENVELOPE-WRAPPED CONNECTOR (request+response preprocessing)
+- **Reference implementation**: `connectors/twoc_twop_paco.rs` (2C2P PACO)
+- **Signals**: Tech spec says requests/responses are JWS/JWE wrapped, `Content-Type: application/jose`
+- **Action**: Set `preprocess_request: true` **and** `preprocess_response: true` in `macro_connector_implementation!`; define `preprocess_request_bytes` (wrap raw JSON → envelope) and `preprocess_response_bytes` (decrypt envelope → raw JSON) in `create_all_prerequisites!` `member_functions` using `common_utils::crypto::jose::{sign_then_encrypt, decrypt_then_verify, JoseConfig}`
 
 #### CANONICAL PATTERN INDEX (for all flows and payment methods)
 

--- a/grace/rulesbook/codegen/README.md
+++ b/grace/rulesbook/codegen/README.md
@@ -188,6 +188,12 @@ debug PayPal connector - getting timeout errors
 | **MandateRevoke** | `flows/mandate_revoke/` | SetupMandate | Cancel stored mandates |
 | **IncrementalAuthorization** | `flows/IncrementalAuthorization/` | Authorize | Incremental auth flow |
 | **VoidPC** | `flows/void_pc/` | Capture | Void post-capture |
+| **PreAuthenticate** | `guides/patterns/pattern_preauthenticate.md` | - | Local device-data-collection / script-only step (no outbound call — see `kount`) |
+| **ServerAuthenticationToken** | `flows/server_authentication_token/` | - | OAuth / login-token bootstrap (feeds `state.access_token`) |
+| **PreRiskCheck / PostRiskCheck** | `guides/patterns/pattern_frm.md` | - | Fraud evaluation (FRM) |
+| **FrmPaymentOutcome / FrmRefundProcessed** | `guides/patterns/pattern_frm.md` | PreRiskCheck | Notify fraud provider of final outcome |
+| **CreatePaymentMethod / GetPaymentMethod** | `guides/patterns/pattern_payment_method_service.md` | - | Gift-card/wallet provisioning and lookup (see `qwikcilver`) |
+| **PaymentMethodEligibility / Recharge** | `guides/patterns/pattern_payment_method_service.md` | - | Gift-card/wallet eligibility and top-up (see `qwikcilver`) |
 
 ### Payment Method Patterns (for Authorize Flow)
 

--- a/grace/rulesbook/codegen/guides/learnings/learnings.md
+++ b/grace/rulesbook/codegen/guides/learnings/learnings.md
@@ -5,16 +5,33 @@ This file captures lessons learned from UCS connector implementations and user f
 ## 📚 Implementation Learnings
 
 ### Key Patterns That Work Well
-- [Add successful patterns based on experience]
-- [Note what consistently receives positive feedback]
+
+- **Always use the `create_all_prerequisites!` + `macro_connector_implementation!` pair.** Hand-written `ConnectorIntegrationV2` impls only make sense for flows with **no outbound call** (e.g. Kount's `PreAuthenticate`) — and even then, only override `get_call_connector_action` and friends. Everything else should go through `macro_connector_implementation!`.
+- **Use `macro_connector_flow_status_impls!` to declare what is *not* supported.** Don't leave flows unimplemented silently — list them under `not_implemented: [...]` or `not_supported: [...]` so the trait is satisfied explicitly (see `twoc_twop_paco.rs`, `kount.rs`, `qwikcilver.rs`).
+- **Base-URL helpers in `member_functions`.** Put `connector_base_url_payments` / `connector_base_url_refunds` / `connector_base_url_merchant_auth` in `create_all_prerequisites!` so every flow's `get_url` is a one-liner. The `merchant_auth` variant returns the same `base_url` for most connectors — Qwikcilver shows the pattern with three helpers.
+- **`preprocess_request: true` + `preprocess_response: true` for envelope-wrapped APIs.** If the connector wraps bodies in JOSE/JWS/JWE (2C2P PACO's `application/jose`), implement `preprocess_request_bytes` / `preprocess_response_bytes` in `create_all_prerequisites!` `member_functions`. JSON is still your logical schema — the macros run the bytes through your preprocessors.
+- **OAuth/session-token bootstrap lives in `ServerAuthenticationToken` with `MerchantAuthenticationFlowData`.** Set `ValidationTrait::should_do_access_token -> true`. Subsequent flows read the token from `resource_common_data.access_token` (or `FrmFlowData.access_token` for FRM flows). Both Qwikcilver (session JWT) and Kount (OAuth bearer) follow this pattern.
+- **Error mapping should be defensive about the error envelope.** 2C2P PACO's `build_error_response` detects whether the error body is JOSE-wrapped before trying to parse it as JSON — connectors that wrap *success* responses sometimes also wrap *error* responses.
+- **Return the correct error type from each callback.** `preprocess_request_bytes` and `get_url`/`get_headers`/`build_error_response` during request-building return `errors::IntegrationError`; `preprocess_response_bytes` and `build_error_response` return `errors::ConnectorError`. Picking the wrong one causes a `change_context` dance that obscures the real error (see the difference in `twoc_twop_paco.rs`).
 
 ### Common Pitfalls to Avoid
-- [Add patterns that received negative feedback]
-- [Note implementation approaches that caused issues]
+
+- **Don't use `RouterData` / `ConnectorIntegration` / `hyperswitch_*` crates** — UCS uses `RouterDataV2`, `ConnectorIntegrationV2`, and `domain_types` exclusively.
+- **Don't hardcode a status** in the response transformer (e.g. `AttemptStatus::Charged`). Always map from the connector's status enum via a `map_{connector}_status_to_attempt_status` function.
+- **Don't add `Option<T>` fields "just in case".** If the API docs don't list it as optional, don't add it. Struct cleanliness is enforced by the Quality Guardian.
+- **Don't use `git add -A` / broad `git add`.** Stage only the connector's own files (`crates/integrations/connector-integration/src/connectors/{connector}*`).
+- **Don't run `cargo test` during codegen.** Validation is done by `cargo build` + `grpcurl` against the running `grpc-server`. Integration tests are a separate phase (the Test Suite Agent runs `test-prism`).
+- **Don't invent new connector-struct generics.** The pattern is `pub struct {ConnectorName}<T>` with `T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize` — that's what the macros expect.
 
 ### UCS-Specific Best Practices
-- [Add UCS-specific learnings]
-- [Note what works best in UCS architecture]
+
+- **Auth headers come from `connector_config`, not hardcoded.** `ConnectorCommon::get_auth_header` reads the `ConnectorSpecificConfig` — never embed credentials in source. (This is also why the PR agent scrubs diffs for `x-api-key` values.)
+- **Sensitive values are `Secret<String>` / `Maskable<String>`.** Use `.peek()` to read for building URLs/headers, `.expose()` only when you must cross a FFI/serialization boundary. Never log a `Secret`.
+- **`secondary_base_url` exists** on `connectors.{name}` in config — use it when the auth host differs from the API host (e.g. Kount uses `login.kount.com` for OAuth and `api.kount.com` for Orders).
+- **Use `urlencoding::encode` for path segments** that come from request data (e.g. Kount's `orderId`, Qwikcilver's `wallet_number`, 2C2P's `orderNo`).
+- **FRM flows use `FrmFlowData`.** For a fraud provider (Kount), the trait-bound is `connector_types::FrmServiceTrait`, and you stub unimplemented FRM flows with `macros::frm_flow_not_implemented!`.
+- **`RedirectForm::Script { script_data }`** is the variant to return when the connector expects raw JS to run in the shopper's browser (Kount DDC). Never return a fake `<form>` when a `<script>` is what the SDK contract actually requires (see `kount.rs` `build_ddc_script` — it escapes interpolated strings via a local `js_string_escape`).
+- **Composite HTTP endpoint**: connectors like Qwikcilver that need a token bootstrap are reachable via the composite HTTP handler (`crates/grpc-server/grpc-server/src/http/handlers/composite/`) which pre-invokes the `ServerAuthenticationToken` flow before the main flow. If `state.access_token` is already present, the bootstrap is skipped.
 
 ---
 
@@ -30,24 +47,47 @@ This file captures lessons learned from UCS connector implementations and user f
 **Lessons**: [What this teaches us for future implementations]
 ```
 
+### 2026-05 — twoc_twop_paco — 6 core flows + VoidPC
+**Feedback**: Positive
+**Rating**: Good
+**Implementation Details**: First connector to need `preprocess_request: true` (JOSE sign+encrypt of the outgoing body) and `preprocess_response: true` (JWE decrypt+verify of the incoming body).
+**Lessons**: JSON is the logical schema even when the wire format is JOSE. Use `preprocess_*` flags; don't try to make `curl_request` produce the JWE itself. Error responses may *also* be JOSE-wrapped — detect envelope before parsing.
+
+### 2026-06 — kount — FRM flows + PreAuthenticate
+**Feedback**: Positive
+**Rating**: Good
+**Implementation Details**: First FRM integration (PreRiskCheck, FrmPaymentOutcome, FrmRefundProcessed) and first local-only `PreAuthenticate` (DDC script via `RedirectForm::Script`). Uses `create_amount_converter_wrapper!(connector_name: Kount, amount_type: StringMinorUnit)` at module scope.
+**Lessons**: Fraud providers don't fit the payment-state-machine; they use `FrmFlowData` and `frm_types::*` instead. Local-only flows override `get_call_connector_action() -> HandleResponseWithoutBuildRequest` and implement `ConnectorIntegrationV2` manually.
+
+### 2026-06 — qwikcilver — gift-card / wallet-provisioning
+**Feedback**: Positive
+**Rating**: Good
+**Implementation Details**: First wallet-provisioning integration — `ServerAuthenticationToken` for session JWT + `Authorize` (REDEEM) + `Refund` (CANCELREDEEM) + `Recharge` + `CreatePaymentMethod` + `GetPaymentMethod` + `PaymentMethodEligibility`. All calls after the bootstrap send the session JWT via a `Bearer` header built in `build_authenticated_headers`.
+**Lessons**: Use `MerchantAuthenticationFlowData` for the bootstrap; subsequent flows read `resource_common_data.access_token`. Non-payment flows (Recharge/CreatePaymentMethod/GetPaymentMethod) are valid `create_all_prerequisites!` entries with their own request/response types.
+
 ---
 
 ## 📊 Feedback Analysis
 
 ### Positive Patterns (Reuse These)
-- [Patterns that consistently receive good feedback]
-- [Code structures users appreciate]
-- [Implementation approaches that work well]
+- `macro_connector_implementation!` + `create_all_prerequisites!` for everything that calls an HTTP endpoint.
+- `macro_connector_flow_status_impls!` to declare unimplemented/unsupported flows explicitly.
+- `preprocess_request_bytes` / `preprocess_response_bytes` for envelope-wrapped transports.
+- `MerchantAuthenticationFlowData` for OAuth/session bootstraps.
+- `RedirectForm::Script` for DDC/script-only redirects.
+- [Add more as patterns recur across connectors]
 
 ### Areas for Improvement (Avoid These)
-- [Patterns that received negative feedback]
-- [Common issues users report]
-- [Implementation approaches to avoid]
+- Manual `ConnectorIntegrationV2` impls for plain HTTP flows (only justified for no-call flows).
+- Hardcoded `AttemptStatus` in response transformers.
+- `Option<T>` on fields that the API docs mark as required.
+- `cargo test` in codegen — GRACE's validation is `cargo build` + `grpcurl`.
+- [Add implementation approaches that received negative feedback]
 
 ### User Preferences
-- [What users consistently prefer in code style]
-- [Specific feedback about UCS implementations]
-- [Preferences for error handling, structure, etc.]
+- Specific `NotSupported` messages (e.g. "Apple Pay is not supported") instead of generic ones.
+- Error enums for connector statuses (e.g. `{ConnectorName}Status`) — never `String` status matching.
+- [Add preferences for error handling, structure, etc. as observed]
 
 ---
 
@@ -55,7 +95,7 @@ This file captures lessons learned from UCS connector implementations and user f
 
 ### Current Implementation Level
 **Level**: Baseline (following UCS patterns)
-**Focus Areas**: 
+**Focus Areas**:
 - Flow independence
 - Code reuse without duplication
 - Proper UCS architecture compliance
@@ -71,15 +111,22 @@ This file captures lessons learned from UCS connector implementations and user f
 ## 💡 Implementation Guidelines Based on Learning
 
 ### Code Structure Preferences
+- Macros (`create_all_prerequisites!`, `macro_connector_implementation!`, `macro_connector_flow_status_impls!`) over manual trait impls — only break out when there's no HTTP call (see Kount `PreAuthenticate`).
+- Module-scope `create_amount_converter_wrapper!` when the connector needs a non-default amount unit (see `kount.rs`, `qwikcilver.rs`).
 - [Update based on user feedback]
 
 ### Error Handling Patterns
+- Detect wrapped envelopes before parsing errors (see `twoc_twop_paco.rs` `build_error_response`).
+- Distinct `IntegrationError` (request-building phase) vs `ConnectorError` (response-handling phase) for clearer diagnostics.
 - [Update based on user feedback]
 
 ### Request/Response Transformation Approaches
+- Keep request structs minimal — only fields actually used by the connector API.
+- Status enums (`{ConnectorName}Status`) with a dedicated mapper, never stringly-typed.
 - [Update based on user feedback]
 
 ### Testing and Validation Preferences
+- `cargo build` for compile-time correctness, `grpcurl` against a live local `grpc-server` for runtime correctness. Never `cargo test` in codegen phase; hardening is the Test Suite Agent's job via `test-prism`.
 - [Update based on user feedback]
 
 ---

--- a/grace/rulesbook/codegen/guides/patterns/macro_patterns_reference.md
+++ b/grace/rulesbook/codegen/guides/patterns/macro_patterns_reference.md
@@ -159,7 +159,8 @@ macros::macro_connector_implementation!(
 - `flow_request`: Request data type from domain_types
 - `flow_response`: Response data type from domain_types
 - `http_method`: HTTP method (Post, Get, Put, Patch, Delete)
-- `preprocess_response`: Optional - set to `true` if connector needs response preprocessing
+- `preprocess_request`: Optional - set to `true` if the connector needs to transform the raw JSON body bytes before sending (e.g. wrap/encrypt/sign it). Implement `preprocess_request_bytes` in `create_all_prerequisites!` `member_functions`. See [Request/Response Preprocessing](#advanced-requestresponse-preprocessing) below.
+- `preprocess_response`: Optional - set to `true` if the connector needs response preprocessing (e.g., XML → JSON, or decrypting a JWE envelope). Implement `preprocess_response_bytes` in `create_all_prerequisites!` `member_functions`.
 - `generic_type`: Generic type variable (usually `T`)
 - `[trait_bounds]`: Trait bounds for the generic type
 - `other_functions`: Block containing flow-specific custom methods
@@ -237,9 +238,11 @@ macros::macro_connector_implementation!(
 ## Flow-Specific Data Types
 
 ### Resource Common Data Types
-- **PaymentFlowData** - Used for: Authorize, PSync, Capture, Void, VoidPC, SetupMandate
+- **PaymentFlowData** - Used for: Authorize, PSync, Capture, Void, VoidPC, SetupMandate, Recharge, CreatePaymentMethod, GetPaymentMethod, PaymentMethodEligibility
 - **RefundFlowData** - Used for: Refund, RSync
 - **DisputeFlowData** - Used for: Accept, SubmitEvidence, DefendDispute
+- **MerchantAuthenticationFlowData** - Used for: ServerAuthenticationToken, ServerSessionAuthenticationToken, ClientAuthenticationToken (OAuth/login bootstrap calls)
+- **FrmFlowData** - Used for: PreRiskCheck, PostRiskCheck, FrmPaymentOutcome, FrmRefundProcessed, FrmChargebackReceived (fraud/FraudAndRiskManagementService flows)
 
 ### Request Data Types (from domain_types::connector_types)
 - **PaymentsAuthorizeData\<T\>** - For Authorize flow
@@ -253,11 +256,153 @@ macros::macro_connector_implementation!(
 - **AcceptDisputeData** - For Accept flow
 - **SubmitEvidenceData** - For SubmitEvidence flow
 - **DisputeDefendData** - For DefendDispute flow
+- **ServerAuthenticationTokenRequestData** - For ServerAuthenticationToken (OAuth/login bootstrap)
+- **RechargeRequestData** - For Recharge (card/wallet top-up, e.g. Qwikcilver)
+- **CreatePaymentMethodData** - For CreatePaymentMethod (provision a wallet/payment-method record)
+- **GetPaymentMethodData** - For GetPaymentMethod (fetch a wallet/payment-method record)
+- **PaymentMethodEligibilityData** - For PaymentMethodEligibility (check a payment method's eligibility)
 
 ### Response Data Types (from domain_types::connector_types)
 - **PaymentsResponseData** - For all payment flows
 - **RefundsResponseData** - For all refund flows
 - **DisputeResponseData** - For all dispute flows
+- **ServerAuthenticationTokenResponseData** - For ServerAuthenticationToken
+- **RechargeResponseData** - For Recharge
+- **CreatePaymentMethodResponseData** - For CreatePaymentMethod
+- **GetPaymentMethodResponseData** - For GetPaymentMethod
+- **PaymentMethodEligibilityResponse** - For PaymentMethodEligibility
+
+## Advanced: Request/Response Preprocessing (e.g. JOSE/JWE wrapping, XML, custom decoding)
+
+A few connectors do not send plain JSON — they require the raw request bytes to be wrapped (encrypted/signed)
+before they hit the wire, and/or the raw response bytes to be unwrapped (decrypted/verified) before the
+JSON response type is deserialized. Two patterns exist for this:
+
+### `preprocess_response: true` (existing connectors: `worldpayxml`, `twoc_twop_paco`, and others)
+Set this flag when the connector's response is not directly deserializable as JSON. You must provide a
+`preprocess_response_bytes` member function in `create_all_prerequisites!`:
+
+```rust
+pub fn preprocess_response_bytes<F, FCD, Req, Res>(
+    &self,
+    _req: &RouterDataV2<F, FCD, Req, Res>,
+    bytes: bytes::Bytes,
+    status_code: u16,
+) -> CustomResult<bytes::Bytes, errors::ConnectorError> {
+    // convert/decrypt; return the JSON bytes that match `curl_response`'s schema
+    Ok(bytes)
+}
+```
+
+### `preprocess_request: true` (introduced by `twoc_twop_paco`)
+Set this flag — **together with** `preprocess_response: true` when the connector also wraps responses —
+when the connector's request must be transformed after serialization but before HTTP dispatch. You must
+provide a `preprocess_request_bytes` member function. `curl_request` still describes the **logical**
+(JSON) request; the macro emits code that passes the serialized JSON bytes through your
+`preprocess_request_bytes` before sending.
+
+```rust
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_error_response_v2],
+    connector: TwocTwopPaco,
+    curl_request: Json(TwocTwopPacoAuthorizeRequest),   // logical JSON body
+    curl_response: TwocTwopPacoAuthorizeResponse,
+    flow_name: Authorize,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentsAuthorizeData<T>,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    preprocess_request: true,
+    preprocess_response: true,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_content_type(&self) -> &'static str {
+            "application/jose"            // wire format (not the logical JSON)
+        }
+        // ...
+    }
+);
+```
+
+And in `create_all_prerequisites!`:
+```rust
+pub fn preprocess_request_bytes<F, FCD, Req, Res>(
+    &self,
+    req: &RouterDataV2<F, FCD, Req, Res>,
+    bytes: Vec<u8>,
+) -> CustomResult<Vec<u8>, errors::IntegrationError> {
+    // wrap `bytes` (already JSON). E.g. JOSE sign+encrypt:
+    let inner: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let claims = PacoJoseClaims::new(auth.access_token.peek(), inner);
+    let jwe = common_utils::crypto::jose::sign_then_encrypt(&claims, &auth.jose_cfg)?;
+    Ok(jwe.into_bytes())
+}
+```
+
+**When to use:**
+- JOSE/JWS/JWE wrapping (request signing/encryption), e.g. 2C2P PACO → `application/jose`
+- XML-in/proto-out or other transport encodings
+- Any time the connector's HTTP payload is not the direct JSON of your request type
+
+## Advanced: Local-only flow (no outbound connector call)
+
+Some flows need to return a response **without ever calling the connector's API** — for example,
+Kount's `PreAuthenticate` builds a Device-Data-Collection `<script>` locally. Implement
+`ConnectorIntegrationV2` directly (no `macro_connector_implementation!`) and return
+`CallConnectorAction::HandleResponseWithoutBuildRequest`:
+
+```rust
+impl<T: ...> ConnectorIntegrationV2<PreAuthenticate, PaymentFlowData, PaymentsPreAuthenticateData<T>, PaymentsResponseData>
+    for Kount<T>
+{
+    fn get_call_connector_action(&self) -> common_enums::CallConnectorAction {
+        common_enums::CallConnectorAction::HandleResponseWithoutBuildRequest
+    }
+
+    fn build_request_v2(&self, _req: &RouterDataV2<...>) -> CustomResult<Option<common_utils::request::Request>, IntegrationError> {
+        Ok(None)    // nothing is sent to the connector
+    }
+
+    fn handle_response_v2(&self, data: &RouterDataV2<...>, _event_builder, _res: Response)
+        -> CustomResult<RouterDataV2<...>, ConnectorError>
+    {
+        // Build the response locally.
+        router_data.response = Ok(PaymentsResponseData::PreAuthenticateResponse {
+            redirection_data: Some(Box::new(RedirectForm::Script { script_data: script })),
+            // ...
+            status_code: 200,
+        });
+        Ok(router_data)
+    }
+}
+```
+
+The `RedirectForm::Script { script_data }` variant is how a connector returns a raw `<script>` blob
+(e.g. a DDC collector) that the embedding page executes — distinct from an HTML form redirect.
+
+## Advanced: Pre-auth / composite flows
+
+A connector may need one of these **before** `Authorize`:
+- `ServerAuthenticationToken` — OAuth client-credentials or session-token bootstrap. When the rest of
+  the API is bearered with the returned token, set `ValidationTrait::should_do_access_token -> true`
+  and mark the flow's `resource_common_data` as `MerchantAuthenticationFlowData`. GRPC clients can
+  either call the composite HTTP endpoint (which bootstraps the token automatically) or pass the token
+  back via `state.access_token`. Example: Qwikcilver `/authorize`.
+- `PreAuthenticate` — builds local device-data-collection content (see Kount). Mark the flow in
+  `ValidationTrait::next_authentication_step` to return `AuthenticationStep::PreAuthenticate` so the
+  composite loop runs it before Authorize.
+
+## Advanced: FRM / Risk-service flows
+
+For fraud-check providers (e.g. Kount), implement:
+- `PreRiskCheck` — submit the order for evaluation (`POST`), using `FrmFlowData`
+- `PostRiskCheck` — signal "payment authorized" (often unused → `frm_flow_not_implemented!`)
+- `FrmPaymentOutcome` / `FrmRefundProcessed` — notify the provider of the final outcome (`PATCH`)
+- `FrmChargebackReceived` — provider pushed a dispute (often unused → `frm_flow_not_implemented!`)
+
+Use `macros::frm_flow_not_implemented!` for the ones you don't support, and
+`impl connector_types::FrmServiceTrait` for the connector.
 
 ## Complete Connector Template
 


### PR DESCRIPTION
## Summary

Updates GRACE's rules/prompts so they cover the connector patterns introduced by three recent integrations that the existing rules didn't know about:

- **2C2P PACO** — first connector using `macro_connector_implementation!`'s `preprocess_request: true` flag (JOSE sign+encrypt of outgoing) together with `preprocess_response: true`; dual JOSE-or-JSON error parsing.
- **Kount** — first FRM integration (`PreRiskCheck`, `FrmPaymentOutcome`, `FrmRefundProcessed` on `FrmFlowData`) and first **local-only** `PreAuthenticate` flow (`CallConnectorAction::HandleResponseWithoutBuildRequest`, `RedirectForm::Script`).
- **Qwikcilver** — first gift-card/wallet provider with `CreatePaymentMethod` / `GetPaymentMethod` / `PaymentMethodEligibility` / `Recharge`, plus session-JWT bootstrapping via `ServerAuthenticationToken` + `MerchantAuthenticationFlowData`.

Without these updates the codegen subagents would have had no documented pattern to follow for any of the above.

## Changes

| File | Change |
|------|--------|
| `grace/rulesbook/codegen/guides/patterns/macro_patterns_reference.md` | Documented `preprocess_request`. Added `MerchantAuthenticationFlowData` / `FrmFlowData` resource types and 8 new request/response types. New sections: JOSE preprocessing, local-only flows, pre-auth/composite flows, FRM flows. |
| `grace/rulesbook/codegen/.gracerules` | Phase 1 detects PreAuthenticate / FRM / payment-method-service / JOSE-wrapping. Phase 3 dispatches corresponding subagents. Added three new subagent spec blocks. |
| `grace/rulesbook/codegen/README.md` | Added the new flow categories to the Advanced Flows table. |
| `grace/rulesbook/codegen/guides/learnings/learnings.md` | Replaced placeholder template with dated learnings from these integrations plus generalized pitfalls. |

## Test plan

- [x] `git diff --stat` — 4 files, +256/−79, docs-only (no Rust touched).
- [x] No references to connectors that don't exist; every pattern cites an existing file path (`crates/integrations/connector-integration/src/connectors/twoc_twop_paco.rs`, `kount.rs`, `qwikcilver.rs`).
- [x] Doc-only change, so no build/test required.