### PR TITLE
fix(grpc-server): add missing apply_url_overrides on outgoing connector calls

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -468,9 +468,19 @@ impl EventServiceImpl {
         let request_data =
             SurchargePaymentSucceededRequest::foreign_try_from(req.clone()).to_grpc_error()?;
 
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
+            &config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
+        )
+        .to_grpc_error()?;
+
         let common_flow_data = SurchargeFlowData::foreign_try_from((
             req.clone(),
-            config.connectors.clone(),
+            connectors,
             &masked_metadata,
         ))
         .to_grpc_error()?;
@@ -581,9 +591,19 @@ impl EventServiceImpl {
         let request_data =
             SurchargeRefundSucceededRequest::foreign_try_from(req.clone()).to_grpc_error()?;
 
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
+            &config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
+        )
+        .to_grpc_error()?;
+
         let common_flow_data = SurchargeFlowData::foreign_try_from((
             req.clone(),
-            config.connectors.clone(),
+            connectors,
             &masked_metadata,
         ))
         .to_grpc_error()?;
@@ -694,9 +714,19 @@ impl EventServiceImpl {
         let request_data =
             FrmPaymentOutcomeRequest::foreign_try_from(req.clone()).to_grpc_error()?;
 
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
+            &config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
+        )
+        .to_grpc_error()?;
+
         let common_flow_data = FrmFlowData::foreign_try_from((
             req.clone(),
-            config.connectors.clone(),
+            connectors,
             &masked_metadata,
         ))
         .to_grpc_error()?;
@@ -804,9 +834,19 @@ impl EventServiceImpl {
         let request_data =
             FrmRefundProcessedRequest::foreign_try_from(req.clone()).to_grpc_error()?;
 
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
+            &config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
+        )
+        .to_grpc_error()?;
+
         let common_flow_data = FrmFlowData::foreign_try_from((
             req.clone(),
-            config.connectors.clone(),
+            connectors,
             &masked_metadata,
         ))
         .to_grpc_error()?;
@@ -914,9 +954,19 @@ impl EventServiceImpl {
         let request_data =
             FrmChargebackReceivedRequest::foreign_try_from(req.clone()).to_grpc_error()?;
 
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
+            &config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
+        )
+        .to_grpc_error()?;
+
         let common_flow_data = FrmFlowData::foreign_try_from((
             req.clone(),
-            config.connectors.clone(),
+            connectors,
             &masked_metadata,
         ))
         .to_grpc_error()?;
