### PR TITLE
refactor(logs): remove duplicate connector outgoing request logs

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -848,7 +848,6 @@ where
                         .record("request.method", tracing::field::display(method));
 
                     let masked_headers = request.headers.clone();
-                    tracing::info!(headers=?masked_headers, "headers of connector request");
                     record_json_fields_on_span(vec![(
                         "request.headers",
                         maskable_headers_to_json(&masked_headers),
@@ -858,7 +857,6 @@ where
                         .typed_connector_request_value
                         .clone()
                         .unwrap_or_else(|| mask_connector_request(&request.body));
-                    tracing::info!(request=?masked_request, "request of connector");
                     record_json_fields_on_span(vec![("request.body", masked_request.clone())]);
 
                     let response = if let Some(token_data) = token_data {
@@ -1085,14 +1083,12 @@ where
                     tracing::Span::current().record("request.url", tracing::field::display(&topic));
 
                     let masked_headers = record.headers.clone();
-                    tracing::info!(headers=?masked_headers, "headers of connector request");
                     record_json_fields_on_span(vec![(
                         "request.headers",
                         maskable_headers_to_json(&masked_headers),
                     )]);
 
                     let masked_request = mask_connector_request(&record.payload);
-                    tracing::info!(request=?masked_request, "request of connector");
                     record_json_fields_on_span(vec![("request.body", masked_request.clone())]);
 
                     let response = publish_to_kafka(record)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently we have two duplicate logs for request headers and body. This PR removes the duplicate tracing log and uses record_json_fields_on_span for logging.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Before Change
<img width="3456" height="882" alt="image" src="https://github.com/user-attachments/assets/bf4b7af4-bccb-4e3c-bce4-fb9a076bb332" />

After Change
<img width="3456" height="422" alt="image" src="https://github.com/user-attachments/assets/7db56367-6cf0-47fa-ad25-e161ca973575" />

