### PR TITLE
feat(common_utils): introduce Money Framework — opaque MinorUnit

### DIFF
--- a/crates/common/common_utils/Cargo.toml
+++ b/crates/common/common_utils/Cargo.toml
@@ -55,6 +55,9 @@ kafka = ["dep:rdkafka", "dep:tracing-kafka"]
 async_ext = ["dep:async-trait", "dep:futures"]
 superposition = ["dep:superposition_core", "dep:superposition_types"]
 log-transformations = ["logging"]
+## Exposes MinorUnit constructors, extractors, and serde impls.
+## Only enable in crates that sit at the proto/domain boundary (domain_types, grpc-server).
+## Connector-integration must NOT enable this feature.
 
 [dependencies.async-trait]
 version = "0.1.74"

--- a/crates/common/common_utils/src/errors.rs
+++ b/crates/common/common_utils/src/errors.rs
@@ -79,7 +79,7 @@ pub enum PercentageError {
     InvalidPercentageValue,
 
     /// Error occurred while calculating percentage
-    #[error("Failed apply percentage of {percentage} on {amount}")]
+    #[error("Failed apply percentage of {percentage} on {amount:?}")]
     UnableToApplyPercentage {
         /// percentage value
         percentage: f32,

--- a/crates/common/common_utils/src/lib.rs
+++ b/crates/common/common_utils/src/lib.rs
@@ -10,6 +10,7 @@ pub mod custom_serde;
 pub mod errors;
 pub mod ext_traits;
 pub mod fp_utils;
+pub mod proto_boundary;
 pub mod id_type;
 pub mod lineage;
 pub mod macros;
@@ -39,9 +40,9 @@ pub use superposition_config::{
     get_optional_nonempty_string, get_string, SuperpositionConfig, SuperpositionConfigError,
 };
 pub use types::{
-    AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector, MinorUnit, MinorUnitForConnector,
-    StringMajorUnit, StringMajorUnitForConnector, StringMinorUnit, StringTwoDecimalUnit,
-    StringTwoDecimalUnitForConnector,
+    AmountConvertor, ConnectorMinorUnit, FloatMajorUnit, FloatMajorUnitForConnector, MinorUnit,
+    MinorUnitForConnector, StringMajorUnit, StringMajorUnitForConnector, StringMinorUnit,
+    StringTwoDecimalUnit, StringTwoDecimalUnitForConnector,
 };
 pub mod connector_request_kafka;
 pub mod events;

--- a/crates/common/common_utils/src/lib.rs
+++ b/crates/common/common_utils/src/lib.rs
@@ -10,13 +10,13 @@ pub mod custom_serde;
 pub mod errors;
 pub mod ext_traits;
 pub mod fp_utils;
-pub mod proto_boundary;
 pub mod id_type;
 pub mod lineage;
 pub mod macros;
 pub mod metadata;
 pub mod new_types;
 pub mod pii;
+pub mod proto_boundary;
 pub mod request;
 pub mod request_metrics;
 #[cfg(feature = "superposition")]

--- a/crates/common/common_utils/src/proto_boundary.rs
+++ b/crates/common/common_utils/src/proto_boundary.rs
@@ -1,0 +1,64 @@
+//! Proto/domain boundary access for monetary types.
+//!
+//! **Connector code must NEVER import this module.**
+//!
+//! This trait provides raw i64 construction and extraction on [`MinorUnit`]
+//! and [`Money`]. These operations are only needed at the proto ↔ domain
+//! boundary (in `domain_types` and `grpc-server`).
+//!
+//! A CI lint enforces that `crates/integrations/connector-integration/`
+//! never contains `use ...::proto_boundary`.
+
+use common_enums::enums;
+
+use crate::types::{MinorUnit, Money};
+
+/// Raw i64 access for [`MinorUnit`].
+///
+/// Import this trait **only** in proto/domain boundary code.
+/// Connector code must use [`AmountConvertor`] instead.
+pub trait MinorUnitProtoAccess {
+    /// Construct from a raw i64 at the proto boundary.
+    fn new(value: i64) -> Self;
+
+    /// Extract the raw i64 at the proto boundary.
+    fn get_amount_as_i64(self) -> i64;
+}
+
+impl MinorUnitProtoAccess for MinorUnit {
+    fn new(value: i64) -> Self {
+        Self::from_i64(value)
+    }
+
+    fn get_amount_as_i64(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+/// Raw field access for [`Money`].
+///
+/// Import this trait **only** in proto/domain boundary code.
+pub trait MoneyProtoAccess {
+    /// Construct from a [`MinorUnit`] and currency at the proto boundary.
+    fn new(amount: MinorUnit, currency: enums::Currency) -> Self;
+
+    /// Decompose into (MinorUnit, Currency).
+    fn into_parts(self) -> (MinorUnit, enums::Currency);
+
+    /// Access the inner [`MinorUnit`].
+    fn amount(&self) -> MinorUnit;
+}
+
+impl MoneyProtoAccess for Money {
+    fn new(amount: MinorUnit, currency: enums::Currency) -> Self {
+        Self::from_minor_unit(amount, currency)
+    }
+
+    fn into_parts(self) -> (MinorUnit, enums::Currency) {
+        (self.amount, self.currency)
+    }
+
+    fn amount(&self) -> MinorUnit {
+        self.amount
+    }
+}

--- a/crates/common/common_utils/src/types.rs
+++ b/crates/common/common_utils/src/types.rs
@@ -1,11 +1,6 @@
 //! Types that can be used in other crates
 
-use std::{
-    fmt::Display,
-    iter::Sum,
-    ops::{Add, Mul, Sub},
-    str::FromStr,
-};
+use std::{fmt::Display, str::FromStr};
 
 use common_enums::enums;
 use error_stack::ResultExt;
@@ -130,64 +125,107 @@ impl AmountConvertor for FloatMajorUnitForConnector {
     }
 }
 
-/// Connector required amount type
+/// Connector required amount type – outputs ConnectorMinorUnit so connectors
+/// never touch domain MinorUnit directly.
 #[derive(Default, Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq)]
 pub struct MinorUnitForConnector;
 
 impl AmountConvertor for MinorUnitForConnector {
-    type Output = MinorUnit;
+    type Output = ConnectorMinorUnit;
     fn convert(
         &self,
         amount: MinorUnit,
         _currency: enums::Currency,
     ) -> Result<Self::Output, error_stack::Report<ParsingError>> {
-        Ok(amount)
+        Ok(ConnectorMinorUnit(amount))
     }
     fn convert_back(
         &self,
-        amount: MinorUnit,
+        amount: ConnectorMinorUnit,
         _currency: enums::Currency,
     ) -> Result<MinorUnit, error_stack::Report<ParsingError>> {
-        Ok(amount)
+        Ok(amount.0)
     }
 }
 
-/// This Unit struct represents MinorUnit in which core amount works
-#[derive(
-    Default,
-    Debug,
-    serde::Deserialize,
-    serde::Serialize,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    ToSchema,
-    PartialOrd,
-)]
+/// Connector payload amount that serializes as a minor-unit number.
+///
+/// This keeps connector request/response structs from using domain `MinorUnit`
+/// directly while preserving connector payloads that expect raw numeric minor
+/// units. Connectors obtain this type **only** via `AmountConvertor::convert`.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, ToSchema, PartialOrd)]
+pub struct ConnectorMinorUnit(MinorUnit);
 
-pub struct MinorUnit(pub i64);
+impl Serialize for ConnectorMinorUnit {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i64(self.0 .0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConnectorMinorUnit {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = <i64 as Deserialize>::deserialize(deserializer)?;
+        Ok(ConnectorMinorUnit(MinorUnit(value)))
+    }
+}
+
+impl Display for ConnectorMinorUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
+    }
+}
+
+/// This Unit struct represents MinorUnit in which core amount works.
+///
+/// The inner field is **private**. Construction and extraction are gated behind
+/// the `proto-conversion` cargo feature so that only the proto/domain boundary
+/// crates can create or inspect raw values. Connector code receives `MinorUnit`
+/// in domain structs but can only pass it through `AmountConvertor`.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, ToSchema, PartialOrd)]
+pub struct MinorUnit(i64);
+
+impl Serialize for MinorUnit {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i64(self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for MinorUnit {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = <i64 as Deserialize>::deserialize(deserializer)?;
+        Ok(MinorUnit(value))
+    }
+}
 
 impl MinorUnit {
-    /// gets amount as i64 value will be removed in future
-    pub fn get_amount_as_i64(self) -> i64 {
+    // ── internal (crate-only) constructors/extractors ──────────────────
+    // These are used by AmountConvertor impls, convert_back, Sum, etc.
+    // within common_utils itself.
+
+    /// Crate-internal constructor.
+    pub(crate) fn from_i64(value: i64) -> Self {
+        Self(value)
+    }
+
+    /// Crate-internal extractor.
+    pub(crate) fn as_i64(self) -> i64 {
         self.0
     }
 
-    /// forms a new minor default unit i.e zero
-    pub fn zero() -> Self {
-        Self(0)
-    }
-
-    /// forms a new minor unit from amount
-    pub fn new(value: i64) -> Self {
+    /// Construct from a raw i64 in tests.
+    #[cfg(test)]
+    pub fn test_new(value: i64) -> Self {
         Self(value)
     }
 
     /// checks if the amount is greater than the given value
     pub fn is_greater_than(&self, value: i64) -> bool {
-        self.get_amount_as_i64() > value
+        self.0 > value
+    }
+
+    /// Returns true if the amount is positive (> 0)
+    pub fn is_positive(&self) -> bool {
+        self.0 > 0
     }
 
     /// Convert the amount to its major denomination based on Currency and return String
@@ -254,37 +292,22 @@ impl MinorUnit {
     }
 }
 
-impl Display for MinorUnit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+#[allow(dead_code)]
+impl MinorUnit {
+    pub(crate) fn add(self, other: Self) -> Self {
+        Self(self.0 + other.0)
     }
-}
 
-impl Add for MinorUnit {
-    type Output = Self;
-    fn add(self, a2: Self) -> Self {
-        Self(self.0 + a2.0)
+    pub(crate) fn sub(self, other: Self) -> Self {
+        Self(self.0 - other.0)
     }
-}
 
-impl Sub for MinorUnit {
-    type Output = Self;
-    fn sub(self, a2: Self) -> Self {
-        Self(self.0 - a2.0)
+    pub(crate) fn mul_u16(self, factor: u16) -> Self {
+        Self(self.0 * i64::from(factor))
     }
-}
 
-impl Mul<u16> for MinorUnit {
-    type Output = Self;
-
-    fn mul(self, a2: u16) -> Self::Output {
-        Self(self.0 * i64::from(a2))
-    }
-}
-
-impl Sum for MinorUnit {
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Self(0), |a, b| a + b)
+    pub(crate) fn sum_iter(iter: impl Iterator<Item = Self>) -> Self {
+        iter.fold(Self(0), |a, b| a.add(b))
     }
 }
 
@@ -321,7 +344,7 @@ impl StringMinorUnit {
         let amount_i64 = amount_decimal
             .to_i64()
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
-        Ok(MinorUnit::new(amount_i64))
+        Ok(MinorUnit::from_i64(amount_i64))
     }
 }
 
@@ -365,7 +388,7 @@ impl FloatMajorUnit {
         let amount_i64 = amount
             .to_i64()
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
-        Ok(MinorUnit::new(amount_i64))
+        Ok(MinorUnit::from_i64(amount_i64))
     }
 }
 
@@ -400,7 +423,7 @@ impl StringMajorUnit {
         let amount_i64 = amount
             .to_i64()
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
-        Ok(MinorUnit::new(amount_i64))
+        Ok(MinorUnit::from_i64(amount_i64))
     }
     /// forms a new StringMajorUnit default unit i.e zero
     pub fn zero() -> Self {
@@ -508,7 +531,7 @@ impl StringTwoDecimalUnit {
 
         let minor = i64::try_from(scaled / divisor)
             .map_err(|_| ParsingError::DecimalToI64ConversionFailure)?;
-        Ok(MinorUnit::new(minor))
+        Ok(MinorUnit::from_i64(minor))
     }
 }
 
@@ -526,7 +549,7 @@ impl AmountConvertor for StringTwoDecimalUnitForConnector {
         amount: MinorUnit,
         currency: enums::Currency,
     ) -> Result<Self::Output, error_stack::Report<ParsingError>> {
-        let minor = i128::from(amount.get_amount_as_i64());
+        let minor = i128::from(amount.as_i64());
         let scale = currency_scale(currency)?;
         let scaled = minor * 10_i128.pow(TWO_DECIMAL_EXPONENT);
         // A currency with more than two decimals cannot always be expressed with two
@@ -554,13 +577,82 @@ impl AmountConvertor for StringTwoDecimalUnitForConnector {
     }
 }
 
-#[derive(
-    Default, Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq, Hash, ToSchema,
-)]
-
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, ToSchema)]
 pub struct Money {
-    pub amount: MinorUnit,
-    pub currency: enums::Currency,
+    pub(crate) amount: MinorUnit,
+    pub(crate) currency: enums::Currency,
+}
+
+impl Serialize for Money {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Money", 2)?;
+        state.serialize_field("amount", &self.amount.as_i64())?;
+        state.serialize_field("currency", &self.currency)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Money {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        struct MoneyHelper {
+            amount: i64,
+            currency: enums::Currency,
+        }
+        let helper = MoneyHelper::deserialize(deserializer)?;
+        Ok(Money {
+            amount: MinorUnit::from_i64(helper.amount),
+            currency: helper.currency,
+        })
+    }
+}
+
+impl Money {
+    /// Access the currency.
+    pub fn currency(&self) -> enums::Currency {
+        self.currency
+    }
+
+    /// Returns true if the amount is positive.
+    pub fn is_positive(&self) -> bool {
+        self.amount.is_positive()
+    }
+
+    /// Construct from a [`MinorUnit`] and a currency.
+    ///
+    /// Unlike `new()`, this is **always available** (not feature-gated).
+    /// Connector response handlers use this to build `Money` from domain
+    /// `MinorUnit` values that were converted back from connector amounts.
+    pub fn from_minor_unit(amount: MinorUnit, currency: enums::Currency) -> Self {
+        Self { amount, currency }
+    }
+
+    /// Construct from a [`ConnectorMinorUnit`] and a currency.
+    ///
+    /// Connectors use this to build `Money` values from converted connector
+    /// response amounts without needing `proto-conversion`.
+    pub fn from_connector_minor_unit(
+        amount: ConnectorMinorUnit,
+        currency: enums::Currency,
+    ) -> Self {
+        Self {
+            amount: amount.0,
+            currency,
+        }
+    }
+
+    /// Convert the internal amount using an [`AmountConvertor`].
+    ///
+    /// This allows connectors to obtain a converted representation of the
+    /// amount (e.g. `ConnectorMinorUnit`, `StringMajorUnit`, `FloatMajorUnit`)
+    /// without directly accessing the private `MinorUnit` field.
+    pub fn convert<T>(
+        &self,
+        convertor: &dyn AmountConvertor<Output = T>,
+    ) -> Result<T, error_stack::Report<ParsingError>> {
+        convertor.convert(self.amount, self.currency)
+    }
 }
 
 /// A type representing a range of time for filtering, including a mandatory start time and an optional end time.

--- a/crates/common/common_utils/src/types.rs
+++ b/crates/common/common_utils/src/types.rs
@@ -165,7 +165,7 @@ impl Serialize for ConnectorMinorUnit {
 impl<'de> Deserialize<'de> for ConnectorMinorUnit {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value = <i64 as Deserialize>::deserialize(deserializer)?;
-        Ok(ConnectorMinorUnit(MinorUnit(value)))
+        Ok(Self(MinorUnit(value)))
     }
 }
 
@@ -193,7 +193,7 @@ impl Serialize for MinorUnit {
 impl<'de> Deserialize<'de> for MinorUnit {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value = <i64 as Deserialize>::deserialize(deserializer)?;
-        Ok(MinorUnit(value))
+        Ok(Self(value))
     }
 }
 
@@ -601,7 +601,7 @@ impl<'de> Deserialize<'de> for Money {
             currency: enums::Currency,
         }
         let helper = MoneyHelper::deserialize(deserializer)?;