@@ -991,8 +1041,18 @@ async fn verify_webhook_source_external(
     metadata_payload: &utils::MetadataPayload,
     service_name: &str,
 ) -> Result<bool, error_stack::Report<ucs_env::error::GrpcError>> {
+    // Resolve effective connector URLs — applies superposition (x-environment) first,
+    // then any caller-supplied base_url override from x-connector-config on top.
+    let connectors = utils::apply_url_overrides(
+        config,
+        &metadata_payload.connector,
+        connector_config,
+        metadata_payload.environment.as_deref(),
+    )
+    .to_grpc_error()?;
+
     let verify_webhook_flow_data = VerifyWebhookSourceFlowData {
-        connectors: config.connectors.clone().into(),
+        connectors: connectors.into(),
         connector_request_reference_id: format!("webhook_verify_{}", metadata_payload.request_id),
         raw_connector_response: None,
         raw_connector_request: None,

--- a/crates/grpc-server/grpc-server/src/server/events.rs
+++ b/crates/grpc-server/grpc-server/src/server/events.rs
@@ -478,12 +478,9 @@ impl EventServiceImpl {
         )
         .to_grpc_error()?;
 
-        let common_flow_data = SurchargeFlowData::foreign_try_from((
-            req.clone(),
-            connectors,
-            &masked_metadata,
-        ))
-        .to_grpc_error()?;
+        let common_flow_data =
+            SurchargeFlowData::foreign_try_from((req.clone(), connectors, &masked_metadata))
+                .to_grpc_error()?;
 
         let router_data = RouterDataV2::<
             SurchargePaymentSucceeded,
@@ -601,12 +598,9 @@ impl EventServiceImpl {
         )
         .to_grpc_error()?;
 
-        let common_flow_data = SurchargeFlowData::foreign_try_from((
-            req.clone(),
-            connectors,
-            &masked_metadata,
-        ))
-        .to_grpc_error()?;
+        let common_flow_data =
+            SurchargeFlowData::foreign_try_from((req.clone(), connectors, &masked_metadata))
+                .to_grpc_error()?;
 
         let router_data = RouterDataV2::<
             SurchargeRefundSucceeded,
@@ -724,12 +718,9 @@ impl EventServiceImpl {
         )
         .to_grpc_error()?;
 
-        let common_flow_data = FrmFlowData::foreign_try_from((
-            req.clone(),
-            connectors,
-            &masked_metadata,
-        ))
-        .to_grpc_error()?;
+        let common_flow_data =
+            FrmFlowData::foreign_try_from((req.clone(), connectors, &masked_metadata))
+                .to_grpc_error()?;
 
         let router_data = RouterDataV2::<
             FrmPaymentOutcome,
@@ -844,12 +835,9 @@ impl EventServiceImpl {
         )
         .to_grpc_error()?;
 
-        let common_flow_data = FrmFlowData::foreign_try_from((
-            req.clone(),
-            connectors,
-            &masked_metadata,
-        ))
-        .to_grpc_error()?;
+        let common_flow_data =
+            FrmFlowData::foreign_try_from((req.clone(), connectors, &masked_metadata))
+                .to_grpc_error()?;
 
         let router_data = RouterDataV2::<
             FrmRefundProcessed,
@@ -964,12 +952,9 @@ impl EventServiceImpl {
         )
         .to_grpc_error()?;
 
-        let common_flow_data = FrmFlowData::foreign_try_from((
-            req.clone(),
-            connectors,
-            &masked_metadata,
-        ))
-        .to_grpc_error()?;
+        let common_flow_data =
+            FrmFlowData::foreign_try_from((req.clone(), connectors, &masked_metadata))
+                .to_grpc_error()?;
 
         let router_data = RouterDataV2::<
             FrmChargebackReceived,

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -2657,9 +2657,13 @@ impl PaymentMethod {
             PaymentMethodTokenResponse,
         > = connector_data.connector.get_connector_integration_v2();
 
-        let connectors = utils::connectors_with_connector_config_overrides(
-            &metadata_payload.connector_config,
+        // Resolve effective connector URLs — applies superposition (x-environment) first,
+        // then any caller-supplied base_url override from x-connector-config on top.
+        let connectors = utils::apply_url_overrides(
             config,
+            &metadata_payload.connector,
+            &metadata_payload.connector_config,
+            metadata_payload.environment.as_deref(),
         )
         .to_grpc_error()?;
 


### PR DESCRIPTION
## What

`utils::apply_url_overrides` is the single entry point for connector URL resolution — it applies superposition (`x-environment`) dynamic URLs first, then any caller-supplied `base_url` override from `x-connector-config` on top. Several flows that make **outgoing connector calls** were bypassing it, so those requests silently ignored both override mechanisms.

This routes them all through `apply_url_overrides`.

## Flows fixed

| Flow | Location | Was using | Missing |
|---|---|---|---|
| PaymentMethod tokenize — authenticator connectors (`handle_tokenize_authenticator_flow`) | `server/payments.rs` | `connectors_with_connector_config_overrides` | superposition / `x-environment` |
| `NotifyConnector` — surcharge payment succeeded | `server/events.rs` | raw `config.connectors.clone()` | both |
| `NotifyConnector` — surcharge refund succeeded | `server/events.rs` | raw | both |
| `NotifyConnector` — FRM payment outcome | `server/events.rs` | raw | both |
| `NotifyConnector` — FRM refund processed | `server/events.rs` | raw | both |
| `NotifyConnector` — FRM chargeback received | `server/events.rs` | raw | both |
| Incoming webhook source verification (`verify_webhook_source_external`) | `server/events.rs` | raw | both |

All seven call `external_services::service::execute_connector_processing_step(..., CallConnectorAction::Trigger, ...)`. For `verify_webhook_source_external` this is a real outbound HTTP call to the connector (e.g. PayPal `v1/notifications/verify-webhook-signature`), and the endpoint's `base_url` is read from exactly this `Connectors` struct.

## Not changed

- `handle_tokenize_internal` (generic payment-connector tokenize) — already calls `apply_url_overrides`.
- `verify_redirect_response` — no outbound connector call (local decode/verify only).

## Testing
check is superposition url is resolved
<img width="3456" height="360" alt="image" src="https://github.com/user-attachments/assets/0a22349c-0fc2-4e24-99cc-d7dc5e6cd7f6" />
