### PR TITLE
fix(config): derive the connector override key as snake_case, not lowercase

### DIFF
--- a/crates/types-traits/domain_types/src/router_data.rs
+++ b/crates/types-traits/domain_types/src/router_data.rs
@@ -1496,11 +1496,40 @@ impl ConnectorSpecificConfig {
             return None;
         }
 
+        /// Map a `ConnectorSpecificConfig` variant name to its [`Connectors`] field name.
+        ///
+        /// This used to be a plain `to_ascii_lowercase()`, which is wrong for every
+        /// multi-word variant: `AbsaSanlam` produced `absasanlam` while the field is
+        /// `absa_sanlam`, and because `ConfigPatch` is `deny_unknown_fields` the
+        /// `x-connector-config` base-URL override failed with `InvalidDataFormat`
+        /// instead of applying. It silently broke `AbsaSanlam`, `GotymeSanlam`,
+        /// `PinelabsOnline`, `TsysTransit` and `TwocTwopPaco`.
+        ///
+        /// Snake-casing is therefore the default, so a newly added multi-word connector
+        /// is correct without anyone remembering this function. Two pre-existing fields
+        /// in `Connectors` are not snake_case and are pinned here — snake-casing them
+        /// would break overrides that work today.
+        fn connector_field_key(variant: &str) -> String {
+            match variant {
+                "BankOfAmerica" => return "bankofamerica".to_string(),
+                "RazorpayV2" => return "razorpayv2".to_string(),
+                _ => {}
+            }
+            let mut key = String::with_capacity(variant.len() + 4);
+            for (index, ch) in variant.char_indices() {
+                if ch.is_ascii_uppercase() && index != 0 {
+                    key.push('_');
+                }
+                key.push(ch.to_ascii_lowercase());
+            }
+            key
+        }
+
         macro_rules! connector_key {
                 ($($variant:ident { $($field:ident),* $(,)? }),* $(,)?) => {
                     match self {
                         Self::NoKey => "nokey".to_string(),
-                        $(Self::$variant { .. } => stringify!($variant).to_ascii_lowercase(),)*
+                        $(Self::$variant { .. } => connector_field_key(stringify!($variant)),)*
                     }
                 };
             }


### PR DESCRIPTION
## What

`ConnectorSpecificConfig::connector_config_override_patch` derived the `Connectors` field key with `stringify!($variant).to_ascii_lowercase()`. That is correct only for single-word variants.

| Variant | Key produced | Actual `Connectors` field |
|---|---|---|
| `AbsaSanlam` | `absasanlam` | `absa_sanlam` |
| `GotymeSanlam` | `gotymesanlam` | `gotyme_sanlam` |
| `PinelabsOnline` | `pinelabsonline` | `pinelabs_online` |
| `TsysTransit` | `tsystransit` | `tsys_transit` |
| `TwocTwopPaco` | `twoctwoppaco` | `twoc_twop_paco` |

`ConfigPatch` is `deny_unknown_fields`, so the patch did not merely get ignored — it failed with `InvalidDataFormat` and the `x-connector-config` base-URL override never applied. For any connector whose production host is region-dependent, merchants in the non-default region have **no working production path**.

## The fix, and the trap in it

Snake-casing is now the default, so a newly added multi-word connector is correct without anyone having to remember this function exists.

But a naive snake_case conversion **breaks two connectors that work today**: `Connectors` has two fields that predate the convention and are not snake_case — `bankofamerica` and `razorpayv2`. `BankOfAmerica` → `bank_of_america` and `RazorpayV2` → `razorpay_v2` are both missing fields. Those two variants are pinned explicitly, with a comment saying why.

## Verification

Checked all **116** variants in the `connector_key!` macro against the real field list parsed out of `struct Connectors`:

- 5 multi-word variants fixed (table above)
- 2 legacy fields keep their current key
- **no variant that resolves today changes**

Five single-word variants (`Coinbase`, `Coingate`, `Ebanx`, `Globepay`, `Screenstream`) have no matching `Connectors` field under either scheme. That is pre-existing and deliberately untouched here.

Build clean.

## Provenance

Reported by @JeevaRamu0104 while reviewing #2206, where it blocks the NA production path for Elavon PG. Split into its own PR because it changes behaviour for connectors outside that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAkcU35CogeVE4psCe8bfR