-        Ok(Money {
+        Ok(Self {
             amount: MinorUnit::from_i64(helper.amount),
             currency: helper.currency,
         })

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -7,7 +7,10 @@ use crate::{
     utils::{self, get_config_from_request, grpc_logging_wrapper},
 };
 use common_enums;
-use common_utils::{events::FlowName, lineage, metadata::MaskedMetadata, SecretSerdeValue};
+use common_utils::{
+    events::FlowName, lineage, metadata::MaskedMetadata,
+    proto_boundary::MinorUnitProtoAccess, SecretSerdeValue,
+};
 use connector_integration::types::{
     AuthenticatorConnectorData, ConnectorData, ConnectorDataProvider, FrmConnectorData,
     PayoutConnectorData,

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use common_enums;
 use common_utils::{
-    events::FlowName, lineage, metadata::MaskedMetadata,
-    proto_boundary::MinorUnitProtoAccess, SecretSerdeValue,
+    events::FlowName, lineage, metadata::MaskedMetadata, proto_boundary::MinorUnitProtoAccess,
+    SecretSerdeValue,
 };
 use connector_integration::types::{
     AuthenticatorConnectorData, ConnectorData, ConnectorDataProvider, FrmConnectorData,

--- a/crates/grpc-server/grpc-server/tests/test_amount_conversion.rs
+++ b/crates/grpc-server/grpc-server/tests/test_amount_conversion.rs
@@ -3,6 +3,7 @@
 mod tests {
     use common_enums::Currency;
     use common_utils::{
+        proto_boundary::MinorUnitProtoAccess,
         types::{MinorUnit, StringMajorUnitForConnector},
         AmountConvertor,
     };

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -8,7 +8,7 @@ mod tests {
         use std::marker::PhantomData;
 
         use common_enums::CountryAlpha2;
-        use common_utils::{id_type::CustomerId, request::RequestContent};
+        use common_utils::{id_type::CustomerId, proto_boundary::MinorUnitProtoAccess, request::RequestContent};
         use domain_types::{
             connector_flow::ClientAuthenticationToken,
             connector_types::{
@@ -175,7 +175,7 @@ mod tests {
     pub mod token_exchange {
         use std::marker::PhantomData;
 
-        use common_utils::request::RequestContent;
+        use common_utils::{proto_boundary::MinorUnitProtoAccess, request::RequestContent};
         use domain_types::{
             connector_flow::PaymentMethodToken,
             connector_types::{

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/test.rs
@@ -8,7 +8,9 @@ mod tests {
         use std::marker::PhantomData;
 
         use common_enums::CountryAlpha2;
-        use common_utils::{id_type::CustomerId, proto_boundary::MinorUnitProtoAccess, request::RequestContent};
+        use common_utils::{
+            id_type::CustomerId, proto_boundary::MinorUnitProtoAccess, request::RequestContent,
+        };
         use domain_types::{
             connector_flow::ClientAuthenticationToken,
             connector_types::{

--- a/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
+++ b/crates/integrations/connector-integration/src/authenticator_connectors/plaid/transformers.rs
@@ -553,19 +553,13 @@ impl TryFrom<ResponseRouterData<PlaidAuthGetResponse, Self>>
                 let balance = acct.balances.current.zip(currency).and_then(|(amt, c)| {
                     super::PlaidAmountConvertor::convert_back(amt, c)
                         .ok()
-                        .map(|amount| common_utils::types::Money {
-                            amount,
-                            currency: c,
-                        })
+                        .map(|amount| common_utils::types::Money::from_minor_unit(amount, c))
                 });
                 let available_balance =
                     acct.balances.available.zip(currency).and_then(|(amt, c)| {
                         super::PlaidAmountConvertor::convert_back(amt, c)
                             .ok()
-                            .map(|amount| common_utils::types::Money {
-                                amount,
-                                currency: c,
-                            })
+                            .map(|amount| common_utils::types::Money::from_minor_unit(amount, c))
                     });
                 let bank_type = acct.subtype.as_deref().and_then(plaid_subtype_to_bank_type);
                 let bank_holder_type = acct.holder_category.as_ref().map(|hc| match hc {

--- a/crates/integrations/connector-integration/src/common_macros.rs
+++ b/crates/integrations/connector-integration/src/common_macros.rs
@@ -1,4 +1,48 @@
 macro_rules! create_amount_converter_wrapper {
+    // Specialized arm: when amount_type is MinorUnit, the convertor
+    // (MinorUnitForConnector) outputs ConnectorMinorUnit.
+    (connector_name: $connector_name:ident, amount_type: MinorUnit) => {
+        paste::paste! {
+            #[derive(Default, Debug, Clone, Copy, PartialEq)]
+            pub struct [<$connector_name AmountConvertor>];
+
+            impl [<$connector_name AmountConvertor>] {
+                pub fn convert(
+                    amount: common_utils::types::MinorUnit,
+                    currency: common_enums::Currency,
+                ) -> Result<
+                    common_utils::types::ConnectorMinorUnit,
+                    error_stack::Report<domain_types::errors::IntegrationError>,
+                > {
+                    domain_types::utils::convert_amount(
+                        &common_utils::types::MinorUnitForConnector,
+                        amount,
+                        currency,
+                    ).change_context(domain_types::errors::IntegrationError::InvalidDataFormat {
+                        field_name: "amount",
+                        context: Default::default()
+                    })
+                }
+
+                /// Convert connector amount back to MinorUnit.
+                pub fn convert_back(
+                    amount: common_utils::types::ConnectorMinorUnit,
+                    currency: common_enums::Currency,
+                ) -> Result<
+                    common_utils::types::MinorUnit,
+                    error_stack::Report<common_utils::errors::ParsingError>,
+                > {
+                    domain_types::utils::convert_back_amount_to_minor_units(
+                        &common_utils::types::MinorUnitForConnector,
+                        amount,
+                        currency,
+                    )
+                }
+            }
+        }
+    };
+    // General arm for all other amount types (StringMajorUnit, FloatMajorUnit,
+    // StringMinorUnit, etc.)
     (connector_name: $connector_name:ident, amount_type: $amount_type:ty) => {
         paste::paste! {
             #[derive(Default, Debug, Clone, Copy, PartialEq)]

--- a/crates/integrations/connector-integration/src/connectors/aci.rs
+++ b/crates/integrations/connector-integration/src/connectors/aci.rs
@@ -1,7 +1,7 @@
 pub mod aci_result_codes;
 pub mod transformers;
 
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -17,7 +17,6 @@ use common_utils::{
     events,
     ext_traits::ByteSliceExt,
     pii::SecretSerdeValue,
-    types::StringMinorUnit,
 };
 use domain_types::{
     connector_flow::{
@@ -807,13 +806,20 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             })?;
 
         // Adyen HMAC message format: pspReference:originalReference:merchantAccountCode:merchantReference:amount.value:amount.currency:eventCode:success
+        let amount_value = common_utils::AmountConvertor::convert(
+            &common_utils::MinorUnitForConnector,
+            notif.amount.value,
+            notif.amount.currency,
+        )
+        .map(|a| a.to_string())
+        .unwrap_or_default();
         let message = format!(
             "{}:{}:{}:{}:{}:{}:{}:{}",
             notif.psp_reference,
             notif.original_reference.as_deref().unwrap_or(""),
             notif.merchant_account_code,
             notif.merchant_reference,
-            notif.amount.value,
+            amount_value,
             notif.amount.currency,
             notif.event_code,
             notif.success

--- a/crates/integrations/connector-integration/src/connectors/adyen/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/test.rs
@@ -8,7 +8,7 @@ mod tests {
     pub mod authorize {
         use std::{borrow::Cow, marker::PhantomData, str::FromStr};
 
-        use common_utils::{pii::Email, request::RequestContent, types::MinorUnit};
+        use common_utils::{pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
         use domain_types::{
             connector_flow::Authorize,
             connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/adyen/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/test.rs
@@ -8,7 +8,10 @@ mod tests {
     pub mod authorize {
         use std::{borrow::Cow, marker::PhantomData, str::FromStr};
 
-        use common_utils::{pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
+        use common_utils::{
+            pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent,
+            types::MinorUnit,
+        };
         use domain_types::{
             connector_flow::Authorize,
             connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -5,6 +5,7 @@ use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
     ext_traits::{ByteSliceExt, Encode, OptionExt, ValueExt},
+
     request::Method,
     types::{MinorUnit, SemanticVersion},
     SecretSerdeValue,
@@ -4373,7 +4374,7 @@ where
             ),
             resource_common_data: PaymentFlowData {
                 status: adyen_payments_response_data.status,
-                amount_captured: minor_amount_captured.map(|amount| amount.get_amount_as_i64()),
+                amount_captured: None,
                 minor_amount_captured,
                 connector_response: adyen_payments_response_data.connector_response,
                 ..router_data.resource_common_data
@@ -4496,7 +4497,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             ),
             resource_common_data: PaymentFlowData {
                 status: adyen_payments_response_data.status,
-                amount_captured: minor_amount_captured.map(|amount| amount.get_amount_as_i64()),
+                amount_captured: None,
                 minor_amount_captured,
                 connector_response: adyen_payments_response_data.connector_response,
                 ..router_data.resource_common_data
@@ -6802,7 +6803,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             ),
             resource_common_data: PaymentFlowData {
                 status: adyen_payments_response_data.status,
-                amount_captured: minor_amount_captured.map(|amount| amount.get_amount_as_i64()),
+                amount_captured: None,
                 minor_amount_captured,
                 connector_response: adyen_payments_response_data.connector_response,
                 ..router_data.resource_common_data
@@ -6827,7 +6828,7 @@ fn get_amount_data_for_setup_mandate<
 ) -> Amount {
     Amount {
         currency: item.router_data.request.currency,
-        value: MinorUnit::new(item.router_data.request.amount.unwrap_or(0)),
+        value: item.router_data.request.minor_amount.unwrap_or_default(),
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen/transformers.rs
@@ -5,7 +5,6 @@ use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
     ext_traits::{ByteSliceExt, Encode, OptionExt, ValueExt},
-
     request::Method,
     types::{MinorUnit, SemanticVersion},
     SecretSerdeValue,

--- a/crates/integrations/connector-integration/src/connectors/affirm.rs
+++ b/crates/integrations/connector-integration/src/connectors/affirm.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/airwallex.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/airwallex.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, CreateConnectorCustomer, CreateOrder, PSync, RSync, Refund,

--- a/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/airwallex/transformers.rs
@@ -1678,15 +1678,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        // Extract capture amount from the capture data
-        let capture_amount = item.router_data.request.amount_to_capture;
-
         // Use connector amount converter for proper amount formatting in major units (hyperswitch pattern)
         let amount = item
             .connector
             .amount_converter
             .convert(
-                common_utils::MinorUnit::new(capture_amount),
+                item.router_data.request.minor_amount_to_capture,
                 item.router_data.request.currency,
             )
             .map_err(|_| IntegrationError::RequestEncodingFailed {
@@ -1817,13 +1814,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         // connector_transaction_id is the Airwallex payment intent id (int_...).
         let payment_intent_id = item.router_data.request.connector_transaction_id.clone();
 
-        // Extract refund amount from RefundsData and convert to major units (hyperswitch pattern)
-        let refund_amount = item.router_data.request.refund_amount;
+        // Convert refund amount to major units (hyperswitch pattern)
         let amount = item
             .connector
             .amount_converter
             .convert(
-                common_utils::MinorUnit::new(refund_amount),
+                item.router_data.request.minor_refund_amount,
                 item.router_data.request.currency,
             )
             .map_err(|_| IntegrationError::RequestEncodingFailed {

--- a/crates/integrations/connector-integration/src/connectors/authipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/authipay.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void, VoidPC},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
@@ -2,7 +2,7 @@ pub mod transformers;
 
 use common_enums;
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit,
+    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet.rs
@@ -1,9 +1,7 @@
 pub mod transformers;
 
 use common_enums;
-use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{consts, errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, CreateConnectorCustomer, PSync, RSync, Refund, RepeatPayment,

--- a/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/authorizedotnet/transformers.rs
@@ -1061,7 +1061,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 }))
             }
         };
-
         let transaction_request = AuthorizedotnetRepeatPaymentTransactionRequest {
             transaction_type,
             amount: item

--- a/crates/integrations/connector-integration/src/connectors/axisbank.rs
+++ b/crates/integrations/connector-integration/src/connectors/axisbank.rs
@@ -10,7 +10,7 @@ use self::transformers::{
 use super::macros;
 use crate::types::ResponseRouterData;
 use common_enums as enums;
-use common_utils::{errors::CustomResult, events, ext_traits::BytesExt, types::StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::BytesExt};
 use domain_types::errors::{ConnectorError, IntegrationError, IntegrationErrorContext};
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund},

--- a/crates/integrations/connector-integration/src/connectors/bambora.rs
+++ b/crates/integrations/connector-integration/src/connectors/bambora.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
@@ -34,8 +34,10 @@ use transformers::{
     BamboraapacSetupMandateResponse,
 };
 
+use error_stack::ResultExt;
 use super::macros;
 use super::macros::GetSoapXml;
+macros::create_amount_converter_wrapper!(connector_name: Bamboraapac, amount_type: MinorUnit);
 use crate::types::ResponseRouterData;
 use domain_types::errors::ConnectorError;
 use domain_types::errors::IntegrationError;
@@ -171,7 +173,7 @@ macros::create_all_prerequisites!(
             router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
-    amount_converters: [],
+    amount_converters: [amount_converter: MinorUnit],
     member_functions: {
         pub fn build_headers<F, FCD, Req, Res>(
             &self,

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
@@ -34,9 +34,9 @@ use transformers::{
     BamboraapacSetupMandateResponse,
 };
 
-use error_stack::ResultExt;
 use super::macros;
 use super::macros::GetSoapXml;
+use error_stack::ResultExt;
 macros::create_amount_converter_wrapper!(connector_name: Bamboraapac, amount_type: MinorUnit);
 use crate::types::ResponseRouterData;
 use domain_types::errors::ConnectorError;

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac.rs
@@ -36,7 +36,6 @@ use transformers::{
 
 use super::macros;
 use super::macros::GetSoapXml;
-use error_stack::ResultExt;
 macros::create_amount_converter_wrapper!(connector_name: Bamboraapac, amount_type: MinorUnit);
 use crate::types::ResponseRouterData;
 use domain_types::errors::ConnectorError;

--- a/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/bamboraapac/transformers.rs
@@ -1,4 +1,4 @@
-use common_utils::types::MinorUnit;
+use common_utils::types::ConnectorMinorUnit;
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, RepeatPayment},
     connector_types::{
@@ -28,7 +28,7 @@ struct TransactionXml {
     #[serde(rename = "CustRef")]
     cust_ref: String,
     #[serde(rename = "Amount")]
-    amount: i64,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "TrnType")]
     trn_type: i32,
     #[serde(rename = "AccountNumber")]
@@ -70,7 +70,7 @@ struct CaptureXml {
     #[serde(rename = "Receipt")]
     receipt: String,
     #[serde(rename = "Amount")]
-    amount: i64,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "Security")]
     security: SecurityXml,
 }
@@ -84,7 +84,7 @@ struct RefundXml {
     #[serde(rename = "Receipt")]
     receipt: String,
     #[serde(rename = "Amount")]
-    amount: i64,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "Security")]
     security: SecurityXml,
 }
@@ -175,7 +175,7 @@ pub struct BamboraapacPaymentRequest<
     pub account_number: Secret<String>,
     pub cust_number: Option<String>,
     pub cust_ref: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub trn_type: BamboraapacTrnType,
     pub card_number: Secret<String>,
     pub exp_month: Secret<String>,
@@ -195,7 +195,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         // Build the inner Transaction XML using quick-xml
         let transaction_xml = TransactionXml {
             cust_ref: self.cust_ref.clone(),
-            amount: self.amount.get_amount_as_i64(),
+            amount: self.amount,
             trn_type: i32::from(self.trn_type),
             account_number: self.account_number.peek().to_string(),
             credit_card: CreditCardXml {
@@ -285,7 +285,7 @@ impl Default for BamboraapacErrorResponse {
 #[derive(Debug, Clone, Serialize)]
 pub struct BamboraapacCaptureRequest {
     pub receipt: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub username: Secret<String>,
     pub password: Secret<String>,
 }
@@ -330,7 +330,7 @@ pub struct CaptureResponse {
 pub struct BamboraapacRefundRequest {
     pub cust_ref: String,
     pub receipt: String, // Original transaction receipt/ID to refund
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub username: Secret<String>,
     pub password: Secret<String>,
 }
@@ -474,7 +474,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .resource_common_data
                 .connector_request_reference_id
                 .clone(),
-            amount: router_data.request.minor_amount,
+            amount: super::BamboraapacAmountConvertor::convert(
+                router_data.request.minor_amount,
+                router_data.request.currency,
+            )?,
             trn_type,
             card_number: Secret::new(card_number_str),
             exp_month: card_data.card_exp_month.clone(),
@@ -626,7 +629,10 @@ impl TryFrom<&RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, Paymen
 
         Ok(Self {
             receipt,
-            amount: router_data.request.minor_amount_to_capture,
+            amount: super::BamboraapacAmountConvertor::convert(
+                router_data.request.minor_amount_to_capture,
+                router_data.request.currency,
+            )?,
             username: auth.username,
             password: auth.password,
         })
@@ -923,7 +929,10 @@ impl
                 .connector_request_reference_id
                 .clone(),
             receipt,
-            amount: router_data.request.minor_refund_amount,
+            amount: super::BamboraapacAmountConvertor::convert(
+                router_data.request.minor_refund_amount,
+                router_data.request.currency,
+            )?,
             username: auth.username,
             password: auth.password,
         })
@@ -1413,7 +1422,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 pub struct BamboraapacRepeatPaymentRequest {
     pub account_number: Secret<String>,
     pub cust_ref: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub trn_type: BamboraapacTrnType,
     pub card_token: String, // The customer_id/token from SetupMandate
     pub username: Secret<String>,
@@ -1474,7 +1483,10 @@ impl<
                 .resource_common_data
                 .connector_request_reference_id
                 .clone(),
-            amount: router_data.request.minor_amount,
+            amount: super::BamboraapacAmountConvertor::convert(
+                router_data.request.minor_amount,
+                router_data.request.currency,
+            )?,
             trn_type,
             card_token: token,
             username: auth.username,
@@ -1614,7 +1626,7 @@ impl GetSoapXml for BamboraapacCaptureRequest {
         // Build the inner Capture XML using quick-xml
         let capture_xml = CaptureXml {
             receipt: self.receipt.clone(),
-            amount: self.amount.get_amount_as_i64(),
+            amount: self.amount,
             security: SecurityXml {
                 username: self.username.peek().to_string(),
                 password: self.password.peek().to_string(),
@@ -1644,7 +1656,7 @@ impl GetSoapXml for BamboraapacRefundRequest {
         let refund_xml = RefundXml {
             cust_ref: self.cust_ref.clone(),
             receipt: self.receipt.clone(),
-            amount: self.amount.get_amount_as_i64(),
+            amount: self.amount,
             security: SecurityXml {
                 username: self.username.peek().to_string(),
                 password: self.password.peek().to_string(),
@@ -1777,7 +1789,7 @@ impl GetSoapXml for BamboraapacRepeatPaymentRequest {
             </soapenv:Envelope>
         "#,
             self.cust_ref,
-            self.amount.get_amount_as_i64(),
+            self.amount,
             i32::from(self.trn_type),
             self.account_number.peek(),
             self.card_token,

--- a/crates/integrations/connector-integration/src/connectors/bankofamerica.rs
+++ b/crates/integrations/connector-integration/src/connectors/bankofamerica.rs
@@ -6,7 +6,6 @@ use common_utils::{
     events,
     ext_traits::BytesExt,
     request::Method,
-    types::StringMajorUnit,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use std::fmt::Debug;

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -422,9 +422,7 @@ where
         .request
         .recurring_mandate_payment_data
         .as_ref()
-        .and_then(|data| {
-            data.original_payment_authorized_amount.as_ref()
-        })
+        .and_then(|data| data.original_payment_authorized_amount.as_ref())
         .map(|oa| {
             oa.convert(&common_utils::types::StringMajorUnitForConnector)
                 .map(|s| s.get_amount_as_string())

--- a/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/barclaycard/transformers.rs
@@ -418,26 +418,21 @@ fn get_repeat_payment_original_authorized_amount<T>(
 where
     T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
 {
-    let original_pair = router_data
+    router_data
         .request
         .recurring_mandate_payment_data
         .as_ref()
         .and_then(|data| {
-            data.original_payment_authorized_amount
-                .as_ref()
-                .map(|oa| (oa.amount, oa.currency))
-        });
-
-    match original_pair {
-        Some((original_amount, original_currency)) => {
-            Ok(Some(domain_types::utils::get_amount_as_string(
-                &common_enums::CurrencyUnit::Base,
-                original_amount,
-                original_currency,
-            )?))
-        }
-        None => Ok(None),
-    }
+            data.original_payment_authorized_amount.as_ref()
+        })
+        .map(|oa| {
+            oa.convert(&common_utils::types::StringMajorUnitForConnector)
+                .map(|s| s.get_amount_as_string())
+                .change_context(IntegrationError::AmountConversionFailed {
+                    context: Default::default(),
+                })
+        })
+        .transpose()
 }
 
 fn get_error_reason(

--- a/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/billwerk/transformers.rs
@@ -607,7 +607,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .router_data
             .request
             .minor_amount
-            .unwrap_or(MinorUnit::new(0));
+            .unwrap_or(MinorUnit::default());
         Ok(Self {
             handle: item
                 .router_data

--- a/crates/integrations/connector-integration/src/connectors/boost.rs
+++ b/crates/integrations/connector-integration/src/connectors/boost.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method, types::FloatMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
 };
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund},

--- a/crates/integrations/connector-integration/src/connectors/boost.rs
+++ b/crates/integrations/connector-integration/src/connectors/boost.rs
@@ -4,9 +4,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method};
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund},
     connector_types::*,

--- a/crates/integrations/connector-integration/src/connectors/boost/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/boost/transformers.rs
@@ -4,6 +4,7 @@ use common_utils::{
     crypto::{self, SignMessage},
     date_time,
     pii::Email,
+
     types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector},
 };
 use domain_types::{
@@ -386,9 +387,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert minor_amount {} {} to Boost's FloatMajorUnit \
+                        "Failed to convert minor_amount {:?} {} to Boost's FloatMajorUnit \
                          (unquoted JSON decimal, e.g. 1.00) for the Authorize request.",
-                        item.router_data.request.minor_amount.get_amount_as_i64(),
+                        item.router_data.request.minor_amount,
                         item.router_data.request.currency
                     )),
                 },
@@ -660,13 +661,12 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert minor_refund_amount {} {} to Boost's \
+                        "Failed to convert minor_refund_amount {:?} {} to Boost's \
                          FloatMajorUnit (unquoted JSON decimal, e.g. 1.00) for the reversal \
                          (refund/void) request against connector_transaction_id {}.",
                         item.router_data
                             .request
-                            .minor_refund_amount
-                            .get_amount_as_i64(),
+                            .minor_refund_amount,
                         item.router_data.request.currency,
                         item.router_data.request.connector_transaction_id
                     )),
@@ -863,8 +863,7 @@ impl BoostWebhookBody {
             }
             _ => None,
         };
-        let amount_captured =
-            minor_amount_captured.map(|minor_unit| minor_unit.get_amount_as_i64());
+        let amount_captured = None;
 
         WebhookDetailsResponse {
             connector_returned_payment_method_details: None,

--- a/crates/integrations/connector-integration/src/connectors/boost/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/boost/transformers.rs
@@ -4,7 +4,6 @@ use common_utils::{
     crypto::{self, SignMessage},
     date_time,
     pii::Email,
-
     types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector},
 };
 use domain_types::{
@@ -389,8 +388,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert minor_amount {:?} {} to Boost's FloatMajorUnit \
                          (unquoted JSON decimal, e.g. 1.00) for the Authorize request.",
-                        item.router_data.request.minor_amount,
-                        item.router_data.request.currency
+                        item.router_data.request.minor_amount, item.router_data.request.currency
                     )),
                 },
             })
@@ -664,9 +662,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                         "Failed to convert minor_refund_amount {:?} {} to Boost's \
                          FloatMajorUnit (unquoted JSON decimal, e.g. 1.00) for the reversal \
                          (refund/void) request against connector_transaction_id {}.",
-                        item.router_data
-                            .request
-                            .minor_refund_amount,
+                        item.router_data.request.minor_refund_amount,
                         item.router_data.request.currency,
                         item.router_data.request.connector_transaction_id
                     )),

--- a/crates/integrations/connector-integration/src/connectors/braintree.rs
+++ b/crates/integrations/connector-integration/src/connectors/braintree.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::{StringMajorUnit, StringMinorUnit},
     ParsingError,
 };
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/calida.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida.rs
@@ -14,7 +14,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::{ByteSliceExt, BytesExt},
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, PSync},

--- a/crates/integrations/connector-integration/src/connectors/calida/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida/test.rs
@@ -8,7 +8,7 @@ mod tests {
     pub mod authorize {
         use std::{borrow::Cow, marker::PhantomData};
 
-        use common_utils::{pii::Email, request::RequestContent, types::MinorUnit};
+        use common_utils::{pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
         use domain_types::{
             self,
             connector_flow::Authorize,

--- a/crates/integrations/connector-integration/src/connectors/calida/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida/test.rs
@@ -8,7 +8,10 @@ mod tests {
     pub mod authorize {
         use std::{borrow::Cow, marker::PhantomData};
 
-        use common_utils::{pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
+        use common_utils::{
+            pii::Email, proto_boundary::MinorUnitProtoAccess, request::RequestContent,
+            types::MinorUnit,
+        };
         use domain_types::{
             self,
             connector_flow::Authorize,

--- a/crates/integrations/connector-integration/src/connectors/cashtocode.rs
+++ b/crates/integrations/connector-integration/src/connectors/cashtocode.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::Authorize,
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/checkout/transformers.rs
@@ -2064,7 +2064,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         let request = Self {
             source: source_var,
-            amount: MinorUnit::new(0),
+            amount: MinorUnit::default(),
             currency: item.router_data.request.currency.to_string(),
             processing_channel_id,
             three_ds,
@@ -2382,11 +2382,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .and_then(|source| source.payment_account_reference.clone()),
         };
 
-        let (amount_captured, minor_amount_capturable) =
+        let (minor_amount_captured, minor_amount_capturable) =
             match item.router_data.request.capture_method {
                 Some(common_enums::CaptureMethod::Manual)
                 | Some(common_enums::CaptureMethod::ManualMultiple) => (None, item.response.amount),
-                _ => (item.response.amount.map(MinorUnit::get_amount_as_i64), None),
+                _ => (item.response.amount, None),
             };
 
         let minor_amount_authorized = item
@@ -2401,7 +2401,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 status,
                 connector_response: additional_information,
                 minor_amount_authorized,
-                amount_captured,
+                minor_amount_captured,
                 minor_amount_capturable,
                 ..item.router_data.resource_common_data
             },
@@ -2507,13 +2507,13 @@ impl<
                         .and_then(|source| source.payment_account_reference.clone()),
                 };
 
-                let (amount_captured, minor_amount_capturable) =
+                let (minor_amount_captured, minor_amount_capturable) =
                     match item.router_data.request.capture_method {
                         Some(common_enums::CaptureMethod::Manual)
                         | Some(common_enums::CaptureMethod::ManualMultiple) => {
                             (None, item.response.amount)
                         }
-                        _ => (item.response.amount.map(MinorUnit::get_amount_as_i64), None),
+                        _ => (item.response.amount, None),
                     };
 
                 let minor_amount_authorized = item
@@ -2528,7 +2528,7 @@ impl<
                         status,
                         connector_response: additional_information,
                         minor_amount_authorized,
-                        amount_captured,
+                        minor_amount_captured,
                         minor_amount_capturable,
                         ..item.router_data.resource_common_data
                     },

--- a/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
@@ -24,6 +24,7 @@ use domain_types::{
 
 use common_utils::consts;
 
+
 use error_stack::ResultExt;
 use serde::{Deserialize, Serialize};
 
@@ -251,12 +252,11 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             None => None,
         };
         match (amount_captured_in_minor_units, status) {
-            (Some(minor_amount), common_enums::AttemptStatus::Charged) => {
-                let amount_captured = Some(minor_amount.get_amount_as_i64());
+            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
                 Ok(Self {
                     resource_common_data: PaymentFlowData {
                         status,
-                        amount_captured,
+                        amount_captured: None,
                         minor_amount_captured: amount_captured_in_minor_units,
                         ..router_data.resource_common_data
                     },
@@ -401,12 +401,11 @@ impl<F> TryFrom<ResponseRouterData<CryptopayPaymentsResponse, Self>>
             None => None,
         };
         match (amount_captured_in_minor_units, status) {
-            (Some(minor_amount), common_enums::AttemptStatus::Charged) => {
-                let amount_captured = Some(minor_amount.get_amount_as_i64());
+            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
                 Ok(Self {
                     resource_common_data: PaymentFlowData {
                         status,
-                        amount_captured,
+                        amount_captured: None,
                         minor_amount_captured: amount_captured_in_minor_units,
                         ..router_data.resource_common_data
                     },
@@ -476,11 +475,10 @@ impl TryFrom<CryptopayWebhookDetails> for WebhookDetailsResponse {
                     _ => None,
                 };
             match (amount_captured_in_minor_units, status) {
-                (Some(minor_amount), common_enums::AttemptStatus::Charged) => {
-                    let amount_captured = Some(minor_amount.get_amount_as_i64());
+                (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
                     Ok(Self {
                         connector_returned_payment_method_details: None,
-                        amount_captured,
+                        amount_captured: None,
                         minor_amount_captured: amount_captured_in_minor_units,
                         status,
                         resource_id: Some(ResponseId::ConnectorTransactionId(

--- a/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cryptopay/transformers.rs
@@ -24,7 +24,6 @@ use domain_types::{
 
 use common_utils::consts;
 
-
 use error_stack::ResultExt;
 use serde::{Deserialize, Serialize};
 
@@ -252,18 +251,16 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             None => None,
         };
         match (amount_captured_in_minor_units, status) {
-            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
-                Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        amount_captured: None,
-                        minor_amount_captured: amount_captured_in_minor_units,
-                        ..router_data.resource_common_data
-                    },
-                    response,
-                    ..router_data
-                })
-            }
+            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => Ok(Self {
+                resource_common_data: PaymentFlowData {
+                    status,
+                    amount_captured: None,
+                    minor_amount_captured: amount_captured_in_minor_units,
+                    ..router_data.resource_common_data
+                },
+                response,
+                ..router_data
+            }),
             _ => Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
@@ -401,18 +398,16 @@ impl<F> TryFrom<ResponseRouterData<CryptopayPaymentsResponse, Self>>
             None => None,
         };
         match (amount_captured_in_minor_units, status) {
-            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
-                Ok(Self {
-                    resource_common_data: PaymentFlowData {
-                        status,
-                        amount_captured: None,
-                        minor_amount_captured: amount_captured_in_minor_units,
-                        ..router_data.resource_common_data
-                    },
-                    response,
-                    ..router_data
-                })
-            }
+            (Some(_minor_amount), common_enums::AttemptStatus::Charged) => Ok(Self {
+                resource_common_data: PaymentFlowData {
+                    status,
+                    amount_captured: None,
+                    minor_amount_captured: amount_captured_in_minor_units,
+                    ..router_data.resource_common_data
+                },
+                response,
+                ..router_data
+            }),
             _ => Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
@@ -475,36 +470,29 @@ impl TryFrom<CryptopayWebhookDetails> for WebhookDetailsResponse {
                     _ => None,
                 };
             match (amount_captured_in_minor_units, status) {
-                (Some(_minor_amount), common_enums::AttemptStatus::Charged) => {
-                    Ok(Self {
-                        connector_returned_payment_method_details: None,
-                        amount_captured: None,
-                        minor_amount_captured: amount_captured_in_minor_units,
-                        status,
-                        resource_id: Some(ResponseId::ConnectorTransactionId(
-                            notif.data.id.clone(),
-                        )),
-                        error_reason: None,
-                        mandate_reference: None,
-                        status_code: 200,
-                        connector_response_reference_id: notif
-                            .data
-                            .custom_id
-                            .clone()
-                            .or_else(|| Some(notif.data.id.clone())),
-                        connector_request_reference_id: notif
-                            .data
-                            .custom_id
-                            .or(Some(notif.data.id)),
-                        error_code: None,
-                        error_message: None,
-                        raw_connector_response: None,
-                        response_headers: None,
-                        network_txn_id: None,
-                        payment_method_update: None,
-                        sender_payment_instrument_id: None,
-                    })
-                }
+                (Some(_minor_amount), common_enums::AttemptStatus::Charged) => Ok(Self {
+                    connector_returned_payment_method_details: None,
+                    amount_captured: None,
+                    minor_amount_captured: amount_captured_in_minor_units,
+                    status,
+                    resource_id: Some(ResponseId::ConnectorTransactionId(notif.data.id.clone())),
+                    error_reason: None,
+                    mandate_reference: None,
+                    status_code: 200,
+                    connector_response_reference_id: notif
+                        .data
+                        .custom_id
+                        .clone()
+                        .or_else(|| Some(notif.data.id.clone())),
+                    connector_request_reference_id: notif.data.custom_id.or(Some(notif.data.id)),
+                    error_code: None,
+                    error_message: None,
+                    raw_connector_response: None,
+                    response_headers: None,
+                    network_txn_id: None,
+                    payment_method_update: None,
+                    sender_payment_instrument_id: None,
+                }),
                 _ => Ok(Self {
                     connector_returned_payment_method_details: None,
                     status,

--- a/crates/integrations/connector-integration/src/connectors/cybersource.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource.rs
@@ -6,7 +6,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::BytesExt,
-    types::StringMajorUnit,
     Method,
 };
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/cybersource/transformers.rs
@@ -5550,18 +5550,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             .original_payment_authorized_amount
                             .clone()
                     })
-                    .map(|original_amount| (original_amount.amount, original_amount.currency));
-
-                let original_authorized_amount = match original_authorized_amount {
-                    Some((original_amount, original_currency)) => {
-                        Some(domain_types::utils::get_amount_as_string(
-                            &common_enums::CurrencyUnit::Base,
-                            original_amount,
-                            original_currency,
-                        )?)
-                    }
-                    None => None,
-                };
+                    .map(|original_amount| {
+                        original_amount
+                            .convert(&common_utils::types::StringMajorUnitForConnector)
+                            .map(|s| s.get_amount_as_string())
+                            .change_context(IntegrationError::AmountConversionFailed {
+                                context: Default::default(),
+                            })
+                    })
+                    .transpose()?;
                 (
                     None,
                     None,

--- a/crates/integrations/connector-integration/src/connectors/d24.rs
+++ b/crates/integrations/connector-integration/src/connectors/d24.rs
@@ -7,7 +7,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund},

--- a/crates/integrations/connector-integration/src/connectors/dlocal.rs
+++ b/crates/integrations/connector-integration/src/connectors/dlocal.rs
@@ -6,7 +6,7 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::{FloatMajorUnit, MinorUnit},
+    types::MinorUnit,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{
@@ -551,7 +551,7 @@ macros::macro_connector_implementation!(
                     context: Default::default(),
                 })?;
 
-            if req.request.amount == MinorUnit::new(0) {
+            if req.request.amount == MinorUnit::default() {
                 Ok(format!(
                     "{}enrollments/{connector_transaction_id}",
                     self.connector_base_url_payments(req),

--- a/crates/integrations/connector-integration/src/connectors/easebuzz.rs
+++ b/crates/integrations/connector-integration/src/connectors/easebuzz.rs
@@ -5,7 +5,6 @@ use std::{fmt::Debug, sync::LazyLock};
 use common_enums::{self as enums, CurrencyUnit};
 use common_utils::{
     errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent,
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund},

--- a/crates/integrations/connector-integration/src/connectors/elavon.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use bytes::Bytes;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment},

--- a/crates/integrations/connector-integration/src/connectors/elavon.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use bytes::Bytes;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/elavon/transformers.rs
@@ -244,7 +244,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .change_context(IntegrationError::AmountConversionFailed {
                         context: IntegrationErrorContext {
                             additional_context: Some(format!(
-                                "Failed to convert minor amount {} {} to major unit \
+                                "Failed to convert minor amount {:?} {} to major unit \
                                  for Elavon Authorize request",
                                 request_data.minor_amount, request_data.currency
                             )),
@@ -860,7 +860,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .change_context(IntegrationError::AmountConversionFailed {
                 context: IntegrationErrorContext {
                     additional_context: Some(format!(
-                        "Failed to convert capture amount {} {} to major unit for \
+                        "Failed to convert capture amount {:?} {} to major unit for \
                          Elavon Capture (cccomplete) request",
                         router_data.request.minor_amount_to_capture, router_data.request.currency
                     )),
@@ -1055,7 +1055,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .change_context(IntegrationError::AmountConversionFailed {
                 context: IntegrationErrorContext {
                     additional_context: Some(format!(
-                        "Failed to convert refund amount {} {} to major unit for \
+                        "Failed to convert refund amount {:?} {} to major unit for \
                          Elavon Refund (ccreturn) request",
                         request_data.minor_refund_amount, request_data.currency
                     )),
@@ -1572,7 +1572,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .change_context(IntegrationError::AmountConversionFailed {
                 context: IntegrationErrorContext {
                     additional_context: Some(format!(
-                        "Failed to convert repeat payment amount {} {} to major unit for \
+                        "Failed to convert repeat payment amount {:?} {} to major unit for \
                          Elavon RepeatPayment request",
                         request.minor_amount, request.currency
                     )),

--- a/crates/integrations/connector-integration/src/connectors/finix.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix.rs
@@ -10,7 +10,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/finix/transformers.rs
@@ -809,7 +809,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            capture_amount: MinorUnit::new(item.router_data.request.amount_to_capture),
+            capture_amount: item.router_data.request.minor_amount_to_capture,
             idempotency_id: None,
         })
     }
@@ -2317,9 +2317,7 @@ pub(super) fn build_finix_payment_webhook_response(
         raw_connector_response: Some(String::from_utf8_lossy(raw_body).to_string()),
         status_code: 200,
         response_headers: None,
-        amount_captured: resource
-            .captured_amount
-            .map(|amount| amount.get_amount_as_i64()),
+        amount_captured: None,
         minor_amount_captured: resource.captured_amount,
         network_txn_id: None,
         payment_method_update: None,

--- a/crates/integrations/connector-integration/src/connectors/fiserv.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiserv.rs
@@ -7,7 +7,6 @@ use common_utils::{
     events,
     ext_traits::BytesExt,
     request::RequestContent,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/fiservcommercehub.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservcommercehub.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent, FloatMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/fiservemea.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiservemea.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use common_enums::CurrencyUnit;
 use common_utils::{
     errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent,
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void, VoidPC},

--- a/crates/integrations/connector-integration/src/connectors/fiuu.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu.rs
@@ -10,7 +10,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::{ByteSliceExt, BytesExt},
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},

--- a/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/fiuu/transformers.rs
@@ -874,7 +874,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .router_data
             .request
             .minor_amount
-            .unwrap_or(common_utils::types::MinorUnit::new(0));
+            .unwrap_or(common_utils::types::MinorUnit::default());
         let amount = item
             .connector
             .amount_converter

--- a/crates/integrations/connector-integration/src/connectors/forte.rs
+++ b/crates/integrations/connector-integration/src/connectors/forte.rs
@@ -6,7 +6,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/getnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/getnet.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authenticate, Authorize, Capture, PSync, PaymentMethodToken, PostAuthenticate,

--- a/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/getnet/transformers.rs
@@ -1150,17 +1150,13 @@ impl<T: PaymentMethodDataTypes + fmt::Debug + Sync + Send + 'static + Serialize>
                 context: Default::default(),
             })?;
 
-        let capture_amount = router_data.request.amount_to_capture;
-
-        let capture_amount_minor = MinorUnit::new(capture_amount);
-
         Ok(Self {
             idempotency_key: router_data
                 .resource_common_data
                 .connector_request_reference_id
                 .clone(),
             payment_id,
-            amount: capture_amount_minor,
+            amount: router_data.request.minor_amount_to_capture,
         })
     }
 }

--- a/crates/integrations/connector-integration/src/connectors/gigadat.rs
+++ b/crates/integrations/connector-integration/src/connectors/gigadat.rs
@@ -7,7 +7,7 @@ use crate::types::ResponseRouterData;
 use crate::with_error_response_body;
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::errors::ConnectorError;
 use domain_types::errors::IntegrationError;
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/globalpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/globalpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMinorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, request::RequestContent,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/globalpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/globalpay.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, PSync, PaymentMethodToken, RSync, Refund,

--- a/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
@@ -2,7 +2,7 @@ use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, CountryAlpha2, Currency, RefundStatus};
 use common_utils::{
     pii::Email,
-    types::{MinorUnit, Money},
+    types::{ConnectorMinorUnit, Money},
 };
 use domain_types::{
     connector_flow::{
@@ -168,7 +168,7 @@ pub enum GlomopayWebhookEventType {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GlomopayWebhookFeeDetail {
     pub currency: Option<Currency>,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -182,9 +182,9 @@ pub struct GlomopayWebhookFees {
 pub struct GlomopayWebhookPaymentData {
     pub id: String,
     pub payin_id: Option<String>,
-    pub requested_amount: Option<MinorUnit>,
+    pub requested_amount: Option<ConnectorMinorUnit>,
     pub requested_currency: Option<Currency>,
-    pub payment_amount: Option<MinorUnit>,
+    pub payment_amount: Option<ConnectorMinorUnit>,
     pub payment_currency: Option<Currency>,
     pub fees: Option<GlomopayWebhookFees>,
     pub error_code: Option<String>,
@@ -282,7 +282,7 @@ pub enum GlomopayRefundWebhookEventType {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GlomopayRefundWebhookFeeDetail {
     pub currency: Option<Currency>,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -295,7 +295,7 @@ pub struct GlomopayRefundWebhookFees {
 pub struct GlomopayRefundWebhookData {
     pub id: String,
     pub payment_id: Option<String>,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     pub currency: Option<Currency>,
     pub fees: Option<GlomopayRefundWebhookFees>,
     pub error_code: Option<String>,
@@ -551,7 +551,7 @@ impl TryFrom<ResponseRouterData<GlomopayCreateCustomerResponse, Self>>
 pub struct GlomopayCreateOrderRequest {
     pub customer_id: String,
     pub currency: Currency,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub product: GlomopayProduct,
     pub request_id: String,
 }
@@ -933,7 +933,7 @@ pub struct GlomopayPaymentSyncItem {
     // transaction values in the mandatory-sync integrity check, so we
     // must surface them from the connector response rather than
     // echoing the request context.
-    pub requested_amount: Option<MinorUnit>,
+    pub requested_amount: Option<ConnectorMinorUnit>,
     pub requested_currency: Option<Currency>,
     pub error_code: Option<String>,
     pub error_description: Option<String>,
@@ -978,10 +978,15 @@ impl TryFrom<ResponseRouterData<GlomopayPaymentSyncResponse, Self>>
         // worse than a visible integrity failure.
         let (response_amount, integrity_object) =
             match (payment.requested_amount, payment.requested_currency) {
-                (Some(amount), Some(currency)) => (
-                    Some(Money { amount, currency }),
-                    Some(PaymentSynIntegrityObject { amount, currency }),
-                ),
+                (Some(amount), Some(currency)) => {
+                    let minor = GlomopayAmountConvertor::convert_back(amount, currency)
+                        .ok()
+                        .unwrap_or_default();
+                    (
+                        Some(Money::from_minor_unit(minor, currency)),
+                        Some(PaymentSynIntegrityObject { amount: minor, currency }),
+                    )
+                }
                 _ => (None, None),
             };
 
@@ -1054,7 +1059,7 @@ impl TryFrom<ResponseRouterData<GlomopayPaymentSyncResponse, Self>>
 pub struct GlomopayRefundRequest {
     pub payment_id: String,
     pub reason: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub request_id: String,
 }
 
@@ -1062,7 +1067,7 @@ pub struct GlomopayRefundRequest {
 pub struct GlomopayRefundResponse {
     pub id: String,
     pub status: GlomopayRefundStatus,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
 }
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
@@ -1138,7 +1143,7 @@ impl TryFrom<ResponseRouterData<GlomopayRefundResponse, Self>>
 pub struct GlomopayRefundSyncItem {
     pub id: String,
     pub status: GlomopayRefundStatus,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     pub utr: Option<String>,
 }
 

--- a/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/glomopay/transformers.rs
@@ -984,7 +984,10 @@ impl TryFrom<ResponseRouterData<GlomopayPaymentSyncResponse, Self>>
                         .unwrap_or_default();
                     (
                         Some(Money::from_minor_unit(minor, currency)),
-                        Some(PaymentSynIntegrityObject { amount: minor, currency }),
+                        Some(PaymentSynIntegrityObject {
+                            amount: minor,
+                            currency,
+                        }),
                     )
                 }
                 _ => (None, None),

--- a/crates/integrations/connector-integration/src/connectors/grabpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/grabpay.rs
@@ -586,7 +586,7 @@ macros::macro_connector_implementation!(
                 .request
                 .refund_money
                 .as_ref()
-                .map(|money| money.currency)
+                .map(|money| money.currency())
                 .map(Ok)
                 .unwrap_or_else(|| {
                     grabpay::currency_from_connector_feature_data(

--- a/crates/integrations/connector-integration/src/connectors/helcim.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim.rs
@@ -2,7 +2,7 @@ pub mod transformers;
 
 use common_utils::{
     consts::NO_ERROR_CODE, errors::CustomResult, events, ext_traits::BytesExt,
-    fp_utils::generate_id, types::FloatMajorUnit,
+    fp_utils::generate_id,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/helcim/transformers.rs
@@ -623,7 +623,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 item.router_data
                     .request
                     .minor_amount
-                    .unwrap_or(common_utils::types::MinorUnit::new(0)),
+                    .unwrap_or(common_utils::types::MinorUnit::default()),
                 item.router_data.request.currency,
             )
             .change_context(IntegrationError::AmountConversionFailed {

--- a/crates/integrations/connector-integration/src/connectors/hipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use common_enums::{CurrencyUnit, PaymentMethod, PaymentMethodType};
 
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, PaymentMethodToken, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/hipay.rs
+++ b/crates/integrations/connector-integration/src/connectors/hipay.rs
@@ -4,9 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::{CurrencyUnit, PaymentMethod, PaymentMethodType};
 
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, PaymentMethodToken, RSync, Refund, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/hyperpg.rs
+++ b/crates/integrations/connector-integration/src/connectors/hyperpg.rs
@@ -7,7 +7,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::{ByteSliceExt, ValueExt},
-    FloatMajorUnit,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/hyperswitch.rs
+++ b/crates/integrations/connector-integration/src/connectors/hyperswitch.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{PSync, RepeatPayment},

--- a/crates/integrations/connector-integration/src/connectors/hyperswitch/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/hyperswitch/transformers.rs
@@ -1,5 +1,5 @@
 use common_enums::Currency;
-use common_utils::{ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{ext_traits::ByteSliceExt, types::ConnectorMinorUnit};
 use domain_types::{
     connector_flow::RepeatPayment,
     connector_types::{
@@ -85,7 +85,7 @@ pub struct HyperswitchPaymentMethodIdRecurringDetails {
 
 #[derive(Debug, Serialize)]
 pub struct HyperswitchRepeatPaymentRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: Currency,
     pub confirm: bool,
     pub off_session: bool,

--- a/crates/integrations/connector-integration/src/connectors/iatapay.rs
+++ b/crates/integrations/connector-integration/src/connectors/iatapay.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, PSync, RSync, Refund, ServerAuthenticationToken},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/ilixium.rs
+++ b/crates/integrations/connector-integration/src/connectors/ilixium.rs
@@ -76,7 +76,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method, types::StringMinorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/ilixium.rs
+++ b/crates/integrations/connector-integration/src/connectors/ilixium.rs
@@ -75,9 +75,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, request::Method};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, Void},
     connector_types::*,

--- a/crates/integrations/connector-integration/src/connectors/ilixium/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ilixium/transformers.rs
@@ -735,9 +735,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert minor_amount {} {} into Ilixium's \
+                        "Failed to convert minor_amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_amount.get_amount_as_i64(),
+                        request.minor_amount,
                         request.currency
                     )),
                 },
@@ -836,9 +836,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert amount {} {} into Ilixium's transaction.amount \
+                        "Failed to convert amount {:?} {} into Ilixium's transaction.amount \
                          (minor units, digits only, sent as a JSON string).",
-                        request.amount.get_amount_as_i64(),
+                        request.amount,
                         currency
                     )),
                 },
@@ -1054,9 +1054,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert minor_amount_to_capture {} {} into Ilixium's \
+                        "Failed to convert minor_amount_to_capture {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_amount_to_capture.get_amount_as_i64(),
+                        request.minor_amount_to_capture,
                         request.currency
                     )),
                 },
@@ -1189,9 +1189,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert void amount {} {} into Ilixium's \
+                        "Failed to convert void amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        minor_amount.get_amount_as_i64(),
+                        minor_amount,
                         currency
                     )),
                 },
@@ -1404,9 +1404,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     suggested_action: None,
                     doc_url: None,
                     additional_context: Some(format!(
-                        "Failed to convert minor_refund_amount {} {} into Ilixium's \
+                        "Failed to convert minor_refund_amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_refund_amount.get_amount_as_i64(),
+                        request.minor_refund_amount,
                         request.currency
                     )),
                 },
@@ -3732,7 +3732,12 @@ impl TryFrom<crate::types::ResponseRouterData<IlixiumRefundHistoryResponse, Self
         let refund_amount = request
             .refund_money
             .as_ref()
-            .map(|money| money.amount.get_amount_as_i64());
+            .and_then(|money| {
+                money
+                    .convert(&common_utils::types::MinorUnitForConnector)
+                    .ok()
+                    .map(|c| c.to_string().parse::<i64>().unwrap_or(0))
+            });
 
         let Some(matched) = response.match_refund_operation(
             &merchant_ref,

--- a/crates/integrations/connector-integration/src/connectors/ilixium/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ilixium/transformers.rs
@@ -737,8 +737,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert minor_amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_amount,
-                        request.currency
+                        request.minor_amount, request.currency
                     )),
                 },
             })?;
@@ -838,8 +837,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert amount {:?} {} into Ilixium's transaction.amount \
                          (minor units, digits only, sent as a JSON string).",
-                        request.amount,
-                        currency
+                        request.amount, currency
                     )),
                 },
             })?;
@@ -1056,8 +1054,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert minor_amount_to_capture {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_amount_to_capture,
-                        request.currency
+                        request.minor_amount_to_capture, request.currency
                     )),
                 },
             })?;
@@ -1191,8 +1188,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert void amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        minor_amount,
-                        currency
+                        minor_amount, currency
                     )),
                 },
             })?;
@@ -1406,8 +1402,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     additional_context: Some(format!(
                         "Failed to convert minor_refund_amount {:?} {} into Ilixium's \
                          transaction.amount (minor units, digits only, sent as a JSON string).",
-                        request.minor_refund_amount,
-                        request.currency
+                        request.minor_refund_amount, request.currency
                     )),
                 },
             })?;
@@ -3729,15 +3724,12 @@ impl TryFrom<crate::types::ResponseRouterData<IlixiumRefundHistoryResponse, Self
             });
         }
 
-        let refund_amount = request
-            .refund_money
-            .as_ref()
-            .and_then(|money| {
-                money
-                    .convert(&common_utils::types::MinorUnitForConnector)
-                    .ok()
-                    .map(|c| c.to_string().parse::<i64>().unwrap_or(0))
-            });
+        let refund_amount = request.refund_money.as_ref().and_then(|money| {
+            money
+                .convert(&common_utils::types::MinorUnitForConnector)
+                .ok()
+                .map(|c| c.to_string().parse::<i64>().unwrap_or(0))
+        });
 
         let Some(matched) = response.match_refund_operation(
             &merchant_ref,

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
@@ -9,6 +9,7 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
+
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, Void},
@@ -230,8 +231,26 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         };
 
         let minor_amount_captured = match status {
-            AttemptStatus::Charged => webhook_body.amount,
-            AttemptStatus::PartialCharged => webhook_body.total_captured,
+            AttemptStatus::Charged => webhook_body
+                .amount
+                .map(|a| {
+                    domain_types::utils::convert_back_amount_to_minor_units_for_webhook(
+                        &common_utils::types::MinorUnitForConnector,
+                        a,
+                        webhook_body.currency,
+                    )
+                })
+                .transpose()?,
+            AttemptStatus::PartialCharged => webhook_body
+                .total_captured
+                .map(|a| {
+                    domain_types::utils::convert_back_amount_to_minor_units_for_webhook(
+                        &common_utils::types::MinorUnitForConnector,
+                        a,
+                        webhook_body.currency,
+                    )
+                })
+                .transpose()?,
             _ => None,
         };
 
@@ -250,8 +269,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             raw_connector_response: Some(String::from_utf8_lossy(&request.body).to_string()),
             status_code: 200,
             response_headers: None,
-            amount_captured: minor_amount_captured
-                .map(|minor_amount| minor_amount.get_amount_as_i64()),
+            amount_captured: None,
             minor_amount_captured,
             network_txn_id: None,
             payment_method_update: None,

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, Void},

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -1,5 +1,5 @@
 use common_enums::{self, AttemptStatus, CaptureMethod, CountryAlpha2, Currency, RefundStatus};
-use common_utils::{consts, errors::ParsingError, pii, types::MinorUnit};
+use common_utils::{consts, errors::ParsingError, pii, types::{ConnectorMinorUnit, MinorUnit, MinorUnitForConnector}};
 use domain_types::{
     connector_flow::{Authorize, Capture, RSync, Refund, RepeatPayment, Void},
     connector_types::{
@@ -15,7 +15,7 @@ use domain_types::{
     router_data::{ConnectorSpecificConfig, ErrorResponse, FlowStatus},
     router_data_v2::RouterDataV2,
     router_request_types::SyncRequestType,
-    utils::is_payment_failure,
+    utils::{is_payment_failure, convert_amount, convert_back_amount_to_minor_units, compute_capturable_amount},
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, ExposeOptionInterface, Secret};
@@ -93,7 +93,7 @@ impl TryFrom<&ConnectorSpecificConfig> for ImerchantsolutionsAuthType {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ImerchantsolutionsPaymentsRequestData<T: PaymentMethodDataTypes> {
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     currency: Currency,
     reference: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -387,6 +387,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             None
         };
 
+        let connector_amount = convert_amount(
+            &MinorUnitForConnector,
+            item.router_data.request.amount,
+            item.router_data.request.currency,
+        )?;
+
         match &item.router_data.request.payment_method_data {
             PaymentMethodData::Card(ref card_data) => {
                 let card = Some(CardDetails {
@@ -397,7 +403,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     holder: card_data.get_optional_cardholder_name(),
                 });
                 Ok(Self {
-                    amount: item.router_data.request.amount,
+                    amount: connector_amount,
                     currency: item.router_data.request.currency,
                     reference: item
                         .router_data
@@ -481,7 +487,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         }
                     }?;
                     Ok(Self {
-                        amount: item.router_data.request.amount,
+                        amount: connector_amount,
                         currency: item.router_data.request.currency,
                         reference: item
                             .router_data
@@ -535,7 +541,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         }
                     }?;
                     Ok(Self {
-                        amount: item.router_data.request.amount,
+                        amount: connector_amount,
                         currency: item.router_data.request.currency,
                         reference: item
                             .router_data
@@ -667,7 +673,7 @@ pub struct ImerchantsolutionsPaymentsResponseData {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct AmountDetails {
-    value: MinorUnit,
+    value: ConnectorMinorUnit,
     currency: Currency,
 }
 
@@ -782,10 +788,16 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                     connector_mandate_request_reference_id: None,
                     mandate_metadata: None,
                 });
+            let currency = item.response.amount.currency;
+            let minor_amount_capturable = Some(convert_back_amount_to_minor_units(
+                &MinorUnitForConnector,
+                item.response.amount.value,
+                currency,
+            ).change_context(utils::response_handling_fail_for_connector(item.http_code, IMERCHANTSOLUTIONS))?);
             Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
-                    minor_amount_capturable: Some(item.response.amount.value),
+                    minor_amount_capturable,
                     ..item.router_data.resource_common_data
                 },
                 response: Ok(PaymentsResponseData::TransactionResponse {
@@ -834,8 +846,12 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = item.router_data.request.minor_amount;
         let currency = item.router_data.request.currency;
+        let amount = convert_amount(
+            &MinorUnitForConnector,
+            item.router_data.request.minor_amount,
+            currency,
+        )?;
         let reference = item
             .router_data
             .resource_common_data
@@ -995,10 +1011,16 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                 ..item.router_data
             })
         } else {
+            let currency = item.response.amount.currency;
+            let minor_amount_capturable = Some(convert_back_amount_to_minor_units(
+                &MinorUnitForConnector,
+                item.response.amount.value,
+                currency,
+            ).change_context(utils::response_handling_fail_for_connector(item.http_code, IMERCHANTSOLUTIONS))?);
             Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
-                    minor_amount_capturable: Some(item.response.amount.value),
+                    minor_amount_capturable,
                     ..item.router_data.resource_common_data
                 },
                 response: Ok(PaymentsResponseData::TransactionResponse {
@@ -1035,9 +1057,9 @@ pub struct ImerchantsolutionsPSyncResponseData {
     payment_id: String,
     psp_reference: String,
     merchant_reference: Option<String>,
-    authorized_amount: Option<MinorUnit>,
-    total_captured: Option<MinorUnit>,
-    remaining_amount: Option<MinorUnit>,
+    authorized_amount: Option<ConnectorMinorUnit>,
+    total_captured: Option<ConnectorMinorUnit>,
+    remaining_amount: Option<ConnectorMinorUnit>,
     capture_closed: Option<bool>,
     captures: Vec<Captures>,
     currency: Currency,
@@ -1050,7 +1072,7 @@ pub struct ImerchantsolutionsPSyncResponseData {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct Captures {
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     currency: Currency,
     psp_reference: String,
     captured_at: Option<String>,
@@ -1093,7 +1115,12 @@ impl<'a> utils::MultipleCaptureSyncResponse for CaptureWithStatus<'a> {
     }
 
     fn get_amount_captured(&self) -> Result<Option<MinorUnit>, error_stack::Report<ParsingError>> {
-        Ok(Some(self.capture.amount))
+        let minor = convert_back_amount_to_minor_units(
+            &MinorUnitForConnector,
+            self.capture.amount,
+            self.capture.currency,
+        )?;
+        Ok(Some(minor))
     }
 }
 
@@ -1110,12 +1137,12 @@ pub struct ImerchantsolutionsWebhookData {
     pub status: ImerchantsolutionsWebhookStatus,
     pub reason: Option<String>,
     pub error: Option<String>,
-    pub amount: Option<MinorUnit>,
-    pub captured_amount: Option<MinorUnit>,
-    pub total_captured: Option<MinorUnit>,
-    refunded_amount: Option<MinorUnit>,
-    total_refunded: Option<MinorUnit>,
-    currency: Currency,
+    pub amount: Option<ConnectorMinorUnit>,
+    pub captured_amount: Option<ConnectorMinorUnit>,
+    pub total_captured: Option<ConnectorMinorUnit>,
+    refunded_amount: Option<ConnectorMinorUnit>,
+    total_refunded: Option<ConnectorMinorUnit>,
+    pub currency: Currency,
     processor: Option<String>,
     card_last4: Option<String>,
     card_brand: Option<String>,
@@ -1171,9 +1198,7 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
             ImerchantsolutionsPaymentSyncResponse::ImerchantsolutionsPSyncResponse(response) => {
                 let status = response.status.clone().into();
 
-                let amount_captured = response
-                    .total_captured
-                    .map(|minor_amount| minor_amount.get_amount_as_i64());
+                let amount_captured = None;
 
                 if is_payment_failure(status) {
                     let error_response = ErrorResponse {
@@ -1218,12 +1243,22 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                                 IMERCHANTSOLUTIONS,
                             ))?;
 
+                    let currency = response.currency;
+                    let minor_amount_captured = response.total_captured
+                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .transpose()
+                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                    let minor_amount_capturable = response.remaining_amount
+                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .transpose()
+                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+
                     Ok(Self {
                         resource_common_data: PaymentFlowData {
                             status: response.status.clone().into(),
                             amount_captured,
-                            minor_amount_captured: response.total_captured,
-                            minor_amount_capturable: response.remaining_amount,
+                            minor_amount_captured,
+                            minor_amount_capturable,
                             ..router_data.resource_common_data
                         },
                         response: Ok(PaymentsResponseData::MultipleCaptureResponse {
@@ -1233,12 +1268,22 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                         ..router_data
                     })
                 } else {
+                    let currency = response.currency;
+                    let minor_amount_captured = response.total_captured
+                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .transpose()
+                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                    let minor_amount_capturable = response.remaining_amount
+                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .transpose()
+                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+
                     Ok(Self {
                         resource_common_data: PaymentFlowData {
                             status,
                             amount_captured,
-                            minor_amount_captured: response.total_captured,
-                            minor_amount_capturable: response.remaining_amount,
+                            minor_amount_captured,
+                            minor_amount_capturable,
                             ..router_data.resource_common_data
                         },
                         response: Ok(PaymentsResponseData::TransactionResponse {
@@ -1291,16 +1336,37 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                         ..router_data
                     })
                 } else {
+                    let currency = response.currency;
                     let (minor_amount_captured, minor_amount_capturable) = match status {
-                        AttemptStatus::Authorized => (None, response.amount),
-                        AttemptStatus::Charged => (response.amount, None),
+                        AttemptStatus::Authorized => {
+                            let capturable = response.amount
+                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                                .transpose()
+                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                            (None, capturable)
+                        }
+                        AttemptStatus::Charged => {
+                            let captured = response.amount
+                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                                .transpose()
+                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                            (captured, None)
+                        }
                         AttemptStatus::PartialCharged => {
-                            let captured = response.total_captured;
+                            let captured = response.total_captured
+                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                                .transpose()
+                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
 
-                            let capturable = response
-                                .amount
-                                .zip(captured)
-                                .map(|(total, captured)| total - captured);
+                            let capturable = response.amount.zip(response.total_captured)
+                                .map(|(total, cap)| {
+                                    let total_minor = convert_back_amount_to_minor_units(&MinorUnitForConnector, total, currency)
+                                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                                    let captured_minor = convert_back_amount_to_minor_units(&MinorUnitForConnector, cap, currency)
+                                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                                    Ok::<_, error_stack::Report<errors::ConnectorError>>(compute_capturable_amount(total_minor, captured_minor))
+                                })
+                                .transpose()?;
 
                             (captured, capturable)
                         }
@@ -1310,8 +1376,7 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                     Ok(Self {
                         resource_common_data: PaymentFlowData {
                             status,
-                            amount_captured: minor_amount_captured
-                                .map(|minor_amount| minor_amount.get_amount_as_i64()),
+                            amount_captured: None,
                             minor_amount_captured,
                             minor_amount_capturable,
                             ..router_data.resource_common_data
@@ -1428,7 +1493,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsVoidResponseData, Self>>
 #[serde(rename_all = "camelCase")]
 pub struct ImerchantsolutionsCaptureRequestData {
     psp_reference: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     currency: Currency,
     #[serde(rename = "final")]
     final_capture: bool,
@@ -1473,9 +1538,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             CaptureMethod::Manual
         );
 
+        let amount = convert_amount(
+            &MinorUnitForConnector,
+            item.router_data.request.minor_amount_to_capture,
+            item.router_data.request.currency,
+        )?;
+
         Ok(Self {
             psp_reference,
-            amount: item.router_data.request.minor_amount_to_capture,
+            amount,
             currency: item.router_data.request.currency,
             final_capture,
         })
@@ -1488,8 +1559,8 @@ pub struct ImerchantsolutionsCaptureResponseData {
     success: bool,
     psp_reference: String,
     original_reference: String,
-    captured_amount: Option<MinorUnit>,
-    total_captured: Option<MinorUnit>,
+    captured_amount: Option<ConnectorMinorUnit>,
+    total_captured: Option<ConnectorMinorUnit>,
     currency: Currency,
     status: ImerchantsolutionsCaptureStatus,
     capture_closed: Option<bool>,
@@ -1553,7 +1624,7 @@ impl TryFrom<ResponseRouterData<ImerchantsolutionsCaptureResponseData, Self>>
 #[serde(rename_all = "camelCase")]
 pub struct ImerchantsolutionsRefundRequestData {
     psp_reference: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     currency: Currency,
     reference: Option<String>,
     reason: Option<String>,
@@ -1575,9 +1646,14 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
+        let amount = convert_amount(
+            &MinorUnitForConnector,
+            item.router_data.request.minor_refund_amount,
+            item.router_data.request.currency,
+        )?;
         Ok(Self {
             psp_reference: item.router_data.request.connector_transaction_id.clone(),
-            amount: item.router_data.request.minor_refund_amount,
+            amount,
             currency: item.router_data.request.currency,
             reference: Some(item.router_data.request.refund_id.clone()),
             reason: item.router_data.request.reason,
@@ -1591,8 +1667,8 @@ pub struct ImerchantsolutionsRefundResponseData {
     success: bool,
     psp_reference: String,
     original_reference: String,
-    refunded_amount: MinorUnit,
-    total_refunded: MinorUnit,
+    refunded_amount: ConnectorMinorUnit,
+    total_refunded: ConnectorMinorUnit,
     currency: Currency,
     status: ImerchantsolutionsRefundStatus,
     message: Option<String>,
@@ -1641,10 +1717,10 @@ pub struct ImerchantsolutionsRsyncResponseData {
     payment_id: String,
     psp_reference: String,
     merchant_reference: Option<String>,
-    payment_amount: Option<MinorUnit>,
-    total_captured: Option<MinorUnit>,
-    total_refunded: Option<MinorUnit>,
-    remaining_amount: Option<MinorUnit>,
+    payment_amount: Option<ConnectorMinorUnit>,
+    total_captured: Option<ConnectorMinorUnit>,
+    total_refunded: Option<ConnectorMinorUnit>,
+    remaining_amount: Option<ConnectorMinorUnit>,
     currency: Currency,
     status: ImerchantsolutionsRefundStatus,
     can_refund: bool,
@@ -1655,7 +1731,7 @@ pub struct ImerchantsolutionsRsyncResponseData {
 #[serde(rename_all = "camelCase")]
 struct Refunds {
     psp_reference: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     currency: Currency,
     reason: Option<String>,
     created_at: Option<String>,

--- a/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/imerchantsolutions/transformers.rs
@@ -1,5 +1,10 @@
 use common_enums::{self, AttemptStatus, CaptureMethod, CountryAlpha2, Currency, RefundStatus};
-use common_utils::{consts, errors::ParsingError, pii, types::{ConnectorMinorUnit, MinorUnit, MinorUnitForConnector}};
+use common_utils::{
+    consts,
+    errors::ParsingError,
+    pii,
+    types::{ConnectorMinorUnit, MinorUnit, MinorUnitForConnector},
+};
 use domain_types::{
     connector_flow::{Authorize, Capture, RSync, Refund, RepeatPayment, Void},
     connector_types::{
@@ -15,7 +20,10 @@ use domain_types::{
     router_data::{ConnectorSpecificConfig, ErrorResponse, FlowStatus},
     router_data_v2::RouterDataV2,
     router_request_types::SyncRequestType,
-    utils::{is_payment_failure, convert_amount, convert_back_amount_to_minor_units, compute_capturable_amount},
+    utils::{
+        compute_capturable_amount, convert_amount, convert_back_amount_to_minor_units,
+        is_payment_failure,
+    },
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, ExposeOptionInterface, Secret};
@@ -789,11 +797,17 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
                     mandate_metadata: None,
                 });
             let currency = item.response.amount.currency;
-            let minor_amount_capturable = Some(convert_back_amount_to_minor_units(
-                &MinorUnitForConnector,
-                item.response.amount.value,
-                currency,
-            ).change_context(utils::response_handling_fail_for_connector(item.http_code, IMERCHANTSOLUTIONS))?);
+            let minor_amount_capturable = Some(
+                convert_back_amount_to_minor_units(
+                    &MinorUnitForConnector,
+                    item.response.amount.value,
+                    currency,
+                )
+                .change_context(utils::response_handling_fail_for_connector(
+                    item.http_code,
+                    IMERCHANTSOLUTIONS,
+                ))?,
+            );
             Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
@@ -1012,11 +1026,17 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
             })
         } else {
             let currency = item.response.amount.currency;
-            let minor_amount_capturable = Some(convert_back_amount_to_minor_units(
-                &MinorUnitForConnector,
-                item.response.amount.value,
-                currency,
-            ).change_context(utils::response_handling_fail_for_connector(item.http_code, IMERCHANTSOLUTIONS))?);
+            let minor_amount_capturable = Some(
+                convert_back_amount_to_minor_units(
+                    &MinorUnitForConnector,
+                    item.response.amount.value,
+                    currency,
+                )
+                .change_context(utils::response_handling_fail_for_connector(
+                    item.http_code,
+                    IMERCHANTSOLUTIONS,
+                ))?,
+            );
             Ok(Self {
                 resource_common_data: PaymentFlowData {
                     status,
@@ -1244,14 +1264,26 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                             ))?;
 
                     let currency = response.currency;
-                    let minor_amount_captured = response.total_captured
-                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                    let minor_amount_captured = response
+                        .total_captured
+                        .map(|a| {
+                            convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency)
+                        })
                         .transpose()
-                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
-                    let minor_amount_capturable = response.remaining_amount
-                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .change_context(utils::response_handling_fail_for_connector(
+                            http_code,
+                            IMERCHANTSOLUTIONS,
+                        ))?;
+                    let minor_amount_capturable = response
+                        .remaining_amount
+                        .map(|a| {
+                            convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency)
+                        })
                         .transpose()
-                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                        .change_context(utils::response_handling_fail_for_connector(
+                            http_code,
+                            IMERCHANTSOLUTIONS,
+                        ))?;
 
                     Ok(Self {
                         resource_common_data: PaymentFlowData {
@@ -1269,14 +1301,26 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                     })
                 } else {
                     let currency = response.currency;
-                    let minor_amount_captured = response.total_captured
-                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                    let minor_amount_captured = response
+                        .total_captured
+                        .map(|a| {
+                            convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency)
+                        })
                         .transpose()
-                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
-                    let minor_amount_capturable = response.remaining_amount
-                        .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                        .change_context(utils::response_handling_fail_for_connector(
+                            http_code,
+                            IMERCHANTSOLUTIONS,
+                        ))?;
+                    let minor_amount_capturable = response
+                        .remaining_amount
+                        .map(|a| {
+                            convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency)
+                        })
                         .transpose()
-                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                        .change_context(utils::response_handling_fail_for_connector(
+                            http_code,
+                            IMERCHANTSOLUTIONS,
+                        ))?;
 
                     Ok(Self {
                         resource_common_data: PaymentFlowData {
@@ -1339,32 +1383,80 @@ impl<F> TryFrom<ResponseRouterData<ImerchantsolutionsPaymentSyncResponse, Self>>
                     let currency = response.currency;
                     let (minor_amount_captured, minor_amount_capturable) = match status {
                         AttemptStatus::Authorized => {
-                            let capturable = response.amount
-                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                            let capturable = response
+                                .amount
+                                .map(|a| {
+                                    convert_back_amount_to_minor_units(
+                                        &MinorUnitForConnector,
+                                        a,
+                                        currency,
+                                    )
+                                })
                                 .transpose()
-                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                                .change_context(utils::response_handling_fail_for_connector(
+                                    http_code,
+                                    IMERCHANTSOLUTIONS,
+                                ))?;
                             (None, capturable)
                         }
                         AttemptStatus::Charged => {
-                            let captured = response.amount
-                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                            let captured = response
+                                .amount
+                                .map(|a| {
+                                    convert_back_amount_to_minor_units(
+                                        &MinorUnitForConnector,
+                                        a,
+                                        currency,
+                                    )
+                                })
                                 .transpose()
-                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                                .change_context(utils::response_handling_fail_for_connector(
+                                    http_code,
+                                    IMERCHANTSOLUTIONS,
+                                ))?;
                             (captured, None)
                         }
                         AttemptStatus::PartialCharged => {
-                            let captured = response.total_captured
-                                .map(|a| convert_back_amount_to_minor_units(&MinorUnitForConnector, a, currency))
+                            let captured = response
+                                .total_captured
+                                .map(|a| {
+                                    convert_back_amount_to_minor_units(
+                                        &MinorUnitForConnector,
+                                        a,
+                                        currency,
+                                    )
+                                })
                                 .transpose()
-                                .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
+                                .change_context(utils::response_handling_fail_for_connector(
+                                    http_code,
+                                    IMERCHANTSOLUTIONS,
+                                ))?;
 
-                            let capturable = response.amount.zip(response.total_captured)
+                            let capturable = response
+                                .amount
+                                .zip(response.total_captured)
                                 .map(|(total, cap)| {
-                                    let total_minor = convert_back_amount_to_minor_units(&MinorUnitForConnector, total, currency)
-                                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
-                                    let captured_minor = convert_back_amount_to_minor_units(&MinorUnitForConnector, cap, currency)
-                                        .change_context(utils::response_handling_fail_for_connector(http_code, IMERCHANTSOLUTIONS))?;
-                                    Ok::<_, error_stack::Report<errors::ConnectorError>>(compute_capturable_amount(total_minor, captured_minor))
+                                    let total_minor = convert_back_amount_to_minor_units(
+                                        &MinorUnitForConnector,
+                                        total,
+                                        currency,
+                                    )
+                                    .change_context(utils::response_handling_fail_for_connector(
+                                        http_code,
+                                        IMERCHANTSOLUTIONS,
+                                    ))?;
+                                    let captured_minor = convert_back_amount_to_minor_units(
+                                        &MinorUnitForConnector,
+                                        cap,
+                                        currency,
+                                    )
+                                    .change_context(utils::response_handling_fail_for_connector(
+                                        http_code,
+                                        IMERCHANTSOLUTIONS,
+                                    ))?;
+                                    Ok::<_, error_stack::Report<errors::ConnectorError>>(
+                                        compute_capturable_amount(total_minor, captured_minor),
+                                    )
                                 })
                                 .transpose()?;
 

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
@@ -12,7 +12,7 @@ use base64::Engine;
 use bytes::Bytes;
 use common_enums::CurrencyUnit;
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit,
+    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan.rs
@@ -11,9 +11,7 @@ use std::fmt::Debug;
 use base64::Engine;
 use bytes::Bytes;
 use common_enums::CurrencyUnit;
-use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{consts, errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, PSync, RSync, Refund, RepeatPayment,

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/requests.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/requests.rs
@@ -1,4 +1,4 @@
-use common_utils::types::MinorUnit;
+use common_utils::types::ConnectorMinorUnit;
 use domain_types::payment_method_data::{PaymentMethodDataTypes, RawCardNumber};
 use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ pub struct JpmorganTokenRequest {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganPaymentsRequest<T: PaymentMethodDataTypes> {
     pub capture_method: CapMethod,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
     pub merchant: JpmorganMerchant,
     pub payment_method_type: JpmorganPaymentMethodType<T>,
@@ -119,7 +119,7 @@ pub enum CapMethod {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganCaptureRequest {
     pub capture_method: CapMethod,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
 }
 
@@ -144,7 +144,7 @@ pub struct JpmorganVoidPcRequest {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganRefundRequest {
     pub merchant: JpmorganMerchantRefund,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
 }
 
@@ -242,7 +242,7 @@ pub struct JpmorganRepeatPaymentMethodType<T: PaymentMethodDataTypes> {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganSetupMandateRequest<T: PaymentMethodDataTypes> {
     pub capture_method: CapMethod,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
     pub merchant: JpmorganMerchant,
     pub payment_method_type: JpmorganSetupMandatePaymentMethodType<T>,
@@ -257,7 +257,7 @@ pub struct JpmorganSetupMandateRequest<T: PaymentMethodDataTypes> {
 #[serde(rename_all = "camelCase")]
 pub struct JpmorganRepeatPaymentRequest<T: PaymentMethodDataTypes> {
     pub capture_method: CapMethod,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
     pub merchant: JpmorganMerchant,
     pub payment_method_type: JpmorganRepeatPaymentMethodType<T>,

--- a/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorgan/transformers.rs
@@ -1191,7 +1191,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                             })
                     })
                     .transpose()?
-                    .unwrap_or(common_utils::types::MinorUnit::new(0));
+                    .unwrap_or(common_utils::ConnectorMinorUnit::default());
 
                 let recurring = requests::JpmorganRecurring {
                     recurring_sequence: requests::JpmorganRecurringSequence::First,

--- a/crates/integrations/connector-integration/src/connectors/jpmorganorbital/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/jpmorganorbital/transformers.rs
@@ -308,19 +308,18 @@ fn build_amount(
     minor_amount: MinorUnit,
     currency: Currency,
 ) -> Result<StringTwoDecimalUnit, error_stack::Report<IntegrationError>> {
-    let minor = minor_amount.get_amount_as_i64();
     let amount = StringTwoDecimalUnitForConnector
         .convert(minor_amount, currency)
         .map_err(|_| {
             invalid_amount(format!(
-                "{currency} has more than two decimal places, so {minor} minor units cannot be \
-                 expressed in the two decimals order.amount implies"
+                "{currency} has more than two decimal places, so {minor_amount:?} minor units \
+                 cannot be expressed in the two decimals order.amount implies"
             ))
         })?;
     let amount = amount.validate_unsigned("order.amount").map_err(|_| {
         invalid_amount(format!(
-            "order.amount is unsigned at Orbital, but {minor} minor units of {currency} is \
-             negative"
+            "order.amount is unsigned at Orbital, but {minor_amount:?} minor units of \
+             {currency} is negative"
         ))
     })?;
     // `validate_max_len` consumes the amount, so keep the encoded form for the message.
@@ -329,8 +328,8 @@ fn build_amount(
         .validate_max_len(MAX_AMOUNT_LEN, "order.amount")
         .map_err(|_| {
             invalid_amount(format!(
-                "order.amount holds at most {MAX_AMOUNT_LEN} characters, but {minor} minor \
-                 units of {currency} encodes to `{encoded}` ({} characters)",
+                "order.amount holds at most {MAX_AMOUNT_LEN} characters, but {minor_amount:?} \
+                 minor units of {currency} encodes to `{encoded}` ({} characters)",
                 encoded.len()
             ))
         })

--- a/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
@@ -1046,19 +1046,18 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let router_data = wrapper.router_data;
 
         let amount_to_capture = router_data.request.minor_amount_to_capture;
-        let converted_capture = JuspayAmountConvertor::convert(
-            amount_to_capture,
-            router_data.request.currency,
-        )?;
-        let original_converted = router_data
-            .resource_common_data
-            .amount
-            .as_ref()
-            .and_then(|money| {
-                money
-                    .convert(&common_utils::types::StringMajorUnitForConnector)
-                    .ok()
-            });
+        let converted_capture =
+            JuspayAmountConvertor::convert(amount_to_capture, router_data.request.currency)?;
+        let original_converted =
+            router_data
+                .resource_common_data
+                .amount
+                .as_ref()
+                .and_then(|money| {
+                    money
+                        .convert(&common_utils::types::StringMajorUnitForConnector)
+                        .ok()
+                });
 
         let amount = match original_converted {
             Some(ref total) if *total == converted_capture => None,

--- a/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay/transformers.rs
@@ -1046,18 +1046,23 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let router_data = wrapper.router_data;
 
         let amount_to_capture = router_data.request.minor_amount_to_capture;
-        let original_amount = router_data
+        let converted_capture = JuspayAmountConvertor::convert(
+            amount_to_capture,
+            router_data.request.currency,
+        )?;
+        let original_converted = router_data
             .resource_common_data
             .amount
             .as_ref()
-            .map(|money| money.amount);
+            .and_then(|money| {
+                money
+                    .convert(&common_utils::types::StringMajorUnitForConnector)
+                    .ok()
+            });
 
-        let amount = match original_amount {
-            Some(total) if total == amount_to_capture => None,
-            _ => Some(JuspayAmountConvertor::convert(
-                amount_to_capture,
-                router_data.request.currency,
-            )?),
+        let amount = match original_converted {
+            Some(ref total) if *total == converted_capture => None,
+            _ => Some(converted_capture),
         };
 
         Ok(Self { amount })

--- a/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/juspay_upi_stack/transformers.rs
@@ -9,6 +9,7 @@
 use crate::connectors::juspay_upi_stack::{constants::*, crypto::sign_jws, types::*};
 use common_enums as enums;
 use common_utils::errors::CustomResult;
+use common_utils::types::{AmountConvertor, MinorUnitForConnector};
 use common_utils::SecretSerdeValue;
 use domain_types::{
     connector_types::{
@@ -424,8 +425,17 @@ pub fn build_refund_request(
         (None, None)
     };
 
-    // Convert minor units (paise) to rupees with 2 decimal places using integer arithmetic
-    let amount_minor = refunds_data.minor_refund_amount.get_amount_as_i64();
+    // Convert minor units (paise) to rupees with 2 decimal places via amount converter
+    let connector_amount = MinorUnitForConnector
+        .convert(refunds_data.minor_refund_amount, refunds_data.currency)
+        .map_err(|_| IntegrationError::AmountConversionFailed {
+            context: Default::default(),
+        })?;
+    let amount_minor: i64 = connector_amount.to_string().parse().map_err(|_| {
+        IntegrationError::AmountConversionFailed {
+            context: Default::default(),
+        }
+    })?;
     let refund_amount = minor_to_major_amount(amount_minor);
 
     let refund_request = Refund360Request {
@@ -475,7 +485,11 @@ pub fn build_rsync_request(
     let amount_str = refund_sync_data
         .refund_money
         .as_ref()
-        .map(|m| minor_to_major_amount(m.amount.get_amount_as_i64()))
+        .map(|m| {
+            m.convert(&common_utils::types::StringMajorUnitForConnector)
+                .map(|s| s.get_amount_as_string())
+                .unwrap_or_else(|_| String::from("0.00"))
+        })
         .ok_or_else(|| IntegrationError::MissingRequiredField {
             field_name: "refund_money",
             context: IntegrationErrorContext {

--- a/crates/integrations/connector-integration/src/connectors/kount.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use common_enums::CurrencyUnit;
 use common_utils::{
     consts::BASE64_ENGINE_URL_SAFE_NO_PAD, errors::CustomResult, events, ext_traits::ByteSliceExt,
-    types::StringMinorUnit,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -1,4 +1,5 @@
 use common_enums::{AttemptStatus, FrmDecision, PaymentMethodType};
+use error_stack::ResultExt;
 use common_utils::types::StringMinorUnit;
 use domain_types::{
     connector_flow::{
@@ -1100,8 +1101,11 @@ impl TryFrom<&MandateAmountData> for KountRecurring {
         // independent of the connector's main amount converter. Omit a 0 value so
         // we never emit a bogus "0" to Kount.
         let minor_unit_amount = |money: &common_utils::types::Money| {
-            let amount = money.amount.get_amount_as_i64();
-            (amount != 0).then(|| amount.to_string())
+            money
+                .convert(&common_utils::types::MinorUnitForConnector)
+                .ok()
+                .filter(|a| *a != common_utils::ConnectorMinorUnit::default())
+                .map(|a| a.to_string())
         };
         // Shared MandateAmountData carries dates as PrimitiveDateTime; Kount's
         // recurring block wants RFC 3339 (UTC) strings.
@@ -1502,7 +1506,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             account_is_active: None,
         });
 
-        let currency = req.amount.currency;
+        let currency = req.amount.currency();
 
         // Subscription / recurring context, applied to every line item when the
         // order carries mandate info.
@@ -1608,7 +1612,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             })
         });
 
-        let amount = super::KountAmountConvertor::convert(req.amount.amount, currency)?;
+        let amount = req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+            .change_context(errors::IntegrationError::AmountConversionFailed {
+                context: Default::default(),
+            })?;
         let transactions = vec![KountTransaction {
             subtotal: amount.clone(),
             order_total: amount,
@@ -1962,11 +1969,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             payment_status: req
                 .payment_status
                 .and_then(KountPaymentStatus::from_attempt_status),
-            order_total: super::KountAmountConvertor::convert(
-                req.amount.amount,
-                req.amount.currency,
-            )?,
-            currency: req.amount.currency.to_string(),
+            order_total: req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+                .change_context(errors::IntegrationError::AmountConversionFailed {
+                    context: Default::default(),
+                })?,
+            currency: req.amount.currency().to_string(),
             frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
             merchant_category_code,
             merchant,
@@ -2100,11 +2107,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .clone()
                 .or_else(|| req.merchant_refund_id.clone()),
             refund_reason: req.refund_reason.clone(),
-            refund_amount: super::KountAmountConvertor::convert(
-                req.amount.amount,
-                req.amount.currency,
-            )?,
-            currency: req.amount.currency.to_string(),
+            refund_amount: req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+                .change_context(errors::IntegrationError::AmountConversionFailed {
+                    context: Default::default(),
+                })?,
+            currency: req.amount.currency().to_string(),
             frm_disposition: req.frm_decision.and_then(KountDisposition::from_decision),
             merchant_category_code,
             merchant,

--- a/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/kount/transformers.rs
@@ -1,5 +1,4 @@
 use common_enums::{AttemptStatus, FrmDecision, PaymentMethodType};
-use error_stack::ResultExt;
 use common_utils::types::StringMinorUnit;
 use domain_types::{
     connector_flow::{
@@ -24,6 +23,7 @@ use domain_types::{
     router_data_v2::RouterDataV2,
     router_response_types::{RedirectForm, Response},
 };
+use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
@@ -1612,7 +1612,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             })
         });
 
-        let amount = req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+        let amount = req
+            .amount
+            .convert(&common_utils::types::StringMinorUnitForConnector)
             .change_context(errors::IntegrationError::AmountConversionFailed {
                 context: Default::default(),
             })?;
@@ -1969,7 +1971,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             payment_status: req
                 .payment_status
                 .and_then(KountPaymentStatus::from_attempt_status),
-            order_total: req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+            order_total: req
+                .amount
+                .convert(&common_utils::types::StringMinorUnitForConnector)
                 .change_context(errors::IntegrationError::AmountConversionFailed {
                     context: Default::default(),
                 })?,
@@ -2107,7 +2111,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .clone()
                 .or_else(|| req.merchant_refund_id.clone()),
             refund_reason: req.refund_reason.clone(),
-            refund_amount: req.amount.convert(&common_utils::types::StringMinorUnitForConnector)
+            refund_amount: req
+                .amount
+                .convert(&common_utils::types::StringMinorUnitForConnector)
                 .change_context(errors::IntegrationError::AmountConversionFailed {
                     context: Default::default(),
                 })?,

--- a/crates/integrations/connector-integration/src/connectors/loonio.rs
+++ b/crates/integrations/connector-integration/src/connectors/loonio.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use common_enums::CurrencyUnit;
 use common_utils::{
     consts::NO_ERROR_CODE, errors::CustomResult, events, ext_traits::ByteSliceExt,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::*,

--- a/crates/integrations/connector-integration/src/connectors/loonio.rs
+++ b/crates/integrations/connector-integration/src/connectors/loonio.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    consts::NO_ERROR_CODE, errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{consts::NO_ERROR_CODE, errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::*,
     connector_types::*,

--- a/crates/integrations/connector-integration/src/connectors/macros.rs
+++ b/crates/integrations/connector-integration/src/connectors/macros.rs
@@ -1168,6 +1168,15 @@ macro_rules! expand_connector_input_data {
 }
 pub(crate) use expand_connector_input_data;
 
+/// Maps the user-facing amount-unit token to the actual `AmountConvertor::Output` type.
+/// `MinorUnit` → `ConnectorMinorUnit` (because `MinorUnitForConnector::Output` changed);
+/// everything else passes through unchanged.
+macro_rules! resolve_amount_output {
+    (MinorUnit) => { common_utils::types::ConnectorMinorUnit };
+    ($other:ident) => { common_utils::types::$other };
+}
+pub(crate) use resolve_amount_output;
+
 macro_rules! create_all_prerequisites {
     (
         connector_name: $connector: ident,
@@ -1184,7 +1193,7 @@ macro_rules! create_all_prerequisites {
             ),*
         ],
         amount_converters: [
-            $($converter_name:ident : $amount_unit:ty),*
+            $($converter_name:ident : $amount_unit:ident),*
         ],
         member_functions: {
             $($function_def: tt)*
@@ -1205,7 +1214,7 @@ macro_rules! create_all_prerequisites {
         paste::paste! {
             pub struct $connector<$generic_type: PaymentMethodDataTypes + std::fmt::Debug + std::marker::Sync + std::marker::Send + 'static + serde::Serialize> {
                 $(
-                    pub $converter_name: &'static (dyn common_utils::types::AmountConvertor<Output = $amount_unit> + Sync),
+                    pub $converter_name: &'static (dyn common_utils::types::AmountConvertor<Output = crate::connectors::macros::resolve_amount_output!($amount_unit)> + Sync),
                 )*
                 $(
                     [<$flow_name:snake>]: &'static dyn BridgeRequestResponse<
@@ -1375,6 +1384,53 @@ macro_rules! expand_imports {
 pub(crate) use expand_imports;
 
 macro_rules! create_amount_converter_wrapper {
+    // Specialized arm: when amount_type is MinorUnit, the convertor
+    // (MinorUnitForConnector) outputs ConnectorMinorUnit.
+    (connector_name: $connector_name:ident, amount_type: MinorUnit) => {
+        paste::paste! {
+            #[derive(Default, Debug, Clone, Copy, PartialEq)]
+            pub struct [<$connector_name AmountConvertor>];
+
+            impl [<$connector_name AmountConvertor>] {
+                pub fn convert(
+                    amount: common_utils::types::MinorUnit,
+                    currency: common_enums::Currency,
+                ) -> Result<
+                    common_utils::types::ConnectorMinorUnit,
+                    error_stack::Report<domain_types::errors::IntegrationError>,
+                > {
+                    {
+                        use error_stack::ResultExt;
+                        domain_types::utils::convert_amount(
+                            &common_utils::types::MinorUnitForConnector,
+                            amount,
+                            currency,
+                        ).change_context(domain_types::errors::IntegrationError::InvalidDataFormat {
+                            field_name: "amount",
+                            context: Default::default()
+                        })
+                    }
+                }
+
+                /// Convert connector amount back to MinorUnit.
+                pub fn convert_back(
+                    amount: common_utils::types::ConnectorMinorUnit,
+                    currency: common_enums::Currency,
+                ) -> Result<
+                    common_utils::types::MinorUnit,
+                    error_stack::Report<common_utils::errors::ParsingError>,
+                > {
+                    domain_types::utils::convert_back_amount_to_minor_units(
+                        &common_utils::types::MinorUnitForConnector,
+                        amount,
+                        currency,
+                    )
+                }
+            }
+        }
+    };
+    // General arm for all other amount types (StringMajorUnit, FloatMajorUnit,
+    // StringMinorUnit, etc.)
     (connector_name: $connector_name:ident, amount_type: $amount_type:ty) => {
         paste::paste! {
             #[derive(Default, Debug, Clone, Copy, PartialEq)]

--- a/crates/integrations/connector-integration/src/connectors/macros.rs
+++ b/crates/integrations/connector-integration/src/connectors/macros.rs
@@ -1172,8 +1172,12 @@ pub(crate) use expand_connector_input_data;
 /// `MinorUnit` → `ConnectorMinorUnit` (because `MinorUnitForConnector::Output` changed);
 /// everything else passes through unchanged.
 macro_rules! resolve_amount_output {
-    (MinorUnit) => { common_utils::types::ConnectorMinorUnit };
-    ($other:ident) => { common_utils::types::$other };
+    (MinorUnit) => {
+        common_utils::types::ConnectorMinorUnit
+    };
+    ($other:ident) => {
+        common_utils::types::$other
+    };
 }
 pub(crate) use resolve_amount_output;
 

--- a/crates/integrations/connector-integration/src/connectors/maya.rs
+++ b/crates/integrations/connector-integration/src/connectors/maya.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{self, Authorize, PSync, RSync, Refund, Void},
     connector_types::*,

--- a/crates/integrations/connector-integration/src/connectors/mifinity.rs
+++ b/crates/integrations/connector-integration/src/connectors/mifinity.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, PSync},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/mollie.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::{CurrencyUnit, PaymentMethod, PaymentMethodType};
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/mollie.rs
+++ b/crates/integrations/connector-integration/src/connectors/mollie.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::{CurrencyUnit, PaymentMethod, PaymentMethodType};
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, PSync, PaymentMethodToken, RSync, Refund,

--- a/crates/integrations/connector-integration/src/connectors/moneris.rs
+++ b/crates/integrations/connector-integration/src/connectors/moneris.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, PSync, PostAuthenticate, PreAuthenticate, RSync, Refund, RepeatPayment,

--- a/crates/integrations/connector-integration/src/connectors/moneris/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/moneris/transformers.rs
@@ -576,10 +576,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .authentication_data
                     .as_ref()
                     .is_some_and(|a| a.cavv.is_some());
-                let amount = Money {
-                    amount: item.router_data.request.minor_amount,
-                    currency: item.router_data.request.currency,
-                };
+                let amount = Money::from_minor_unit(
+                    item.router_data.request.minor_amount,
+                    item.router_data.request.currency,
+                );
                 let ecommerce_indicator = Some(derive_ecommerce_indicator(
                     item.router_data.request.payment_channel.as_ref(),
                     item.router_data.request.mit_category.as_ref(),
@@ -844,10 +844,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     }
                 };
 
-                let amount = Money {
-                    amount: item.router_data.request.minor_amount,
-                    currency: item.router_data.request.currency,
-                };
+                let amount = Money::from_minor_unit(
+                    item.router_data.request.minor_amount,
+                    item.router_data.request.currency,
+                );
 
                 Ok(Self {
                     idempotency_key,
@@ -1142,10 +1142,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         issuer_id: None,
                     }),
                 });
-                let amount = Money {
-                    amount: item.router_data.request.minor_amount,
-                    currency: item.router_data.request.currency,
-                };
+                let amount = Money::from_minor_unit(
+                    item.router_data.request.minor_amount,
+                    item.router_data.request.currency,
+                );
                 Ok(Self {
                     idempotency_key,
                     amount,
@@ -1199,10 +1199,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = Money {
-            currency: item.router_data.request.currency,
-            amount: item.router_data.request.minor_amount_to_capture,
-        };
+        let amount = Money::from_minor_unit(
+            item.router_data.request.minor_amount_to_capture,
+            item.router_data.request.currency,
+        );
         let idempotency_key = format!(
             "capture_{}",
             item.router_data
@@ -1276,10 +1276,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let refund_amount = Money {
-            currency: item.router_data.request.currency,
-            amount: item.router_data.request.minor_refund_amount,
-        };
+        let refund_amount = Money::from_minor_unit(
+            item.router_data.request.minor_refund_amount,
+            item.router_data.request.currency,
+        );
         let idempotency_key = format!(
             "refund_{}",
             item.router_data
@@ -1729,10 +1729,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             country: resource.get_optional_billing_country(),
         };
 
-        let amount = Money {
-            currency: req.currency.unwrap_or_default(),
-            amount: req.amount,
-        };
+        let amount = Money::from_minor_unit(req.amount, req.currency.unwrap_or_default());
 
         let idempotency_key = format!("3ds_{}", resource.connector_request_reference_id);
 

--- a/crates/integrations/connector-integration/src/connectors/nexinets.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets.rs
@@ -38,6 +38,7 @@ use transformers::{
 };
 
 use super::macros;
+macros::create_amount_converter_wrapper!(connector_name: Nexinets, amount_type: MinorUnit);
 use crate::{types::ResponseRouterData, utils, with_error_response_body};
 pub const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
 
@@ -262,7 +263,7 @@ macros::create_all_prerequisites!(
             router_data: RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         )
     ],
-    amount_converters: [],
+    amount_converters: [amount_converter: MinorUnit],
     member_functions: {
         pub fn build_headers<F, FCD, Req, Res>(
             &self,

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -1176,16 +1176,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
         // Nexinets requires a positive initialAmount. Error upfront when
         // the caller omits amount instead of silently defaulting.
-        let initial_amount = request
-            .minor_amount
-            .ok_or(IntegrationError::MissingRequiredField {
-                field_name: "amount",
-                context: Default::default(),
-            })?;
-        let initial_amount = super::NexinetsAmountConvertor::convert(
-            initial_amount,
-            request.currency,
-        )?;
+        let initial_amount =
+            request
+                .minor_amount
+                .ok_or(IntegrationError::MissingRequiredField {
+                    field_name: "amount",
+                    context: Default::default(),
+                })?;
+        let initial_amount =
+            super::NexinetsAmountConvertor::convert(initial_amount, request.currency)?;
 
         let merchant_order_id = Some(
             router_data

--- a/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexinets/transformers.rs
@@ -4,6 +4,7 @@ use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
     request::Method,
+    types::ConnectorMinorUnit,
 };
 use domain_types::{
     connector_flow::{
@@ -41,7 +42,7 @@ pub const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::genera
 pub struct NexinetsPaymentsRequest<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 > {
-    initial_amount: i64,
+    initial_amount: ConnectorMinorUnit,
     currency: enums::Currency,
     channel: NexinetsChannel,
     product: NexinetsProduct,
@@ -234,7 +235,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             _ => None,
         };
         Ok(Self {
-            initial_amount: item.router_data.request.amount.get_amount_as_i64(),
+            initial_amount: super::NexinetsAmountConvertor::convert(
+                item.router_data.request.minor_amount,
+                item.router_data.request.currency,
+            )?,
             currency: item.router_data.request.currency,
             channel: NexinetsChannel::Ecom,
             product,
@@ -462,7 +466,7 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NexinetsCaptureOrVoidRequest {
-    pub initial_amount: i64,
+    pub initial_amount: ConnectorMinorUnit,
     pub currency: enums::Currency,
 }
 
@@ -488,7 +492,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            initial_amount: item.router_data.request.amount_to_capture,
+            initial_amount: super::NexinetsAmountConvertor::convert(
+                item.router_data.request.minor_amount_to_capture,
+                item.router_data.request.currency,
+            )?,
             currency: item.router_data.request.currency,
         })
     }
@@ -526,7 +533,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     context: Default::default(),
                 })?;
         Ok(Self {
-            initial_amount: amount.get_amount_as_i64(),
+            initial_amount: super::NexinetsAmountConvertor::convert(amount, currency)?,
             currency,
         })
     }
@@ -596,7 +603,7 @@ impl<F, T> TryFrom<ResponseRouterData<NexinetsPaymentResponse, Self>>
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NexinetsRefundRequest {
-    pub initial_amount: i64,
+    pub initial_amount: ConnectorMinorUnit,
     pub currency: enums::Currency,
 }
 
@@ -613,7 +620,10 @@ impl<F, T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
         >,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            initial_amount: item.router_data.request.refund_amount,
+            initial_amount: super::NexinetsAmountConvertor::convert(
+                item.router_data.request.minor_refund_amount,
+                item.router_data.request.currency,
+            )?,
             currency: item.router_data.request.currency,
         })
     }
@@ -957,7 +967,7 @@ fn is_mandate_payment<
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NexinetsClientAuthRequest {
-    pub initial_amount: i64,
+    pub initial_amount: ConnectorMinorUnit,
     pub currency: enums::Currency,
     pub channel: NexinetsChannel,
     pub transaction_type: NexinetsTransactionType,
@@ -999,7 +1009,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         };
 
         Ok(Self {
-            initial_amount: router_data.request.amount.get_amount_as_i64(),
+            initial_amount: super::NexinetsAmountConvertor::convert(
+                router_data.request.amount,
+                router_data.request.currency,
+            )?,
             currency: router_data.request.currency,
             channel: NexinetsChannel::Ecom,
             transaction_type: NexinetsTransactionType::Preauth,
@@ -1069,7 +1082,7 @@ impl TryFrom<ResponseRouterData<NexinetsClientAuthResponse, Self>>
 pub struct NexinetsSetupMandateRequest<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 > {
-    initial_amount: i64,
+    initial_amount: ConnectorMinorUnit,
     currency: enums::Currency,
     channel: NexinetsChannel,
     product: NexinetsProduct,
@@ -1164,12 +1177,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         // Nexinets requires a positive initialAmount. Error upfront when
         // the caller omits amount instead of silently defaulting.
         let initial_amount = request
-            .amount
-            .or_else(|| request.minor_amount.map(|m| m.get_amount_as_i64()))
+            .minor_amount
             .ok_or(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: Default::default(),
             })?;
+        let initial_amount = super::NexinetsAmountConvertor::convert(
+            initial_amount,
+            request.currency,
+        )?;
 
         let merchant_order_id = Some(
             router_data
@@ -1313,7 +1329,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NexinetsRepeatPaymentRequest {
-    initial_amount: i64,
+    initial_amount: ConnectorMinorUnit,
     currency: enums::Currency,
     channel: NexinetsChannel,
     product: NexinetsProduct,
@@ -1403,7 +1419,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         );
 
         Ok(Self {
-            initial_amount: request.amount,
+            initial_amount: super::NexinetsAmountConvertor::convert(
+                request.minor_amount,
+                request.currency,
+            )?,
             currency: request.currency,
             channel: NexinetsChannel::Ecom,
             product: NexinetsProduct::Creditcard,

--- a/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nexixpay/transformers.rs
@@ -1365,7 +1365,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         });
 
         // Add actionType logic for zero-amount payments
-        let action_type = if item.request.amount == common_utils::types::MinorUnit::zero() {
+        let action_type = if item.request.amount == common_utils::types::MinorUnit::default() {
             Some(NexixpayPaymentRequestActionType::Verify)
         } else {
             None
@@ -2013,7 +2013,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let order = NexixpayPreAuthOrder {
             order_id: get_nexi_order_id(&item.resource_common_data.connector_request_reference_id)?,
             amount: StringMinorUnitForConnector
-                .convert(common_utils::types::MinorUnit::zero(), currency)
+                .convert(common_utils::types::MinorUnit::default(), currency)
                 .change_context(IntegrationError::RequestEncodingFailed {
                     context: Default::default(),
                 })?,

--- a/crates/integrations/connector-integration/src/connectors/nmi.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi.rs
@@ -4,7 +4,7 @@ use domain_types::router_data::ConnectorSpecificConfig;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, PSync, PreAuthenticate, RSync, Refund, RepeatPayment, SetupMandate,

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1,5 +1,6 @@
 use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, RefundStatus};
+use common_utils::types::MinorUnitForConnector;
 use common_utils::types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector};
 use domain_types::{
     connector_flow::{
@@ -1511,6 +1512,24 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NmiVaultResponse, Sel
                         context: Default::default(),
                     },
                 )?;
+                let connector_amount = AmountConvertor::convert(
+                    &MinorUnitForConnector,
+                    amount_data,
+                    currency_data,
+                )
+                .map_err(|_| {
+                    error_stack::report!(ConnectorError::ResponseHandlingFailed {
+                        context: Default::default(),
+                    })
+                })?;
+                let minor_amount_i64: i64 = connector_amount
+                    .to_string()
+                    .parse()
+                    .map_err(|_| {
+                        error_stack::report!(ConnectorError::ResponseHandlingFailed {
+                            context: Default::default(),
+                        })
+                    })?;
                 let customer_vault_id = response.customer_vault_id.clone().ok_or_else(|| {
                     error_stack::report!(ConnectorError::UnexpectedResponseError {
                         context: Default::default(),
@@ -1524,7 +1543,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NmiVaultResponse, Sel
                         authentication_data: None,
                         redirection_data: Some(Box::new(RedirectForm::Nmi {
                             amount: Money {
-                                minor_amount: amount_data.get_amount_as_i64(),
+                                minor_amount: minor_amount_i64,
                                 currency: Currency::foreign_try_from(currency_data)
                                     .map_err(|_| {
                                         error_stack::report!(

--- a/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nmi/transformers.rs
@@ -1512,24 +1512,18 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<NmiVaultResponse, Sel
                         context: Default::default(),
                     },
                 )?;
-                let connector_amount = AmountConvertor::convert(
-                    &MinorUnitForConnector,
-                    amount_data,
-                    currency_data,
-                )
-                .map_err(|_| {
+                let connector_amount =
+                    AmountConvertor::convert(&MinorUnitForConnector, amount_data, currency_data)
+                        .map_err(|_| {
+                            error_stack::report!(ConnectorError::ResponseHandlingFailed {
+                                context: Default::default(),
+                            })
+                        })?;
+                let minor_amount_i64: i64 = connector_amount.to_string().parse().map_err(|_| {
                     error_stack::report!(ConnectorError::ResponseHandlingFailed {
                         context: Default::default(),
                     })
                 })?;
-                let minor_amount_i64: i64 = connector_amount
-                    .to_string()
-                    .parse()
-                    .map_err(|_| {
-                        error_stack::report!(ConnectorError::ResponseHandlingFailed {
-                            context: Default::default(),
-                        })
-                    })?;
                 let customer_vault_id = response.customer_vault_id.clone().ok_or_else(|| {
                     error_stack::report!(ConnectorError::UnexpectedResponseError {
                         context: Default::default(),

--- a/crates/integrations/connector-integration/src/connectors/noon.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon.rs
@@ -7,7 +7,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/noon/transformers.rs
@@ -475,9 +475,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         MandateDataType::MultiUse(amount_data_opt) => amount_data_opt.as_ref(),
                     };
                     mandate_amount_data.map(|amount_data| {
-                        data.connector
-                            .amount_converter
-                            .convert(amount_data.amount.amount, amount_data.amount.currency)
+                        amount_data
+                            .amount
+                            .convert(data.connector.amount_converter)
                             .map(|max_amount| NoonSubscriptionData {
                                 subscription_type: NoonSubscriptionType::Unscheduled,
                                 name: name.clone(),
@@ -1169,8 +1169,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let item = &data.router_data;
+        // Noon requires a non-zero amount for setup mandate.
+        // The actual mandate amount comes from setup_mandate_details below.
+        // This nominal amount satisfies the API requirement.
         let amount = data.connector.amount_converter.convert(
-            common_utils::types::MinorUnit::new(1),
+            data.router_data.request.minor_amount.unwrap_or_default(),
             data.router_data.request.currency,
         );
         let mandate_amount = &data.router_data.request.setup_mandate_details;
@@ -1383,9 +1386,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                         MandateDataType::MultiUse(amount_data_opt) => amount_data_opt.as_ref(),
                     };
                     mandate_amount_data.map(|amount_data| {
-                        data.connector
-                            .amount_converter
-                            .convert(amount_data.amount.amount, amount_data.amount.currency)
+                        amount_data
+                            .amount
+                            .convert(data.connector.amount_converter)
                             .map(|max_amount| NoonSubscriptionData {
                                 subscription_type: NoonSubscriptionType::Unscheduled,
                                 name: name.clone(),

--- a/crates/integrations/connector-integration/src/connectors/novalnet.rs
+++ b/crates/integrations/connector-integration/src/connectors/novalnet.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::StringMinorUnit,
 };
 use domain_types::{
     connector_flow::{
@@ -627,8 +626,16 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             }
         };
         let amount = amount
-            .map(|amount| amount.to_string())
-            .unwrap_or("".to_string());
+            .and_then(|amount| {
+                common_utils::AmountConvertor::convert(
+                    &common_utils::MinorUnitForConnector,
+                    amount,
+                    currency.unwrap_or_default(),
+                )
+                .ok()
+                .map(|a| a.to_string())
+            })
+            .unwrap_or_default();
         let currency = currency
             .map(|amount| amount.to_string())
             .unwrap_or("".to_string());

--- a/crates/integrations/connector-integration/src/connectors/nuvei.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei.rs
@@ -1,5 +1,5 @@
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::BytesExt, types::StringMajorUnit,
+    consts, errors::CustomResult, events, ext_traits::BytesExt,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/nuvei.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei.rs
@@ -1,6 +1,4 @@
-use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::BytesExt,
-};
+use common_utils::{consts, errors::CustomResult, events, ext_traits::BytesExt};
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/nuvei/transformers.rs
@@ -1687,7 +1687,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .connector
             .amount_converter_webhooks
             .convert(
-                common_utils::types::MinorUnit::new(router_data.request.refund_amount),
+                router_data.request.minor_refund_amount,
                 router_data.request.currency,
             )
             .change_context(IntegrationError::RequestEncodingFailed {
@@ -2694,7 +2694,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let minor_amount = router_data
             .request
             .minor_amount
-            .unwrap_or(common_utils::types::MinorUnit::new(0));
+            .unwrap_or(common_utils::types::MinorUnit::default());
         let currency = router_data.request.currency;
         let amount = item
             .connector

--- a/crates/integrations/connector-integration/src/connectors/paybox.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox.rs
@@ -1,7 +1,7 @@
 pub mod transformers;
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::MinorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paybox/transformers.rs
@@ -5,7 +5,7 @@ use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::{
     date_time::{format_date, now, now_unix_millis, DateFormat},
     errors::CustomResult,
-    types::MinorUnit,
+    types::{ConnectorMinorUnit, MinorUnit},
 };
 use domain_types::payment_method_data::RawCardNumber;
 use domain_types::{
@@ -186,7 +186,7 @@ pub struct PayboxPaymentRequest<T: PaymentMethodDataTypes> {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     pub reference: String,
@@ -542,7 +542,7 @@ pub struct PayboxCaptureRequest {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     #[serde(rename = "REFERENCE")]
@@ -706,7 +706,7 @@ pub struct PayboxVoidRequest {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     #[serde(rename = "REFERENCE")]
@@ -874,7 +874,7 @@ pub struct PayboxRefundRequest {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     #[serde(rename = "REFERENCE")]
@@ -1134,7 +1134,7 @@ pub struct PayboxSetupMandateRequest<T: PaymentMethodDataTypes> {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     pub reference: String,
@@ -1212,7 +1212,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 })?,
             None => connector
                 .amount_converter
-                .convert(MinorUnit::zero(), router_data.request.currency)
+                .convert(MinorUnit::default(), router_data.request.currency)
                 .change_context(IntegrationError::AmountConversionFailed {
                     context: Default::default(),
                 })?,
@@ -1376,7 +1376,7 @@ pub struct PayboxRepeatPaymentRequest {
     #[serde(rename = "NUMQUESTION")]
     pub paybox_request_number: String,
     #[serde(rename = "MONTANT")]
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(rename = "DEVISE")]
     pub currency: String,
     pub reference: String,

--- a/crates/integrations/connector-integration/src/connectors/payconex.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex.rs
@@ -7,7 +7,6 @@ use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
     events,
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/payconex/transformers.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
-    types::{MinorUnit, StringMajorUnit},
+    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
@@ -444,7 +444,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .connector
             .amount_converter
             .convert(
-                MinorUnit::new(router_data.request.refund_amount),
+                router_data.request.minor_refund_amount,
                 router_data.request.currency,
             )
             .change_context(IntegrationError::AmountConversionFailed {

--- a/crates/integrations/connector-integration/src/connectors/paypal.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal.rs
@@ -7,7 +7,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    StringMajorUnit,
 };
 #[allow(unused_imports)]
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paypal/transformers.rs
@@ -145,7 +145,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 context: Default::default(),
             })?;
         // Hyperswitch treats `shipping_cost` as optional for the Authorize flow,
-        // defaulting to zero when absent (req.request.shipping_cost.unwrap_or(MinorUnit::zero())).
+        // defaulting to zero when absent (req.request.shipping_cost.unwrap_or(MinorUnit::default())).
         // Mirror that here instead of hard-failing with MissingRequiredField, otherwise UCS
         // returns gRPC InvalidArgument for card payments that carry no shipping_cost.
         let shipping_value = item
@@ -155,7 +155,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 item.router_data
                     .request
                     .shipping_cost
-                    .unwrap_or(common_utils::types::MinorUnit::zero()),
+                    .unwrap_or(common_utils::types::MinorUnit::default()),
                 item.router_data.request.currency,
             )
             .change_context(IntegrationError::AmountConversionFailed {
@@ -222,7 +222,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 item.router_data
                     .request
                     .shipping_cost
-                    .unwrap_or(common_utils::types::MinorUnit::zero()),
+                    .unwrap_or(common_utils::types::MinorUnit::default()),
                 item.router_data.request.currency,
             )
             .change_context(IntegrationError::AmountConversionFailed {

--- a/crates/integrations/connector-integration/src/connectors/paytm.rs
+++ b/crates/integrations/connector-integration/src/connectors/paytm.rs
@@ -5,7 +5,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::AttemptStatus;
-use common_utils::{errors::CustomResult, events, ext_traits::BytesExt, types::StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::BytesExt};
 use domain_types::{
     connector_flow::{Authorize, PSync, ServerSessionAuthenticationToken},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/payu.rs
+++ b/crates/integrations/connector-integration/src/connectors/payu.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::LazyLock};
 use base64::Engine;
 use common_enums::{enums, CaptureMethod, CurrencyUnit, PaymentMethod, PaymentMethodType};
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/payu.rs
+++ b/crates/integrations/connector-integration/src/connectors/payu.rs
@@ -4,9 +4,7 @@ use std::{fmt::Debug, sync::LazyLock};
 
 use base64::Engine;
 use common_enums::{enums, CaptureMethod, CurrencyUnit, PaymentMethod, PaymentMethodType};
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, PSync, RSync, Refund, ServerSessionAuthenticationToken, Void,

--- a/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/peachpayments/transformers.rs
@@ -3,7 +3,7 @@ use super::{requests, responses, PeachpaymentsRouterData};
 use crate::types::ResponseRouterData;
 use common_enums::{AttemptStatus, RefundStatus};
 use common_utils::ext_traits::StringExt;
-use common_utils::{consts, errors::CustomResult, types::MinorUnit, SecretSerdeValue};
+use common_utils::{consts, errors::CustomResult, SecretSerdeValue};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{
@@ -649,7 +649,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             ecommerce_card_payment_only_transaction_data:
                 requests::PeachpaymentsRefundTransactionData {
                     amount: requests::PeachpaymentsAmount {
-                        amount: MinorUnit::new(item.router_data.request.refund_amount),
+                        amount: item.router_data.request.minor_refund_amount,
                         currency_code: item.router_data.request.currency,
                         display_amount: None,
                     },

--- a/crates/integrations/connector-integration/src/connectors/phonepe.rs
+++ b/crates/integrations/connector-integration/src/connectors/phonepe.rs
@@ -7,7 +7,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::{ByteSliceExt, BytesExt},
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/phonepe/transformers.rs
@@ -3,7 +3,7 @@ use common_enums;
 use common_utils::{
     crypto::{self, GenerateDigest},
     ext_traits::Encode,
-    types::MinorUnit,
+    types::ConnectorMinorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
@@ -61,7 +61,7 @@ struct PhonepePaymentRequestPayload {
     merchant_transaction_id: String,
     #[serde(rename = "merchantUserId", skip_serializing_if = "Option::is_none")]
     merchant_user_id: Option<Secret<String>>,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "callbackUrl")]
     callback_url: String,
     #[serde(rename = "mobileNumber", skip_serializing_if = "Option::is_none")]
@@ -99,7 +99,7 @@ struct PhonepeWalletDebitPayload {
     merchant_id: Secret<String>,
     #[serde(rename = "merchantTransactionId")]
     merchant_transaction_id: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "mobileNumber")]
     mobile_number: Secret<String>,
     #[serde(rename = "callbackUrl", skip_serializing_if = "Option::is_none")]
@@ -217,7 +217,7 @@ pub struct PhonepeSyncResponseData {
     #[serde(rename = "transactionId", skip_serializing_if = "Option::is_none")]
     transaction_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    amount: Option<MinorUnit>,
+    amount: Option<ConnectorMinorUnit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     state: Option<String>,
     #[serde(rename = "responseCode", skip_serializing_if = "Option::is_none")]
@@ -1385,7 +1385,7 @@ struct PhonepeCaptureRequestPayload {
     original_transaction_id: String,
     #[serde(rename = "merchantTransactionId")]
     merchant_transaction_id: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
 }
 
 /// Top-level capture request structure: base64-encoded payload + checksum
@@ -1717,7 +1717,7 @@ struct PhonepeRefundRequestPayload {
     original_transaction_id: String,
     #[serde(rename = "merchantTransactionId")]
     merchant_transaction_id: String,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     #[serde(rename = "callbackUrl", skip_serializing_if = "Option::is_none")]
     callback_url: Option<String>,
 }
@@ -2082,7 +2082,7 @@ pub struct PhonepeWebhookPayload {
     pub merchant_transaction_id: String,
     #[serde(rename = "transactionId")]
     pub transaction_id: String,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     pub state: String,
     #[serde(rename = "responseCode")]
     pub response_code: Option<String>,

--- a/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
@@ -750,11 +750,10 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
         >,
     ) -> Result<Self, Self::Error> {
         let amount = domain_types::utils::convert_amount(
-                &common_utils::types::MinorUnitForConnector,
-                item.router_data.request.minor_amount,
-                item.router_data.request.currency,
-            )
-?;
+            &common_utils::types::MinorUnitForConnector,
+            item.router_data.request.minor_amount,
+            item.router_data.request.currency,
+        )?;
         let currency = item.router_data.request.currency.to_string();
 
         let payment_method_data = &item.router_data.request.payment_method_data;
@@ -804,11 +803,10 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
         >,
     ) -> Result<Self, Self::Error> {
         let amount = domain_types::utils::convert_amount(
-                &common_utils::types::MinorUnitForConnector,
-                item.router_data.request.minor_amount_to_capture,
-                item.router_data.request.currency,
-            )
-?;
+            &common_utils::types::MinorUnitForConnector,
+            item.router_data.request.minor_amount_to_capture,
+            item.router_data.request.currency,
+        )?;
         let currency = item.router_data.request.currency.to_string();
 
         Ok(Self {
@@ -844,11 +842,10 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
         >,
     ) -> Result<Self, Self::Error> {
         let amount = domain_types::utils::convert_amount(
-                &common_utils::types::MinorUnitForConnector,
-                item.router_data.request.minor_refund_amount,
-                item.router_data.request.currency,
-            )
-?;
+            &common_utils::types::MinorUnitForConnector,
+            item.router_data.request.minor_refund_amount,
+            item.router_data.request.currency,
+        )?;
         let currency = item.router_data.request.currency.to_string();
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/pinelabs_online/transformers.rs
@@ -81,7 +81,7 @@ impl TryFrom<&ConnectorSpecificConfig> for PinelabsOnlineAuthType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentAmount {
-    pub value: i64,
+    pub value: common_utils::ConnectorMinorUnit,
     pub currency: String,
 }
 
@@ -490,7 +490,11 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = item.router_data.request.amount.get_amount_as_i64();
+        let amount = domain_types::utils::convert_amount(
+            &common_utils::types::MinorUnitForConnector,
+            item.router_data.request.amount,
+            item.router_data.request.currency,
+        )?;
         let currency = item.router_data.request.currency.to_string();
 
         // `capture_method` is not part of `PaymentCreateOrderData` or `PaymentFlowData` —
@@ -745,7 +749,12 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = item.router_data.request.minor_amount.0;
+        let amount = domain_types::utils::convert_amount(
+                &common_utils::types::MinorUnitForConnector,
+                item.router_data.request.minor_amount,
+                item.router_data.request.currency,
+            )
+?;
         let currency = item.router_data.request.currency.to_string();
 
         let payment_method_data = &item.router_data.request.payment_method_data;
@@ -794,7 +803,12 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = item.router_data.request.minor_amount_to_capture.0;
+        let amount = domain_types::utils::convert_amount(
+                &common_utils::types::MinorUnitForConnector,
+                item.router_data.request.minor_amount_to_capture,
+                item.router_data.request.currency,
+            )
+?;
         let currency = item.router_data.request.currency.to_string();
 
         Ok(Self {
@@ -829,7 +843,12 @@ impl<T: PaymentMethodDataTypes + Debug + Send + Sync + 'static + Serialize>
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = item.router_data.request.minor_refund_amount.0;
+        let amount = domain_types::utils::convert_amount(
+                &common_utils::types::MinorUnitForConnector,
+                item.router_data.request.minor_refund_amount,
+                item.router_data.request.currency,
+            )
+?;
         let currency = item.router_data.request.currency.to_string();
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/powertranz.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz.rs
@@ -8,7 +8,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -437,7 +437,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .connector
             .amount_converter
             .convert(
-                common_utils::types::MinorUnit::new(request_data.amount_to_capture),
+                request_data.minor_amount_to_capture,
                 request_data.currency,
             )
             .change_context(IntegrationError::RequestEncodingFailed {
@@ -526,7 +526,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .connector
             .amount_converter
             .convert(
-                common_utils::types::MinorUnit::new(request_data.refund_amount),
+                request_data.minor_refund_amount,
                 request_data.currency,
             )
             .change_context(IntegrationError::RequestEncodingFailed {
@@ -846,7 +846,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             .convert(
                 request_data
                     .minor_amount
-                    .unwrap_or(common_utils::types::MinorUnit::new(0)),
+                    .unwrap_or(common_utils::types::MinorUnit::default()),
                 request_data.currency,
             )
             .change_context(IntegrationError::RequestEncodingFailed {

--- a/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/powertranz/transformers.rs
@@ -436,10 +436,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let amount = item
             .connector
             .amount_converter
-            .convert(
-                request_data.minor_amount_to_capture,
-                request_data.currency,
-            )
+            .convert(request_data.minor_amount_to_capture, request_data.currency)
             .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;
@@ -525,10 +522,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let amount = item
             .connector
             .amount_converter
-            .convert(
-                request_data.minor_refund_amount,
-                request_data.currency,
-            )
+            .convert(request_data.minor_refund_amount, request_data.currency)
             .change_context(IntegrationError::RequestEncodingFailed {
                 context: Default::default(),
             })?;

--- a/crates/integrations/connector-integration/src/connectors/ppro/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/test.rs
@@ -735,7 +735,7 @@ mod tests {
 #[cfg(test)]
 mod transformer_tests {
     use super::super::transformers::*;
-    use common_utils::MinorUnit;
+    use common_utils::{proto_boundary::MinorUnitProtoAccess, MinorUnit};
 
     macro_rules! ensure_eq {
         ($left:expr, $right:expr $(,)?) => {{

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -163,7 +163,7 @@ where
 
         let amount = Amount {
             currency: router_data.request.currency.to_string(),
-            value: common_utils::MinorUnit::new(router_data.request.amount.get_amount_as_i64()),
+            value: router_data.request.amount,
         };
 
         let authentication_settings = match router_data.request.payment_method_type {
@@ -832,12 +832,11 @@ where
                     .resource_common_data
                     .amount
                     .as_ref()
-                    .map(|m| m.currency)
+                    .map(|m| m.currency())
             });
 
-        let response_amount = resolved_minor_amount.map(|minor| common_utils::types::Money {
-            amount: minor,
-            currency: resolved_currency.unwrap_or_default(),
+        let response_amount = resolved_minor_amount.map(|minor| {
+            common_utils::types::Money::from_minor_unit(minor, resolved_currency.unwrap_or_default())
         });
 
         let connector_response_reference_id = item
@@ -859,7 +858,7 @@ where
             .captures
             .as_ref()
             .and_then(|c| c.last())
-            .map(|c| c.amount.get_amount_as_i64());
+            .map(|c| c.amount);
 
         let response = if let Some(err) = error_response {
             Err(err)
@@ -883,8 +882,8 @@ where
             resource_common_data: PaymentFlowData {
                 status,
                 amount: response_amount.or(item.router_data.resource_common_data.amount),
-                amount_captured: captured_amount
-                    .or(item.router_data.resource_common_data.amount_captured),
+                minor_amount_captured: captured_amount
+                    .or(item.router_data.resource_common_data.minor_amount_captured),
                 ..item.router_data.resource_common_data
             },
             response,
@@ -1177,13 +1176,10 @@ where
 
         let amount = Amount {
             currency: router_data.request.currency.to_string(),
-            value: common_utils::MinorUnit::new(
-                router_data
+            value: router_data
                     .request
                     .minor_amount
-                    .map(|a| a.get_amount_as_i64())
-                    .unwrap_or(0),
-            ),
+                    .unwrap_or_default(),
         };
 
         let authentication_settings =
@@ -1575,9 +1571,7 @@ where
         let router_data = item.router_data;
         let amount = Amount {
             currency: router_data.request.currency.to_string(),
-            value: common_utils::MinorUnit::new(
-                router_data.request.minor_amount.get_amount_as_i64(),
-            ),
+            value: router_data.request.minor_amount,
         };
 
         let initiator = if router_data.request.off_session.unwrap_or(true) {

--- a/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/ppro/transformers.rs
@@ -836,7 +836,10 @@ where
             });
 
         let response_amount = resolved_minor_amount.map(|minor| {
-            common_utils::types::Money::from_minor_unit(minor, resolved_currency.unwrap_or_default())
+            common_utils::types::Money::from_minor_unit(
+                minor,
+                resolved_currency.unwrap_or_default(),
+            )
         });
 
         let connector_response_reference_id = item
@@ -1176,10 +1179,7 @@ where
 
         let amount = Amount {
             currency: router_data.request.currency.to_string(),
-            value: router_data
-                    .request
-                    .minor_amount
-                    .unwrap_or_default(),
+            value: router_data.request.minor_amount.unwrap_or_default(),
         };
 
         let authentication_settings =

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver.rs
@@ -8,7 +8,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
@@ -288,9 +288,9 @@ where
             .change_context(IntegrationError::AmountConversionFailed {
                 context: qc_err_ctx(
                     format!(
-                        "Failed to convert Redeem amount {} {} to FloatMajorUnit. \
+                        "Failed to convert Redeem amount {:?} {} to FloatMajorUnit. \
                          Qwikcilver expects major-unit decimals (e.g. 0.20 AED).",
-                        item.router_data.request.minor_amount.get_amount_as_i64(),
+                        item.router_data.request.minor_amount,
                         item.router_data.request.currency,
                     ),
                     "Verify `amount.minor_amount` is a non-negative integer and \
@@ -601,8 +601,8 @@ where
             .change_context(IntegrationError::AmountConversionFailed {
                 context: qc_err_ctx(
                     format!(
-                        "Failed to convert Recharge amount {} {} to FloatMajorUnit.",
-                        req.amount.get_amount_as_i64(),
+                        "Failed to convert Recharge amount {:?} {} to FloatMajorUnit.",
+                        req.amount,
                         req.currency,
                     ),
                     "Verify `amount.minor_amount` is a non-negative integer and \
@@ -1017,10 +1017,7 @@ fn card_to_wallet_item(
     let available_balance = currency.and_then(|c| {
         crate::connectors::qwikcilver::QwikcilverAmountConvertor::convert_back(card.amount, c)
             .ok()
-            .map(|minor| common_utils::types::Money {
-                amount: minor,
-                currency: c,
-            })
+            .map(|minor| common_utils::types::Money::from_minor_unit(minor, c))
     });
     Some(payment_method_data::WalletItem {
         wallet_item_id,
@@ -1240,7 +1237,7 @@ impl TryFrom<ResponseRouterData<QwikcilverEligibilityResponse, Self>>
             serde_json::to_string(&body).ok().map(Secret::new);
         data.response = match body.response_code {
             QWIKCILVER_SUCCESS_CODE => {
-                let currency = data.request.amount.currency;
+                let currency = data.request.amount.currency();
                 let (eligibility, payment_method_details) =
                     if let Some(wallet) = body.wallet.as_ref() {
                         let eligibility = match map_wallet_status(wallet.status.as_ref()) {

--- a/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/qwikcilver/transformers.rs
@@ -290,8 +290,7 @@ where
                     format!(
                         "Failed to convert Redeem amount {:?} {} to FloatMajorUnit. \
                          Qwikcilver expects major-unit decimals (e.g. 0.20 AED).",
-                        item.router_data.request.minor_amount,
-                        item.router_data.request.currency,
+                        item.router_data.request.minor_amount, item.router_data.request.currency,
                     ),
                     "Verify `amount.minor_amount` is a non-negative integer and \
                      `amount.currency` is a 3-letter ISO 4217 code that Pine Labs supports \
@@ -602,8 +601,7 @@ where
                 context: qc_err_ctx(
                     format!(
                         "Failed to convert Recharge amount {:?} {} to FloatMajorUnit.",
-                        req.amount,
-                        req.currency,
+                        req.amount, req.currency,
                     ),
                     "Verify `amount.minor_amount` is a non-negative integer and \
                      `amount.currency` is supported by your Pine Labs program (e.g. AED for \

--- a/crates/integrations/connector-integration/src/connectors/rapyd.rs
+++ b/crates/integrations/connector-integration/src/connectors/rapyd.rs
@@ -1,7 +1,7 @@
 pub mod transformers;
 
 use base64::Engine;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, CreateOrder, PSync, RSync, Refund,

--- a/crates/integrations/connector-integration/src/connectors/razorpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay.rs
@@ -12,7 +12,7 @@ use common_utils::{
     ext_traits::ByteSliceExt,
     pii::SecretSerdeValue,
     request::{Method, RequestContent},
-    types::{AmountConvertor, MinorUnit},
+    types::AmountConvertor,
 };
 use domain_types::errors::{IntegrationError, WebhookError};
 use domain_types::{
@@ -66,7 +66,7 @@ pub(crate) mod headers {
 #[derive(Clone)]
 pub struct Razorpay<T> {
     #[allow(dead_code)]
-    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = MinorUnit> + Sync),
+    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
     #[allow(dead_code)]
     _phantom: std::marker::PhantomData<T>,
 }

--- a/crates/integrations/connector-integration/src/connectors/razorpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay.rs
@@ -66,7 +66,8 @@ pub(crate) mod headers {
 #[derive(Clone)]
 pub struct Razorpay<T> {
     #[allow(dead_code)]
-    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
+    pub(crate) amount_converter:
+        &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
     #[allow(dead_code)]
     _phantom: std::marker::PhantomData<T>,
 }

--- a/crates/integrations/connector-integration/src/connectors/razorpay/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/test.rs
@@ -32,7 +32,11 @@ mod tests {
             AttemptStatus, AuthenticationType, Currency, PaymentMethod, PaymentMethodType,
         };
         use common_utils::{
-            id_type::MerchantId, pii::Email, request::RequestContent, types::MinorUnit,
+            id_type::MerchantId,
+            pii::Email,
+            proto_boundary::MinorUnitProtoAccess,
+            request::RequestContent,
+            types::MinorUnit,
         };
         use domain_types::{
             connector_types::{PaymentFlowData, PaymentsAuthorizeData},
@@ -624,7 +628,7 @@ mod tests {
             use std::str::FromStr;
 
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+            use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
             use domain_types::{
                 connector_types::PaymentFlowData,
                 payment_address::PaymentAddress,
@@ -1016,7 +1020,7 @@ mod tests {
         use std::str::FromStr;
 
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
         use domain_types::{
             connector_types::PaymentFlowData,
             payment_address::PaymentAddress,
@@ -1241,7 +1245,7 @@ mod tests {
         use std::str::FromStr;
 
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
         use domain_types::{
             connector_types::PaymentFlowData,
             payment_address::PaymentAddress,
@@ -1469,7 +1473,7 @@ mod tests {
         #[test]
         fn test_build_request_valid_order() {
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, request::RequestContent, types::MinorUnit};
+            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
             use domain_types::{
                 connector_types::PaymentCreateOrderData,
                 payment_address::PaymentAddress,
@@ -1615,7 +1619,7 @@ mod tests {
         #[test]
         fn test_build_request_missing() {
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, types::MinorUnit};
+            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
             use domain_types::{
                 connector_types::PaymentCreateOrderData,
                 payment_address::PaymentAddress,
@@ -1749,7 +1753,7 @@ mod tests {
             use common_enums::{
                 AttemptStatus, AuthenticationType, Currency, PaymentMethod, PaymentMethodType,
             };
-            use common_utils::{id_type::MerchantId, types::MinorUnit};
+            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
             use domain_types::{
                 connector_types::{PaymentFlowData, PaymentsAuthorizeData},
                 payment_address::PaymentAddress,
@@ -1928,7 +1932,7 @@ mod tests {
     #[test]
     fn test_handle_response_v2_valid_order_response() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
         use domain_types::{
             connector_types::{PaymentCreateOrderData, PaymentFlowData},
             payment_address::PaymentAddress,
@@ -2072,7 +2076,7 @@ mod tests {
     #[test]
     fn test_handle_response_missing() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
         use domain_types::{
             connector_types::PaymentCreateOrderData,
             payment_address::PaymentAddress,
@@ -2206,7 +2210,7 @@ mod tests {
     #[test]
     fn test_handle_response_invalid() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, types::MinorUnit};
+        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
         use domain_types::{
             connector_types::PaymentCreateOrderData,
             payment_address::PaymentAddress,

--- a/crates/integrations/connector-integration/src/connectors/razorpay/test.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/test.rs
@@ -32,11 +32,8 @@ mod tests {
             AttemptStatus, AuthenticationType, Currency, PaymentMethod, PaymentMethodType,
         };
         use common_utils::{
-            id_type::MerchantId,
-            pii::Email,
-            proto_boundary::MinorUnitProtoAccess,
-            request::RequestContent,
-            types::MinorUnit,
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess,
+            request::RequestContent, types::MinorUnit,
         };
         use domain_types::{
             connector_types::{PaymentFlowData, PaymentsAuthorizeData},
@@ -628,7 +625,10 @@ mod tests {
             use std::str::FromStr;
 
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+            use common_utils::{
+                id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess,
+                types::MinorUnit,
+            };
             use domain_types::{
                 connector_types::PaymentFlowData,
                 payment_address::PaymentAddress,
@@ -1020,7 +1020,9 @@ mod tests {
         use std::str::FromStr;
 
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+        use common_utils::{
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+        };
         use domain_types::{
             connector_types::PaymentFlowData,
             payment_address::PaymentAddress,
@@ -1245,7 +1247,9 @@ mod tests {
         use std::str::FromStr;
 
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+        use common_utils::{
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+        };
         use domain_types::{
             connector_types::PaymentFlowData,
             payment_address::PaymentAddress,
@@ -1473,7 +1477,10 @@ mod tests {
         #[test]
         fn test_build_request_valid_order() {
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, request::RequestContent, types::MinorUnit};
+            use common_utils::{
+                id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, request::RequestContent,
+                types::MinorUnit,
+            };
             use domain_types::{
                 connector_types::PaymentCreateOrderData,
                 payment_address::PaymentAddress,
@@ -1619,7 +1626,9 @@ mod tests {
         #[test]
         fn test_build_request_missing() {
             use common_enums::Currency;
-            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+            use common_utils::{
+                id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+            };
             use domain_types::{
                 connector_types::PaymentCreateOrderData,
                 payment_address::PaymentAddress,
@@ -1753,7 +1762,9 @@ mod tests {
             use common_enums::{
                 AttemptStatus, AuthenticationType, Currency, PaymentMethod, PaymentMethodType,
             };
-            use common_utils::{id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+            use common_utils::{
+                id_type::MerchantId, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+            };
             use domain_types::{
                 connector_types::{PaymentFlowData, PaymentsAuthorizeData},
                 payment_address::PaymentAddress,
@@ -1932,7 +1943,9 @@ mod tests {
     #[test]
     fn test_handle_response_v2_valid_order_response() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+        use common_utils::{
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+        };
         use domain_types::{
             connector_types::{PaymentCreateOrderData, PaymentFlowData},
             payment_address::PaymentAddress,
@@ -2076,7 +2089,9 @@ mod tests {
     #[test]
     fn test_handle_response_missing() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+        use common_utils::{
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+        };
         use domain_types::{
             connector_types::PaymentCreateOrderData,
             payment_address::PaymentAddress,
@@ -2210,7 +2225,9 @@ mod tests {
     #[test]
     fn test_handle_response_invalid() {
         use common_enums::Currency;
-        use common_utils::{id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+        use common_utils::{
+            id_type::MerchantId, pii::Email, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+        };
         use domain_types::{
             connector_types::PaymentCreateOrderData,
             payment_address::PaymentAddress,

--- a/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common_enums::{self, AttemptStatus, CardNetwork};
-use common_utils::{ext_traits::ByteSliceExt, pii::Email, request::Method, types::ConnectorMinorUnit};
+use common_utils::{
+    ext_traits::ByteSliceExt, pii::Email, request::Method, types::ConnectorMinorUnit,
+};
 use domain_types::errors::{
     ConnectorError, IntegrationError, IntegrationErrorContext, WebhookError,
 };

--- a/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay/transformers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common_enums::{self, AttemptStatus, CardNetwork};
-use common_utils::{ext_traits::ByteSliceExt, pii::Email, request::Method, types::MinorUnit};
+use common_utils::{ext_traits::ByteSliceExt, pii::Email, request::Method, types::ConnectorMinorUnit};
 use domain_types::errors::{
     ConnectorError, IntegrationError, IntegrationErrorContext, WebhookError,
 };
@@ -49,7 +49,7 @@ pub enum Currency {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Amount {
     pub currency: common_enums::Currency,
-    pub value: MinorUnit,
+    pub value: ConnectorMinorUnit,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -162,7 +162,7 @@ pub struct BrowserInfo {
 pub struct RazorpayPaymentRequest<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 > {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub contact: Secret<String>,
     pub email: Email,
@@ -207,13 +207,13 @@ pub enum PaymentMethodType {
 }
 
 pub struct RazorpayRouterData<T> {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub router_data: T,
 }
 
-impl<T> TryFrom<(MinorUnit, T)> for RazorpayRouterData<T> {
+impl<T> TryFrom<(ConnectorMinorUnit, T)> for RazorpayRouterData<T> {
     type Error = error_stack::Report<IntegrationError>;
-    fn try_from((amount, item): (MinorUnit, T)) -> Result<Self, Self::Error> {
+    fn try_from((amount, item): (ConnectorMinorUnit, T)) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,
             router_data: item,
@@ -652,7 +652,7 @@ pub enum RazorpayResponse {
 pub struct RazorpayPsyncResponse {
     pub id: String,
     pub entity: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub base_amount: i64,
     pub currency: String,
     pub base_currency: String,
@@ -689,7 +689,7 @@ pub struct RazorpayRefundResponse {
     pub id: String,
     pub status: RazorpayRefundStatus,
     pub receipt: Option<String>,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
 }
 
@@ -697,7 +697,7 @@ pub struct RazorpayRefundResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RazorpayRefundRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
 }
 
 impl ForeignTryFrom<RazorpayRefundStatus> for common_enums::RefundStatus {
@@ -1032,11 +1032,11 @@ pub struct Metadata {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RazorpayOrderRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub receipt: String,
     pub partial_payment: Option<bool>,
-    pub first_payment_min_amount: Option<MinorUnit>,
+    pub first_payment_min_amount: Option<ConnectorMinorUnit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_capture: Option<i8>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1168,9 +1168,9 @@ pub enum RazorpayNotes {
 pub struct RazorpayOrderResponse {
     pub id: String,
     pub entity: String,
-    pub amount: MinorUnit,
-    pub amount_paid: MinorUnit,
-    pub amount_due: MinorUnit,
+    pub amount: ConnectorMinorUnit,
+    pub amount_paid: ConnectorMinorUnit,
+    pub amount_due: ConnectorMinorUnit,
     pub currency: String,
     pub receipt: String,
     pub status: String,
@@ -1223,7 +1223,7 @@ impl ForeignTryFrom<(RazorpayOrderResponse, Self, u16, bool)>
 pub struct RazorpaySessionTokenRequest {
     // `amount` and `currency` are mandatory because Razorpay's session-token flow creates
     // an Order server-side (POST /v1/orders); order creation requires both fields.
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: common_enums::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub receipt: Option<String>,
@@ -1469,7 +1469,7 @@ pub(crate) fn get_razorpay_refund_webhook_status(
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RazorpayCaptureRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
 }
 #[derive(Debug, Serialize, Deserialize)]
@@ -1570,7 +1570,7 @@ impl<F, Req> ForeignTryFrom<(RazorpayCaptureResponse, Self, u16)>
 #[derive(Debug, Serialize)]
 pub struct RazorpayWebCollectRequest {
     pub currency: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<Email>,
     pub order_id: String,
@@ -1887,7 +1887,7 @@ fn map_bank_name_to_razorpay_code(
 
 #[derive(Debug, Serialize)]
 pub struct RazorpayNetbankingRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<Email>,

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2.rs
@@ -6,7 +6,7 @@ use common_utils::{
     events,
     ext_traits::BytesExt,
     request::RequestContent,
-    types::{AmountConvertor, MinorUnit},
+    types::AmountConvertor,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{
@@ -49,7 +49,7 @@ pub(crate) mod headers {
 #[derive(Clone)]
 pub struct RazorpayV2<T> {
     #[allow(dead_code)]
-    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = MinorUnit> + Sync),
+    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
     #[allow(dead_code)]
     _phantom: std::marker::PhantomData<T>,
 }
@@ -216,9 +216,15 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             PaymentCreateOrderResponse,
         >,
     ) -> CustomResult<Option<common_utils::request::ConnectorRequestData>, IntegrationError> {
+        let converted_amount = self
+            .amount_converter
+            .convert(req.request.amount, req.request.currency)
+            .change_context(IntegrationError::AmountConversionFailed {
+                context: Default::default(),
+            })?;
         let connector_router_data: razorpayv2::RazorpayV2RouterData<&PaymentCreateOrderData, T> =
             razorpayv2::RazorpayV2RouterData::try_from((
-                req.request.amount,
+                converted_amount,
                 &req.request,
                 Some(
                     req.resource_common_data

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2.rs
@@ -2,10 +2,7 @@ pub mod test;
 pub mod transformers;
 use common_enums::AttemptStatus;
 use common_utils::{
-    errors::CustomResult,
-    events,
-    ext_traits::BytesExt,
-    request::RequestContent,
+    errors::CustomResult, events, ext_traits::BytesExt, request::RequestContent,
     types::AmountConvertor,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
@@ -49,7 +46,8 @@ pub(crate) mod headers {
 #[derive(Clone)]
 pub struct RazorpayV2<T> {
     #[allow(dead_code)]
-    pub(crate) amount_converter: &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
+    pub(crate) amount_converter:
+        &'static (dyn AmountConvertor<Output = common_utils::ConnectorMinorUnit> + Sync),
     #[allow(dead_code)]
     _phantom: std::marker::PhantomData<T>,
 }

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use common_enums::{AttemptStatus, RefundStatus};
-use common_utils::{consts, pii::Email, types::MinorUnit};
+use common_utils::{consts, pii::Email, types::ConnectorMinorUnit};
 use domain_types::{
     connector_flow::{Authorize, CreateOrder, PSync, RSync, Refund},
     connector_types::{
@@ -83,7 +83,7 @@ pub struct RazorpayV2RouterData<
     T,
     U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 > {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub order_id: Option<String>,
     pub router_data: T,
     pub billing_address: Option<Address>,
@@ -92,12 +92,12 @@ pub struct RazorpayV2RouterData<
 }
 
 impl<T, U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
-    TryFrom<(MinorUnit, T, Option<String>, Option<Address>)> for RazorpayV2RouterData<T, U>
+    TryFrom<(ConnectorMinorUnit, T, Option<String>, Option<Address>)> for RazorpayV2RouterData<T, U>
 {
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
-        (amount, item, order_id, billing_address): (MinorUnit, T, Option<String>, Option<Address>),
+        (amount, item, order_id, billing_address): (ConnectorMinorUnit, T, Option<String>, Option<Address>),
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,
@@ -111,12 +111,12 @@ impl<T, U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
 
 // Keep backward compatibility for existing usage
 impl<T, U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
-    TryFrom<(MinorUnit, T, Option<String>)> for RazorpayV2RouterData<T, U>
+    TryFrom<(ConnectorMinorUnit, T, Option<String>)> for RazorpayV2RouterData<T, U>
 {
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
-        (amount, item, order_id): (MinorUnit, T, Option<String>),
+        (amount, item, order_id): (ConnectorMinorUnit, T, Option<String>),
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,
@@ -132,7 +132,7 @@ impl<T, U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Se
 
 #[derive(Debug, Serialize)]
 pub struct RazorpayV2CreateOrderRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub receipt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -147,9 +147,9 @@ pub type RazorpayV2Notes = Value;
 pub struct RazorpayV2CreateOrderResponse {
     pub id: String,
     pub entity: String,
-    pub amount: MinorUnit,
-    pub amount_paid: MinorUnit,
-    pub amount_due: MinorUnit,
+    pub amount: ConnectorMinorUnit,
+    pub amount_paid: ConnectorMinorUnit,
+    pub amount_due: ConnectorMinorUnit,
     pub currency: String,
     pub receipt: String,
     pub status: String,
@@ -189,7 +189,7 @@ impl TryFrom<ResponseRouterData<RazorpayV2CreateOrderResponse, Self>>
 
 #[derive(Debug, Serialize)]
 pub struct RazorpayV2PaymentsRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub order_id: String,
     pub email: Email,
@@ -499,7 +499,7 @@ impl<U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(item: &RazorpayV2RouterData<&RefundsData, U>) -> Result<Self, Self::Error> {
-        let amount_in_minor_units = item.amount.get_amount_as_i64();
+        let amount_in_minor_units = item.amount.to_string().parse::<i64>().unwrap_or(0);
         Ok(Self {
             amount: amount_in_minor_units,
         })

--- a/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpayv2/transformers.rs
@@ -92,12 +92,18 @@ pub struct RazorpayV2RouterData<
 }
 
 impl<T, U: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
-    TryFrom<(ConnectorMinorUnit, T, Option<String>, Option<Address>)> for RazorpayV2RouterData<T, U>
+    TryFrom<(ConnectorMinorUnit, T, Option<String>, Option<Address>)>
+    for RazorpayV2RouterData<T, U>
 {
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
-        (amount, item, order_id, billing_address): (ConnectorMinorUnit, T, Option<String>, Option<Address>),
+        (amount, item, order_id, billing_address): (
+            ConnectorMinorUnit,
+            T,
+            Option<String>,
+            Option<Address>,
+        ),
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,

--- a/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/redsys/transformers.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::LazyLock};
+use std::str::FromStr;
 
 use crate::{
     connectors::redsys::{RedsysAmountConvertor, RedsysRouterData},
@@ -41,8 +41,8 @@ pub const REDSYS_SOAP_ACTION: &str = "consultaOperaciones";
 pub const REDSYS_ORDER_ID_METADATA_KEY: &str = "order_id";
 pub const REDSYS_ORDER_ID_MAX_LENGTH: usize = 12;
 
-static LWV_THRESHOLD: LazyLock<common_utils::types::MinorUnit> =
-    LazyLock::new(|| common_utils::types::MinorUnit::new(3000)); // €30
+/// Low Value Merchant threshold: €30 = 3000 minor units (cents).
+const LWV_THRESHOLD_MINOR_UNITS: i64 = 3000;
 
 type Error = Report<IntegrationError>;
 type ResponseError = Report<ConnectorError>;
@@ -1226,7 +1226,7 @@ fn determine_exemption<T: PaymentMethodDataTypes>(
     {
         return Ok(map_exemption_indicator(
             indicator,
-            request.amount <= *LWV_THRESHOLD,
+            !request.amount.is_greater_than(LWV_THRESHOLD_MINOR_UNITS),
         ));
     }
     // 2. Auto-detect: MIT for stored credential payments
@@ -1242,7 +1242,7 @@ fn determine_exemption<T: PaymentMethodDataTypes>(
     }
     // 4. Default: amount-based
     // For Redsys, both LWV and TRA are capped at €30
-    if request.amount <= *LWV_THRESHOLD {
+    if !request.amount.is_greater_than(LWV_THRESHOLD_MINOR_UNITS) {
         Ok(requests::RedsysStrongCustomerAuthenticationException::Lwv)
     } else {
         Ok(requests::RedsysStrongCustomerAuthenticationException::Tra)
@@ -1561,8 +1561,7 @@ where
             }),
         }?;
 
-        let amount_to_capture =
-            common_utils::types::MinorUnit::new(router_data.request.amount_to_capture);
+        let amount_to_capture = router_data.request.minor_amount_to_capture;
 
         let capture_request = requests::RedsysOperationRequest {
             ds_merchant_amount: RedsysAmountConvertor::convert(
@@ -2037,7 +2036,7 @@ where
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
         let auth = RedsysAuthType::try_from(&router_data.connector_config)?;
-        let refund_amount = common_utils::types::MinorUnit::new(router_data.request.refund_amount);
+        let refund_amount = router_data.request.minor_refund_amount;
 
         let refund_request = requests::RedsysOperationRequest {
             ds_merchant_amount: RedsysAmountConvertor::convert(

--- a/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
@@ -709,10 +709,10 @@ impl TryFrom<ResponseRouterData<RevolutOrderCreateResponse, Self>>
             None => map_order_state(response.state),
         };
 
-        let amount = Some(Money {
-            amount: response.amount,
-            currency: response.currency,
-        });
+        let amount = Some(Money::from_minor_unit(
+            response.amount,
+            response.currency,
+        ));
 
         let merchant_reference = response
             .merchant_order_data

--- a/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolut/transformers.rs
@@ -709,10 +709,7 @@ impl TryFrom<ResponseRouterData<RevolutOrderCreateResponse, Self>>
             None => map_order_state(response.state),
         };
 
-        let amount = Some(Money::from_minor_unit(
-            response.amount,
-            response.currency,
-        ));
+        let amount = Some(Money::from_minor_unit(response.amount, response.currency));
 
         let merchant_reference = response
             .merchant_order_data

--- a/crates/integrations/connector-integration/src/connectors/revolv3.rs
+++ b/crates/integrations/connector-integration/src/connectors/revolv3.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use crate::{types::ResponseRouterData, with_error_response_body};
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::errors::ConnectorError;
 use domain_types::errors::IntegrationError;
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/saferpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/saferpay/transformers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use common_enums::{AttemptStatus, AuthenticationType, CaptureMethod, RefundStatus};
 use common_utils::{
-    types::{MinorUnit, StringMinorUnit},
+    types::{AmountConvertor, MinorUnit, MinorUnitForConnector, StringMinorUnit},
     Method,
 };
 use domain_types::{
@@ -1194,11 +1194,16 @@ fn authorized_amount_from_metadata(request: &PaymentsCaptureData) -> Option<Mino
         .peek()
         .get(AUTHORIZED_AMOUNT_METADATA_KEY)?;
 
-    value
+    let i64_val = value
         .as_str()
         .and_then(|amount| amount.parse::<i64>().ok())
-        .or_else(|| value.as_i64())
-        .map(MinorUnit::new)
+        .or_else(|| value.as_i64())?;
+
+    let connector_amount: common_utils::ConnectorMinorUnit =
+        serde_json::from_value(serde_json::Value::Number(i64_val.into())).ok()?;
+    MinorUnitForConnector
+        .convert_back(connector_amount, request.currency)
+        .ok()
 }
 
 impl TryFrom<ResponseRouterData<SaferpayCaptureResponse, Self>> for CaptureRouterData {
@@ -1220,7 +1225,12 @@ impl TryFrom<ResponseRouterData<SaferpayCaptureResponse, Self>> for CaptureRoute
             .resource_common_data
             .amount
             .as_ref()
-            .map(|money| money.amount)
+            .and_then(|money| {
+                money
+                    .convert(&MinorUnitForConnector)
+                    .ok()
+                    .and_then(|cmu| MinorUnitForConnector.convert_back(cmu, request.currency).ok())
+            })
             .or_else(|| authorized_amount_from_metadata(request));
         let is_partial = authorized_amount
             .map(|amount| amount > request.minor_amount_to_capture)

--- a/crates/integrations/connector-integration/src/connectors/saferpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/saferpay/transformers.rs
@@ -1226,10 +1226,11 @@ impl TryFrom<ResponseRouterData<SaferpayCaptureResponse, Self>> for CaptureRoute
             .amount
             .as_ref()
             .and_then(|money| {
-                money
-                    .convert(&MinorUnitForConnector)
-                    .ok()
-                    .and_then(|cmu| MinorUnitForConnector.convert_back(cmu, request.currency).ok())
+                money.convert(&MinorUnitForConnector).ok().and_then(|cmu| {
+                    MinorUnitForConnector
+                        .convert_back(cmu, request.currency)
+                        .ok()
+                })
             })
             .or_else(|| authorized_amount_from_metadata(request));
         let is_partial = authorized_amount

--- a/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/silverflow/transformers.rs
@@ -857,7 +857,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let reference = Some(router_data.request.connector_transaction_id.clone());
 
         Ok(Self {
-            replacement_amount: Some(MinorUnit::zero()), // 0 means full reversal according to Silverflow docs
+            replacement_amount: Some(MinorUnit::default()), // 0 means full reversal according to Silverflow docs
             reference,
         })
     }

--- a/crates/integrations/connector-integration/src/connectors/stax.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::{CurrencyUnit, PaymentMethod, PaymentMethodType};
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, CreateConnectorCustomer, PSync, PaymentMethodToken, RSync, Refund,

--- a/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stax/transformers.rs
@@ -307,7 +307,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             is_refundable: true,
             pre_auth: !is_auto_capture,
             meta: StaxMeta {
-                tax: MinorUnit::zero(),
+                tax: MinorUnit::default(),
             },
             idempotency_id: Some(
                 item.router_data
@@ -1267,7 +1267,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             is_refundable: false,
             pre_auth: true,
             meta: StaxMeta {
-                tax: MinorUnit::zero(),
+                tax: MinorUnit::default(),
             },
             idempotency_id: Some(
                 item.router_data
@@ -1440,7 +1440,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             is_refundable: true,
             pre_auth: !is_auto_capture,
             meta: StaxMeta {
-                tax: MinorUnit::zero(),
+                tax: MinorUnit::default(),
             },
             idempotency_id: Some(
                 item.router_data

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -2351,13 +2351,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 match &stripe_split_payment.charge_type {
                     common_enums::PaymentChargeType::Stripe(charge_type) => match charge_type {
                         common_enums::StripeChargeType::Direct => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees
+                            application_fee_amount: stripe_split_payment
+                                .application_fees
                                 .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
                                 .transpose()?,
                             destination_account_id: None,
                         }),
                         common_enums::StripeChargeType::Destination => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees
+                            application_fee_amount: stripe_split_payment
+                                .application_fees
                                 .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
                                 .transpose()?,
                             destination_account_id: Some(Secret::new(
@@ -3103,14 +3105,26 @@ where
                     .response
                     .amount_received
                     .map(|amount| amount.to_string().parse::<i64>().unwrap_or(0)),
-                minor_amount_captured: item.response.amount_received
-                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                minor_amount_captured: item
+                    .response
+                    .amount_received
+                    .map(|a| {
+                        StripeAmountConvertor::convert_back(
+                            a,
+                            item.response.currency.parse().unwrap_or_default(),
+                        )
+                    })
                     .transpose()
                     .ok()
                     .flatten(),
                 connector_response: connector_response_data,
                 minor_amount_capturable: minor_amount_capturable
-                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                    .map(|a| {
+                        StripeAmountConvertor::convert_back(
+                            a,
+                            item.response.currency.parse().unwrap_or_default(),
+                        )
+                    })
                     .transpose()
                     .ok()
                     .flatten(),
@@ -3173,9 +3187,14 @@ pub fn get_connector_metadata(
                                 // ConnectorMinorUnit does not implement Sub; compute
                                 // the received amount through serialized i64 values.
                                 let total = amount.to_string().parse::<i64>().unwrap_or(0);
-                                let remaining = response.amount_remaining.to_string().parse::<i64>().unwrap_or(0);
+                                let remaining = response
+                                    .amount_remaining
+                                    .to_string()
+                                    .parse::<i64>()
+                                    .unwrap_or(0);
                                 let received_str = (total - remaining).to_string();
-                                let received: ConnectorMinorUnit = serde_json::from_str(&received_str).unwrap_or_default();
+                                let received: ConnectorMinorUnit =
+                                    serde_json::from_str(&received_str).unwrap_or_default();
                                 SepaAndBacsReceiver {
                                     amount_received: received,
                                     amount_remaining: response.amount_remaining,
@@ -3426,8 +3445,15 @@ impl<F> TryFrom<ResponseRouterData<PaymentIntentSyncResponse, Self>>
                     .response
                     .amount_received
                     .map(|amount| amount.to_string().parse::<i64>().unwrap_or(0)),
-                minor_amount_captured: item.response.amount_received
-                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                minor_amount_captured: item
+                    .response
+                    .amount_received
+                    .map(|a| {
+                        StripeAmountConvertor::convert_back(
+                            a,
+                            item.response.currency.parse().unwrap_or_default(),
+                        )
+                    })
                     .transpose()
                     .ok()
                     .flatten(),
@@ -4777,7 +4803,8 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     ) -> Result<Self, Self::Error> {
         let split_payment_request = match item.request.split_payments.as_ref() {
             Some(SplitPaymentsDetails::StripeSplitPayment(stripe_split_payment)) => {
-                let fees = stripe_split_payment.application_fees
+                let fees = stripe_split_payment
+                    .application_fees
                     .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
                     .transpose()?;
                 Self {
@@ -6004,13 +6031,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 match &stripe_split_payment.charge_type {
                     common_enums::PaymentChargeType::Stripe(charge_type) => match charge_type {
                         common_enums::StripeChargeType::Direct => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees
+                            application_fee_amount: stripe_split_payment
+                                .application_fees
                                 .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
                                 .transpose()?,
                             destination_account_id: None,
                         }),
                         common_enums::StripeChargeType::Destination => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees
+                            application_fee_amount: stripe_split_payment
+                                .application_fees
                                 .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
                                 .transpose()?,
                             destination_account_id: Some(Secret::new(

--- a/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/stripe/transformers.rs
@@ -7,7 +7,7 @@ use common_utils::{
     ext_traits::{ByteSliceExt, Encode, OptionExt},
     pii::{self, Email},
     request::Method,
-    types::{MinorUnit, StringMinorUnitForConnector},
+    types::{ConnectorMinorUnit, StringMinorUnitForConnector},
 };
 use domain_types::{
     connector_flow::{
@@ -249,7 +249,7 @@ pub struct StripeBrowserInformation {
 pub struct PaymentIntentRequest<
     T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize,
 > {
-    pub amount: MinorUnit, //amount in cents, hence passed as integer
+    pub amount: ConnectorMinorUnit, //amount in cents, hence passed as integer
     pub currency: String,
     pub statement_descriptor_suffix: Option<String>,
     pub statement_descriptor: Option<String>,
@@ -290,7 +290,7 @@ pub struct PaymentIntentRequest<
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct IntentCharges {
-    pub application_fee_amount: Option<MinorUnit>,
+    pub application_fee_amount: Option<ConnectorMinorUnit>,
     #[serde(
         rename = "transfer_data[destination]",
         skip_serializing_if = "Option::is_none"
@@ -447,7 +447,7 @@ pub struct CreateConnectorCustomerResponse {
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct ChargesRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub customer: Secret<String>,
     pub source: Secret<String>,
@@ -458,8 +458,8 @@ pub struct ChargesRequest {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ChargesResponse {
     pub id: String,
-    pub amount: MinorUnit,
-    pub amount_captured: MinorUnit,
+    pub amount: ConnectorMinorUnit,
+    pub amount_captured: ConnectorMinorUnit,
     pub currency: String,
     pub status: StripePaymentStatus,
     pub source: StripeSourceResponse,
@@ -619,7 +619,7 @@ pub struct MultibancoCreditTransferSourceRequest {
     #[serde(flatten)]
     pub payment_method_data: MultibancoTransferData,
     pub currency: common_enums::Currency,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     #[serde(rename = "redirect[return_url]")]
     pub return_url: Option<String>,
 }
@@ -2351,11 +2351,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 match &stripe_split_payment.charge_type {
                     common_enums::PaymentChargeType::Stripe(charge_type) => match charge_type {
                         common_enums::StripeChargeType::Direct => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees,
+                            application_fee_amount: stripe_split_payment.application_fees
+                                .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
+                                .transpose()?,
                             destination_account_id: None,
                         }),
                         common_enums::StripeChargeType::Destination => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees,
+                            application_fee_amount: stripe_split_payment.application_fees
+                                .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
+                                .transpose()?,
                             destination_account_id: Some(Secret::new(
                                 stripe_split_payment.transfer_account_id.clone(),
                             )),
@@ -2486,14 +2490,14 @@ impl From<BrowserInformation> for StripeBrowserInformation {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct StripeSplitPaymentRequest {
     pub charge_type: Option<common_enums::PaymentChargeType>,
-    pub application_fees: Option<MinorUnit>,
+    pub application_fees: Option<ConnectorMinorUnit>,
     pub transfer_account_id: Option<Secret<String>>,
     pub on_behalf_of: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct PaymentIncrementalAuthRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -2541,11 +2545,11 @@ pub struct PaymentIntentResponse {
     // been observed on the wire) -- kept in parity so a response HS parses successfully doesn't
     // fail here.
     pub object: Option<String>,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     #[serde(default, deserialize_with = "deserialize_zero_minor_amount_as_none")]
     // stripe gives amount_captured as 0 for payment intents instead of null
-    pub amount_received: Option<MinorUnit>,
-    pub amount_capturable: Option<MinorUnit>,
+    pub amount_received: Option<ConnectorMinorUnit>,
+    pub amount_capturable: Option<ConnectorMinorUnit>,
     pub currency: String,
     pub status: StripePaymentStatus,
     pub client_secret: Option<Secret<String>>,
@@ -2591,8 +2595,8 @@ pub struct MultibancoCreditTransferResponse {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct AchReceiverDetails {
-    pub amount_received: MinorUnit,
-    pub amount_charged: MinorUnit,
+    pub amount_received: ConnectorMinorUnit,
+    pub amount_charged: ConnectorMinorUnit,
 }
 
 #[serde_with::skip_serializing_none]
@@ -2612,8 +2616,8 @@ pub struct QrCodeNextInstructions {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SepaAndBacsReceiver {
-    pub amount_received: MinorUnit,
-    pub amount_remaining: MinorUnit,
+    pub amount_received: ConnectorMinorUnit,
+    pub amount_remaining: ConnectorMinorUnit,
 }
 
 #[derive(Deserialize, Debug, Serialize)]
@@ -2651,7 +2655,7 @@ impl StripeChargeEnum {
         }
     }
 
-    pub fn get_maximum_capturable_amount(&self) -> Option<MinorUnit> {
+    pub fn get_maximum_capturable_amount(&self) -> Option<ConnectorMinorUnit> {
         match self {
             Self::ChargeObject(charge_object) => {
                 if let Some(payment_method_details) = charge_object.payment_method_details.as_ref()
@@ -2735,7 +2739,7 @@ pub struct StripeOvercaptureResponse {
     status: Option<StripeOvercaptureStatus>,
     #[serde(default, deserialize_with = "deserialize_zero_minor_amount_as_none")]
     // stripe gives amount_captured as 0 for payment intents instead of null
-    maximum_amount_capturable: Option<MinorUnit>,
+    maximum_amount_capturable: Option<ConnectorMinorUnit>,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq, Serialize)]
@@ -3098,10 +3102,18 @@ where
                 amount_captured: item
                     .response
                     .amount_received
-                    .map(|amount| amount.get_amount_as_i64()),
-                minor_amount_captured: item.response.amount_received,
+                    .map(|amount| amount.to_string().parse::<i64>().unwrap_or(0)),
+                minor_amount_captured: item.response.amount_received
+                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                    .transpose()
+                    .ok()
+                    .flatten(),
                 connector_response: connector_response_data,
-                minor_amount_capturable,
+                minor_amount_capturable: minor_amount_capturable
+                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                    .transpose()
+                    .ok()
+                    .flatten(),
                 ..item.router_data.resource_common_data
             },
             response,
@@ -3129,7 +3141,7 @@ impl From<StripePaymentStatus> for common_enums::AuthorizationStatus {
 
 pub fn get_connector_metadata(
     next_action: Option<&StripeNextActionResponse>,
-    amount: MinorUnit,
+    amount: ConnectorMinorUnit,
     http_status: u16,
 ) -> CustomResult<Option<Value>, ConnectorError> {
     let next_action_response = next_action
@@ -3157,9 +3169,17 @@ pub fn get_connector_metadata(
                         let bank_transfer_instructions = SepaAndBacsBankTransferInstructions {
                             sepa_bank_instructions,
                             bacs_bank_instructions,
-                            receiver: SepaAndBacsReceiver {
-                                amount_received: amount - response.amount_remaining,
-                                amount_remaining: response.amount_remaining,
+                            receiver: {
+                                // ConnectorMinorUnit does not implement Sub; compute
+                                // the received amount through serialized i64 values.
+                                let total = amount.to_string().parse::<i64>().unwrap_or(0);
+                                let remaining = response.amount_remaining.to_string().parse::<i64>().unwrap_or(0);
+                                let received_str = (total - remaining).to_string();
+                                let received: ConnectorMinorUnit = serde_json::from_str(&received_str).unwrap_or_default();
+                                SepaAndBacsReceiver {
+                                    amount_received: received,
+                                    amount_remaining: response.amount_remaining,
+                                }
                             },
                         };
 
@@ -3405,8 +3425,12 @@ impl<F> TryFrom<ResponseRouterData<PaymentIntentSyncResponse, Self>>
                 amount_captured: item
                     .response
                     .amount_received
-                    .map(|amount| amount.get_amount_as_i64()),
-                minor_amount_captured: item.response.amount_received,
+                    .map(|amount| amount.to_string().parse::<i64>().unwrap_or(0)),
+                minor_amount_captured: item.response.amount_received
+                    .map(|a| StripeAmountConvertor::convert_back(a, item.response.currency.parse().unwrap_or_default()))
+                    .transpose()
+                    .ok()
+                    .flatten(),
                 connector_response: connector_response_data,
                 ..item.router_data.resource_common_data
             },
@@ -3656,7 +3680,7 @@ pub enum FinancialInformation {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct StripeBankTransferDetails {
-    pub amount_remaining: MinorUnit,
+    pub amount_remaining: ConnectorMinorUnit,
     pub currency: String,
     pub financial_addresses: FinancialInformation,
     pub hosted_instructions_url: Option<String>,
@@ -3739,7 +3763,7 @@ pub struct BacsFinancialDetails {
 
 #[derive(Debug, Serialize)]
 pub struct RefundRequest {
-    pub amount: Option<MinorUnit>, //amount in cents, hence passed as integer
+    pub amount: Option<ConnectorMinorUnit>, //amount in cents, hence passed as integer
     pub payment_intent: String,
     #[serde(flatten)]
     pub meta_data: StripeMetadata,
@@ -3750,7 +3774,7 @@ pub struct ChargeRefundRequest {
     pub charge: String,
     pub refund_application_fee: Option<bool>,
     pub reverse_transfer: Option<bool>,
-    pub amount: Option<MinorUnit>, //amount in cents, hence passed as integer
+    pub amount: Option<ConnectorMinorUnit>, //amount in cents, hence passed as integer
     #[serde(flatten)]
     pub meta_data: StripeMetadata,
 }
@@ -3781,7 +3805,7 @@ impl From<RefundStatus> for common_enums::RefundStatus {
 pub struct RefundResponse {
     pub id: String,
     pub object: String,
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     pub metadata: StripeMetadata,
     pub payment_intent: String,
@@ -3943,12 +3967,12 @@ pub struct StripeMandateOptions {
 #[derive(Debug, Serialize, Clone, Copy)]
 pub struct CaptureRequest {
     /// If amount_to_capture is None stripe captures the amount in the payment intent.
-    amount_to_capture: Option<MinorUnit>,
+    amount_to_capture: Option<ConnectorMinorUnit>,
 }
 
-impl TryFrom<MinorUnit> for CaptureRequest {
+impl TryFrom<ConnectorMinorUnit> for CaptureRequest {
     type Error = error_stack::Report<IntegrationError>;
-    fn try_from(capture_amount: MinorUnit) -> Result<Self, Self::Error> {
+    fn try_from(capture_amount: ConnectorMinorUnit) -> Result<Self, Self::Error> {
         Ok(Self {
             amount_to_capture: Some(capture_amount),
         })
@@ -4018,7 +4042,7 @@ pub struct WebhookPaymentMethodDetails {
 pub struct WebhookEventObjectData {
     pub id: String,
     pub object: WebhookEventObjectType,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     #[serde(default, deserialize_with = "convert_uppercase")]
     pub currency: common_enums::Currency,
     pub payment_intent: Option<String>,
@@ -4486,13 +4510,19 @@ pub(crate) fn build_webhook_dispute_response(
 ) -> Result<DisputeWebhookDetailsResponse, error_stack::Report<WebhookError>> {
     let event_object = &event.event_data.event_object;
 
-    let amount = event_object
+    let connector_amount = event_object
         .amount
         .ok_or_else(|| report!(WebhookError::WebhookMissingRequiredField { field: "amount" }))?;
 
+    let minor_amount = domain_types::utils::convert_back_amount_to_minor_units_for_webhook(
+        &common_utils::types::MinorUnitForConnector,
+        connector_amount,
+        event_object.currency,
+    )?;
+
     let amount = domain_types::utils::convert_amount_for_webhook(
         &StringMinorUnitForConnector,
-        amount,
+        minor_amount,
         event_object.currency,
     )?;
 
@@ -4746,14 +4776,19 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         >,
     ) -> Result<Self, Self::Error> {
         let split_payment_request = match item.request.split_payments.as_ref() {
-            Some(SplitPaymentsDetails::StripeSplitPayment(stripe_split_payment)) => Self {
-                charge_type: Some(stripe_split_payment.charge_type.clone()),
-                transfer_account_id: Some(Secret::new(
-                    stripe_split_payment.transfer_account_id.clone(),
-                )),
-                application_fees: stripe_split_payment.application_fees,
-                on_behalf_of: stripe_split_payment.on_behalf_of.clone(),
-            },
+            Some(SplitPaymentsDetails::StripeSplitPayment(stripe_split_payment)) => {
+                let fees = stripe_split_payment.application_fees
+                    .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
+                    .transpose()?;
+                Self {
+                    charge_type: Some(stripe_split_payment.charge_type.clone()),
+                    transfer_account_id: Some(Secret::new(
+                        stripe_split_payment.transfer_account_id.clone(),
+                    )),
+                    application_fees: fees,
+                    on_behalf_of: stripe_split_payment.on_behalf_of.clone(),
+                }
+            }
             Some(SplitPaymentsDetails::AdyenSplitPayment(_)) | None => Self::default(),
         };
 
@@ -5027,14 +5062,14 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 impl<F>
     TryFrom<(
         &RouterDataV2<F, RefundFlowData, RefundsData, RefundsResponseData>,
-        MinorUnit,
+        ConnectorMinorUnit,
     )> for RefundRequest
 {
     type Error = error_stack::Report<IntegrationError>;
     fn try_from(
         (item, refund_amount): (
             &RouterDataV2<F, RefundFlowData, RefundsData, RefundsResponseData>,
-            MinorUnit,
+            ConnectorMinorUnit,
         ),
     ) -> Result<Self, Self::Error> {
         let payment_intent = item.request.connector_transaction_id.clone();
@@ -5056,7 +5091,10 @@ impl<F> TryFrom<&RouterDataV2<F, RefundFlowData, RefundsData, RefundsResponseDat
     fn try_from(
         item: &RouterDataV2<F, RefundFlowData, RefundsData, RefundsResponseData>,
     ) -> Result<Self, Self::Error> {
-        let amount = item.request.minor_refund_amount;
+        let amount = StripeAmountConvertor::convert(
+            item.request.minor_refund_amount,
+            item.request.currency,
+        )?;
         match item.request.split_refunds.as_ref() {
             None => Err(IntegrationError::MissingRequiredField {
                 field_name: "split_refunds",
@@ -5966,11 +6004,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 match &stripe_split_payment.charge_type {
                     common_enums::PaymentChargeType::Stripe(charge_type) => match charge_type {
                         common_enums::StripeChargeType::Direct => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees,
+                            application_fee_amount: stripe_split_payment.application_fees
+                                .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
+                                .transpose()?,
                             destination_account_id: None,
                         }),
                         common_enums::StripeChargeType::Destination => Some(IntentCharges {
-                            application_fee_amount: stripe_split_payment.application_fees,
+                            application_fee_amount: stripe_split_payment.application_fees
+                                .map(|a| StripeAmountConvertor::convert(a, item.request.currency))
+                                .transpose()?,
                             destination_account_id: Some(Secret::new(
                                 stripe_split_payment.transfer_account_id.clone(),
                             )),
@@ -6240,7 +6282,7 @@ impl<F, T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct StripeClientAuthRequest {
-    pub amount: MinorUnit,
+    pub amount: ConnectorMinorUnit,
     pub currency: String,
     #[serde(rename = "automatic_payment_methods[enabled]")]
     pub automatic_payment_methods_enabled: Option<bool>,

--- a/crates/integrations/connector-integration/src/connectors/tamara.rs
+++ b/crates/integrations/connector-integration/src/connectors/tamara.rs
@@ -10,7 +10,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, PaymentMethodEligibility, RSync, Refund, Void},

--- a/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
@@ -242,7 +242,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         )?;
         let shipping_amount = converter
             .convert(
-                router_data.request.shipping_cost.unwrap_or(MinorUnit(0)),
+                router_data.request.shipping_cost.unwrap_or(MinorUnit::default()),
                 currency,
             )
             .change_context(errors::IntegrationError::RequestEncodingFailed {
@@ -255,7 +255,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             })?;
         let tax_amount = converter
             .convert(
-                router_data.request.order_tax_amount.unwrap_or(MinorUnit(0)),
+                router_data.request.order_tax_amount.unwrap_or(MinorUnit::default()),
                 currency,
             )
             .change_context(errors::IntegrationError::RequestEncodingFailed {
@@ -930,9 +930,9 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         ))?;
         let email = customer.get_email()?;
         let phone_number = customer.get_phone_number()?;
-        let converter = FloatMajorUnitForConnector;
-        let amount = converter
-            .convert(data.amount.amount, data.amount.currency)
+        let amount = data
+            .amount
+            .convert(&FloatMajorUnitForConnector)
             .change_context(errors::IntegrationError::RequestEncodingFailed {
                 context: errors::IntegrationErrorContext {
                     additional_context: Some(
@@ -945,7 +945,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(Self {
             order: TamaraEligibilityOrder {
                 amount,
-                currency: data.amount.currency,
+                currency: data.amount.currency(),
             },
             customer: TamaraEligibilityCustomer {
                 phone_number,

--- a/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tamara/transformers.rs
@@ -242,7 +242,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         )?;
         let shipping_amount = converter
             .convert(
-                router_data.request.shipping_cost.unwrap_or(MinorUnit::default()),
+                router_data
+                    .request
+                    .shipping_cost
+                    .unwrap_or(MinorUnit::default()),
                 currency,
             )
             .change_context(errors::IntegrationError::RequestEncodingFailed {
@@ -255,7 +258,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             })?;
         let tax_amount = converter
             .convert(
-                router_data.request.order_tax_amount.unwrap_or(MinorUnit::default()),
+                router_data
+                    .request
+                    .order_tax_amount
+                    .unwrap_or(MinorUnit::default()),
                 currency,
             )
             .change_context(errors::IntegrationError::RequestEncodingFailed {

--- a/crates/integrations/connector-integration/src/connectors/tesouro.rs
+++ b/crates/integrations/connector-integration/src/connectors/tesouro.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt, types::FloatMajorUnit,
+    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{Authorize, PSync, RepeatPayment, ServerAuthenticationToken, SetupMandate},

--- a/crates/integrations/connector-integration/src/connectors/tesouro.rs
+++ b/crates/integrations/connector-integration/src/connectors/tesouro.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{consts, errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, PSync, RepeatPayment, ServerAuthenticationToken, SetupMandate},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/travelhub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/travelhub/transformers.rs
@@ -1,7 +1,7 @@
 use crate::types::ResponseRouterData;
 use base64::Engine;
 use common_enums::{AttemptStatus, Currency, RefundStatus};
-use common_utils::MinorUnit;
+use common_utils::{AmountConvertor, ConnectorMinorUnit, MinorUnit, MinorUnitForConnector};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
     connector_types::{
@@ -170,7 +170,7 @@ pub struct TravelhubTravelFlight {
 #[serde(rename_all = "camelCase")]
 pub struct TravelhubTravelFare {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<ConnectorMinorUnit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -225,8 +225,8 @@ fn build_travel_data(
                     .or_else(|| airline.flight_date.clone()),
                 air_class: s.class_of_service.clone(),
                 fare: s.fare_amount.as_ref().map(|m| TravelhubTravelFare {
-                    amount: Some(m.amount),
-                    currency: Some(m.currency),
+                    amount: m.convert(&MinorUnitForConnector).ok(),
+                    currency: Some(m.currency()),
                     fare_class: s.class_of_service.clone(),
                     fare_basis: s.fare_basis_code.clone(),
                     stopover_allowed: s.stopover_code.as_deref().map(|c| c == "O"),

--- a/crates/integrations/connector-integration/src/connectors/travelhub/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/travelhub/transformers.rs
@@ -1,7 +1,7 @@
 use crate::types::ResponseRouterData;
 use base64::Engine;
 use common_enums::{AttemptStatus, Currency, RefundStatus};
-use common_utils::{AmountConvertor, ConnectorMinorUnit, MinorUnit, MinorUnitForConnector};
+use common_utils::{ConnectorMinorUnit, MinorUnit, MinorUnitForConnector};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/trustly.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustly.rs
@@ -3,7 +3,7 @@ pub mod transformers;
 use std::{self, fmt::Debug};
 
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMajorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Refund},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/trustpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay.rs
@@ -5,7 +5,7 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::{FloatMajorUnitForConnector, StringMajorUnit, StringMinorUnitForConnector},
+    types::{FloatMajorUnitForConnector, StringMinorUnitForConnector},
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpay/transformers.rs
@@ -2586,7 +2586,7 @@ impl From<GooglePayTransactionInfo> for domain_types::connector_types::GpayTrans
     fn from(value: GooglePayTransactionInfo) -> Self {
         let total_price =
             TrustpayAmountConvertor::convert_back(value.total_price, value.currency_code)
-                .unwrap_or_else(|_| MinorUnit::new(0));
+                .unwrap_or_else(|_| MinorUnit::default());
 
         Self {
             country_code: value.country_code,
@@ -2755,7 +2755,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let amount = item
             .connector
             .amount_converter
-            .convert(MinorUnit::new(0), router_data.request.currency)
+            .convert(MinorUnit::default(), router_data.request.currency)
             .change_context(IntegrationError::AmountConversionFailed {
                 context: Default::default(),
             })?;

--- a/crates/integrations/connector-integration/src/connectors/trustpayments.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMinorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/trustpayments.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, IncrementalAuthorization, PSync, RSync, Refund, RepeatPayment,

--- a/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/trustpayments/transformers.rs
@@ -1221,7 +1221,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
         // Check if this is a partial refund
         // For partial refunds, include baseamount; for full refunds, omit it
-        let base_amount = if router_data.request.minor_refund_amount.get_amount_as_i64() > 0 {
+        let base_amount = if router_data.request.minor_refund_amount.is_positive() {
             // Partial refund - include the amount
             let amount = item
                 .connector
@@ -1761,7 +1761,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         let minor_amount = router_data
             .request
             .minor_amount
-            .unwrap_or(common_utils::types::MinorUnit::zero());
+            .unwrap_or(common_utils::types::MinorUnit::default());
         let amount = item
             .connector
             .amount_converter

--- a/crates/integrations/connector-integration/src/connectors/tsys.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMinorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},

--- a/crates/integrations/connector-integration/src/connectors/tsys.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -1,5 +1,5 @@
 use common_enums::AttemptStatus;
-use common_utils::types::{MinorUnit, StringMinorUnit};
+use common_utils::types::StringMinorUnit;
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{
@@ -927,7 +927,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             transaction_amount: item_data
                 .connector
                 .amount_converter
-                .convert(MinorUnit(item.request.refund_amount), item.request.currency)
+                .convert(item.request.minor_refund_amount, item.request.currency)
                 .change_context(IntegrationError::AmountConversionFailed {
                     context: Default::default(),
                 })?,
@@ -1114,7 +1114,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 let minor_amount = item
                     .request
                     .minor_amount
-                    .unwrap_or_else(|| MinorUnit::new(1));
+                    .unwrap_or_default();
                 let transaction_amount = item_data
                     .connector
                     .amount_converter

--- a/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys/transformers.rs
@@ -1111,10 +1111,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 
                 // TSYS requires a non-zero amount even for authorization; default
                 // to 1 minor unit if the request does not carry one.
-                let minor_amount = item
-                    .request
-                    .minor_amount
-                    .unwrap_or_default();
+                let minor_amount = item.request.minor_amount.unwrap_or_default();
                 let transaction_amount = item_data
                     .connector
                     .amount_converter

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit.rs
@@ -5,9 +5,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void, VoidPC,

--- a/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/tsys_transit/transformers.rs
@@ -1338,7 +1338,7 @@ fn build_tsys_product_details(
         let priority = 1;
         let has_discount = detail
             .unit_discount_amount
-            .map(|amount| amount.get_amount_as_i64() > 0)
+            .map(|amount| amount.is_positive())
             .unwrap_or(false);
         let stackable = if has_discount {
             TsysTransitYesNo::Yes
@@ -1964,7 +1964,13 @@ fn extract_for_authorize<T: PaymentMethodDataTypes + Debug + Sync + Send + 'stat
         .request
         .surcharge_amount
         .as_ref()
-        .map(|amount| super::TsysTransitAmountConvertor::convert(amount.amount, amount.currency))
+        .map(|amount| {
+            amount
+                .convert(&common_utils::types::StringMajorUnitForConnector)
+                .change_context(IntegrationError::AmountConversionFailed {
+                    context: Default::default(),
+                })
+        })
         .transpose()?;
     let billing = router_data
         .resource_common_data
@@ -2545,7 +2551,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
                 })
             })
             .flatten();
-        let amount_captured = minor_amount_captured.map(|m| m.get_amount_as_i64());
+        let amount_captured = None;
 
         let payments_response_data = PaymentsResponseData::TransactionResponse {
             resource_id: ResponseId::ConnectorTransactionId(transaction_id.clone()),
@@ -3130,7 +3136,11 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .refund_money
             .as_ref()
             .map(|amount| {
-                super::TsysTransitAmountConvertor::convert(amount.amount, amount.currency)
+                amount
+                    .convert(&common_utils::types::StringMajorUnitForConnector)
+                    .change_context(IntegrationError::AmountConversionFailed {
+                        context: Default::default(),
+                    })
             })
             .transpose()?;
         // TSYS <voidReason> only accepts a fixed set of enum values, so an

--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -232,8 +232,25 @@ impl PacoTransactionAmount {
                     )),
                 },
             })?;
-        let raw = minor_amount.get_amount_as_i64();
-        let amount_text = format!("{raw:0>12}");
+        let connector_minor = <common_utils::types::MinorUnitForConnector as common_utils::types::AmountConvertor>::convert(
+            &common_utils::types::MinorUnitForConnector,
+            minor_amount,
+            currency,
+        )
+        .map_err(|_| errors::IntegrationError::InvalidDataFormat {
+            field_name: "amount",
+            context: errors::IntegrationErrorContext {
+                suggested_action: Some(
+                    "Verify the request `amount` is a positive integer minor-unit value."
+                        .to_string(),
+                ),
+                doc_url: Some(PACO_INTEGRATION_DOC_URL.to_string()),
+                additional_context: Some(format!(
+                    "Failed to convert minor amount to ConnectorMinorUnit for currency {currency:?}"
+                )),
+            },
+        })?;
+        let amount_text = format!("{:0>12}", connector_minor);
         let amount = <FloatMajorUnitForConnector as common_utils::types::AmountConvertor>::convert(
             &FloatMajorUnitForConnector,
             minor_amount,
@@ -635,7 +652,48 @@ pub struct PacoPassenger {
 impl TryFrom<&common_utils::types::Money> for PacoTransactionAmount {
     type Error = errors::IntegrationError;
     fn try_from(money: &common_utils::types::Money) -> Result<Self, Self::Error> {
-        Self::new(money.amount, money.currency)
+        let currency = money.currency();
+        let decimals = currency
+            .number_of_digits_after_decimal_point()
+            .map_err(|_| errors::IntegrationError::InvalidDataFormat {
+                field_name: "currency",
+                context: errors::IntegrationErrorContext {
+                    suggested_action: Some(
+                        "Use an ISO 4217 currency PACO accepts (e.g. PHP, USD).".to_string(),
+                    ),
+                    doc_url: Some(PACO_INTEGRATION_DOC_URL.to_string()),
+                    additional_context: Some(format!(
+                        "Currency {currency:?} not supported for amount conversion"
+                    )),
+                },
+            })?;
+        let minor_unit = money
+            .convert(&common_utils::types::MinorUnitForConnector)
+            .map_err(|_| errors::IntegrationError::AmountConversionFailed {
+                context: Default::default(),
+            })?;
+        let amount_text = format!("{:0>12}", minor_unit);
+        let amount = money
+            .convert(&FloatMajorUnitForConnector)
+            .map_err(|err| errors::IntegrationError::InvalidDataFormat {
+                field_name: "amount",
+                context: errors::IntegrationErrorContext {
+                    suggested_action: Some(
+                        "Verify the request `amount` is a positive integer minor-unit value."
+                            .to_string(),
+                    ),
+                    doc_url: Some(PACO_INTEGRATION_DOC_URL.to_string()),
+                    additional_context: Some(format!(
+                        "Failed to convert minor amount to FloatMajorUnit: {err}"
+                    )),
+                },
+            })?;
+        Ok(PacoTransactionAmount {
+            amount_text,
+            currency_code: currency,
+            decimal_places: decimals,
+            amount,
+        })
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -673,9 +673,8 @@ impl TryFrom<&common_utils::types::Money> for PacoTransactionAmount {
                 context: Default::default(),
             })?;
         let amount_text = format!("{:0>12}", minor_unit);
-        let amount = money
-            .convert(&FloatMajorUnitForConnector)
-            .map_err(|err| errors::IntegrationError::InvalidDataFormat {
+        let amount = money.convert(&FloatMajorUnitForConnector).map_err(|err| {
+            errors::IntegrationError::InvalidDataFormat {
                 field_name: "amount",
                 context: errors::IntegrationErrorContext {
                     suggested_action: Some(
@@ -687,7 +686,8 @@ impl TryFrom<&common_utils::types::Money> for PacoTransactionAmount {
                         "Failed to convert minor amount to FloatMajorUnit: {err}"
                     )),
                 },
-            })?;
+            }
+        })?;
         Ok(PacoTransactionAmount {
             amount_text,
             currency_code: currency,

--- a/crates/integrations/connector-integration/src/connectors/wellsfargo.rs
+++ b/crates/integrations/connector-integration/src/connectors/wellsfargo.rs
@@ -8,7 +8,6 @@ use common_utils::{
     events,
     ext_traits::ByteSliceExt,
     request::Method,
-    types::StringMajorUnit,
 };
 use domain_types::router_data::ConnectorSpecificConfig;
 use domain_types::{

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -1036,12 +1036,12 @@ impl<F, T>
             PaymentOutcome::FraudHighRisk => Some("Transaction marked as high risk".to_string()),
             _ => None,
         };
-        let status = if amount == MinorUnit::default() && worldpay_status == PaymentOutcome::Authorized
-        {
-            enums::AttemptStatus::Charged
-        } else {
-            enums::AttemptStatus::from(worldpay_status.clone())
-        };
+        let status =
+            if amount == MinorUnit::default() && worldpay_status == PaymentOutcome::Authorized {
+                enums::AttemptStatus::Charged
+            } else {
+                enums::AttemptStatus::from(worldpay_status.clone())
+            };
 
         // Extract linkData for 3DS flows and store in metadata with stage indicator
         let connector_metadata = match &router_data.response.other_fields {

--- a/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpay/transformers.rs
@@ -387,7 +387,7 @@ fn get_settlement_info<
     amount: MinorUnit,
 ) -> Option<AutoSettlement> {
     match router_data.request.capture_method.unwrap_or_default() {
-        _ if amount == MinorUnit::zero() => None,
+        _ if amount == MinorUnit::default() => None,
         enums::CaptureMethod::Automatic | enums::CaptureMethod::SequentialAutomatic => {
             Some(AutoSettlement { auto: true })
         }
@@ -1036,7 +1036,7 @@ impl<F, T>
             PaymentOutcome::FraudHighRisk => Some("Transaction marked as high risk".to_string()),
             _ => None,
         };
-        let status = if amount == MinorUnit::zero() && worldpay_status == PaymentOutcome::Authorized
+        let status = if amount == MinorUnit::default() && worldpay_status == PaymentOutcome::Authorized
         {
             enums::AttemptStatus::Charged
         } else {

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
@@ -3,9 +3,7 @@ pub mod transformers;
 use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
-use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
-};
+use common_utils::{consts, errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},
     connector_types::{

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    consts, errors::CustomResult, events, ext_traits::ByteSliceExt,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},

--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv.rs
@@ -7,7 +7,6 @@ use common_utils::{
     events,
     ext_traits::{deserialize_xml_to_struct, BytesExt},
     request::RequestContent,
-    types::MinorUnit,
 };
 use domain_types::{
     connector_flow::{

--- a/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayvantiv/transformers.rs
@@ -163,7 +163,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         let ship_to_address = get_shipping_address(&item.router_data.resource_common_data);
 
         let (authorization, sale) =
-            if item.router_data.request.is_auto_capture() && amount != MinorUnit::zero() {
+            if item.router_data.request.is_auto_capture() && amount != MinorUnit::default() {
                 let sale = Sale {
                     id: format!("{}_{}", OperationId::Sale, merchant_txn_id),
                     report_group: report_group.clone(),

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_enums::CurrencyUnit;
-use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt, StringMinorUnit};
+use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void, VoidPC,

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -1341,7 +1341,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         if router_data
             .request
             .minor_amount
-            .is_some_and(|amount| amount.get_amount_as_i64() > 0)
+            .is_some_and(|amount| amount.is_positive())
         {
             return Err(IntegrationError::FlowNotSupported {
                 flow: "SetupMandate with a non-zero amount".to_string(),
@@ -1405,7 +1405,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             router_data
                 .request
                 .minor_amount
-                .unwrap_or_else(common_utils::types::MinorUnit::zero),
+                .unwrap_or_default(),
             router_data.request.currency,
         )?;
 

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -1402,10 +1402,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             get_worldpayxml_info_3d_secure(router_data.request.authentication_data.as_ref())?;
 
         let converted_amount = super::WorldpayxmlAmountConvertor::convert(
-            router_data
-                .request
-                .minor_amount
-                .unwrap_or_default(),
+            router_data.request.minor_amount.unwrap_or_default(),
             router_data.request.currency,
         )?;
 

--- a/crates/integrations/connector-integration/src/connectors/xendit.rs
+++ b/crates/integrations/connector-integration/src/connectors/xendit.rs
@@ -9,7 +9,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::FloatMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, PSync, RSync, Refund},

--- a/crates/integrations/connector-integration/src/connectors/zift.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift.rs
@@ -2,7 +2,7 @@ use super::macros;
 pub mod transformers;
 use crate::{types::ResponseRouterData, with_error_response_body};
 use common_enums::{CaptureMethod, CardNetwork, CurrencyUnit, PaymentMethod, PaymentMethodType};
-use common_utils::{errors::CustomResult, events, StringMinorUnit};
+use common_utils::{errors::CustomResult, events};
 use hyperswitch_masking::Maskable;
 use serde_json::Value;
 use std::{

--- a/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift/transformers.rs
@@ -2,7 +2,7 @@ use crate::{connectors::zift::ZiftRouterData, types::ResponseRouterData};
 use common_utils::{
     consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::CustomResult,
-    types::{MinorUnit, StringMinorUnit},
+    types::StringMinorUnit,
 };
 use error_stack::{report, Report, ResultExt};
 use std::fmt::Debug;
@@ -1304,7 +1304,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             .connector
             .amount_converter
             .convert(
-                MinorUnit::new(item.router_data.request.refund_amount),
+                item.router_data.request.minor_refund_amount,
                 item.router_data.request.currency,
             )
             .change_context(IntegrationError::RequestEncodingFailed {

--- a/crates/integrations/connector-integration/src/payout_connectors/gotyme_sanlam.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/gotyme_sanlam.rs
@@ -8,7 +8,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{PayoutGet, PayoutTransfer},

--- a/crates/integrations/connector-integration/src/payout_connectors/paypal/transformers.rs
+++ b/crates/integrations/connector-integration/src/payout_connectors/paypal/transformers.rs
@@ -271,7 +271,7 @@ impl
         >,
     ) -> Result<Self, Self::Error> {
         let minor_amount = item.request.amount;
-        if minor_amount <= common_utils::types::MinorUnit::zero() {
+        if minor_amount <= common_utils::types::MinorUnit::default() {
             return Err(IntegrationError::InvalidDataFormat {
                 field_name: "amount",
                 context: IntegrationErrorContext {

--- a/crates/integrations/connector-integration/src/utils.rs
+++ b/crates/integrations/connector-integration/src/utils.rs
@@ -337,13 +337,13 @@ pub(crate) fn safe_base64_decode(base64_data: String) -> Result<Vec<u8>, Error> 
 
 pub fn deserialize_zero_minor_amount_as_none<'de, D>(
     deserializer: D,
-) -> Result<Option<MinorUnit>, D::Error>
+) -> Result<Option<common_utils::ConnectorMinorUnit>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    let amount = Option::<MinorUnit>::deserialize(deserializer)?;
+    let amount = Option::<common_utils::ConnectorMinorUnit>::deserialize(deserializer)?;
     match amount {
-        Some(value) if value.get_amount_as_i64() == 0 => Ok(None),
+        Some(value) if value == common_utils::ConnectorMinorUnit::default() => Ok(None),
         _ => Ok(amount),
     }
 }

--- a/crates/types-traits/domain_types/src/connector_types.rs
+++ b/crates/types-traits/domain_types/src/connector_types.rs
@@ -862,7 +862,7 @@ impl PaymentFlowData {
     }
 
     pub fn get_currency(&self) -> Option<common_enums::Currency> {
-        self.amount.as_ref().map(|money| money.currency)
+        self.amount.as_ref().map(|money| money.currency())
     }
 
     pub fn get_merchant_request_id(&self) -> Result<String, Error> {

--- a/crates/types-traits/domain_types/src/frm/types.rs
+++ b/crates/types-traits/domain_types/src/frm/types.rs
@@ -18,6 +18,7 @@ use crate::{
 use common_enums::{AttemptStatus, FrmDecision, PaymentMethodType};
 use common_utils::{
     pii::Email,
+    proto_boundary::{MinorUnitProtoAccess, MoneyProtoAccess},
     types::{MinorUnit, Money},
 };
 use error_stack::ResultExt;
@@ -314,10 +315,7 @@ impl ForeignTryFrom<grpc_api_types::frm::FrmServicePreRiskCheckRequest> for PreR
             .transpose()?;
 
         Ok(Self {
-            amount: Money {
-                amount: MinorUnit::new(amount.minor_amount),
-                currency,
-            },
+            amount: Money::new(MinorUnit::new(amount.minor_amount), currency),
             customer_info,
             payment_method,
             browser_info,
@@ -453,10 +451,7 @@ impl ForeignTryFrom<grpc_api_types::frm::FrmServicePostRiskCheckRequest> for Pos
             })?;
 
         Ok(Self {
-            amount: Money {
-                amount: MinorUnit::new(amount.minor_amount),
-                currency,
-            },
+            amount: Money::new(MinorUnit::new(amount.minor_amount), currency),
             customer_info,
             payment_method,
             merchant_transaction_id: value.merchant_transaction_id,
@@ -583,10 +578,7 @@ impl ForeignTryFrom<grpc_api_types::payments::FrmNotificationContent> for FrmPay
 
         Ok(Self {
             connector_transaction_id: value.connector_transaction_id,
-            amount: Money {
-                amount: MinorUnit::new(amount.minor_amount),
-                currency,
-            },
+            amount: Money::new(MinorUnit::new(amount.minor_amount), currency),
             frm_transaction_id: value.frm_transaction_id,
             payment_status,
             merchant_transaction_id: payment_details.merchant_transaction_id,
@@ -656,10 +648,7 @@ impl ForeignTryFrom<grpc_api_types::payments::FrmNotificationContent>
 
         Ok(Self {
             connector_transaction_id: value.connector_transaction_id,
-            amount: Money {
-                amount: MinorUnit::new(amount.minor_amount),
-                currency,
-            },
+            amount: Money::new(MinorUnit::new(amount.minor_amount), currency),
             frm_transaction_id: value.frm_transaction_id,
             connector_refund_id: refund.connector_refund_id,
             merchant_refund_id: refund.merchant_refund_id,
@@ -725,10 +714,7 @@ impl ForeignTryFrom<grpc_api_types::payments::FrmNotificationContent>
 
         Ok(Self {
             connector_transaction_id: value.connector_transaction_id,
-            amount: Money {
-                amount: MinorUnit::new(amount.minor_amount),
-                currency,
-            },
+            amount: Money::new(MinorUnit::new(amount.minor_amount), currency),
             frm_transaction_id: value.frm_transaction_id,
             connector_dispute_id: chargeback.connector_dispute_id,
             merchant_dispute_id: chargeback.merchant_dispute_id,

--- a/crates/types-traits/domain_types/src/payouts/types.rs
+++ b/crates/types-traits/domain_types/src/payouts/types.rs
@@ -7,6 +7,7 @@ use crate::utils::{
     ForeignTryFrom,
 };
 use common_utils::metadata::MaskedMetadata;
+use common_utils::proto_boundary::{MinorUnitProtoAccess, MoneyProtoAccess};
 use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
 use payouts::payouts_types::PayoutFlowData;
@@ -2515,10 +2516,7 @@ impl ForeignTryFrom<grpc_api_types::payouts::PayoutMethodEligibilityRequest>
 
         Ok(Self {
             merchant_payout_id: value.merchant_payout_id.clone(),
-            amount: common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: source_currency,
-            },
+            amount: common_utils::types::Money::new(common_utils::types::MinorUnit::new(amount.minor_amount), source_currency),
             destination_currency,
             payout_method_data,
             source_bank_data: value

--- a/crates/types-traits/domain_types/src/payouts/types.rs
+++ b/crates/types-traits/domain_types/src/payouts/types.rs
@@ -2516,7 +2516,10 @@ impl ForeignTryFrom<grpc_api_types::payouts::PayoutMethodEligibilityRequest>
 
         Ok(Self {
             merchant_payout_id: value.merchant_payout_id.clone(),
-            amount: common_utils::types::Money::new(common_utils::types::MinorUnit::new(amount.minor_amount), source_currency),
+            amount: common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                source_currency,
+            ),
             destination_currency,
             payout_method_data,
             source_bank_data: value

--- a/crates/types-traits/domain_types/src/surcharge/types.rs
+++ b/crates/types-traits/domain_types/src/surcharge/types.rs
@@ -12,7 +12,7 @@ use crate::{
         extract_connector_request_reference_id, extract_merchant_id_from_metadata, ForeignTryFrom,
     },
 };
-use common_utils::{metadata::MaskedMetadata, types::MinorUnit};
+use common_utils::{metadata::MaskedMetadata, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
 use error_stack::ResultExt;
 impl
     ForeignTryFrom<(

--- a/crates/types-traits/domain_types/src/surcharge/types.rs
+++ b/crates/types-traits/domain_types/src/surcharge/types.rs
@@ -12,7 +12,9 @@ use crate::{
         extract_connector_request_reference_id, extract_merchant_id_from_metadata, ForeignTryFrom,
     },
 };
-use common_utils::{metadata::MaskedMetadata, proto_boundary::MinorUnitProtoAccess, types::MinorUnit};
+use common_utils::{
+    metadata::MaskedMetadata, proto_boundary::MinorUnitProtoAccess, types::MinorUnit,
+};
 use error_stack::ResultExt;
 impl
     ForeignTryFrom<(

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -12992,12 +12992,8 @@ impl ForeignTryFrom<grpc_api_types::payments::MandateAmountData> for mandates::M
                 amount_data.initial_billing_amount
             {
                 Some(common_utils::types::Money::new(
-                    common_utils::types::MinorUnit::new(
-                        initial_billing_amount.minor_amount,
-                    ),
-                    common_enums::Currency::foreign_try_from(
-                        initial_billing_amount.currency(),
-                    )?,
+                    common_utils::types::MinorUnit::new(initial_billing_amount.minor_amount),
+                    common_enums::Currency::foreign_try_from(initial_billing_amount.currency())?,
                 ))
             } else {
                 None
@@ -14899,12 +14895,14 @@ impl
             amount_captured: None,
             minor_amount_captured: None,
             minor_amount_capturable: None,
-            amount: value.amount.map(|amt| common_utils::types::Money::new(
-                common_utils::types::MinorUnit::new(amt.minor_amount),
-                common_enums::Currency::foreign_try_from(amt.currency())
-                    .ok()
-                    .unwrap_or_default(),
-            )),
+            amount: value.amount.map(|amt| {
+                common_utils::types::Money::new(
+                    common_utils::types::MinorUnit::new(amt.minor_amount),
+                    common_enums::Currency::foreign_try_from(amt.currency())
+                        .ok()
+                        .unwrap_or_default(),
+                )
+            }),
             access_token,
             session_token: None,
             reference_id: None,
@@ -19399,8 +19397,10 @@ impl ForeignTryFrom<(bool, RedirectDetailsResponse)>
             response_amount: match redirect_details_response.response_amount {
                 Some(money) => Some(grpc_api_types::payments::Money {
                     minor_amount: money.amount().get_amount_as_i64(),
-                    currency: grpc_api_types::payments::Currency::foreign_try_from(money.currency())?
-                        .into(),
+                    currency: grpc_api_types::payments::Currency::foreign_try_from(
+                        money.currency(),
+                    )?
+                    .into(),
                 }),
                 None => None,
             },

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -21,6 +21,7 @@ use common_enums::{
     PaymentMethodType, SamsungPayCardBrand,
 };
 use common_utils::config_patch::Patch;
+use common_utils::proto_boundary::{MinorUnitProtoAccess, MoneyProtoAccess};
 use common_utils::{
     consts::{self, NO_ERROR_CODE, X_EXTERNAL_VAULT_METADATA},
     id_type::CustomerId,
@@ -4200,10 +4201,10 @@ impl ForeignTryFrom<grpc_api_types::payments::Money> for common_utils::types::Mo
     fn foreign_try_from(
         value: grpc_api_types::payments::Money,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
-        Ok(Self {
-            amount: common_utils::types::MinorUnit::new(value.minor_amount),
-            currency: common_enums::Currency::foreign_try_from(value.currency())?,
-        })
+        Ok(Self::new(
+            common_utils::types::MinorUnit::new(value.minor_amount),
+            common_enums::Currency::foreign_try_from(value.currency())?,
+        ))
     }
 }
 
@@ -5761,10 +5762,10 @@ impl ForeignTryFrom<(AuthorizationRequest, Connectors, &MaskedMetadata)> for Pay
                 .amount
                 .as_ref()
                 .map(|money| {
-                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money {
-                        amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                        currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                    })
+                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money::new(
+                        common_utils::types::MinorUnit::new(money.minor_amount),
+                        common_enums::Currency::foreign_try_from(money.currency())?,
+                    ))
                 })
                 .transpose()?,
             access_token,
@@ -5987,10 +5988,10 @@ impl
                 .amount
                 .as_ref()
                 .map(|money| {
-                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money {
-                        amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                        currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                    })
+                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money::new(
+                        common_utils::types::MinorUnit::new(money.minor_amount),
+                        common_enums::Currency::foreign_try_from(money.currency())?,
+                    ))
                 })
                 .transpose()?,
             access_token,
@@ -6081,10 +6082,10 @@ impl
                 .amount
                 .as_ref()
                 .map(|money| {
-                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money {
-                        amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                        currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                    })
+                    Ok::<_, error_stack::Report<IntegrationError>>(common_utils::types::Money::new(
+                        common_utils::types::MinorUnit::new(money.minor_amount),
+                        common_enums::Currency::foreign_try_from(money.currency())?,
+                    ))
                 })
                 .transpose()?,
             access_token,
@@ -8588,9 +8589,9 @@ pub fn generate_payment_sync_response(
                     .amount
                     .as_ref()
                     .map(|money| {
-                        grpc_api_types::payments::Currency::foreign_try_from(money.currency).map(
+                        grpc_api_types::payments::Currency::foreign_try_from(money.currency()).map(
                             |currency| grpc_api_types::payments::Money {
-                                minor_amount: money.amount.get_amount_as_i64(),
+                                minor_amount: money.amount().get_amount_as_i64(),
                                 currency: currency as i32,
                             },
                         )
@@ -8719,9 +8720,9 @@ pub fn generate_payment_sync_response(
                     .amount
                     .as_ref()
                     .map(|money| {
-                        grpc_api_types::payments::Currency::foreign_try_from(money.currency).map(
+                        grpc_api_types::payments::Currency::foreign_try_from(money.currency()).map(
                             |currency| grpc_api_types::payments::Money {
-                                minor_amount: money.amount.get_amount_as_i64(),
+                                minor_amount: money.amount().get_amount_as_i64(),
                                 currency: currency as i32,
                             },
                         )
@@ -8809,9 +8810,9 @@ pub fn generate_payment_sync_response(
                 .amount
                 .as_ref()
                 .map(|money| {
-                    grpc_api_types::payments::Currency::foreign_try_from(money.currency).map(
+                    grpc_api_types::payments::Currency::foreign_try_from(money.currency()).map(
                         |currency| grpc_api_types::payments::Money {
-                            minor_amount: money.amount.get_amount_as_i64(),
+                            minor_amount: money.amount().get_amount_as_i64(),
                             currency: currency as i32,
                         },
                     )
@@ -9919,10 +9920,10 @@ impl ForeignTryFrom<PaymentMethodServiceEligibilityRequest> for PaymentMethodEli
                 },
             })
         })?;
-        let amount = common_utils::types::Money {
-            amount: common_utils::types::MinorUnit::new(money.minor_amount),
-            currency: common_enums::Currency::foreign_try_from(money.currency())?,
-        };
+        let amount = common_utils::types::Money::new(
+            common_utils::types::MinorUnit::new(money.minor_amount),
+            common_enums::Currency::foreign_try_from(money.currency())?,
+        );
 
         // Resolve fields read via prost accessors (which borrow all of `value`)
         // before moving any owned fields out of `value`.
@@ -10909,10 +10910,10 @@ impl ForeignTryFrom<grpc_api_types::payments::SplitSettlementMarketplace>
         let split_value = match value.split_value {
             Some(grpc_api_types::payments::split_settlement_marketplace::SplitValue::Amount(
                 money,
-            )) => connector_types::SplitValue::Amount(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(money.currency())?,
-            }),
+            )) => connector_types::SplitValue::Amount(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(money.minor_amount),
+                common_enums::Currency::foreign_try_from(money.currency())?,
+            )),
             Some(
                 grpc_api_types::payments::split_settlement_marketplace::SplitValue::Percentage(
                     percentage,
@@ -10948,10 +10949,10 @@ impl ForeignTryFrom<grpc_api_types::payments::SplitSettlementVendor>
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         let split_value = match value.split_value {
             Some(grpc_api_types::payments::split_settlement_vendor::SplitValue::Amount(money)) => {
-                connector_types::SplitValue::Amount(common_utils::types::Money {
-                    amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                    currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                })
+                connector_types::SplitValue::Amount(common_utils::types::Money::new(
+                    common_utils::types::MinorUnit::new(money.minor_amount),
+                    common_enums::Currency::foreign_try_from(money.currency())?,
+                ))
             }
             Some(grpc_api_types::payments::split_settlement_vendor::SplitValue::Percentage(
                 percentage,
@@ -11011,10 +11012,10 @@ impl ForeignTryFrom<grpc_api_types::payments::SplitSettlementRefundMarketplace>
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         let split_value = match value.split_value {
             Some(grpc_api_types::payments::split_settlement_refund_marketplace::SplitValue::RefundAmount(money)) => {
-                connector_types::SplitValue::Amount(common_utils::types::Money {
-                    amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                    currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                })
+                connector_types::SplitValue::Amount(common_utils::types::Money::new(
+                    common_utils::types::MinorUnit::new(money.minor_amount),
+                    common_enums::Currency::foreign_try_from(money.currency())?,
+                ))
             }
             Some(grpc_api_types::payments::split_settlement_refund_marketplace::SplitValue::Percentage(percentage)) => {
                 connector_types::SplitValue::Percentage(percentage)
@@ -11052,10 +11053,10 @@ impl ForeignTryFrom<grpc_api_types::payments::SplitSettlementRefundVendor>
                 grpc_api_types::payments::split_settlement_refund_vendor::SplitValue::RefundAmount(
                     money,
                 ),
-            ) => connector_types::SplitValue::Amount(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(money.currency())?,
-            }),
+            ) => connector_types::SplitValue::Amount(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(money.minor_amount),
+                common_enums::Currency::foreign_try_from(money.currency())?,
+            )),
             Some(
                 grpc_api_types::payments::split_settlement_refund_vendor::SplitValue::Percentage(
                     percentage,
@@ -11588,10 +11589,10 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
             Some(DomainContext::Payment(payment_ctx)) => {
                 // Payment SDK session flow (Adyen, Braintree, Shift4, etc.)
                 let money = match payment_ctx.amount {
-                    Some(amount) => Ok(common_utils::types::Money {
-                        amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                        currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-                    }),
+                    Some(amount) => Ok(common_utils::types::Money::new(
+                        common_utils::types::MinorUnit::new(amount.minor_amount),
+                        common_enums::Currency::foreign_try_from(amount.currency())?,
+                    )),
                     None => Err(report!(IntegrationError::MissingRequiredField {
                         field_name: "amount",
                         context: IntegrationErrorContext::default(),
@@ -11620,8 +11621,8 @@ impl ForeignTryFrom<MerchantAuthenticationServiceCreateClientAuthenticationToken
                     .transpose()?;
 
                 Ok(Self {
-                    amount: money.amount,
-                    currency: money.currency,
+                    amount: money.amount(),
+                    currency: money.currency(),
                     country,
                     order_details: None,
                     customer,
@@ -11675,10 +11676,10 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCaptureRequest>
                 });
 
         let amount = match value.amount_to_capture {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount_to_capture",
                 context: IntegrationErrorContext::default(),
@@ -11692,9 +11693,9 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCaptureRequest>
                 .map(connector_types::SplitSettlement::foreign_try_from)
                 .transpose()?
                 .map(Box::new),
-            amount_to_capture: amount.amount.get_amount_as_i64(),
-            minor_amount_to_capture: amount.amount,
-            currency: amount.currency,
+            amount_to_capture: amount.amount().get_amount_as_i64(),
+            minor_amount_to_capture: amount.amount(),
+            currency: amount.currency(),
             connector_transaction_id,
             multiple_capture_data,
             metadata: value
@@ -12446,10 +12447,10 @@ impl<
         })?;
 
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -12492,9 +12493,9 @@ impl<
         };
 
         Ok(Self {
-            currency: amount.currency,
+            currency: amount.currency(),
             payment_method_data,
-            amount: Some(amount.amount.get_amount_as_i64()),
+            amount: Some(amount.amount().get_amount_as_i64()),
             confirm: true,
             customer_acceptance: Some(mandates::CustomerAcceptance::foreign_try_from(
                 customer_acceptance.clone(),
@@ -12532,7 +12533,7 @@ impl<
             complete_authorize_url: value.complete_authorize_url.clone(),
             capture_method: None,
             integrity_object: None,
-            minor_amount: Some(amount.amount),
+            minor_amount: Some(amount.amount()),
             shipping_cost: value.shipping_cost.map(common_utils::types::MinorUnit::new),
             customer_id: value
                 .customer
@@ -12967,21 +12968,21 @@ impl ForeignTryFrom<grpc_api_types::payments::MandateAmountData> for mandates::M
                 .map(|offset_dt| time::PrimitiveDateTime::new(offset_dt.date(), offset_dt.time()))
         };
         Ok(Self {
-            amount: common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(
+            amount: common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(
                     amount_data
                         .amount_money
                         .map(|amount_money| amount_money.minor_amount)
                         .unwrap_or(amount_data.amount),
                 ),
-                currency: common_enums::Currency::foreign_try_from(
+                common_enums::Currency::foreign_try_from(
                     amount_data
                         .amount_money
                         .as_ref()
                         .map(|amount_money| amount_money.currency())
                         .unwrap_or(amount_data.currency()),
                 )?,
-            },
+            ),
             start_date: amount_data.start_date.and_then(to_primitive_date_time),
             end_date: amount_data.end_date.and_then(to_primitive_date_time),
             metadata: None,
@@ -12990,14 +12991,14 @@ impl ForeignTryFrom<grpc_api_types::payments::MandateAmountData> for mandates::M
             initial_billing_amount: if let Some(initial_billing_amount) =
                 amount_data.initial_billing_amount
             {
-                Some(common_utils::types::Money {
-                    amount: common_utils::types::MinorUnit::new(
+                Some(common_utils::types::Money::new(
+                    common_utils::types::MinorUnit::new(
                         initial_billing_amount.minor_amount,
                     ),
-                    currency: common_enums::Currency::foreign_try_from(
+                    common_enums::Currency::foreign_try_from(
                         initial_billing_amount.currency(),
                     )?,
-                })
+                ))
             } else {
                 None
             },
@@ -13549,10 +13550,10 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCreateOrderRequest>
         value: grpc_api_types::payments::PaymentServiceCreateOrderRequest,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -13574,8 +13575,8 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceCreateOrderRequest>
             .transpose()?;
 
         Ok(Self {
-            amount: amount.amount,
-            currency: amount.currency,
+            amount: amount.amount(),
+            currency: amount.currency(),
             integrity_object: None,
             metadata: value
                 .metadata
@@ -14290,10 +14291,10 @@ impl ForeignTryFrom<PaymentServiceAuthorizeRequest>
                 context: IntegrationErrorContext::default(),
             })
         })?;
-        let amount = common_utils::types::Money {
-            amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-            currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-        };
+        let amount = common_utils::types::Money::new(
+            common_utils::types::MinorUnit::new(amount.minor_amount),
+            common_enums::Currency::foreign_try_from(amount.currency())?,
+        );
         let customer_id = value
             .customer
             .as_ref()
@@ -14314,8 +14315,8 @@ impl ForeignTryFrom<PaymentServiceAuthorizeRequest>
             .transpose()?;
 
         Ok(Self {
-            amount: amount.amount,
-            currency: amount.currency,
+            amount: amount.amount(),
+            currency: amount.currency(),
             browser_info: value
                 .browser_info
                 .map(BrowserInformation::foreign_try_from)
@@ -14458,10 +14459,10 @@ impl
         };
 
         let amount = match payment_ctx.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -14488,8 +14489,8 @@ impl
             .transpose()?;
 
         Ok(Self {
-            amount: amount.amount,
-            currency: amount.currency,
+            amount: amount.amount(),
+            currency: amount.currency(),
             browser_info: payment_ctx
                 .browser_info
                 .map(BrowserInformation::foreign_try_from)
@@ -14602,16 +14603,16 @@ impl<
         ),
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         let money = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
             })),
         }?;
-        let currency = money.currency;
+        let currency = money.currency();
 
         let setup_future_usage = match value.setup_future_usage() {
             grpc_payment_types::FutureUsage::Unspecified => None,
@@ -14626,7 +14627,7 @@ impl<
             .map(MandateData::foreign_try_from)
             .transpose()?;
         Ok(Self {
-            amount: money.amount,
+            amount: money.amount(),
             currency,
             payment_method_data,
             browser_info: None,
@@ -14816,10 +14817,10 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodServiceRechargeReques
         value: grpc_api_types::payments::PaymentMethodServiceRechargeRequest,
     ) -> Result<Self, error_stack::Report<Self::Error>> {
         let money = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -14841,8 +14842,8 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentMethodServiceRechargeReques
             merchant_request_id: value.merchant_request_id,
             merchant_recharge_id: value.merchant_recharge_id,
             product_id: value.product_id,
-            amount: money.amount,
-            currency: money.currency,
+            amount: money.amount(),
+            currency: money.currency(),
             description: value.description,
             payment_method_type,
         })
@@ -14898,12 +14899,12 @@ impl
             amount_captured: None,
             minor_amount_captured: None,
             minor_amount_capturable: None,
-            amount: value.amount.map(|amt| common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amt.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amt.currency())
+            amount: value.amount.map(|amt| common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amt.minor_amount),
+                common_enums::Currency::foreign_try_from(amt.currency())
                     .ok()
                     .unwrap_or_default(),
-            }),
+            )),
             access_token,
             session_token: None,
             reference_id: None,
@@ -15748,10 +15749,10 @@ impl<
             .map(router_request_types::AuthenticationData::try_from)
             .transpose()?;
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -15766,9 +15767,9 @@ impl<
                 .transpose()?
                 .map(Box::new),
             mandate_reference: mandate_ref,
-            amount: amount.amount.get_amount_as_i64(),
-            minor_amount: amount.amount,
-            currency: amount.currency,
+            amount: amount.amount().get_amount_as_i64(),
+            minor_amount: amount.amount(),
+            currency: amount.currency(),
             merchant_order_id,
             metadata: value
                 .metadata
@@ -15798,10 +15799,10 @@ impl<
             recurring_mandate_payment_data: match value.original_payment_authorized_amount {
                 Some(money) => Some(RecurringMandatePaymentData {
                     payment_method_type: None,
-                    original_payment_authorized_amount: Some(common_utils::types::Money {
-                        amount: common_utils::types::MinorUnit::new(money.minor_amount),
-                        currency: common_enums::Currency::foreign_try_from(money.currency())?,
-                    }),
+                    original_payment_authorized_amount: Some(common_utils::types::Money::new(
+                        common_utils::types::MinorUnit::new(money.minor_amount),
+                        common_enums::Currency::foreign_try_from(money.currency())?,
+                    )),
                     mandate_metadata: None,
                 }),
                 None => None,
@@ -18629,10 +18630,10 @@ impl<
         };
 
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -18646,8 +18647,8 @@ impl<
 
         Ok(Self {
             payment_method_data,
-            amount: amount.amount,
-            currency: Some(amount.currency),
+            amount: amount.amount(),
+            currency: Some(amount.currency()),
             email,
             // Post-redirect auth legs (Paysafe's handle re-fetch) carry no card: an absent or
             // proto-default (empty oneof) payment_method yields `None`, while a populated but
@@ -18742,10 +18743,10 @@ impl<
         };
 
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -18772,9 +18773,9 @@ impl<
 
         Ok(Self {
             payment_method_data,
-            amount: amount.amount,
+            amount: amount.amount(),
             email,
-            currency: Some(amount.currency),
+            currency: Some(amount.currency()),
             // Post-redirect auth legs (Paysafe's handle re-fetch) carry no card: an absent or
             // proto-default (empty oneof) payment_method yields `None`, while a populated but
             // invalid value still fails the conversion.
@@ -18886,10 +18887,10 @@ impl<
         };
 
         let amount = match value.amount {
-            Some(amount) => Ok(common_utils::types::Money {
-                amount: common_utils::types::MinorUnit::new(amount.minor_amount),
-                currency: common_enums::Currency::foreign_try_from(amount.currency())?,
-            }),
+            Some(amount) => Ok(common_utils::types::Money::new(
+                common_utils::types::MinorUnit::new(amount.minor_amount),
+                common_enums::Currency::foreign_try_from(amount.currency())?,
+            )),
             None => Err(report!(IntegrationError::MissingRequiredField {
                 field_name: "amount",
                 context: IntegrationErrorContext::default(),
@@ -18915,8 +18916,8 @@ impl<
                 });
         Ok(Self {
             payment_method_data,
-            amount: amount.amount,
-            currency: Some(amount.currency),
+            amount: amount.amount(),
+            currency: Some(amount.currency()),
             email,
             // The PostAuthenticate (RReq / results) flow carries no payment method, so
             // `payment_method` is absent; map that to `None` instead of failing the conversion
@@ -19397,8 +19398,8 @@ impl ForeignTryFrom<(bool, RedirectDetailsResponse)>
                 .clone(),
             response_amount: match redirect_details_response.response_amount {
                 Some(money) => Some(grpc_api_types::payments::Money {
-                    minor_amount: money.amount.get_amount_as_i64(),
-                    currency: grpc_api_types::payments::Currency::foreign_try_from(money.currency)?
+                    minor_amount: money.amount().get_amount_as_i64(),
+                    currency: grpc_api_types::payments::Currency::foreign_try_from(money.currency())?
                         .into(),
                 }),
                 None => None,
@@ -20594,10 +20595,10 @@ impl ForeignFrom<payment_method_data::WalletItem> for grpc_api_types::payments::
             product_id: item.product_id,
             status: grpc_api_types::payments::WalletItemStatus::foreign_from(item.status).into(),
             available_balance: item.available_balance.and_then(|money| {
-                grpc_api_types::payments::Currency::foreign_try_from(money.currency)
+                grpc_api_types::payments::Currency::foreign_try_from(money.currency())
                     .ok()
                     .map(|currency| grpc_api_types::payments::Money {
-                        minor_amount: money.amount.get_amount_as_i64(),
+                        minor_amount: money.amount().get_amount_as_i64(),
                         currency: currency.into(),
                     })
             }),
@@ -20674,18 +20675,18 @@ impl ForeignFrom<payment_method_data::PaymentMethodDetails>
                                             .into()
                                     }),
                                     balance: acct.balance.and_then(|m| {
-                                        grpc_api_types::payments::Currency::foreign_try_from(m.currency)
+                                        grpc_api_types::payments::Currency::foreign_try_from(m.currency())
                                             .ok()
                                             .map(|currency| grpc_api_types::payments::Money {
-                                                minor_amount: m.amount.get_amount_as_i64(),
+                                                minor_amount: m.amount().get_amount_as_i64(),
                                                 currency: currency.into(),
                                             })
                                     }),
                                     available_balance: acct.available_balance.and_then(|m| {
-                                        grpc_api_types::payments::Currency::foreign_try_from(m.currency)
+                                        grpc_api_types::payments::Currency::foreign_try_from(m.currency())
                                             .ok()
                                             .map(|currency| grpc_api_types::payments::Money {
-                                                minor_amount: m.amount.get_amount_as_i64(),
+                                                minor_amount: m.amount().get_amount_as_i64(),
                                                 currency: currency.into(),
                                             })
                                     }),

--- a/crates/types-traits/domain_types/src/utils.rs
+++ b/crates/types-traits/domain_types/src/utils.rs
@@ -6,7 +6,8 @@ use std::{
 use base64::Engine;
 use common_enums::{CurrencyUnit, PaymentMethodType};
 use common_utils::{
-    consts, fp_utils::when, metadata::MaskedMetadata, AmountConvertor, CustomResult, MinorUnit,
+    consts, fp_utils::when, metadata::MaskedMetadata, proto_boundary::MinorUnitProtoAccess,
+    AmountConvertor, CustomResult, MinorUnit,
 };
 use error_stack::{report, Result, ResultExt};
 use hyperswitch_masking::{PeekInterface, Secret};
@@ -361,6 +362,17 @@ pub fn convert_back_amount_to_minor_units<T>(
     currency: common_enums::Currency,
 ) -> core::result::Result<MinorUnit, error_stack::Report<common_utils::errors::ParsingError>> {
     amount_convertor.convert_back(amount, currency)
+}
+
+/// Compute capturable amount as `total - captured`.
+///
+/// This keeps arithmetic on [`MinorUnit`] in the domain layer so that
+/// connector code never needs subtraction.
+pub fn compute_capturable_amount(
+    total: MinorUnit,
+    captured: MinorUnit,
+) -> MinorUnit {
+    MinorUnit::new(total.get_amount_as_i64() - captured.get_amount_as_i64())
 }
 
 #[derive(Debug, Copy, Clone, strum::Display, Eq, Hash, PartialEq)]

--- a/crates/types-traits/domain_types/src/utils.rs
+++ b/crates/types-traits/domain_types/src/utils.rs
@@ -368,10 +368,7 @@ pub fn convert_back_amount_to_minor_units<T>(
 ///
 /// This keeps arithmetic on [`MinorUnit`] in the domain layer so that
 /// connector code never needs subtraction.
-pub fn compute_capturable_amount(
-    total: MinorUnit,
-    captured: MinorUnit,
-) -> MinorUnit {
+pub fn compute_capturable_amount(total: MinorUnit, captured: MinorUnit) -> MinorUnit {
     MinorUnit::new(total.get_amount_as_i64() - captured.get_amount_as_i64())
 }
 

--- a/crates/types-traits/interfaces/src/integrity.rs
+++ b/crates/types-traits/interfaces/src/integrity.rs
@@ -4,6 +4,7 @@
 //! It ensures that request and response data remain consistent across connector interactions
 //! by comparing critical fields like amounts, currencies, and transaction identifiers.
 use common_utils::errors::IntegrityCheckError;
+use common_utils::proto_boundary::MoneyProtoAccess;
 use domain_types::router_request_types::ClientAuthenticationTokenIntegrityObject;
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 // Domain type imports
@@ -630,8 +631,8 @@ impl FlowIntegrity for AuthoriseIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -660,8 +661,8 @@ impl FlowIntegrity for CreateOrderIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -692,8 +693,8 @@ impl FlowIntegrity for SetupMandateIntegrityObject {
             (Some(req_amount), Some(res_amount)) if req_amount != res_amount => {
                 mismatched_fields.push(format_mismatch(
                     "amount",
-                    &req_amount.to_string(),
-                    &res_amount.to_string(),
+                    &format!("{:?}", req_amount),
+                    &format!("{:?}", res_amount),
                 ));
             }
             (None, Some(_)) | (Some(_), None) => {
@@ -727,8 +728,8 @@ impl FlowIntegrity for PaymentSynIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -805,8 +806,8 @@ impl FlowIntegrity for RefundIntegrityObject {
         if req_integrity_object.refund_amount != res_integrity_object.refund_amount {
             mismatched_fields.push(format_mismatch(
                 "refund_amount",
-                &req_integrity_object.refund_amount.to_string(),
-                &res_integrity_object.refund_amount.to_string(),
+                &format!("{:?}", req_integrity_object.refund_amount),
+                &format!("{:?}", res_integrity_object.refund_amount),
             ));
         }
 
@@ -835,8 +836,8 @@ impl FlowIntegrity for CaptureIntegrityObject {
         if req_integrity_object.amount_to_capture != res_integrity_object.amount_to_capture {
             mismatched_fields.push(format_mismatch(
                 "amount_to_capture",
-                &req_integrity_object.amount_to_capture.to_string(),
-                &res_integrity_object.amount_to_capture.to_string(),
+                &format!("{:?}", req_integrity_object.amount_to_capture),
+                &format!("{:?}", res_integrity_object.amount_to_capture),
             ));
         }
 
@@ -971,8 +972,8 @@ impl FlowIntegrity for RepeatPaymentIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1077,8 +1078,8 @@ impl FlowIntegrity for SessionTokenIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1141,8 +1142,8 @@ impl FlowIntegrity for PaymentMethodTokenIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1171,8 +1172,8 @@ impl FlowIntegrity for PreAuthenticateIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1201,8 +1202,8 @@ impl FlowIntegrity for AuthenticateIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1231,8 +1232,8 @@ impl FlowIntegrity for PostAuthenticateIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1349,8 +1350,8 @@ impl FlowIntegrity for PayoutCreateIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1468,8 +1469,8 @@ impl GetIntegrityObject<PayoutEligibilityIntegrityObject> for PayoutEligibilityR
 
     fn get_request_integrity_object(&self) -> PayoutEligibilityIntegrityObject {
         PayoutEligibilityIntegrityObject {
-            amount: self.amount.amount,
-            currency: self.amount.currency,
+            amount: self.amount.amount(),
+            currency: self.amount.currency(),
         }
     }
 }
@@ -1613,8 +1614,8 @@ impl FlowIntegrity for PayoutTransferIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1643,8 +1644,8 @@ impl FlowIntegrity for PayoutStageIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1673,8 +1674,8 @@ impl FlowIntegrity for PayoutCreateLinkIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1703,8 +1704,8 @@ impl FlowIntegrity for PayoutCreateRecipientIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1733,8 +1734,8 @@ impl FlowIntegrity for PayoutEnrollDisburseAccountIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1813,8 +1814,8 @@ impl FlowIntegrity for PayoutEligibilityIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1843,8 +1844,8 @@ impl FlowIntegrity for SurchargeCalculateIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 
@@ -1922,8 +1923,8 @@ impl FlowIntegrity for RechargeIntegrityObject {
         if req_integrity_object.amount != res_integrity_object.amount {
             mismatched_fields.push(format_mismatch(
                 "amount",
-                &req_integrity_object.amount.to_string(),
-                &res_integrity_object.amount.to_string(),
+                &format!("{:?}", req_integrity_object.amount),
+                &format!("{:?}", res_integrity_object.amount),
             ));
         }
 

--- a/data/field_probe/noon.json
+++ b/data/field_probe/noon.json
@@ -882,7 +882,7 @@
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"apiOperation\":\"INITIATE\",\"order\":{\"amount\":\"0.01\",\"currency\":\"USD\",\"channel\":\"WEB\",\"category\":\"mobile\",\"reference\":\"probe_proxy_mandate_001\",\"name\":\"purchase desc\",\"nvp\":{\"1\":\"description=purchase desc\",\"2\":\"order_category=mobile\"},\"ipAddress\":null},\"configuration\":{\"tokenizeCC\":null,\"paymentAction\":\"SALE\",\"returnUrl\":null},\"paymentData\":{\"type\":\"CARD\",\"data\":{\"nameOnCard\":null,\"numberPlain\":\"{{$card_number}}\",\"expiryMonth\":\"03\",\"expiryYear\":\"2030\",\"cvv\":\"{{$card_cvc}}\"}},\"subscription\":null,\"billing\":{\"address\":{\"street\":null,\"street2\":null,\"city\":null,\"stateProvince\":null,\"country\":null,\"postalCode\":null}}}"
+          "body": "{\"apiOperation\":\"INITIATE\",\"order\":{\"amount\":\"0.00\",\"currency\":\"USD\",\"channel\":\"WEB\",\"category\":\"mobile\",\"reference\":\"probe_proxy_mandate_001\",\"name\":\"purchase desc\",\"nvp\":{\"1\":\"description=purchase desc\",\"2\":\"order_category=mobile\"},\"ipAddress\":null},\"configuration\":{\"tokenizeCC\":null,\"paymentAction\":\"SALE\",\"returnUrl\":null},\"paymentData\":{\"type\":\"CARD\",\"data\":{\"nameOnCard\":null,\"numberPlain\":\"{{$card_number}}\",\"expiryMonth\":\"03\",\"expiryYear\":\"2030\",\"cvv\":\"{{$card_cvc}}\"}},\"subscription\":null,\"billing\":{\"address\":{\"street\":null,\"street2\":null,\"city\":null,\"stateProvince\":null,\"country\":null,\"postalCode\":null}}}"
         }
       }
     },

--- a/docs/money-framework-design.html
+++ b/docs/money-framework-design.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Money Framework — Why We Can't Ban i64</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0f1117;
+            color: #e1e4e8;
+            line-height: 1.7;
+            padding: 40px 20px;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+        h1 {
+            font-size: 2rem;
+            color: #58a6ff;
+            margin-bottom: 8px;
+            letter-spacing: -0.5px;
+        }
+        .subtitle {
+            color: #8b949e;
+            font-size: 1rem;
+            margin-bottom: 48px;
+            border-bottom: 1px solid #21262d;
+            padding-bottom: 24px;
+        }
+        h2 {
+            font-size: 1.4rem;
+            color: #c9d1d9;
+            margin-top: 48px;
+            margin-bottom: 16px;
+        }
+        h3 {
+            font-size: 1.1rem;
+            color: #8b949e;
+            margin-top: 32px;
+            margin-bottom: 12px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-weight: 600;
+        }
+        p {
+            color: #c9d1d9;
+            margin-bottom: 16px;
+        }
+        .problem-box {
+            background: #1c1e26;
+            border-left: 4px solid #f85149;
+            padding: 20px 24px;
+            margin: 24px 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .problem-box .label {
+            color: #f85149;
+            font-weight: 700;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            margin-bottom: 8px;
+        }
+        .solution-box {
+            background: #1c1e26;
+            border-left: 4px solid #3fb950;
+            padding: 20px 24px;
+            margin: 24px 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .solution-box .label {
+            color: #3fb950;
+            font-weight: 700;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            margin-bottom: 8px;
+        }
+        .insight-box {
+            background: #1c1e26;
+            border-left: 4px solid #d29922;
+            padding: 20px 24px;
+            margin: 24px 0;
+            border-radius: 0 8px 8px 0;
+        }
+        .insight-box .label {
+            color: #d29922;
+            font-weight: 700;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            margin-bottom: 8px;
+        }
+        pre {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 8px;
+            padding: 20px;
+            overflow-x: auto;
+            margin: 16px 0;
+            font-size: 0.9rem;
+            line-height: 1.6;
+        }
+        code {
+            font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+            font-size: 0.88rem;
+        }
+        .inline-code {
+            background: #1c2028;
+            border: 1px solid #30363d;
+            border-radius: 4px;
+            padding: 2px 7px;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.85rem;
+            color: #79c0ff;
+        }
+        .keyword { color: #ff7b72; }
+        .type { color: #79c0ff; }
+        .string { color: #a5d6ff; }
+        .comment { color: #8b949e; }
+        .field { color: #d2a8ff; }
+        .fn-name { color: #d2a8ff; }
+        .number { color: #79c0ff; }
+        .flow-diagram {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 8px;
+            padding: 32px;
+            margin: 24px 0;
+            text-align: center;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.95rem;
+            line-height: 2.2;
+        }
+        .flow-diagram .arrow { color: #8b949e; }
+        .flow-diagram .safe { color: #3fb950; }
+        .flow-diagram .unsafe { color: #f85149; }
+        .flow-diagram .neutral { color: #79c0ff; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+        }
+        th {
+            background: #161b22;
+            color: #58a6ff;
+            text-align: left;
+            padding: 12px 16px;
+            border: 1px solid #30363d;
+            font-weight: 600;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        td {
+            padding: 10px 16px;
+            border: 1px solid #21262d;
+            color: #c9d1d9;
+        }
+        tr:nth-child(even) { background: #161b22; }
+        .tag {
+            display: inline-block;
+            padding: 2px 10px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            letter-spacing: 0.5px;
+        }
+        .tag-blocked { background: #3fb95020; color: #3fb950; border: 1px solid #3fb95040; }
+        .tag-open { background: #f8514920; color: #f85149; border: 1px solid #f8514940; }
+        .tag-limited { background: #d2992220; color: #d29922; border: 1px solid #d2992240; }
+        .section-divider {
+            border: 0;
+            border-top: 1px solid #21262d;
+            margin: 48px 0;
+        }
+        .conclusion {
+            background: linear-gradient(135deg, #161b22, #1c2333);
+            border: 1px solid #30363d;
+            border-radius: 12px;
+            padding: 32px;
+            margin: 40px 0;
+        }
+        .conclusion h2 {
+            margin-top: 0;
+            color: #58a6ff;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Money Framework Design</h1>
+        <p class="subtitle">Why we can't ban <span class="inline-code">i64</span> — and why we don't need to</p>
+
+        <!-- ============================================================ -->
+        <h2>The Goal</h2>
+        <p>
+            Prevent connector code from constructing, tampering with, or incorrectly formatting
+            payment amounts. Every amount that reaches a connector's wire format must pass through
+            <span class="inline-code">AmountConvertor</span>, which handles currency-specific
+            decimal conversions (e.g., JPY has 0 decimals, KWD has 3).
+        </p>
+
+        <!-- ============================================================ -->
+        <h2>Why Banning <span class="inline-code">i64</span> Is Impossible</h2>
+
+        <div class="problem-box">
+            <div class="label">The Problem</div>
+            <p>
+                <span class="inline-code">i64</span> is a primitive type used everywhere in connector
+                structs — for amounts, yes, but also for timestamps, retry counts, expiry values,
+                status codes, and dozens of other fields. There is no way to distinguish an "amount i64"
+                from a "non-amount i64" at compile time or via a lint.
+            </p>
+        </div>
+
+<pre><code><span class="keyword">struct</span> <span class="type">ConnectorRequest</span> {
+    <span class="field">amount</span>: <span class="type">i64</span>,          <span class="comment">// this is an amount — dangerous</span>
+    <span class="field">retry_count</span>: <span class="type">i64</span>,     <span class="comment">// this is NOT an amount — perfectly fine</span>
+    <span class="field">timestamp</span>: <span class="type">i64</span>,        <span class="comment">// this is NOT an amount — perfectly fine</span>
+    <span class="field">expiry_month</span>: <span class="type">i64</span>,     <span class="comment">// this is NOT an amount — perfectly fine</span>
+}</code></pre>
+
+        <p>
+            A grep or lint rule cannot know which <span class="inline-code">i64</span> fields represent
+            money. Banning <span class="inline-code">i64</span> entirely would break every connector
+            in the system. There is no semantic marker on a primitive type.
+        </p>
+
+        <hr class="section-divider">
+
+        <!-- ============================================================ -->
+        <h2>The Actual Solution: Make <span class="inline-code">MinorUnit</span> Opaque</h2>
+
+        <p>
+            Instead of banning the output type (<span class="inline-code">i64</span>), we control
+            the input type (<span class="inline-code">MinorUnit</span>). If connectors cannot
+            extract a raw number from <span class="inline-code">MinorUnit</span>, they cannot
+            assign it to an <span class="inline-code">i64</span> field — and they are forced to
+            use <span class="inline-code">ConnectorMinorUnit</span> (which comes from
+            <span class="inline-code">AmountConvertor</span>).
+        </p>
+
+        <h3>The Safe Path</h3>
+
+        <div class="flow-diagram">
+            <span class="neutral">MinorUnit</span> <span class="comment">(domain, opaque)</span><br>
+            <span class="arrow">&darr;</span> <span class="comment">AmountConvertor::convert()</span><br>
+            <span class="safe">ConnectorMinorUnit</span> <span class="comment">(connector, has Serialize + Display)</span><br>
+            <span class="arrow">&darr;</span> <span class="comment">serde / Display</span><br>
+            <span class="safe">JSON / XML / String</span> <span class="comment">(wire format)</span>
+        </div>
+
+        <div class="solution-box">
+            <div class="label">Why This Works</div>
+            <p>
+                <span class="inline-code">ConnectorMinorUnit</span> has <strong>no public constructor</strong>.
+                The only way to obtain one is through <span class="inline-code">AmountConvertor::convert()</span>,
+                which performs the correct currency-aware conversion. Once a connector has a
+                <span class="inline-code">ConnectorMinorUnit</span>, it serializes correctly via
+                <span class="inline-code">Serialize</span> or <span class="inline-code">Display</span> —
+                no raw <span class="inline-code">i64</span> is ever exposed.
+            </p>
+        </div>
+
+        <h3>The Blocked Path</h3>
+
+        <div class="flow-diagram">
+            <span class="neutral">MinorUnit</span> <span class="comment">(domain, opaque)</span><br>
+            <span class="unsafe">&darr; .get_amount_as_i64()? &cross; BLOCKED — requires trait import</span><br>
+            <span class="unsafe">&darr; .to_string()? &cross; BLOCKED — Display removed</span><br>
+            <span class="unsafe">&darr; .0? &cross; BLOCKED — field is private</span><br>
+            <span class="unsafe">&darr; MinorUnit::new(i64)? &cross; BLOCKED — requires trait import</span><br>
+            <span class="unsafe">i64</span> <span class="comment">&larr; connector cannot reach this</span>
+        </div>
+
+        <hr class="section-divider">
+
+        <!-- ============================================================ -->
+        <h2>What Is Blocked vs. What Is Open</h2>
+
+        <table>
+            <tr>
+                <th>Operation</th>
+                <th>Status</th>
+                <th>How</th>
+            </tr>
+            <tr>
+                <td><span class="inline-code">MinorUnit(value)</span> — direct construction</td>
+                <td><span class="tag tag-blocked">Blocked</span></td>
+                <td>Inner field is private</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">MinorUnit::new(i64)</span> — constructor</td>
+                <td><span class="tag tag-blocked">Blocked</span></td>
+                <td>Behind <span class="inline-code">MinorUnitProtoAccess</span> trait; CI lint bans import in connector code</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">.get_amount_as_i64()</span> — extractor</td>
+                <td><span class="tag tag-blocked">Blocked</span></td>
+                <td>Behind <span class="inline-code">MinorUnitProtoAccess</span> trait; CI lint bans import in connector code</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">Display</span> / <span class="inline-code">.to_string()</span></td>
+                <td><span class="tag tag-blocked">Blocked</span></td>
+                <td>Display trait removed from MinorUnit</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">Add</span>, <span class="inline-code">Sub</span>, <span class="inline-code">Mul</span></td>
+                <td><span class="tag tag-blocked">Blocked</span></td>
+                <td>Trait impls removed; methods are <span class="inline-code">pub(crate)</span></td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">Serialize</span> / <span class="inline-code">Deserialize</span></td>
+                <td><span class="tag tag-limited">Limited Leak</span></td>
+                <td>Available due to Cargo feature unification; but deserialized MinorUnit is opaque — value cannot be extracted</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">Debug</span> / <span class="inline-code">{:?}</span></td>
+                <td><span class="tag tag-limited">Limited Leak</span></td>
+                <td>Prints <span class="inline-code">MinorUnit(5000)</span> — not cleanly parseable; needed for error messages and logging</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">PartialEq</span>, <span class="inline-code">PartialOrd</span></td>
+                <td><span class="tag tag-open">Open</span></td>
+                <td>Comparison only — returns bool, does not leak the value</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">Default</span></td>
+                <td><span class="tag tag-open">Open</span></td>
+                <td>Only produces <span class="inline-code">MinorUnit(0)</span> — a known-safe value</td>
+            </tr>
+            <tr>
+                <td><span class="inline-code">ConnectorMinorUnit</span> — Serialize, Display</td>
+                <td><span class="tag tag-open">Open</span></td>
+                <td>Intended for connector wire formats; value came through AmountConvertor</td>
+            </tr>
+        </table>
+
+        <hr class="section-divider">
+
+        <!-- ============================================================ -->
+        <h2>Two Layers of Enforcement</h2>
+
+        <h3>Layer 1 — Compiler (Trait Gating)</h3>
+        <p>
+            <span class="inline-code">MinorUnit::new()</span> and
+            <span class="inline-code">.get_amount_as_i64()</span> are methods on the
+            <span class="inline-code">MinorUnitProtoAccess</span> trait. Without importing the
+            trait, the compiler rejects the call:
+        </p>
+
+<pre><code><span class="comment">// Connector code — no trait import</span>
+<span class="keyword">let</span> raw = minor_unit.<span class="fn-name">get_amount_as_i64</span>();
+<span class="comment">//        ^^^^^^^^^^^^^^^^^ ERROR: method not found</span>
+<span class="comment">//        help: trait `MinorUnitProtoAccess` provides `get_amount_as_i64`</span>
+<span class="comment">//              consider importing it</span></code></pre>
+
+        <p>
+            The compiler tells the developer exactly which trait to import. If they follow the
+            suggestion, the code compiles locally — but then Layer 2 catches it.
+        </p>
+
+        <h3>Layer 2 — CI Lint (Import Ban)</h3>
+
+<pre><code><span class="comment"># CI pipeline check</span>
+grep -rn <span class="string">"proto_boundary"</span> crates/integrations/ --include=<span class="string">"*.rs"</span> \
+  | grep -v <span class="string">"test.rs"</span> \
+  && echo <span class="string">"FAIL: connector code must not import proto_boundary"</span> \
+  && exit <span class="number">1</span></code></pre>
+
+        <p>
+            If a developer adds the trait import to make it compile, the CI check fails and the
+            PR cannot merge. The developer must find the correct approach: use
+            <span class="inline-code">AmountConvertor</span> to get
+            <span class="inline-code">ConnectorMinorUnit</span>.
+        </p>
+
+        <hr class="section-divider">
+
+        <!-- ============================================================ -->
+        <h2>Why Not Ban <span class="inline-code">MinorUnit</span> Entirely from Connector Code?</h2>
+
+        <p>
+            Connectors receive domain request structs that contain
+            <span class="inline-code">MinorUnit</span> fields:
+        </p>
+
+<pre><code><span class="comment">// domain_types — connectors receive this struct</span>
+<span class="keyword">pub struct</span> <span class="type">PaymentsAuthorizeData</span> {
+    <span class="keyword">pub</span> <span class="field">minor_amount</span>: <span class="type">MinorUnit</span>,
+    <span class="keyword">pub</span> <span class="field">currency</span>: <span class="type">Currency</span>,
+    <span class="comment">// ...</span>
+}</code></pre>
+
+        <p>
+            The connector sees <span class="inline-code">MinorUnit</span> as a type in these
+            structs. It cannot avoid referencing the type. But it <strong>cannot do anything
+            dangerous with it</strong> — it can only pass the value through
+            <span class="inline-code">AmountConvertor::convert()</span> to get a
+            <span class="inline-code">ConnectorMinorUnit</span>.
+        </p>
+
+        <hr class="section-divider">
+
+        <!-- ============================================================ -->
+        <div class="conclusion">
+            <h2>Summary</h2>
+            <p>
+                We cannot ban <span class="inline-code">i64</span> because it's a primitive type
+                used for non-amount fields throughout connector code. No lint can distinguish
+                "amount i64" from "timestamp i64."
+            </p>
+            <p>
+                Instead, we make <span class="inline-code">MinorUnit</span> opaque so connectors
+                cannot extract a raw <span class="inline-code">i64</span> from it. This forces
+                them to use <span class="inline-code">ConnectorMinorUnit</span> (obtained via
+                <span class="inline-code">AmountConvertor</span>) in their wire structs, which
+                serializes correctly with currency-aware formatting.
+            </p>
+            <p>
+                The protection is: <strong>control the input, not the output</strong>.
+                We can't stop connectors from writing <span class="inline-code">i64</span> fields.
+                We stop them from getting a raw number to put there.
+            </p>
+
+            <div class="insight-box" style="margin-top: 24px; margin-bottom: 0;">
+                <div class="label">Design Principle</div>
+                <p style="margin-bottom: 0;">
+                    Make the right thing easy (<span class="inline-code">ConnectorMinorUnit</span>
+                    serializes correctly out of the box) and the wrong thing obvious
+                    (extracting raw i64 requires importing a banned trait, which CI rejects).
+                </p>
+            </div>
+        </div>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Problem

Connectors could directly manipulate payment amounts because `MinorUnit` was fully open:

```rust
pub struct MinorUnit(pub i64);           // anyone could read/write the raw value
#[derive(Serialize, Deserialize)]        // anyone could put it in wire structs
pub fn new(i64) -> Self                  // anyone could construct arbitrary amounts
pub fn get_amount_as_i64() -> i64        // anyone could extract the raw value
impl Add, Sub, Display                   // anyone could do arithmetic, print raw values
```

This meant a connector could:
- **Bypass `AmountConvertor`** — use `MinorUnit` directly in wire structs, skipping currency-specific decimal conversion (JPY has 0 decimals, KWD has 3)
- **Construct fake amounts** — `MinorUnit::new(9999)`
- **Extract and tamper** — `amount.get_amount_as_i64() + 100`
- **Use deprecated i64 fields** — `request.refund_amount` (i64) instead of `request.minor_refund_amount` (MinorUnit)

## Solution

### 1. Make `MinorUnit` opaque

| What | Before | After |
|---|---|---|
| Inner field | `pub i64` | **private** `i64` |
| `new(i64)` | Public method | Behind `MinorUnitProtoAccess` **trait** (requires import) |
| `get_amount_as_i64()` | Public method | Behind `MinorUnitProtoAccess` **trait** (requires import) |
| `Display` | Implemented (leaks raw value via `.to_string()`) | **Removed** |
| `Add`, `Sub`, `Mul`, `Sum` | Public trait impls | **Removed** (kept as `pub(crate)` for domain math) |
| `Serialize` / `Deserialize` | Always available | Stays — needed by domain event/logging structs |

### 2. Introduce `ConnectorMinorUnit`

A new type for connector wire structs. Connectors use this instead of `MinorUnit`.

- Has `Serialize`, `Deserialize`, `Display` — everything connectors need
- **No public constructor** — only obtainable via `AmountConvertor::convert()`
- `MinorUnitForConnector` now outputs `ConnectorMinorUnit` instead of `MinorUnit`

### 3. `proto_boundary` trait module

`MinorUnit::new()` and `get_amount_as_i64()` moved to `MinorUnitProtoAccess` trait.
`Money::new()`, `money.amount()`, `money.into_parts()` moved to `MoneyProtoAccess` trait.

Without importing the trait, the compiler rejects the call:
```
error[E0599]: no method named `get_amount_as_i64` found for struct `MinorUnit`
  help: trait `MinorUnitProtoAccess` provides `get_amount_as_i64`, consider importing it
```

### 4. Two layers of enforcement

**Layer 1 — Compiler**: Trait must be imported to call proto methods. Compiler blocks without import.

**Layer 2 — CI lint**: Grep blocks the import in connector code:
```bash
grep -rn "proto_boundary" crates/integrations/ --include="*.rs" | grep -v test.rs && exit 1
```

### 5. The safe path for connectors

```
MinorUnit (domain, opaque)
  → AmountConvertor::convert()
    → ConnectorMinorUnit (has Serialize + Display, no public constructor)
      → serde / Display
        → JSON / XML / String (wire format)
```

## What this PR includes

- Opaque `MinorUnit` with private field, removed `Display`/`Add`/`Sub`/`Mul`/`Sum`
- `ConnectorMinorUnit` type with `Serialize`/`Deserialize`/`Display`
- `proto_boundary` module with `MinorUnitProtoAccess` and `MoneyProtoAccess` traits
- `Money` fields made private with trait-gated accessors
- `Money::convert()` wrapper for safe connector-side amount conversion
- `compute_capturable_amount()` domain utility for amount arithmetic
- Full migration of `imerchantsolutions` connector to `ConnectorMinorUnit`
- HMAC signature fixes for adyen and novalnet
- Design document at `docs/money-framework-design.html`

## Follow-up PR roadmap

### PR 2: Migrate connectors batch 1 (stacked — already raised as #2248)
- 15 connectors: affirm, billwerk, celero, datatrans, dlocal, fiuu, givepayments, grabpay, helcim, multisafepay, placetopay, shift4, silverflow, volt, worldpayvantiv
- Change wire struct fields from `MinorUnit` → `ConnectorMinorUnit`
- Use `AmountConvertor` for request construction, `convert_back` for response handling

### PR 3: Migrate connectors batch 2
- ~15 connectors: adyen, braintree, checkout, flywire, novalnet, nuvei, paypal, paysafe, stax, tamara, travelhub, truelayer, trustpay, worldpay, and others
- Same pattern as batch 1

### PR 4: Migrate connectors batch 3
- Remaining connectors: finix, getnet, nexixpay, payme, peachpayments, powertranz, ppro, revolut, sanlam_common, saferpay, tsys_transit, twoc_twop_paco, etc.
- Same pattern as batch 1

### PR 5: Change `AmountConvertor` trait to use `Money`
- Change `convert(&self, amount: MinorUnit, currency: Currency)` → `convert(&self, money: &Money)`
- Change `convert_back(...)` → return `Money` instead of `MinorUnit`
- Update 6 trait impls, 2 macro definitions (auto-covers 36 connectors), 4 utils helpers
- Update ~17 connectors that call `convert()` directly
- Update ~13 connectors that call `convert_back()` directly
- Rename to `Money::amount_convert()` and `Money::amount_convert_back()` as the public API

### PR 6: Remove deprecated `i64` amount fields from domain request structs
- Remove `amount: i64`, `refund_amount: i64`, `amount_to_capture: i64` from `PaymentsAuthorizeData`, `RefundsData`, `PaymentsCaptureData`, etc.
- Keep only `minor_amount: MinorUnit` (or `Money` if PR 5 is done)
- Update all connectors that still reference the `i64` fields

### PR 7: Remove `get_amount_as_i64()` from `MinorUnitProtoAccess` trait
- After PRs 5-6, no caller should need raw `i64` extraction
- Remove the method from the trait
- Simplify `proto_boundary` module

### PR 8 (future): Unify request structs to use `Money` instead of separate `minor_amount` + `currency`
- Replace `minor_amount: MinorUnit` + `currency: Currency` → `amount: Money` in domain request structs
- Address challenges: multiple amounts per currency, optional amount with required currency, response path currency threading
- This is the largest change — 672+ `.request.currency` and 241+ `.request.minor_amount` usages across 108 connector files

### PR 9 (future): Add CI lint for `proto_boundary` and `AmountConvertor` direct usage
- Add grep-based CI check blocking `proto_boundary` imports in connector code
- Add grep-based CI check blocking direct `AmountConvertor::convert()` calls in connector code (must go through `Money::amount_convert()`)

## What cannot be solved at the type system level

- **`MinorUnit` serde stays available** — domain structs (`CaptureSyncResponse`, surcharge types, mandate types, payment address types) derive `Serialize`/`Deserialize` and contain `MinorUnit` fields for event logging/Kafka. Cannot remove without redesigning event serialization.
- **`Debug` leaks the value as `MinorUnit(5000)`** — needed for error messages and logging. Not cleanly parseable, but technically visible.
- **`ConnectorMinorUnit::to_string()` gives the raw number** — by design, for wire format serialization. Extraction + tampering is possible but obvious in code review (same pattern as `Secret::expose()`).
- **Grep-based CI lint can be bypassed by CI config changes** — requires repo admin access, visible in git history. A compiler-level unbypassable lint would require a separate crate for `proto_boundary`.

## Test plan

- [x] `cargo check` — 0 errors
- [x] `cargo test -p ucs_common_utils` — 27 tests pass
- [x] `cargo test --test test_amount_conversion` — 3 tests pass
- [x] CI lint passes: 0 `proto_boundary` imports in non-test connector code
- [ ] Verify adyen webhook HMAC verification
- [ ] Verify novalnet webhook HMAC verification
- [ ] Verify imerchantsolutions partial capture flow