### PR TITLE
fix(GRABPAY): adding rawConnectorStatus in sync responses

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
@@ -292,7 +292,7 @@ pub struct GrabpayRefundSyncResponse {
     pub echo: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, strum::EnumString)]
+#[derive(Debug, Clone, Deserialize, Serialize, strum::Display, strum::EnumString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case", ascii_case_insensitive)]
 pub enum GrabpayPaymentStatus {
@@ -305,6 +305,7 @@ pub enum GrabpayPaymentStatus {
     TransactionAlreadyExist,
     #[serde(untagged)]
     #[strum(default)]
+    #[strum(to_string = "{0}")]
     Unknown(String),
 }
 
@@ -324,7 +325,7 @@ impl From<GrabpayPaymentStatus> for AttemptStatus {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, strum::EnumString)]
+#[derive(Debug, Clone, Deserialize, Serialize, strum::Display, strum::EnumString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case", ascii_case_insensitive)]
 pub enum GrabpayRefundStatus {
@@ -336,6 +337,7 @@ pub enum GrabpayRefundStatus {
     TransactionAlreadyExist,
     #[serde(untagged)]
     #[strum(default)]
+    #[strum(to_string = "{0}")]
     Unknown(String),
 }
 
@@ -980,6 +982,11 @@ impl TryFrom<ConnectorResponseData<GrabpayRefundResponse, Self>>
     ) -> Result<Self, Self::Error> {
         let response = item.response;
         let refund_status = RefundStatus::from(response.tx_status.clone());
+        let raw_connector_status = grabpay_refund_raw_connector_status(
+            &response.tx_status,
+            response.description.clone(),
+            response.reason.clone(),
+        );
 
         Ok(Self {
             response: Ok(RefundsResponseData {
@@ -990,6 +997,7 @@ impl TryFrom<ConnectorResponseData<GrabpayRefundResponse, Self>>
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
+                raw_connector_status: Some(raw_connector_status),
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1007,6 +1015,11 @@ impl TryFrom<ConnectorResponseData<GrabpayRefundSyncResponse, Self>>
     ) -> Result<Self, Self::Error> {
         let response = item.response;
         let refund_status = RefundStatus::from(response.tx_status.clone());
+        let raw_connector_status = grabpay_refund_raw_connector_status(
+            &response.tx_status,
+            response.description.clone(),
+            response.reason.clone(),
+        );
 
         Ok(Self {
             response: Ok(RefundsResponseData {
@@ -1017,6 +1030,7 @@ impl TryFrom<ConnectorResponseData<GrabpayRefundSyncResponse, Self>>
             }),
             resource_common_data: RefundFlowData {
                 status: refund_status,
+                raw_connector_status: Some(raw_connector_status),
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1416,11 +1430,23 @@ fn charge_tx_id_from_connector_feature_data(
 /// for callers that consume the typed connector status codes.
 fn grabpay_raw_connector_status(response: &GrabpayChargeCompleteResponse) -> RawConnectorStatus {
     RawConnectorStatus {
-        code: serde_json::to_value(&response.tx_status)
-            .ok()
-            .and_then(|value| value.as_str().map(str::to_string)),
+        code: Some(response.tx_status.to_string()),
         message: response.description.clone(),
         reason: response.reason.clone(),
+    }
+}
+
+/// Same as `grabpay_raw_connector_status` but for the refund and refund-sync
+/// responses, which share the same `txStatus`/`reason`/`description` shape.
+fn grabpay_refund_raw_connector_status(
+    tx_status: &GrabpayRefundStatus,
+    description: Option<String>,
+    reason: Option<String>,
+) -> RawConnectorStatus {
+    RawConnectorStatus {
+        code: Some(tx_status.to_string()),
+        message: description,
+        reason,
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay/transformers.rs
@@ -8,7 +8,8 @@ use domain_types::{
         Authenticate, Authorize, PSync, RSync, Refund, ServerSessionAuthenticationToken,
     },
     connector_types::{
-        EventType, PaymentWebhookReference, RefundWebhookReference, WebhookResourceReference,
+        EventType, PaymentWebhookReference, RawConnectorStatus, RefundWebhookReference,
+        WebhookResourceReference,
     },
     connector_types::{
         PaymentFlowData, PaymentsAuthenticateData, PaymentsAuthorizeData, PaymentsResponseData,
@@ -829,6 +830,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             &response,
             session_token.as_deref(),
         );
+        let raw_connector_status = grabpay_raw_connector_status(&response);
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
                 resource_id,
@@ -845,6 +847,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }),
             resource_common_data: PaymentFlowData {
                 status,
+                raw_connector_status: Some(raw_connector_status),
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -881,6 +884,7 @@ impl TryFrom<ConnectorResponseData<GrabpayChargeCompleteResponse, Self>>
             &response,
             session_token.as_deref(),
         );
+        let raw_connector_status = grabpay_raw_connector_status(&response);
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
@@ -903,6 +907,7 @@ impl TryFrom<ConnectorResponseData<GrabpayChargeCompleteResponse, Self>>
             }),
             resource_common_data: PaymentFlowData {
                 status,
+                raw_connector_status: Some(raw_connector_status),
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1404,6 +1409,19 @@ fn charge_tx_id_from_connector_feature_data(
 ) -> Result<String, error_stack::Report<errors::IntegrationError>> {
     let feature_data = parse_connector_feature_data(connector_feature_data)?;
     required_feature_field(feature_data.tx_id, "txID")
+}
+
+/// Fills the opt-in `raw_connector_status` channel with Grab's granular status
+/// (`txStatus`, `reason`, `description`) alongside the unified attempt status,
+/// for callers that consume the typed connector status codes.
+fn grabpay_raw_connector_status(response: &GrabpayChargeCompleteResponse) -> RawConnectorStatus {
+    RawConnectorStatus {
+        code: serde_json::to_value(&response.tx_status)
+            .ok()
+            .and_then(|value| value.as_str().map(str::to_string)),
+        message: response.description.clone(),
+        reason: response.reason.clone(),
+    }
 }
 
 fn build_complete_connector_feature_data(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added rawConnectorStatus in sync response for GRABPAY

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Grabpay was not populating rawConnectorStatus in sync response.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="1727" height="76" alt="Screenshot 2026-09-03 at 3 33 58 PM" src="https://github.com/user-attachments/assets/631d12d8-e58c-44d5-bed4-21aadbb0ce67" />

