### PR TITLE
feat(twoc_twop_paco): send billing email via generalPayerDetails and add cardHolderName fallback

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/twoc_twop_paco/transformers.rs
@@ -363,6 +363,21 @@ impl PacoBrowserInfo {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PacoGeneralPayerDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<common_utils::pii::Email>,
+}
+
+impl PacoGeneralPayerDetails {
+    fn from_billing_email(email: Option<common_utils::pii::Email>) -> Option<Self> {
+        Some(Self {
+            email: Some(email?),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TwocTwopPacoCardAuthorizeRequest {
     pub api_request: ApiRequestEnvelope,
     pub office_id: Secret<String>,
@@ -373,6 +388,8 @@ pub struct TwocTwopPacoCardAuthorizeRequest {
     #[serde(rename = "notificationURLs")]
     pub notification_urls: PacoNotificationUrls,
     pub credit_card_details: PacoCreditCardDetails,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub general_payer_details: Option<PacoGeneralPayerDetails>,
     #[serde(rename = "request3dsFlag")]
     pub request3ds_flag: PacoRequest3dsFlag,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -981,6 +998,27 @@ where
                 .as_ref()
                 .and_then(|bi| bi.user_agent.clone())
                 .map(PacoDeviceDetails::from_user_agent);
+            let general_payer_details = PacoGeneralPayerDetails::from_billing_email(
+                item.resource_common_data.get_optional_billing_email(),
+            );
+            let card_holder_name = card
+                .get_optional_cardholder_name()
+                .filter(|name| {
+                    let n = name.peek().trim();
+                    !n.is_empty() && !n.eq_ignore_ascii_case("name")
+                })
+                .or_else(|| {
+                    let first = item.resource_common_data.get_optional_billing_first_name();
+                    let last = item.resource_common_data.get_optional_billing_last_name();
+                    match (first, last) {
+                        (Some(first), Some(last)) => {
+                            Some(Secret::new(format!("{} {}", first.peek(), last.peek())))
+                        }
+                        (Some(first), None) => Some(first),
+                        (None, Some(last)) => Some(last),
+                        (None, None) => None,
+                    }
+                });
             let body = TwocTwopPacoCardAuthorizeRequest {
                 api_request: ApiRequestEnvelope::new(request_message_id),
                 office_id,
@@ -993,7 +1031,7 @@ where
                     card_number: Secret::new(card.card_number.peek().to_string()),
                     card_expiry_mmyy: mmyy,
                     cvv_code: card.card_cvc.clone(),
-                    card_holder_name: card.get_optional_cardholder_name(),
+                    card_holder_name,
                     card_type,
                 },
                 request3ds_flag,
@@ -1002,6 +1040,7 @@ where
                 billing_address: paco_billing_address,
                 shipping_address: paco_shipping_address,
                 airline_data: airline_data.clone(),
+                general_payer_details,
             };
             Ok(TwocTwopPacoAuthorizeRequest::Card(body))
         }


### PR DESCRIPTION
## Summary

Enhancements to the **2C2P PACO** (`twoc_twop_paco`) connector's **Card authorize** flow, for merchant Cebu Pacific / gateway `TWOC_TWOP_PACO`.

1. **Send billing email → `generalPayerDetails.email`** (Card flow only). The value is sourced **exclusively from the billing address** (`get_optional_billing_email()`); the customer `request.email` is **never** used. When no billing email is present, the entire `generalPayerDetails` object is omitted from the wire payload.
2. **`cardHolderName` fallback.** When *Name on Card* is missing, fall back to the billing-address name — first + last combined when both present, otherwise whichever single name is present; when neither is present the `cardHolderName` key is omitted.

### Wire format (Card payload)
```json
{
  "generalPayerDetails": { "email": "<billing email>" },
  "creditCardDetails": { "cardHolderName": "<card name or billing first+last>", ... }
}
```
`email` is a **sibling** of `personName` per the PACO PersonBase schema (optional, max length 100). No `personType`/`seqNo`/`personName` fields are added, and email is not nested inside `personName`.

### Scope / non-goals
- Wallet (GCash) authorize flow is **unaffected** — it never emits `generalPayerDetails` (the field is not added to the wallet request struct) and has no `creditCardDetails`.
- Both `generalPayerDetails` and `cardHolderName` keys are **entirely absent** when their source value is missing (`skip_serializing_if = "Option::is_none"`).
- Hyperswitch-prism changes only.

## Implementation
- New `PacoGeneralPayerDetails { email: Option<Email> }` struct (camelCase, `skip_serializing_if`) with `from_billing_email(...) -> Option<Self>` (returns `None` → object omitted).
- Added `general_payer_details: Option<PacoGeneralPayerDetails>` field to `TwocTwopPacoCardAuthorizeRequest` only.
- `build_authorize_request` (Card arm) computes `general_payer_details` from the billing email and the `card_holder_name` fallback from `card.get_optional_cardholder_name().or_else(...)`.

## Testing
Added a `#[cfg(test)]` module (`general_payer_details_tests`) that builds a `RouterDataV2<Authorize, ...>` and calls `build_authorize_request` directly, covering 8 scenarios:
1. Billing email present → `generalPayerDetails.email` populated.
2. Billing email absent → `generalPayerDetails` omitted.
3. Only customer `request.email` set → still omitted (never used).
4. Billing email but no `AddressDetails` → `generalPayerDetails` present, `billingAddress` omitted.
5. No billing address → clean payload.
6. Wallet (GCash) + billing email → no `generalPayerDetails`, no `creditCardDetails`.
7. Name on Card wins over billing names.
8. Fallback variations: first+last → `"First Last"`, first-only, last-only, neither → key omitted.

Results:
- `cargo check -p connector-integration --lib` → clean (no warnings from this crate).
- `cargo test -p connector-integration --lib` → **179 passed; 0 failed** (8 new + 171 existing, zero regressions).

---

**1. Problem Description:** PACO Card payments for Cebu Pacific were not forwarding the payer's email, and `cardHolderName` was empty whenever *Name on Card* was not supplied.

**2. How the issue was identified:** Requirement from the merchant/gateway integration for `TWOC_TWOP_PACO`; PACO expects the payer email under `generalPayerDetails.email` and a non-empty cardholder name.

**3. Solution implemented:** See Implementation above — billing-email-sourced `generalPayerDetails` and a billing-name fallback for `cardHolderName`, both omitted when source data is absent; wallet flow untouched.

**4. Documentation:** NA

**5. DB Alter Details:** NA

**6. Data fix Details:** NA

**7. Service Config Changes:** NA

**8. Environment variable Changes:** NA

**9. Library change:** NA

**10. Related PRs:** NA

**11. Testing:** Unit tests for 8 scenarios (see Testing). `cargo test -p connector-integration --lib` → 179 passed, 0 failed.

**12. Deployment plan:** Standard deployment.

**13. Services to deploy:** Services running the `twoc_twop_paco` connector-integration (UCS / hyperswitch-prism payment authorize path).

**14. Verification during/post deployment:** For a PACO Cebu Pacific Card authorize with a billing email, confirm the outgoing request contains `generalPayerDetails.email` equal to the billing email and `creditCardDetails.cardHolderName` populated (Name on Card, else billing first+last). Confirm wallet/GCash authorize requests contain neither `generalPayerDetails` nor `creditCardDetails`.