### PR TITLE
refactor(plaid): fallback redirect_uri/android_package_name via PlaidConfig

### DIFF
--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -38,6 +38,27 @@ mod tests {
             ClientAuthenticationTokenRequestData,
             PaymentsResponseData,
         > {
+            make_req_full(client_name, customer, country_codes, None, None, None, None)
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn make_req_full(
+            client_name: Option<&str>,
+            customer: Option<CustomerInfo>,
+            country_codes: Vec<CountryAlpha2>,
+            return_url: Option<&str>,
+            native_app_identifier: Option<&str>,
+            os_type: Option<&str>,
+            plaid_config_fallback: Option<(Option<&str>, Option<&str>)>,
+        ) -> RouterDataV2<
+            ClientAuthenticationToken,
+            MerchantAuthenticationFlowData,
+            ClientAuthenticationTokenRequestData,
+            PaymentsResponseData,
+        > {
+            let (redirect_uri, android_package_name) =
+                plaid_config_fallback.unwrap_or((None, None));
+
             RouterDataV2 {
                 flow: PhantomData,
                 resource_common_data: MerchantAuthenticationFlowData {
@@ -45,7 +66,7 @@ mod tests {
                     connectors: Connectors::default().into(),
                     connector_request_reference_id: "ref_test".to_owned(),
                     test_mode: None,
-                    return_url: None,
+                    return_url: return_url.map(str::to_owned),
                     connector_feature_data: None,
                     order_details: None,
                     merchant_request_id: None,
@@ -59,6 +80,8 @@ mod tests {
                     client_id: Secret::new("test_client_id".to_owned()),
                     secret: Secret::new("test_secret".to_owned()),
                     client_name: client_name.map(str::to_owned),
+                    redirect_uri: redirect_uri.map(str::to_owned),
+                    android_package_name: android_package_name.map(str::to_owned),
                     base_url: None,
                 },
                 request: ClientAuthenticationTokenRequestData {
@@ -74,7 +97,13 @@ mod tests {
                     country_codes,
                     locale: None,
                     permissions: None,
-                    native_app_identifier: None,
+                    native_app_identifier: native_app_identifier.map(str::to_owned),
+                    browser_info: os_type.map(|os_type| {
+                        domain_types::router_request_types::BrowserInformation {
+                            os_type: Some(os_type.to_owned()),
+                            ..Default::default()
+                        }
+                    }),
                 },
                 response: Err(ErrorResponse::default()),
             }
@@ -118,6 +147,140 @@ mod tests {
             assert_eq!(body.as_ref().unwrap()["client_name"], "My App");
             assert_eq!(body.as_ref().unwrap()["country_codes"], json!(["US"]));
             assert_eq!(body.as_ref().unwrap()["products"], json!(["auth"]));
+        }
+
+        #[test]
+        fn test_build_request_android_os_uses_request_package_name() {
+            let req = make_req_full(
+                Some("My App"),
+                Some(customer()),
+                vec![CountryAlpha2::US],
+                Some("https://example.com/return"),
+                Some("com.example.app"),
+                Some("android"),
+                None,
+            );
+
+            let connector = Plaid::<DefaultPCIHolder>::new();
+            let integration: BoxedConnectorIntegrationV2<
+                '_,
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            > = connector.get_connector_integration_v2();
+
+            let request = integration.build_request_v2(&req).unwrap();
+            let body = request.as_ref().map(|r| match r.body.as_ref() {
+                Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
+                _ => json!({}),
+            });
+            assert_eq!(
+                body.as_ref().unwrap()["android_package_name"],
+                "com.example.app"
+            );
+            assert!(body.as_ref().unwrap().get("redirect_uri").is_none());
+        }
+
+        #[test]
+        fn test_build_request_android_os_falls_back_to_plaid_config() {
+            // Request supplies no native_app_identifier — falls back to the
+            // connector-level PlaidConfig android_package_name.
+            let req = make_req_full(
+                Some("My App"),
+                Some(customer()),
+                vec![CountryAlpha2::US],
+                None,
+                None,
+                Some("Android"),
+                Some((None, Some("com.fallback.app"))),
+            );
+
+            let connector = Plaid::<DefaultPCIHolder>::new();
+            let integration: BoxedConnectorIntegrationV2<
+                '_,
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            > = connector.get_connector_integration_v2();
+
+            let request = integration.build_request_v2(&req).unwrap();
+            let body = request.as_ref().map(|r| match r.body.as_ref() {
+                Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
+                _ => json!({}),
+            });
+            assert_eq!(
+                body.as_ref().unwrap()["android_package_name"],
+                "com.fallback.app"
+            );
+        }
+
+        #[test]
+        fn test_build_request_non_android_os_uses_request_return_url() {
+            let req = make_req_full(
+                Some("My App"),
+                Some(customer()),
+                vec![CountryAlpha2::US],
+                Some("https://example.com/return"),
+                Some("com.example.app"),
+                Some("ios"),
+                None,
+            );
+
+            let connector = Plaid::<DefaultPCIHolder>::new();
+            let integration: BoxedConnectorIntegrationV2<
+                '_,
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            > = connector.get_connector_integration_v2();
+
+            let request = integration.build_request_v2(&req).unwrap();
+            let body = request.as_ref().map(|r| match r.body.as_ref() {
+                Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
+                _ => json!({}),
+            });
+            assert_eq!(
+                body.as_ref().unwrap()["redirect_uri"],
+                "https://example.com/return"
+            );
+            assert!(body.as_ref().unwrap().get("android_package_name").is_none());
+        }
+
+        #[test]
+        fn test_build_request_non_android_os_falls_back_to_plaid_config() {
+            // Request supplies no return_url — falls back to the
+            // connector-level PlaidConfig redirect_uri.
+            let req = make_req_full(
+                Some("My App"),
+                Some(customer()),
+                vec![CountryAlpha2::US],
+                None,
+                None,
+                Some("web"),
+                Some((Some("https://fallback.example.com/return"), None)),
+            );
+
+            let connector = Plaid::<DefaultPCIHolder>::new();
+            let integration: BoxedConnectorIntegrationV2<
+                '_,
+                ClientAuthenticationToken,
+                MerchantAuthenticationFlowData,
+                ClientAuthenticationTokenRequestData,
+                PaymentsResponseData,
+            > = connector.get_connector_integration_v2();
+
+            let request = integration.build_request_v2(&req).unwrap();
+            let body = request.as_ref().map(|r| match r.body.as_ref() {
+                Some(RequestContent::Json(v)) => v.masked_serialize().unwrap_or(json!({})),
+                _ => json!({}),
+            });
+            assert_eq!(
+                body.as_ref().unwrap()["redirect_uri"],
+                "https://fallback.example.com/return"
+            );
         }
 
         #[test]
@@ -256,6 +419,8 @@ mod tests {
                     client_id: Secret::new("test_client_id".to_owned()),
                     secret: Secret::new("test_secret".to_owned()),
                     client_name: Some("My App".to_owned()),
+                    redirect_uri: None,
+                    android_package_name: None,
                     base_url: None,
                 },
                 request: PaymentMethodTokenizationData {
@@ -418,6 +583,8 @@ mod tests {
                     client_id: Secret::new("test_client_id".to_owned()),
                     secret: Secret::new("test_secret".to_owned()),
                     client_name: Some("My App".to_owned()),
+                    redirect_uri: None,
+                    android_package_name: None,
                     base_url: None,
                 },
                 request: GetPaymentMethodData {
@@ -631,6 +798,8 @@ mod tests {
                 client_id: Secret::new("test_client_id".to_owned()),
                 secret: Secret::new("test_secret".to_owned()),
                 client_name: client_name.map(str::to_owned),
+                redirect_uri: None,
+                android_package_name: None,
                 base_url: None,
             }
         }
@@ -640,6 +809,27 @@ mod tests {
             let auth = PlaidAuthType::try_from(&plaid_config(Some("My App")));
             assert!(auth.is_ok());
             assert_eq!(auth.unwrap().client_name.as_deref(), Some("My App"));
+        }
+
+        #[test]
+        fn test_auth_type_carries_redirect_uri_and_android_package_name() {
+            let config = ConnectorSpecificConfig::Plaid {
+                client_id: Secret::new("test_client_id".to_owned()),
+                secret: Secret::new("test_secret".to_owned()),
+                client_name: Some("My App".to_owned()),
+                redirect_uri: Some("https://fallback.example.com/return".to_owned()),
+                android_package_name: Some("com.fallback.app".to_owned()),
+                base_url: None,
+            };
+            let auth = PlaidAuthType::try_from(&config).unwrap();
+            assert_eq!(
+                auth.redirect_uri.as_deref(),
+                Some("https://fallback.example.com/return")
+            );
+            assert_eq!(
+                auth.android_package_name.as_deref(),
+                Some("com.fallback.app")
+            );
         }
 
         #[test]

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
@@ -37,6 +37,12 @@ pub struct PlaidAuthType {
     pub client_id: Secret<String>,
     pub secret: Secret<String>,
     pub client_name: Option<String>,
+    /// Fallback redirect_uri for iOS/web Link sessions, used when the
+    /// request doesn't supply one.
+    pub redirect_uri: Option<String>,
+    /// Fallback android_package_name for native Android Link sessions, used
+    /// when the request doesn't supply one.
+    pub android_package_name: Option<String>,
 }
 
 impl TryFrom<&ConnectorSpecificConfig> for PlaidAuthType {
@@ -48,11 +54,15 @@ impl TryFrom<&ConnectorSpecificConfig> for PlaidAuthType {
                 client_id,
                 secret,
                 client_name,
+                redirect_uri,
+                android_package_name,
                 ..
             } => Ok(Self {
                 client_id: client_id.clone(),
                 secret: secret.clone(),
                 client_name: client_name.clone(),
+                redirect_uri: redirect_uri.clone(),
+                android_package_name: android_package_name.clone(),
             }),
             _ => Err(report!(IntegrationError::FailedToObtainAuthType {
                 context: IntegrationErrorContext {
@@ -198,8 +208,34 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // Plaid's Link token "return target": web/iOS merchants send a return
         // URL (-> redirect_uri), native-app merchants send a native app
-        // identifier (-> android_package_name). We forward whatever was
-        // provided without asserting mutual exclusivity.
+        // identifier (-> android_package_name). We pick which one to send
+        // based on the client's OS (from browser_info), falling back to the
+        // connector-level PlaidConfig default when the request doesn't
+        // supply the value for that platform.
+        let is_android = req
+            .browser_info
+            .as_ref()
+            .and_then(|browser_info| browser_info.os_type.as_deref())
+            .is_some_and(|os_type| os_type.to_lowercase().contains("android"));
+
+        let (redirect_uri, android_package_name) = if is_android {
+            (
+                None,
+                req.native_app_identifier
+                    .clone()
+                    .or_else(|| auth.android_package_name.clone()),
+            )
+        } else {
+            (
+                item.router_data
+                    .resource_common_data
+                    .return_url
+                    .clone()
+                    .or_else(|| auth.redirect_uri.clone()),
+                None,
+            )
+        };
+
         Ok(Self {
             client_id: auth.client_id,
             secret: auth.secret,
@@ -208,8 +244,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             products: vec!["auth".to_owned()],
             country_codes,
             language: req.locale.clone(),
-            redirect_uri: item.router_data.resource_common_data.return_url.clone(),
-            android_package_name: req.native_app_identifier.clone(),
+            redirect_uri,
+            android_package_name,
             webhook: req.webhook_url.clone(),
         })
     }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -2428,6 +2428,8 @@ pub struct ClientAuthenticationTokenRequestData {
     /// flow completes (e.g. an Android package name). Sent instead of a return
     /// URL when the merchant integrates from a native app.
     pub native_app_identifier: Option<String>,
+    /// Client browser/device details.
+    pub browser_info: Option<BrowserInformation>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/types-traits/domain_types/src/router_data.rs
+++ b/crates/types-traits/domain_types/src/router_data.rs
@@ -970,6 +970,12 @@ pub enum ConnectorSpecificConfig {
         client_id: Secret<String>,
         secret: Secret<String>,
         client_name: Option<String>,
+        /// Fallback redirect_uri for iOS/web Link sessions, used when the
+        /// request doesn't supply one.
+        redirect_uri: Option<String>,
+        /// Fallback android_package_name for native Android Link sessions,
+        /// used when the request doesn't supply one.
+        android_package_name: Option<String>,
         base_url: Option<String>,
     },
     Tesouro {
@@ -2685,6 +2691,8 @@ impl ForeignTryFrom<grpc_api_types::payments::ConnectorSpecificConfig> for Conne
                 client_id: plaid.client_id.ok_or_else(err)?,
                 secret: plaid.secret.ok_or_else(err)?,
                 client_name: plaid.client_name,
+                redirect_uri: plaid.redirect_uri,
+                android_package_name: plaid.android_package_name,
                 base_url: plaid.base_url,
             }),
             AuthType::Givepayments(givepayments) => Ok(Self::Givepayments {
@@ -4027,6 +4035,8 @@ impl ForeignTryFrom<(&ConnectorAuthType, &connector_types::ConnectorVariant)>
                             client_id: api_key.clone(),
                             secret: key1.clone(),
                             client_name: None,
+                            redirect_uri: None,
+                            android_package_name: None,
                             base_url: None,
                         }),
                         _ => Err(err().into()),

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -11423,6 +11423,10 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
         use grpc_api_types::payments::merchant_authentication_service_create_client_authentication_token_request::DomainContext;
 
         let permissions = value.permissions.map(|p| p.values);
+        let browser_info = value
+            .browser_info
+            .map(BrowserInformation::foreign_try_from)
+            .transpose()?;
 
         match value.domain_context {
             Some(DomainContext::Authenticator(auth_ctx)) => {
@@ -11457,6 +11461,7 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     locale: auth_ctx.locale,
                     permissions,
                     native_app_identifier: auth_ctx.native_app_identifier,
+                    browser_info: browser_info.clone(),
                 })
             }
             Some(DomainContext::Payment(payment_ctx)) => {
@@ -11511,6 +11516,7 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     country_codes: vec![],
                     locale: None,
                     native_app_identifier: None,
+                    browser_info,
                 })
             }
             _ => Err(report!(IntegrationError::InvalidDataFormat {

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3134,6 +3134,10 @@ message MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest {
   // Connector-specific permissions for client authentication token
   // e.g., ["PMT_POST_Create_Single"] for GlobalPay hosted fields
   optional Permissions permissions = 7;
+
+  // Client browser/device details, used e.g. to detect the OS (Android vs
+  // iOS/web) and select the appropriate return target.
+  optional BrowserInformation browser_info = 9;
 }
 
 // Payment-specific context for client authentication token creation
@@ -5557,6 +5561,12 @@ message PlaidConfig {
   SecretString secret = 2;
   // Application name displayed to users in the Plaid Link UI.
   optional string client_name = 3;
+  // Fallback redirect_uri for iOS/web Link sessions, used when the request
+  // doesn't supply one.
+  optional string redirect_uri = 4;
+  // Fallback android_package_name for native Android Link sessions, used
+  // when the request doesn't supply one.
+  optional string android_package_name = 5;
   optional string base_url = 50;
 }
 

--- a/docs-generated/connectors/travelhub.md
+++ b/docs-generated/connectors/travelhub.md
@@ -18,7 +18,7 @@ Use this config for all flows in this connector. Replace `YOUR_API_KEY` with you
 <details><summary>Python</summary>
 
 ```python
-from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
+from payments.generated import sdk_config_pb2, payment_pb2, events_pb2, payment_methods_pb2
 
 config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -131,7 +131,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py#L115) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L113) · [Rust](../../examples/travelhub/travelhub.rs#L150)
+**Examples:** [Python](../../examples/travelhub/travelhub.py#L115) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L114) · [Rust](../../examples/travelhub/travelhub.rs#L150)
 
 ### Card Payment (Authorize + Capture)
 
@@ -145,25 +145,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py#L134) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L129) · [Rust](../../examples/travelhub/travelhub.rs#L166)
+**Examples:** [Python](../../examples/travelhub/travelhub.py#L134) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L130) · [Rust](../../examples/travelhub/travelhub.rs#L166)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py#L159) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L151) · [Rust](../../examples/travelhub/travelhub.rs#L189)
+**Examples:** [Python](../../examples/travelhub/travelhub.py#L159) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L152) · [Rust](../../examples/travelhub/travelhub.rs#L189)
 
 ### Void Payment
 
 Cancel an authorized but not-yet-captured payment.
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py#L184) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L173) · [Rust](../../examples/travelhub/travelhub.rs#L212)
+**Examples:** [Python](../../examples/travelhub/travelhub.py#L184) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L174) · [Rust](../../examples/travelhub/travelhub.rs#L212)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py#L206) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L192) · [Rust](../../examples/travelhub/travelhub.rs#L231)
+**Examples:** [Python](../../examples/travelhub/travelhub.py#L206) · [JavaScript](../../examples/travelhub/travelhub.js) · [Kotlin](../../examples/travelhub/travelhub.kt#L193) · [Rust](../../examples/travelhub/travelhub.rs#L231)
 
 ## API Reference
 
@@ -308,7 +308,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L239) · [Kotlin](../../examples/travelhub/travelhub.kt#L210) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L239) · [Kotlin](../../examples/travelhub/travelhub.kt#L211) · [Rust](../../examples/travelhub/travelhub.rs)
 
 #### PaymentService.Capture
 
@@ -319,7 +319,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L248) · [Kotlin](../../examples/travelhub/travelhub.kt#L222) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L248) · [Kotlin](../../examples/travelhub/travelhub.kt#L223) · [Rust](../../examples/travelhub/travelhub.rs)
 
 #### PaymentService.Get
 
@@ -330,7 +330,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L257) · [Kotlin](../../examples/travelhub/travelhub.kt#L232) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L257) · [Kotlin](../../examples/travelhub/travelhub.kt#L233) · [Rust](../../examples/travelhub/travelhub.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -341,7 +341,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L266) · [Kotlin](../../examples/travelhub/travelhub.kt#L240) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L266) · [Kotlin](../../examples/travelhub/travelhub.kt#L241) · [Rust](../../examples/travelhub/travelhub.rs)
 
 #### PaymentService.Refund
 
@@ -352,7 +352,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L275) · [Kotlin](../../examples/travelhub/travelhub.kt#L269) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts#L275) · [Kotlin](../../examples/travelhub/travelhub.kt#L270) · [Rust](../../examples/travelhub/travelhub.rs)
 
 #### PaymentService.Void
 
@@ -363,4 +363,4 @@ Cancel an authorized payment that has not been captured. Releases held funds bac
 | **Request** | `PaymentServiceVoidRequest` |
 | **Response** | `PaymentServiceVoidResponse` |
 
-**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts) · [Kotlin](../../examples/travelhub/travelhub.kt#L279) · [Rust](../../examples/travelhub/travelhub.rs)
+**Examples:** [Python](../../examples/travelhub/travelhub.py) · [TypeScript](../../examples/travelhub/travelhub.ts) · [Kotlin](../../examples/travelhub/travelhub.kt#L280) · [Rust](../../examples/travelhub/travelhub.rs)

--- a/examples/travelhub/travelhub.kt
+++ b/examples/travelhub/travelhub.kt
@@ -8,6 +8,7 @@
 package examples.travelhub
 
 import types.Payment.*
+import types.Events.*
 import types.PaymentMethods.*
 import payments.PaymentClient
 import payments.AuthenticationType

--- a/examples/travelhub/travelhub.py
+++ b/examples/travelhub/travelhub.py
@@ -8,7 +8,7 @@
 import asyncio
 import sys
 from payments import PaymentClient
-from payments.generated import sdk_config_pb2, payment_pb2, payment_methods_pb2
+from payments.generated import sdk_config_pb2, payment_pb2, events_pb2, payment_methods_pb2
 
 SUPPORTED_FLOWS = ["authorize", "capture", "get", "proxy_authorize", "refund", "void"]
 

--- a/sdk/javascript/src/payments/_generated_grpc_client.ts
+++ b/sdk/javascript/src/payments/_generated_grpc_client.ts
@@ -468,7 +468,7 @@ const _MSG_FIELD_TYPES: Record<string, Record<string, string>> = {
   MerchantAuthenticationServiceCreateServerSessionAuthenticationTokenRequest: { "state": "ConnectorState", "payment": "PaymentSessionContext" },
   PaymentSessionContext: { "amount": "Money", "browserInfo": "BrowserInformation", "customer": "Customer", "address": "PaymentAddress" },
   MerchantAuthenticationServiceCreateServerSessionAuthenticationTokenResponse: { "error": "ErrorInfo" },
-  MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest: { "payment": "PaymentClientAuthenticationContext", "authenticator": "AuthenticatorClientAuthenticationContext", "permissions": "Permissions" },
+  MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest: { "payment": "PaymentClientAuthenticationContext", "authenticator": "AuthenticatorClientAuthenticationContext", "permissions": "Permissions", "browserInfo": "BrowserInformation" },
   PaymentClientAuthenticationContext: { "amount": "Money", "customer": "Customer" },
   AuthenticatorClientAuthenticationContext: { "customer": "Customer" },
   MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse: { "sessionData": "ClientAuthenticationTokenData", "error": "ErrorInfo" },


### PR DESCRIPTION
## Summary
- Add `redirect_uri` and `android_package_name` to `PlaidConfig` (proto) as merchant-level defaults for the Plaid Link token flow.
- Add `browser_info` to the SDK session token request (`MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest`), threaded through to `ClientAuthenticationTokenRequestData`.
- In the Plaid `link/token/create` transformer, pick the return target based on `os_type` from `browser_info`:
  - `os_type` contains "android" → send `android_package_name` (request's `native_app_identifier`, falling back to `PlaidConfig.android_package_name`).
  - otherwise → send `redirect_uri` (request's `return_url`, falling back to `PlaidConfig.redirect_uri`).

## Testing
```
curl --location 'http://localhost:8011/payments/client_authentication_token' \
--header 'Content-Type: application/json' \
--header 'x-connector-config: {"config":{"Plaid":{"client_id":"-","secret":"-","client_name":"test_app","redirect_uri":"https://example.com/oauth-return","android_package_name":"com.merchant.app"}}}' \
--header 'x-merchant-id: test_merchant' \
--header 'x-tenant-id: public' \
--header 'x-request-id: req-plaid-flow1-001' \
--data-raw '{
    "merchant_client_session_id": "session_plaid_001",
    "domain_context": {
        "Authenticator": {
            "country_codes": [
                "US"
            ],
            "locale": "en",
            "customer": {
                "id": "customer_001",
                "name": "Jane Doe",
                "email": "jane@example.com",
                "phone_number": "1234"
            }
        }
    },
    "browser_info": {
        "os_type": "android"
    }
}'
```
PLAID req for Andriod
<img width="1726" height="124" alt="Screenshot 2026-09-04 at 3 08 30 PM" src="https://github.com/user-attachments/assets/409bcfd6-c605-4af8-8447-f16f881efe29" />

PLAID req for Wed/iOS
<img width="1728" height="109" alt="Screenshot 2026-09-04 at 3 05 41 PM" src="https://github.com/user-attachments/assets/64156ac4-4f71-41cc-8c89-ecfc4eb41fa6" />