### PR TITLE
fix(connector): align authorizedotnet, cybersource and adyen response parsing with hyperswitch

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -392,11 +392,16 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
                     &response,
                     "typed_connector_response",
                 );
+                // Mirror hyperswitch: message -> title -> placeholder.
+                let message = response
+                    .message
+                    .or(response.title)
+                    .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string());
                 Ok(ErrorResponse {
                     status_code: res.status_code,
                     code: response.error_code,
-                    message: response.message.to_owned(),
-                    reason: Some(response.message),
+                    message: message.clone(),
+                    reason: Some(message),
                     attempt_status: None,
                     connector_transaction_id: response.psp_reference,
                     network_decline_code: None,
@@ -413,7 +418,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
                     event.set_connector_response(&serde_json::json!({"error": "Error response parsing failed", "status_code": res.status_code}));
                 }
                 tracing::error!(deserialization_error =? error_msg);
-                utils::handle_json_response_deserialization_failure(res, "mifinity")
+                utils::handle_json_response_deserialization_failure(res, "adyen")
             }
         }
     }

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -5458,8 +5458,13 @@ pub fn get_wait_screen_metadata(
 pub struct AdyenErrorResponse {
     pub status: i32,
     pub error_code: String,
-    pub message: String,
-    pub error_type: String,
+    /// Optional because adyen omits it on some gateway errors, and returns `title`
+    /// instead on others. Hyperswitch models both as optional and falls back
+    /// `message` -> `title` -> placeholder; requiring either here would fail the whole
+    /// parse on bodies hyperswitch handles.
+    pub message: Option<String>,
+    pub title: Option<String>,
+    pub error_type: Option<String>,
     pub psp_reference: Option<String>,
 }
 

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
@@ -259,11 +259,16 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(WebhookDetailsResponse {
             connector_returned_payment_method_details: None,
             resource_id: Some(ResponseId::ConnectorTransactionId(transaction_id.clone())),
-            // `status` is derived from the webhook `event_type`, whose mapping never yields
-            // `SyncStatus::Unknown`, so the retained-status arm is unreachable here.
+            // A webhook carries no prior attempt status. `Unspecified` is the wire value
+            // hyperswitch reads as "retain the stored status"
+            // (hyperswitch_interfaces/src/unified_connector_service/transformers.rs:697,
+            // `PaymentStatus::Unspecified => Ok(prev_status)`), whereas any concrete status —
+            // `Pending` included — is taken at face value and would overwrite it. The webhook
+            // event mapping never yields `SyncStatus::Unknown`, so this argument is unused
+            // today; it must stay a safe no-op in case a future event variant makes it live.
             status: transformers::get_sync_attempt_status(
                 status,
-                common_enums::AttemptStatus::Pending,
+                common_enums::AttemptStatus::Unspecified,
             ),
             status_code: 200,
             mandate_reference: None,

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
@@ -259,17 +259,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(WebhookDetailsResponse {
             connector_returned_payment_method_details: None,
             resource_id: Some(ResponseId::ConnectorTransactionId(transaction_id.clone())),
-            // A webhook carries no prior attempt status. `Unspecified` is the wire value
-            // hyperswitch reads as "retain the stored status"
-            // (hyperswitch_interfaces/src/unified_connector_service/transformers.rs:697,
-            // `PaymentStatus::Unspecified => Ok(prev_status)`), whereas any concrete status —
-            // `Pending` included — is taken at face value and would overwrite it. The webhook
-            // event mapping never yields `SyncStatus::Unknown`, so this argument is unused
-            // today; it must stay a safe no-op in case a future event variant makes it live.
-            status: transformers::get_sync_attempt_status(
-                status,
-                common_enums::AttemptStatus::Unspecified,
-            ),
+            status: common_enums::AttemptStatus::from(status),
             status_code: 200,
             mandate_reference: None,
             connector_response_reference_id: Some(transaction_id.clone()),

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
@@ -259,7 +259,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(WebhookDetailsResponse {
             connector_returned_payment_method_details: None,
             resource_id: Some(ResponseId::ConnectorTransactionId(transaction_id.clone())),
-            status: common_enums::AttemptStatus::from(status),
+            // `status` is derived from the webhook `event_type`, whose mapping never yields
+            // `SyncStatus::Unknown`, so the retained-status arm is unreachable here.
+            status: transformers::get_sync_attempt_status(
+                status,
+                common_enums::AttemptStatus::Pending,
+            ),
             status_code: 200,
             mandate_reference: None,
             connector_response_reference_id: Some(transaction_id.clone()),

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2409,17 +2409,26 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
                 Ok(new_router_data)
             }
             None => {
-                // A psync response with no transaction record. Transient server-side
-                // conditions (server busy / maintenance) are not a payment failure.
+                // A psync poll with no transaction record. `E00053` ("server too
+                // busy") and `E00104` ("server in maintenance") are not payment
+                // failures - Authorize.Net is asking us to retry later.
                 //
-                // Hyperswitch returns `Ok(item.data)` unchanged here, but its psync
-                // `item.data.response` is already an `Ok(TransactionResponse)` rebuilt
-                // from the stored attempt. This connector is stateless: `router_data`
-                // is constructed with `response: Err(ErrorResponse::default())`, so
-                // returning it unchanged surfaces as `HE_00 / 500 / status unspecified`.
-                // Rebuild the same shape hyperswitch presents downstream: keep the
-                // request's connector transaction id and the incoming attempt status
-                // untouched. Any other message code is a real connector error.
+                // Hyperswitch returns `Ok(item.data)` unchanged, keeping the prior
+                // attempt status, because its psync `item.data.response` is a
+                // `TransactionResponse` seeded from the stored attempt
+                // (`construct_payment_router_data`) and `item.data.status` is the
+                // stored `payment_attempt.status`. This connector is stateless:
+                // `router_data` is built with `response: Err(ErrorResponse::default())`
+                // and no prior status, so returning it unchanged surfaces as
+                // `HE_00 / 500 / PAYMENT_STATUS_UNSPECIFIED` (a spurious error).
+                //
+                // Emit instead an `Ok(TransactionResponse)` with `AttemptStatus::Unknown`
+                // ("polled, could not infer") and `status_code = http_code` (200). It
+                // serializes to `PaymentStatus::Unspecified`, which hyperswitch maps
+                // back to the previous attempt status on psync
+                // (`unified_connector_service/transformers.rs`,
+                // `PaymentStatus::Unspecified => Ok(prev_status)`) - matching the
+                // direct connector leg. Any other message code is a real error.
                 match response.messages.message.iter().find(|m| {
                     m.code == TRANSIENT_ERROR_SERVER_BUSY || m.code == TRANSIENT_ERROR_MAINTENANCE
                 }) {
@@ -2430,6 +2439,7 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
                             .get_connector_transaction_id()
                             .ok();
                         let mut new_router_data = router_data;
+                        new_router_data.resource_common_data.status = AttemptStatus::Unknown;
                         new_router_data.response = Ok(PaymentsResponseData::TransactionResponse {
                             resource_id: connector_transaction_id
                                 .clone()

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2410,14 +2410,44 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
             }
             None => {
                 // A psync response with no transaction record. Transient server-side
-                // conditions (server busy / maintenance) are not a payment failure, so
-                // mirror hyperswitch and keep the existing router data unchanged;
-                // otherwise surface the connector error while preserving the prior
-                // attempt status (as hyperswitch's `get_err_response` does).
+                // conditions (server busy / maintenance) are not a payment failure.
+                //
+                // Hyperswitch returns `Ok(item.data)` unchanged here, but its psync
+                // `item.data.response` is already an `Ok(TransactionResponse)` rebuilt
+                // from the stored attempt. This connector is stateless: `router_data`
+                // is constructed with `response: Err(ErrorResponse::default())`, so
+                // returning it unchanged surfaces as `HE_00 / 500 / status unspecified`.
+                // Rebuild the same shape hyperswitch presents downstream: keep the
+                // request's connector transaction id and the incoming attempt status
+                // untouched. Any other message code is a real connector error.
                 match response.messages.message.iter().find(|m| {
                     m.code == TRANSIENT_ERROR_SERVER_BUSY || m.code == TRANSIENT_ERROR_MAINTENANCE
                 }) {
-                    Some(_) => Ok(router_data),
+                    Some(_) => {
+                        let connector_transaction_id = router_data
+                            .request
+                            .connector_transaction_id
+                            .get_connector_transaction_id()
+                            .ok();
+                        let mut new_router_data = router_data;
+                        new_router_data.response = Ok(PaymentsResponseData::TransactionResponse {
+                            resource_id: connector_transaction_id
+                                .clone()
+                                .map(ResponseId::ConnectorTransactionId)
+                                .unwrap_or(ResponseId::NoResponseId),
+                            redirection_data: None,
+                            mandate_reference: None,
+                            connector_metadata: None,
+                            network_txn_id: None,
+                            network_txn_link_id: None,
+                            connector_response_reference_id: connector_transaction_id,
+                            incremental_authorization_allowed: None,
+                            status_code: http_code,
+                            splits: None,
+                            payment_account_reference: None,
+                        });
+                        Ok(new_router_data)
+                    }
                     None => Ok(Self {
                         response: Err(get_err_response(http_code, response.messages)),
                         ..router_data

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2376,7 +2376,10 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
         // Use the clean approach with the From trait implementation
         match response.transaction {
             Some(transaction) => {
-                let payment_status = AttemptStatus::from(transaction.transaction_status);
+                let payment_status = get_sync_attempt_status(
+                    transaction.transaction_status,
+                    router_data.resource_common_data.status,
+                );
 
                 // Create a new RouterDataV2 with updated fields
                 let mut new_router_data = router_data;
@@ -2855,6 +2858,8 @@ pub enum SyncStatus {
     FDSPendingReview,
     #[serde(rename = "FDSAuthorizedPendingReview")]
     FDSAuthorizedPendingReview,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2871,23 +2876,33 @@ pub struct SyncTransactionResponse {
     // Additional fields available but not needed for our implementation
 }
 
-impl From<SyncStatus> for AttemptStatus {
-    fn from(transaction_status: SyncStatus) -> Self {
-        match transaction_status {
-            SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
-                Self::Charged
-            }
-            SyncStatus::AuthorizedPendingCapture => Self::Authorized,
-            SyncStatus::Declined => Self::AuthenticationFailed,
-            SyncStatus::Voided => Self::Voided,
-            SyncStatus::CouldNotVoid => Self::VoidFailed,
-            SyncStatus::GeneralError => Self::Failure,
-            SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
-                Self::Charged
-            }
-            SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
-                Self::Unresolved
-            }
+/// An unrecognised `transactionStatus` must not fail the sync: hyperswitch keeps the
+/// previous attempt status and logs, so mirror that instead of erroring out.
+pub fn get_sync_attempt_status(
+    transaction_status: SyncStatus,
+    prev_status: AttemptStatus,
+) -> AttemptStatus {
+    match transaction_status {
+        SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
+            AttemptStatus::Charged
+        }
+        SyncStatus::AuthorizedPendingCapture => AttemptStatus::Authorized,
+        SyncStatus::Declined => AttemptStatus::AuthenticationFailed,
+        SyncStatus::Voided => AttemptStatus::Voided,
+        SyncStatus::CouldNotVoid => AttemptStatus::VoidFailed,
+        SyncStatus::GeneralError => AttemptStatus::Failure,
+        SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
+            AttemptStatus::Charged
+        }
+        SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
+            AttemptStatus::Unresolved
+        }
+        SyncStatus::Unknown => {
+            tracing::warn!(
+                previous_status = ?prev_status,
+                "Unknown authorizedotnet sync status received; retaining previous status"
+            );
+            prev_status
         }
     }
 }
@@ -2903,6 +2918,8 @@ pub enum RSyncStatus {
     Declined,
     GeneralError,
     Voided,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2919,14 +2936,24 @@ pub struct AuthorizedotnetRSyncResponse {
     messages: ResponseMessages,
 }
 
-impl From<RSyncStatus> for RefundStatus {
-    fn from(transaction_status: RSyncStatus) -> Self {
-        match transaction_status {
-            RSyncStatus::RefundSettledSuccessfully => Self::Success,
-            RSyncStatus::RefundPendingSettlement => Self::Pending,
-            RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
-                Self::Failure
-            }
+/// Refund-sync analogue of [`get_sync_attempt_status`] — an unknown `transactionStatus`
+/// retains the previous refund status rather than failing deserialization.
+pub fn get_rsync_refund_status(
+    transaction_status: RSyncStatus,
+    prev_status: RefundStatus,
+) -> RefundStatus {
+    match transaction_status {
+        RSyncStatus::RefundSettledSuccessfully => RefundStatus::Success,
+        RSyncStatus::RefundPendingSettlement => RefundStatus::Pending,
+        RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
+            RefundStatus::Failure
+        }
+        RSyncStatus::Unknown => {
+            tracing::warn!(
+                previous_status = ?prev_status,
+                "Unknown authorizedotnet rsync status received; retaining previous status"
+            );
+            prev_status
         }
     }
 }
@@ -2947,7 +2974,10 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRSyncResponse, Self>>
 
         match response.transaction {
             Some(transaction) => {
-                let refund_status = RefundStatus::from(transaction.transaction_status);
+                let refund_status = get_rsync_refund_status(
+                    transaction.transaction_status,
+                    router_data.resource_common_data.status,
+                );
 
                 // Create a new RouterDataV2 with updated fields
                 let mut new_router_data = router_data;

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2899,8 +2899,12 @@ pub struct SyncTransactionResponse {
     pub transaction_id: String,
     #[serde(rename = "transactionStatus")]
     pub transaction_status: SyncStatus,
-    pub response_code: Option<u8>,
-    pub response_reason_code: Option<u8>,
+    // Authorize.Net reason codes run past 255 (e.g. 315 invalid card number, 318
+    // duplicate transaction), so `u8` overflows and fails the whole psync body.
+    // Hyperswitch does not model these fields at all and so never fails on them;
+    // they are carried here only for `typed_connector_response`, never read.
+    pub response_code: Option<i32>,
+    pub response_reason_code: Option<i32>,
     pub response_reason_description: Option<String>,
     pub network_trans_id: Option<String>,
     // Additional fields available but not needed for our implementation

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -2376,10 +2376,7 @@ impl<F> TryFrom<ResponseRouterData<AuthorizedotnetPSyncResponse, Self>>
         // Use the clean approach with the From trait implementation
         match response.transaction {
             Some(transaction) => {
-                let payment_status = get_sync_attempt_status(
-                    transaction.transaction_status,
-                    router_data.resource_common_data.status,
-                );
+                let payment_status = AttemptStatus::from(transaction.transaction_status);
 
                 // Create a new RouterDataV2 with updated fields
                 let mut new_router_data = router_data;
@@ -2920,33 +2917,31 @@ pub struct SyncTransactionResponse {
     // Additional fields available but not needed for our implementation
 }
 
-/// An unrecognised `transactionStatus` must not fail the sync: hyperswitch keeps the
-/// previous attempt status and logs, so mirror that instead of erroring out.
-pub fn get_sync_attempt_status(
-    transaction_status: SyncStatus,
-    prev_status: AttemptStatus,
-) -> AttemptStatus {
-    match transaction_status {
-        SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
-            AttemptStatus::Charged
-        }
-        SyncStatus::AuthorizedPendingCapture => AttemptStatus::Authorized,
-        SyncStatus::Declined => AttemptStatus::AuthenticationFailed,
-        SyncStatus::Voided => AttemptStatus::Voided,
-        SyncStatus::CouldNotVoid => AttemptStatus::VoidFailed,
-        SyncStatus::GeneralError => AttemptStatus::Failure,
-        SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
-            AttemptStatus::Charged
-        }
-        SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
-            AttemptStatus::Unresolved
-        }
-        SyncStatus::Unknown => {
-            tracing::warn!(
-                previous_status = ?prev_status,
-                "Unknown authorizedotnet sync status received; retaining previous status"
-            );
-            prev_status
+impl From<SyncStatus> for AttemptStatus {
+    fn from(transaction_status: SyncStatus) -> Self {
+        match transaction_status {
+            SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
+                Self::Charged
+            }
+            SyncStatus::AuthorizedPendingCapture => Self::Authorized,
+            SyncStatus::Declined => Self::AuthenticationFailed,
+            SyncStatus::Voided => Self::Voided,
+            SyncStatus::CouldNotVoid => Self::VoidFailed,
+            SyncStatus::GeneralError => Self::Failure,
+            SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
+                Self::Charged
+            }
+            SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
+                Self::Unresolved
+            }
+            // This service is stateless - there is no prior attempt status to fall back
+            // on, so an unrecognised `transactionStatus` must not resolve to a concrete
+            // status. `Unspecified` serializes to `PaymentStatus::Unspecified`, which
+            // hyperswitch maps back to the stored status
+            // (`unified_connector_service/transformers.rs`,
+            // `PaymentStatus::Unspecified => Ok(prev_status)`), so the retention happens
+            // on the side that actually holds the attempt.
+            SyncStatus::Unknown => Self::Unspecified,
         }
     }
 }
@@ -2980,24 +2975,18 @@ pub struct AuthorizedotnetRSyncResponse {
     messages: ResponseMessages,
 }
 
-/// Refund-sync analogue of [`get_sync_attempt_status`] — an unknown `transactionStatus`
-/// retains the previous refund status rather than failing deserialization.
-pub fn get_rsync_refund_status(
-    transaction_status: RSyncStatus,
-    prev_status: RefundStatus,
-) -> RefundStatus {
-    match transaction_status {
-        RSyncStatus::RefundSettledSuccessfully => RefundStatus::Success,
-        RSyncStatus::RefundPendingSettlement => RefundStatus::Pending,
-        RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
-            RefundStatus::Failure
-        }
-        RSyncStatus::Unknown => {
-            tracing::warn!(
-                previous_status = ?prev_status,
-                "Unknown authorizedotnet rsync status received; retaining previous status"
-            );
-            prev_status
+impl From<RSyncStatus> for RefundStatus {
+    fn from(transaction_status: RSyncStatus) -> Self {
+        match transaction_status {
+            RSyncStatus::RefundSettledSuccessfully => Self::Success,
+            RSyncStatus::RefundPendingSettlement => Self::Pending,
+            RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
+                Self::Failure
+            }
+            // Refund analogue of the `SyncStatus::Unknown` arm above: `RefundStatus::Unknown`
+            // serializes to proto `RefundStatus::Unspecified`, which hyperswitch maps back to
+            // the stored refund status.
+            RSyncStatus::Unknown => Self::Unknown,
         }
     }
 }
@@ -3018,10 +3007,7 @@ impl TryFrom<ResponseRouterData<AuthorizedotnetRSyncResponse, Self>>
 
         match response.transaction {
             Some(transaction) => {
-                let refund_status = get_rsync_refund_status(
-                    transaction.transaction_status,
-                    router_data.resource_common_data.status,
-                );
+                let refund_status = RefundStatus::from(transaction.transaction_status);
 
                 // Create a new RouterDataV2 with updated fields
                 let mut new_router_data = router_data;

--- a/crates/integrations/connector-integration/src/connectors/cybersource.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource.rs
@@ -460,6 +460,27 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         event_builder: Option<&mut events::Event>,
         _connector_config: &ConnectorSpecificConfig,
     ) -> CustomResult<ErrorResponse, ConnectorError> {
+        // An empty body carries no connector error to report. hyperswitch short-circuits
+        // here rather than letting `parse_struct` fail
+        // (crates/hyperswitch_connectors/src/connectors/cybersource.rs:181), so mirror it —
+        // otherwise the deserialization failure escalates past the error handler entirely.
+        if res.response.is_empty() {
+            return Ok(ErrorResponse {
+                status_code: res.status_code,
+                code: NO_ERROR_CODE.to_string(),
+                message: NO_ERROR_MESSAGE.to_string(),
+                reason: None,
+                attempt_status: None,
+                connector_transaction_id: None,
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+                typed_connector_response: None,
+                raw_connector_response: None,
+                raw_connector_request: None,
+                typed_connector_request: None,
+            });
+        }
         let response: Result<
             cybersource::CybersourceErrorResponse,
             Report<common_utils::errors::ParsingError>,

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -4835,6 +4835,8 @@ pub enum Reason {
     SystemError,
     ServerTimeout,
     ServiceTimeout,
+    #[serde(other)]
+    Unknown,
 }
 
 /// std `TryFrom<&Response>` can't be implemented for the foreign `ErrorResponse`
@@ -4865,7 +4867,10 @@ impl ForeignTryFrom<&Response> for ErrorResponse {
             Some(Reason::SystemError) => {
                 Some(FlowStatus::Payment(common_enums::AttemptStatus::Failure))
             }
-            Some(Reason::ServerTimeout) | Some(Reason::ServiceTimeout) | None => None,
+            Some(Reason::ServerTimeout)
+            | Some(Reason::ServiceTimeout)
+            | Some(Reason::Unknown)
+            | None => None,
         };
         Ok(Self {
             status_code: res.status_code,


### PR DESCRIPTION
## What this fixes

Three parity gaps where prism is **stricter than hyperswitch** when deserializing a
connector response, so prism hard-fails on bodies hyperswitch handles cleanly.

In shadow mode this is guaranteed to produce a diff, because the two sides parse
**byte-identical** input: the validation service's `uscHandler` does not forward
prism's connector call upstream — it replays hyperswitch's stored connector response
out of Redis (`controller/ucs/index.js:191`). So any response-parsing divergence is a
real prism defect, not connector flakiness.

When prism fails deserialization it returns `RESPONSE_DESERIALIZATION_FAILED`, whose
proto error code is not `CONNECTOR_ERROR_RESPONSE`, so hyperswitch's decoder rejects it
and the shadow gateway records `Err(String)` instead of a router data. That is why the
affected issues show ~55 keys present on the hyperswitch side and only `{"error": ...}`
on the UCS side — the router data was never built.

| Commit | Connector | Gap vs hyperswitch |
|---|---|---|
| `7bb0db179` | authorizedotnet | `SyncStatus` / `RSyncStatus` had no `#[serde(other)]` catch-all |
| `4c218b56b` | authorizedotnet | psync reason-code fields typed `Option<u8>`, overflowing past 255 |
| `05ce7cc06` | authorizedotnet | psync `transaction: None` + `E00104`/`E00053` returned an unpopulated router data |
| `814c4edc6` | cybersource | `Reason` had no catch-all; no empty-body guard in `build_error_response` |
| `fbcfe5c1b` | adyen | `AdyenErrorResponse` required `message` and `error_type` |

### authorizedotnet — `7bb0db179`

Authorize.Net documents roughly two dozen `transactionStatus` values; this connector
modelled eleven. `underReview`, `expired`, `settlementError`, `communicationError`,
`approvedReview`, `failedReview`, `updatingSettlement`, `returnedItem` and `chargeback`
all aborted the parse with `unknown variant ...`.

Hyperswitch has `#[serde(other)] Unknown` and **retains the previous status**
(`authorizedotnet/transformers.rs:2115`, `:2135`). Mirrored here by replacing the
infallible `From` conversions with `get_sync_attempt_status` / `get_rsync_refund_status`,
which take the previous status.

There is a **second, independent** failure mode behind the same four issues, fixed in
`4c218b56b`: `SyncTransactionResponse::response_code` and `response_reason_code` were typed
`Option<u8>`, which caps at 255. Authorize.Net reason codes run past that — 315 (invalid card
number), 316 (invalid expiry), 318 (duplicate transaction) — so those bodies failed to
deserialize with `invalid value: integer ..., expected u8`, producing an identical
`RESPONSE_DESERIALIZATION_FAILED`. Hyperswitch models neither field, so it never fails on them;
neither is read here, they are carried only for `typed_connector_response`. Both fixes were
needed for these issues to close.

Closes juspay/hyperswitch-cloud#23192, #23193, #23195, #23196.

### cybersource — `814c4edc6`

- `Reason` modelled only `SYSTEM_ERROR` / `SERVER_TIMEOUT` / `SERVICE_TIMEOUT`. Hyperswitch
  adds `#[serde(other)] Unknown` mapped to `attempt_status: None` (`cybersource.rs:522`).
- `build_error_response` parsed unconditionally; hyperswitch short-circuits an empty body
  first (`cybersource.rs:181`).

Deliberately **not** changed: `CybersourceServerErrorResponse` stays permissive (all fields
optional, no `deny_unknown_fields`). Hyperswitch's struct is identically permissive, so
tightening it would introduce a new divergence rather than remove one.

Refs juspay/hyperswitch-cloud#23179, #23180, #23182, #23183 — of these only #23183 is
expected to close from this change; the other three are hyperswitch-side client timeouts
(see "Not addressed here").

### adyen — `fbcfe5c1b`

`AdyenErrorResponse` required both `message` and `error_type`. Adyen omits `errorType` on
gateway errors such as `{"status":403,"errorCode":"901","message":"Invalid Merchant Account"}`
and returns `title` instead of `message` on others. Hyperswitch models both as optional,
does not model `error_type` at all, and resolves `message` → `title` → `NO_ERROR_MESSAGE`
(`adyen.rs:189`).

Also corrects this handler's deserialization-failure path, which reported the connector as
`"mifinity"` from inside the adyen connector.

Refs juspay/hyperswitch-cloud#23165.

## Verification

No unit tests are included in this change set.

Verified end-to-end against the real shadow pipeline, without connector credentials, by
seeding the validation service's Redis with the reported response bytes and driving prism
over gRPC — the harness then replays those bytes to prism exactly as it does in production:

| scenario | pre-fix binary | post-fix binary |
|---|---|---|
| unmodelled `transactionStatus: underReview` | `RESPONSE_DESERIALIZATION_FAILED` (http 200) | `PENDING`, previous status retained |
| `responseReasonCode: 315` | `RESPONSE_DESERIALIZATION_FAILED` (http 200) | `CHARGED`, raw value preserved |

Both failed with the identical error signature before the fix, which is why the second one was
only found by replaying it.

`cargo build`, `cargo clippy --all-targets` and `cargo fmt` are clean on the touched crate.

## Not addressed here

Investigated and root-caused, but **not** fixable in prism:

- **12 issues** (#23075, #23164, #23166, #23172, #23181, #23184, #23185, #23190, #23191,
  #23194, #23197, #23198) are validation-harness artefacts. Either
  hyperswitch's own connector leg died (mitmproxy synthesises a 502 via `HttpErrorHook`,
  which `forward_code.py` does not implement, so no Redis row is ever written), or the
  validation service returned `VS_07` despite a healthy hyperswitch leg. In both cases the
  UCS leg is compared against a response prism was never given. Fixes belong in
  `ucs-shadow-validation-service`.

  (#23188 and #23189 were originally in this group but are **fixed here** by `05ce7cc06`,
  which found a real prism defect behind them: the psync maintenance-code branch mirrored
  hyperswitch's `Ok(item.data)` without accounting for prism being stateless.)
- **#23171** (stripe `payment_method_token` / google_pay) is left alone deliberately. Prism's
  and hyperswitch's encrypted-google-pay branches are now structurally identical, so there is
  no parity gap left to close, and production runs the `2026.08.25.0` build which predates
  `3466a0ffe` (the 2026-08-28 Stripe Google Pay rework). It may already be fixed on `main`.
- **#23167–#23170** (adyen setup-mandate for wallets) deferred at the reporter's request.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSDJ7gES5D56vGqLz2JS4f
