### PR TITLE
fix(pii): mask email fields in connector transformers

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -995,9 +995,9 @@ pub struct RiskData {
     #[serde(rename = "riskdata.deliveryMethod")]
     delivery_method: Option<String>,
     #[serde(rename = "riskdata.emailName")]
-    email_name: Option<String>,
+    email_name: Option<Secret<String>>,
     #[serde(rename = "riskdata.emailDomain")]
-    email_domain: Option<String>,
+    email_domain: Option<Secret<String>>,
     #[serde(rename = "riskdata.lastOrderDate")]
     last_order_date: Option<String>,
     #[serde(rename = "riskdata.merchantReference")]
@@ -6040,8 +6040,8 @@ pub fn get_risk_data(metadata: serde_json::Value) -> Option<RiskData> {
         affiliate_channel,
         avg_order_value,
         delivery_method,
-        email_name,
-        email_domain,
+        email_name: email_name.map(Secret::new),
+        email_domain: email_domain.map(Secret::new),
         last_order_date,
         merchant_reference,
         payment_method,

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -1910,7 +1910,7 @@ struct ShipToList {
 struct Profile<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize> {
     merchant_customer_id: Option<String>,
     description: Option<String>,
-    email: Option<String>,
+    email: Option<Email>,
     payment_profiles: Option<Vec<PaymentProfiles<T>>>,
     ship_to_list: Option<Vec<ShipToList>>,
 }
@@ -3558,7 +3558,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         .request
                         .email
                         .as_ref()
-                        .map(|e| e.peek().clone().expose().expose()),
+                        .map(|e| e.peek().clone()),
                     payment_profiles: None,
                     ship_to_list,
                 },

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -3,6 +3,7 @@ pub type RefundsResponseRouterData<F, T> =
 
 use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
+    pii::Email,
     types::MinorUnit,
 };
 
@@ -130,7 +131,7 @@ pub enum BillwerkPaymentState {
 #[derive(Debug, Serialize)]
 pub struct BillwerkCustomerObject {
     handle: Option<common_utils::id_type::CustomerId>,
-    email: Option<common_utils::pii::Email>,
+    email: Option<Email>,
     address: Option<Secret<String>>,
     address2: Option<Secret<String>>,
     city: Option<Secret<String>>,
@@ -743,7 +744,7 @@ pub struct BillwerkSessionOrder {
 #[derive(Debug, Serialize)]
 pub struct BillwerkSessionCustomer {
     pub handle: String,
-    pub email: Option<String>,
+    pub email: Option<Email>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
 }
@@ -814,10 +815,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let customer = BillwerkSessionCustomer {
             handle: customer_handle,
-            email: customer_info
-                .customer_email
-                .as_ref()
-                .map(|e| e.peek().to_string()),
+            email: customer_info.customer_email.clone(),
             first_name: customer_info
                 .customer_name
                 .as_ref()

--- a/crates/integrations/connector-integration/src/connectors/calida/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida/transformers.rs
@@ -77,7 +77,7 @@ pub struct CalidaWebhookResponse {
     pub payment_method_type: Option<String>,
     pub shop_name: Option<String>,
     pub sender_name: Option<String>,
-    pub sender_email: Option<String>,
+    pub sender_email: Option<Secret<String, pii::EmailStrategy>>,
     pub description: Option<String>,
     pub amount: FloatMajorUnit,
     pub currency: enums::Currency,

--- a/crates/integrations/connector-integration/src/connectors/cashfree/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree/test.rs
@@ -2,6 +2,7 @@
 // Tests will be implemented once the basic connector is working
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use domain_types::payment_method_data::DefaultPCIHolder;
     use interfaces::api::ConnectorCommon;

--- a/crates/integrations/connector-integration/src/connectors/cashfree/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree/test.rs
@@ -15,4 +15,39 @@ mod tests {
             super::super::Cashfree::new();
         assert_eq!(connector.id(), "cashfree");
     }
+
+    /// The customer email must still reach Cashfree verbatim, while the
+    /// structured logs (which serialize the typed struct via
+    /// `masked_serialize`) must never carry the address.
+    #[test]
+    fn test_customer_email_masked_in_logs_but_verbatim_on_the_wire() {
+        use hyperswitch_masking::Secret;
+
+        use crate::connectors::cashfree::transformers::CashfreeCustomerDetails;
+
+        let details = CashfreeCustomerDetails {
+            customer_id: "cust_1".to_string(),
+            customer_email: Some(Secret::new("jane.doe@example.com".to_string())),
+            customer_phone: Secret::new("9999999999".to_string()),
+            customer_name: Some("Jane Doe".to_string()),
+        };
+
+        let wire = serde_json::to_string(&details).expect("wire serialization");
+        assert!(
+            wire.contains("jane.doe@example.com"),
+            "connector payload must be unchanged, got: {wire}"
+        );
+
+        let masked = hyperswitch_masking::masked_serialize(&details)
+            .expect("masked serialization")
+            .to_string();
+        assert!(
+            !masked.contains("jane.doe@example.com"),
+            "email leaked into the log view: {masked}"
+        );
+        assert!(
+            masked.contains("@example.com"),
+            "EmailStrategy should retain the domain, got: {masked}"
+        );
+    }
 }

--- a/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashfree/transformers.rs
@@ -1,5 +1,5 @@
 use common_enums;
-use common_utils::types::AmountConvertor;
+use common_utils::{pii::EmailStrategy, types::AmountConvertor};
 use domain_types::{
     connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void},
     connector_types::{
@@ -106,7 +106,7 @@ pub struct CashfreeOrderSplitsType {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CashfreeCustomerDetails {
     pub customer_id: String,
-    pub customer_email: Option<String>,
+    pub customer_email: Option<Secret<String, EmailStrategy>>,
     pub customer_phone: Secret<String>,
     pub customer_name: Option<String>,
 }
@@ -534,7 +534,7 @@ impl
                 .unwrap_or_else(|| "guest".to_string()),
             customer_email: billing
                 .as_ref()
-                .and_then(|b| b.email.as_ref().map(|e| e.peek().to_string())),
+                .and_then(|b| b.email.clone().map(|email| email.expose())),
             customer_phone: Secret::new(
                 billing
                     .as_ref()

--- a/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/easebuzz/transformers.rs
@@ -1,5 +1,8 @@
 use common_enums::{AttemptStatus, RefundStatus};
-use common_utils::types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector};
+use common_utils::{
+    pii::EmailStrategy,
+    types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
+};
 use domain_types::{
     connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund},
     connector_types::{
@@ -131,7 +134,7 @@ pub struct EasebuzzInitiateLinkRequest {
     pub productinfo: String,
     pub firstname: String,
     pub phone: String,
-    pub email: String,
+    pub email: Secret<String, EmailStrategy>,
     pub surl: String,
     pub furl: String,
     pub hash: String,
@@ -250,7 +253,7 @@ impl
             productinfo,
             firstname,
             phone,
-            email,
+            email: Secret::new(email),
             surl: return_url.clone(),
             furl: return_url,
             hash,
@@ -1102,7 +1105,7 @@ pub struct EasebuzzSyncRequest {
     /// Transaction amount in major units (rupees as float string, e.g. "100.00")
     pub amount: String,
     /// Customer email (defaults to "mail@gmail.com" if empty)
-    pub email: String,
+    pub email: Secret<String, EmailStrategy>,
     /// Customer phone (defaults to "9999999999" if empty)
     pub phone: String,
     /// Merchant API key
@@ -1249,7 +1252,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         Ok(Self {
             txnid,
             amount: amount_str,
-            email,
+            email: Secret::new(email),
             phone,
             key: auth.api_key,
             hash,

--- a/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/multisafepay/transformers.rs
@@ -1,6 +1,6 @@
 use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, RefundStatus};
-use common_utils::types::MinorUnit;
+use common_utils::{pii::Email, types::MinorUnit};
 use domain_types::errors::{ConnectorError, IntegrationError};
 use domain_types::{
     connector_flow::{Authorize, ClientAuthenticationToken, PSync, RSync},
@@ -586,7 +586,7 @@ pub struct CustomerInfo {
     pub ip_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
-    pub email: String,
+    pub email: Email,
 }
 
 #[derive(Debug, Serialize)]
@@ -714,9 +714,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     field_name: "email",
                     context: Default::default(),
                 })
-                .attach_printable("Missing email for transaction")?
-                .expose()
-                .expose(),
+                .attach_printable("Missing email for transaction")?,
         };
 
         // Build payment_options
@@ -818,9 +816,7 @@ impl<T: PaymentMethodDataTypes>
                     field_name: "email",
                     context: Default::default(),
                 })
-                .attach_printable("Missing email for transaction")?
-                .expose()
-                .expose(),
+                .attach_printable("Missing email for transaction")?,
         };
 
         // Build payment_options

--- a/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
@@ -1,4 +1,5 @@
 use common_enums::{AttemptStatus, RefundStatus};
+use common_utils::pii::Email;
 use domain_types::{
     connector_flow::{Authorize, Capture, CreateOrder, RSync, Refund, ServerAuthenticationToken},
     connector_types::{
@@ -110,7 +111,7 @@ pub struct PurchaseDetails {
 #[derive(Debug, Serialize)]
 pub struct CustomerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email_id: Option<String>,
+    pub email_id: Option<Email>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd/transformers.rs
@@ -1,4 +1,6 @@
-use common_utils::{ext_traits::OptionExt, request::Method, FloatMajorUnit, StringMajorUnit};
+use common_utils::{
+    ext_traits::OptionExt, pii::Email, request::Method, FloatMajorUnit, StringMajorUnit,
+};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, CreateOrder, RepeatPayment, SetupMandate,
@@ -22,7 +24,7 @@ use domain_types::{
 };
 use error_stack;
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
+use hyperswitch_masking::{ExposeInterface, Secret};
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Debug;
@@ -274,7 +276,7 @@ pub enum RapydCustomerRef {
 #[derive(Debug, Serialize)]
 pub struct RapydInlineCustomer {
     pub name: String,
-    pub email: String,
+    pub email: Email,
 }
 
 /// Rapyd payment_method field can be either a token string (for saved/tokenized
@@ -1193,12 +1195,14 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                     field_name: "customer.name",
                     context: Default::default(),
                 })?;
-        let customer_email = request.email.as_ref().map(|e| e.peek().to_string()).ok_or(
-            IntegrationError::MissingRequiredField {
-                field_name: "customer.email",
-                context: Default::default(),
-            },
-        )?;
+        let customer_email =
+            request
+                .email
+                .clone()
+                .ok_or(IntegrationError::MissingRequiredField {
+                    field_name: "customer.email",
+                    context: Default::default(),
+                })?;
         let inline_customer = RapydInlineCustomer {
             name: customer_name,
             email: customer_email,

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -1482,7 +1482,7 @@ pub struct Shift4SetupMandateRequest<T: PaymentMethodDataTypes> {
 #[serde(rename_all = "camelCase")]
 pub struct Shift4EmbeddedCustomer {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
+    pub email: Option<pii::Email>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -7,7 +7,7 @@ use common_enums::{
 use common_utils::{
     errors,
     ext_traits::{OptionExt, ValueExt},
-    pii::IpAddress,
+    pii::{EmailStrategy, IpAddress},
     types::{MinorUnit, Money, StringMajorUnit, StringMinorUnit},
     CustomResult, CustomerId, Email, SecretSerdeValue,
 };
@@ -4047,7 +4047,7 @@ pub struct SubmitEvidenceData {
     pub customer_communication: Option<Vec<u8>>,
     pub customer_communication_file_type: Option<String>,
     pub customer_communication_provider_file_id: Option<String>,
-    pub customer_email_address: Option<String>,
+    pub customer_email_address: Option<Secret<String, EmailStrategy>>,
     pub customer_name: Option<String>,
     pub customer_purchase_ip: Option<String>,
 


### PR DESCRIPTION
## Summary

Twelve email-bearing fields across connector transformers and the shared dispute-evidence domain type were declared as plain `String`/`Option<String>`. Because the structured logging path serializes the **typed struct**, a plain `String` field has no masking strategy to invoke and is emitted verbatim into logs.

Six of them were actively unwrapping an already-masked upstream value (`.peek()`, `.expose().expose()`) purely to fit the plain field type.

## Why the existing masker doesn't cover this

`connector_response_masking` (added in #2050) does not help here:

- `enabled = false` in `development.toml`, `sandbox.toml` **and** `production.toml`, with no `connector_keys` configured
- it operates on raw response bytes and writes a *separate* `response.masked_body` field, so it does not sanitise the primary log field
- neither `ALWAYS_MASKED_SUBSTRING` nor `ALWAYS_MASKED_EXACT` lists any email key
- it covers responses only, not outbound requests

So there is no runtime protection for these fields today. The type is the defence.

## Fields

| File | Field | New type |
|---|---|---|
| `rapyd/transformers.rs` | `RapydInlineCustomer.email` | `Email` |
| `multisafepay/transformers.rs` | `CustomerInfo.email` | `Email` |
| `shift4/transformers.rs` | `Shift4EmbeddedCustomer.email` | `Option<pii::Email>` |
| `billwerk/transformers.rs` | `BillwerkSessionCustomer.email` | `Option<Email>` |
| `authorizedotnet/transformers.rs` | `Profile.email` | `Option<Email>` |
| `pinelabs_online/transformers.rs` | `CustomerInfo.email_id` | `Option<Email>` |
| `cashfree/transformers.rs` | `CashfreeCustomerDetails.customer_email` | `Option<Secret<String, EmailStrategy>>` |
| `easebuzz/transformers.rs` | `EasebuzzSyncRequest.email` | `Secret<String, EmailStrategy>` |
| `easebuzz/transformers.rs` | `EasebuzzInitiateLinkRequest.email` | `Secret<String, EmailStrategy>` |
| `calida/transformers.rs` | `CalidaWebhookResponse.sender_email` | `Option<Secret<String, EmailStrategy>>` |
| `adyen/transformers.rs` | `RiskData.email_name`, `.email_domain` | `Option<Secret<String>>` |
| `domain_types/connector_types.rs` | `SubmitEvidenceData.customer_email_address` | `Option<Secret<String, EmailStrategy>>` |

## Type choice

Direction of the struct decides the type:

- **Outbound-only** (`Serialize`, no `Deserialize`) → `pii::Email`, matching the dominant convention (`braintree:276`, `adyen:557`, `cybersource:980`). The value already originates as an `Email`, so the fix is just deleting the unwrap.
- **`Deserialize`-deriving** → `Secret<String, EmailStrategy>`. `pii::Email` is `#[serde(try_from = "String")]` and rejects anything without `@`, so using it on an inbound struct would turn a malformed connector value into a **dropped webhook or failed response parse**.
- **Email fragments** (adyen `email_name`/`email_domain`, no `@`) → `Secret<String>`, matching the existing `secondary_phone_number: ...map(Secret::new)` in the same constructor.

### Known inconsistency, deliberate

`CalidaWebhookResponse` now carries two different masked types — `customer_email: Email` next to `sender_email: Secret<String, EmailStrategy>`. That is intentional for the reason above: `sender_email` arrives on a webhook, and I would rather log-mask it than risk dropping the webhook on a malformed value. Happy to align them if reviewers prefer.

## Wire compatibility

`Secret::serialize` dispatches on serializer type: `PIISerializer` (via `masked_serialize`) emits the redacted `Debug` form, any other serializer passes the inner value through. **Connector payloads are byte-identical; only the log view changes.**

## Testing

- `cargo check --workspace` clean; `cargo clippy -p connector-integration -p domain_types --all-targets` clean
- `cargo test -p connector-integration --lib` → **167 passed, 0 failed**
- New test `test_customer_email_masked_in_logs_but_verbatim_on_the_wire` asserts both halves: the address is present in `serde_json::to_string` (wire unchanged) and absent from `masked_serialize` (log redacted), with the domain retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5cky2sPJ3tghfyRJ3VhxK