### PR TITLE
chore(clippy): disallow raw entropy/clock calls in connector code

### DIFF
--- a/crates/integrations/connector-integration/clippy.toml
+++ b/crates/integrations/connector-integration/clippy.toml
@@ -1,0 +1,18 @@
+# Entropy/clock guardrail for connector code — the enforcement half of the
+# deterministic-entropy refactor (#2224), and the check its helper docs
+# promise. Every wall-clock read and every random value a connector produces
+# must flow through the sanctioned helpers, so the 60+ sites fixed there
+# cannot regress and a new connector cannot reintroduce the pattern. CI runs
+# clippy with `-D warnings`, so a listed call is a build failure, not advice.
+#
+# Deliberately NOT listed: `ring::rand::SystemRandom` — PKCS#1 v1.5 signing
+# uses it for blinding only (the signature output is deterministic), and
+# banning it would force allow-attributes onto legitimate signing code.
+disallowed-methods = [
+    { path = "uuid::Uuid::new_v4", reason = "use common_utils::fp_utils::generate_uuid_v4 — one auditable entropy source" },
+    { path = "uuid::Uuid::now_v7", reason = "use common_utils::fp_utils::generate_uuid_v7 — one auditable entropy source" },
+    { path = "std::time::SystemTime::now", reason = "use common_utils::date_time (now / now_unix_millis) — one clock source" },
+    { path = "time::OffsetDateTime::now_utc", reason = "use common_utils::date_time (now / now_unix_millis) — one clock source" },
+    { path = "rand::thread_rng", reason = "use domain_types::utils::generate_random_bytes — one auditable entropy source" },
+    { path = "openssl::rand::rand_bytes", reason = "use domain_types::utils::generate_random_bytes — one auditable entropy source" },
+]

--- a/crates/integrations/connector-integration/src/connectors/paydotcom.rs
+++ b/crates/integrations/connector-integration/src/connectors/paydotcom.rs
@@ -228,7 +228,7 @@ macros::create_all_prerequisites!(
             ));
             header.push((
                 headers::IDEMPOTENCY_KEY.to_string(),
-                uuid::Uuid::new_v4().to_string().into(),
+                common_utils::fp_utils::generate_uuid_v4().into(),
             ));
             Ok(header)
         }

--- a/crates/integrations/connector-integration/src/connectors/paynearme/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/paynearme/transformers.rs
@@ -128,7 +128,7 @@ impl TryFrom<&ConnectorSpecificConfig> for PaynearmeAuthType {
 
 /// Current Unix epoch **seconds**, as the decimal string PayNearMe expects.
 fn current_timestamp() -> String {
-    time::OffsetDateTime::now_utc().unix_timestamp().to_string()
+    common_utils::date_time::now_unix_timestamp().to_string()
 }
 
 /// Build the `string_to_sign` from an already-serialised request body.


### PR DESCRIPTION
## What

The enforcement half of #2224 (deterministic entropy sources), split out as its own PR — and the check `generate_uuid_v4`'s doc comment already promises. A `clippy.toml` in `crates/integrations/connector-integration/` disallows the raw entry points, each pointing at its sanctioned helper:

| disallowed | use instead |
|---|---|
| `uuid::Uuid::new_v4` | `common_utils::fp_utils::generate_uuid_v4` |
| `uuid::Uuid::now_v7` | `common_utils::fp_utils::generate_uuid_v7` |
| `std::time::SystemTime::now` | `common_utils::date_time` (`now` / `now_unix_millis`) |
| `time::OffsetDateTime::now_utc` | `common_utils::date_time` (`now` / `now_unix_millis`) |
| `rand::thread_rng` | `domain_types::utils::generate_random_bytes` |
| `openssl::rand::rand_bytes` | `domain_types::utils::generate_random_bytes` |

CI's clippy step sets `RUSTFLAGS: -D warnings`, so a listed call is a build failure, not advice. The config is scoped to the connector crate (nearest-`clippy.toml` semantics), so the helpers themselves — which legitimately call the raw functions once — need no allow-attributes.

**Deliberately not listed**: `ring::rand::SystemRandom` — PKCS#1 v1.5 signing uses it for blinding only (signature output is deterministic), and banning it would force allows onto legitimate signing code.

## It already caught two regressions

In the four days since #2224 merged, two raw sites crept back in; both are fixed here in the established helper style:

- `paydotcom.rs` — idempotency-key header used `uuid::Uuid::new_v4()`; now `fp_utils::generate_uuid_v4()` (same shape as volt/nexixpay).
- `paynearme/transformers.rs` — the signing timestamp used `time::OffsetDateTime::now_utc()`; now `date_time::now_unix_timestamp()` (same as rapyd's signing timestamp).

## Verification

- `cargo clippy -p connector-integration --all-features --all-targets` with `-D warnings`: clean.
- Mutation test: a probe file calling `Uuid::new_v4` and `OffsetDateTime::now_utc` fails clippy with `use of a disallowed method` for both — the guardrail demonstrably fires under CI's exact flags.