### PR TITLE
fix(psync): run connector pre-flight validation before dispatching a PSync

### DIFF
--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -1098,11 +1098,7 @@ impl PaymentService for Payments {
                     // status" and write no error for it.
                     if let Err(validation_error) = connector_data.connector.validate_psync_reference_id(
                         &payments_sync_data,
-                        matches!(
-                            payment_flow_data.auth_type,
-                            common_enums::AuthenticationType::ThreeDs
-                        ),
-                        payment_flow_data.status,
+                        &payment_flow_data,
                     ) {
                         // Log with the same fields `IntoGrpcStatus` would emit, while the
                         // report's frames (connector-supplied context) are still attached;
@@ -1123,23 +1119,10 @@ impl PaymentService for Payments {
                             },
                         )));
                     }
-                    let should_do_access_token = connector_data
-                        .connector
-                        .should_do_access_token(Some(payment_flow_data.payment_method));
-
-                    let payment_flow_data = if should_do_access_token {
-                        let access_token = payload
-                            .state
-                            .as_ref()
-                            .and_then(|state| state.access_token.as_ref())
-                            .ok_or_else(|| ucs_env::error::GrpcError::from(IntegrationError::FailedToObtainAuthType { context: domain_types::errors::IntegrationErrorContext::default() }))?;
-                        let access_token_data =
-                            ServerAuthenticationTokenResponseData::foreign_try_from(access_token)
-                                .map_err(|_e| ucs_env::error::GrpcError::from(IntegrationError::FailedToObtainAuthType { context: domain_types::errors::IntegrationErrorContext::default() }))?;
-                        payment_flow_data.set_access_token(Some(access_token_data))
-                    } else {
-                        payment_flow_data
-                    };
+                    // `payment_flow_data.access_token` is already populated above by
+                    // `PaymentFlowData::foreign_try_from` from `payload.state.access_token` —
+                    // unconditionally, the same way Authorize gets it. No extra fetch-or-fail
+                    // needed here.
 
                     // Create router data
                     let router_data = RouterDataV2::<

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -1085,6 +1085,38 @@ impl PaymentService for Payments {
                     ))
                     .to_grpc_error()?;
 
+                    // Connector pre-flight for sync. Hyperswitch's direct path never dispatches a
+                    // PSync the connector cannot serve (Adyen without `encoded_data`, or any
+                    // connector without a connector transaction id); it skips the call and keeps
+                    // the caller's current state. Without this check UCS builds the request
+                    // anyway or, when the connector returns no request, answers with the default
+                    // HE_00 error that callers then persist as a connector failure.
+                    //
+                    // UCS is stateless and cannot echo the caller's status, so the equivalent of
+                    // "skip" here is a no-op reply: gRPC OK, `PAYMENT_STATUS_UNSPECIFIED`, no
+                    // error. Callers already treat an unspecified status as "keep the previous
+                    // status" and write no error for it.
+                    if let Err(validation_error) = connector_data.connector.validate_psync_reference_id(
+                        &payments_sync_data,
+                        matches!(
+                            payment_flow_data.auth_type,
+                            common_enums::AuthenticationType::ThreeDs
+                        ),
+                        payment_flow_data.status,
+                        None,
+                    ) {
+                        info!(
+                            error = ?validation_error,
+                            "PAYMENT_SYNC_FLOW: connector pre-flight rejected the sync; returning a no-op response (status unspecified, no error) without calling the connector"
+                        );
+                        return Ok(tonic::Response::new(PaymentServiceGetResponse {
+                            connector_transaction_id: payload.connector_transaction_id.clone(),
+                            merchant_transaction_id: payload.merchant_transaction_id.clone(),
+                            status: grpc_api_types::payments::PaymentStatus::Unspecified as i32,
+                            error: None,
+                            ..Default::default()
+                        }));
+                    }
                     let should_do_access_token = connector_data
                         .connector
                         .should_do_access_token(Some(payment_flow_data.payment_method));

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -57,9 +57,9 @@ use domain_types::{
         generate_refresh_payment_method_response, generate_refund_response,
         generate_repeat_payment_response, generate_setup_mandate_response,
         tokenized_authorize_to_base, tokenized_setup_recurring_to_base, AuthorizationRequest,
-        PaymentMethodDataAction, SetupRecurringRequest,
+        PaymentMethodDataAction, PaymentSyncSkipped, SetupRecurringRequest,
     },
-    utils::ForeignTryFrom,
+    utils::{ForeignFrom, ForeignTryFrom},
 };
 use external_services::service::EventProcessingParams;
 use grpc_api_types::payments::{
@@ -1103,7 +1103,6 @@ impl PaymentService for Payments {
                             common_enums::AuthenticationType::ThreeDs
                         ),
                         payment_flow_data.status,
-                        None,
                     ) {
                         // Log with the same fields `IntoGrpcStatus` would emit, while the
                         // report's frames (connector-supplied context) are still attached;
@@ -1117,13 +1116,12 @@ impl PaymentService for Payments {
                             http_status_code = ?context.http_status_code(),
                             "PAYMENT_SYNC_FLOW: connector pre-flight rejected the sync; returning a no-op response (status unspecified, no error) without calling the connector"
                         );
-                        return Ok(tonic::Response::new(PaymentServiceGetResponse {
-                            connector_transaction_id: payload.connector_transaction_id.clone(),
-                            merchant_transaction_id: payload.merchant_transaction_id.clone(),
-                            status: grpc_api_types::payments::PaymentStatus::Unspecified as i32,
-                            error: None,
-                            ..Default::default()
-                        }));
+                        return Ok(tonic::Response::new(PaymentServiceGetResponse::foreign_from(
+                            PaymentSyncSkipped {
+                                connector_transaction_id: payload.connector_transaction_id.clone(),
+                                merchant_transaction_id: payload.merchant_transaction_id.clone(),
+                            },
+                        )));
                     }
                     let should_do_access_token = connector_data
                         .connector

--- a/crates/grpc-server/grpc-server/src/server/payments.rs
+++ b/crates/grpc-server/grpc-server/src/server/payments.rs
@@ -1105,8 +1105,16 @@ impl PaymentService for Payments {
                         payment_flow_data.status,
                         None,
                     ) {
-                        info!(
-                            error = ?validation_error,
+                        // Log with the same fields `IntoGrpcStatus` would emit, while the
+                        // report's frames (connector-supplied context) are still attached;
+                        // this reply is never converted to a gRPC status, so it would
+                        // otherwise go unlogged.
+                        let report = validation_error.to_grpc_error();
+                        let context = report.current_context();
+                        tracing::warn!(
+                            error = ?report,
+                            error_code = %context.error_code(),
+                            http_status_code = ?context.http_status_code(),
                             "PAYMENT_SYNC_FLOW: connector pre-flight rejected the sync; returning a no-op response (status unspecified, no error) without calling the connector"
                         );
                         return Ok(tonic::Response::new(PaymentServiceGetResponse {

--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -633,6 +633,22 @@ macros::macro_connector_implementation!(
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::ValidationTrait for Adyen<T>
 {
+    fn validate_psync_reference_id(
+        &self,
+        data: &PaymentsSyncData,
+        _is_three_ds: bool,
+        _status: AttemptStatus,
+        _connector_feature_data: Option<SecretSerdeValue>,
+    ) -> CustomResult<(), IntegrationError> {
+        if data.encoded_data.is_some() {
+            return Ok(());
+        }
+        Err(IntegrationError::MissingRequiredField {
+            field_name: "encoded_data",
+            context: Default::default(),
+        }
+        .into())
+    }
 }
 
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
@@ -1459,22 +1475,6 @@ impl ConnectorValidation for Adyen<DefaultPCIHolder> {
         is_mandate_supported(pm_data, pm_type, mandate_supported_pmd, self.id())
     }
 
-    fn validate_psync_reference_id(
-        &self,
-        data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
-        _connector_feature_data: Option<SecretSerdeValue>,
-    ) -> CustomResult<(), IntegrationError> {
-        if data.encoded_data.is_some() {
-            return Ok(());
-        }
-        Err(IntegrationError::MissingRequiredField {
-            field_name: "encoded_data",
-            context: Default::default(),
-        }
-        .into())
-    }
     fn is_webhook_source_verification_mandatory(&self) -> bool {
         false
     }

--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -16,7 +16,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    pii::SecretSerdeValue,
     types::StringMinorUnit,
 };
 use domain_types::{
@@ -638,7 +637,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         data: &PaymentsSyncData,
         _is_three_ds: bool,
         _status: AttemptStatus,
-        _connector_feature_data: Option<SecretSerdeValue>,
     ) -> CustomResult<(), IntegrationError> {
         if data.encoded_data.is_some() {
             return Ok(());

--- a/crates/integrations/connector-integration/src/connectors/adyen.rs
+++ b/crates/integrations/connector-integration/src/connectors/adyen.rs
@@ -635,8 +635,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     fn validate_psync_reference_id(
         &self,
         data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
+        _payment_flow_data: &PaymentFlowData,
     ) -> CustomResult<(), IntegrationError> {
         if data.encoded_data.is_some() {
             return Ok(());

--- a/crates/integrations/connector-integration/src/connectors/calida.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida.rs
@@ -180,8 +180,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     fn validate_psync_reference_id(
         &self,
         _data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: enums::AttemptStatus,
+        _payment_flow_data: &PaymentFlowData,
     ) -> CustomResult<(), IntegrationError> {
         Ok(())
     }

--- a/crates/integrations/connector-integration/src/connectors/calida.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida.rs
@@ -182,7 +182,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         _data: &PaymentsSyncData,
         _is_three_ds: bool,
         _status: enums::AttemptStatus,
-        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
     ) -> CustomResult<(), IntegrationError> {
         Ok(())
     }

--- a/crates/integrations/connector-integration/src/connectors/calida.rs
+++ b/crates/integrations/connector-integration/src/connectors/calida.rs
@@ -177,6 +177,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Body
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::ValidationTrait for Calida<T>
 {
+    fn validate_psync_reference_id(
+        &self,
+        _data: &PaymentsSyncData,
+        _is_three_ds: bool,
+        _status: enums::AttemptStatus,
+        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
+    ) -> CustomResult<(), IntegrationError> {
+        Ok(())
+    }
 }
 
 macros::create_all_prerequisites!(
@@ -306,16 +315,6 @@ impl ConnectorValidation for Calida<DefaultPCIHolder> {
             .into()),
             _ => Ok(()),
         }
-    }
-
-    fn validate_psync_reference_id(
-        &self,
-        _data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: enums::AttemptStatus,
-        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
-    ) -> CustomResult<(), IntegrationError> {
-        Ok(())
     }
 
     fn is_webhook_source_verification_mandatory(&self) -> bool {

--- a/crates/integrations/connector-integration/src/connectors/razorpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay.rs
@@ -10,7 +10,6 @@ use common_utils::{
     errors::CustomResult,
     events,
     ext_traits::ByteSliceExt,
-    pii::SecretSerdeValue,
     request::{Method, RequestContent},
     types::{AmountConvertor, MinorUnit},
 };
@@ -79,7 +78,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         data: &PaymentsSyncData,
         _is_three_ds: bool,
         _status: AttemptStatus,
-        _connector_meta_data: Option<SecretSerdeValue>,
     ) -> CustomResult<(), IntegrationError> {
         if data.encoded_data.is_some() {
             return Ok(());

--- a/crates/integrations/connector-integration/src/connectors/razorpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay.rs
@@ -74,6 +74,22 @@ pub struct Razorpay<T> {
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     connector_types::ValidationTrait for Razorpay<T>
 {
+    fn validate_psync_reference_id(
+        &self,
+        data: &PaymentsSyncData,
+        _is_three_ds: bool,
+        _status: AttemptStatus,
+        _connector_meta_data: Option<SecretSerdeValue>,
+    ) -> CustomResult<(), IntegrationError> {
+        if data.encoded_data.is_some() {
+            return Ok(());
+        }
+        Err(IntegrationError::MissingRequiredField {
+            field_name: "encoded_data",
+            context: Default::default(),
+        }
+        .into())
+    }
     fn should_do_order_create(&self) -> bool {
         true
     }
@@ -1228,22 +1244,6 @@ impl connector_types::ConnectorValidation for Razorpay<DefaultPCIHolder> {
         is_mandate_supported(pm_data, pm_type, mandate_supported_pmd, self.id())
     }
 
-    fn validate_psync_reference_id(
-        &self,
-        data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
-        _connector_meta_data: Option<SecretSerdeValue>,
-    ) -> CustomResult<(), IntegrationError> {
-        if data.encoded_data.is_some() {
-            return Ok(());
-        }
-        Err(IntegrationError::MissingRequiredField {
-            field_name: "encoded_data",
-            context: Default::default(),
-        }
-        .into())
-    }
     fn is_webhook_source_verification_mandatory(&self) -> bool {
         false
     }

--- a/crates/integrations/connector-integration/src/connectors/razorpay.rs
+++ b/crates/integrations/connector-integration/src/connectors/razorpay.rs
@@ -76,8 +76,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     fn validate_psync_reference_id(
         &self,
         data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
+        _payment_flow_data: &PaymentFlowData,
     ) -> CustomResult<(), IntegrationError> {
         if data.encoded_data.is_some() {
             return Ok(());

--- a/crates/integrations/connector-integration/src/connectors/zift.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift.rs
@@ -121,6 +121,15 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Body
 impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     connector_types::ValidationTrait for Zift<T>
 {
+    fn validate_psync_reference_id(
+        &self,
+        _data: &PaymentsSyncData,
+        _is_three_ds: bool,
+        _status: common_enums::AttemptStatus,
+        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
+    ) -> CustomResult<(), IntegrationError> {
+        Ok(())
+    }
 }
 
 macros::create_amount_converter_wrapper!(connector_name: Zift, amount_type: StringMinorUnit);
@@ -358,16 +367,6 @@ impl ConnectorValidation for Zift<DefaultPCIHolder> {
             }
             .into()),
         }
-    }
-
-    fn validate_psync_reference_id(
-        &self,
-        _data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: common_enums::AttemptStatus,
-        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
-    ) -> CustomResult<(), IntegrationError> {
-        Ok(())
     }
 }
 

--- a/crates/integrations/connector-integration/src/connectors/zift.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift.rs
@@ -126,7 +126,6 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         _data: &PaymentsSyncData,
         _is_three_ds: bool,
         _status: common_enums::AttemptStatus,
-        _connector_meta_data: Option<common_utils::pii::SecretSerdeValue>,
     ) -> CustomResult<(), IntegrationError> {
         Ok(())
     }

--- a/crates/integrations/connector-integration/src/connectors/zift.rs
+++ b/crates/integrations/connector-integration/src/connectors/zift.rs
@@ -124,8 +124,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
     fn validate_psync_reference_id(
         &self,
         _data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: common_enums::AttemptStatus,
+        _payment_flow_data: &PaymentFlowData,
     ) -> CustomResult<(), IntegrationError> {
         Ok(())
     }

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -8516,6 +8516,26 @@ pub fn generate_access_token_response(
     }
 }
 
+/// A PSync that connector pre-flight validation rejected before dispatch.
+pub struct PaymentSyncSkipped {
+    pub connector_transaction_id: String,
+    pub merchant_transaction_id: Option<String>,
+}
+
+impl ForeignFrom<PaymentSyncSkipped> for PaymentServiceGetResponse {
+    fn foreign_from(skipped: PaymentSyncSkipped) -> Self {
+        // Unspecified + no error: UCS is stateless, so this is its "keep the previous
+        // attempt status" reply.
+        Self {
+            connector_transaction_id: skipped.connector_transaction_id,
+            merchant_transaction_id: skipped.merchant_transaction_id,
+            status: grpc_api_types::payments::PaymentStatus::Unspecified as i32,
+            error: None,
+            ..Default::default()
+        }
+    }
+}
+
 #[allow(deprecated)]
 pub fn generate_payment_sync_response(
     router_data_v2: RouterDataV2<PSync, PaymentFlowData, PaymentsSyncData, PaymentsResponseData>,

--- a/crates/types-traits/domain_types/src/types.rs
+++ b/crates/types-traits/domain_types/src/types.rs
@@ -7731,9 +7731,15 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentServiceGetRequest> for Paym
             context: IntegrationErrorContext::default(),
         })?;
         let currency = common_enums::Currency::foreign_try_from(amount.currency())?;
-        // Create ResponseId from resource_id
-        let connector_transaction_id =
-            ResponseId::ConnectorTransactionId(value.connector_transaction_id.clone());
+        // An empty id from the caller means "no connector transaction id yet". Keep that as
+        // `NoResponseId` so connector-level checks (`validate_psync_reference_id`,
+        // `get_connector_transaction_id`) reject the sync instead of building a request URL
+        // with an empty path segment.
+        let connector_transaction_id = if value.connector_transaction_id.trim().is_empty() {
+            ResponseId::NoResponseId
+        } else {
+            ResponseId::ConnectorTransactionId(value.connector_transaction_id.clone())
+        };
 
         let setup_future_usage = match value.setup_future_usage() {
             grpc_payment_types::FutureUsage::Unspecified => None,

--- a/crates/types-traits/interfaces/src/connector_types.rs
+++ b/crates/types-traits/interfaces/src/connector_types.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 
 use common_enums::{AttemptStatus, CaptureMethod, PaymentMethod, PaymentMethodType};
-use common_utils::{CustomResult, SecretSerdeValue};
+use common_utils::CustomResult;
 pub use domain_types::connector_types::WebhookIntegrityCheck;
 use domain_types::{
     connector_flow,
@@ -266,12 +266,14 @@ pub trait ValidationTrait: ConnectorCommon {
         data: &PaymentsSyncData,
         _is_three_ds: bool,
         _status: AttemptStatus,
-        _connector_meta_data: Option<SecretSerdeValue>,
     ) -> CustomResult<(), domain_types::errors::IntegrationError> {
-        // `get_connector_transaction_id` already yields `MissingConnectorTransactionID`
-        // for `NoResponseId` / `EncodedData`; nothing to re-wrap here.
         data.connector_transaction_id
             .get_connector_transaction_id()
+            .change_context(
+                domain_types::errors::IntegrationError::MissingConnectorTransactionID {
+                    context: Default::default(),
+                },
+            )
             .map(|_| ())
     }
 

--- a/crates/types-traits/interfaces/src/connector_types.rs
+++ b/crates/types-traits/interfaces/src/connector_types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use common_enums::{AttemptStatus, CaptureMethod, PaymentMethod, PaymentMethodType};
+use common_enums::{CaptureMethod, PaymentMethod, PaymentMethodType};
 use common_utils::CustomResult;
 pub use domain_types::connector_types::WebhookIntegrityCheck;
 use domain_types::{
@@ -260,12 +260,14 @@ pub trait ValidationTrait: ConnectorCommon {
     /// Mirrors hyperswitch's direct-integration path, which skips the connector call when
     /// this fails instead of sending a request the connector cannot serve. The default
     /// requires a connector transaction id; connectors that sync on other data (for example
-    /// Adyen, which needs `encoded_data`) override it.
+    /// Adyen, which needs `encoded_data`) override it. Takes the full `PaymentFlowData`
+    /// (rather than picking fields out at the call site) so a connector can read whatever
+    /// it needs — `auth_type`, `status`, or anything added later — without another
+    /// signature change.
     fn validate_psync_reference_id(
         &self,
         data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
+        _payment_flow_data: &PaymentFlowData,
     ) -> CustomResult<(), domain_types::errors::IntegrationError> {
         data.connector_transaction_id
             .get_connector_transaction_id()

--- a/crates/types-traits/interfaces/src/connector_types.rs
+++ b/crates/types-traits/interfaces/src/connector_types.rs
@@ -255,6 +255,26 @@ pub trait ValidationTrait: ConnectorCommon {
         false
     }
 
+    /// Pre-flight check run by the server before a PSync is dispatched to the connector.
+    ///
+    /// Mirrors hyperswitch's direct-integration path, which skips the connector call when
+    /// this fails instead of sending a request the connector cannot serve. The default
+    /// requires a connector transaction id; connectors that sync on other data (for example
+    /// Adyen, which needs `encoded_data`) override it.
+    fn validate_psync_reference_id(
+        &self,
+        data: &PaymentsSyncData,
+        _is_three_ds: bool,
+        _status: AttemptStatus,
+        _connector_meta_data: Option<SecretSerdeValue>,
+    ) -> CustomResult<(), domain_types::errors::IntegrationError> {
+        // `get_connector_transaction_id` already yields `MissingConnectorTransactionID`
+        // for `NoResponseId` / `EncodedData`; nothing to re-wrap here.
+        data.connector_transaction_id
+            .get_connector_transaction_id()
+            .map(|_| ())
+    }
+
     /// Returns true if this connector is in the config set of connectors that require
     /// an external API call for webhook source verification (e.g. PayPal).
     fn requires_external_webhook_verification(
@@ -818,24 +838,6 @@ pub trait ConnectorValidation: ConnectorCommon + ConnectorSpecifications {
             }
             .into()),
         }
-    }
-
-    /// fn validate_psync_reference_id
-    fn validate_psync_reference_id(
-        &self,
-        data: &PaymentsSyncData,
-        _is_three_ds: bool,
-        _status: AttemptStatus,
-        _connector_meta_data: Option<SecretSerdeValue>,
-    ) -> CustomResult<(), domain_types::errors::IntegrationError> {
-        data.connector_transaction_id
-            .get_connector_transaction_id()
-            .change_context(
-                domain_types::errors::IntegrationError::MissingConnectorTransactionID {
-                    context: Default::default(),
-                },
-            )
-            .map(|_| ())
     }
 
     /// fn is_webhook_source_verification_mandatory


### PR DESCRIPTION
## Description

`validate_psync_reference_id` existed on `ConnectorValidation`, but that trait is not a supertrait of `ConnectorServiceTrait`, so `PaymentService::get` never called it and the overrides on Adyen, Calida, Razorpay and Zift were dead code. Hyperswitch's direct integration path runs this check before every PSync and skips the connector call when it fails (`psync_flow.rs` `build_flow_specific_connector_request`). UCS did not, and two production symptoms followed:

- **Adyen, PSync without `encoded_data`** (the SDK's post-redirect force sync, and every scheduler retry): `build_request_v2` returns `None`, no HTTP call is made, and the flow answers with the untouched default `ErrorResponse` (`HE_00`, "Something went wrong", `status_code: 500`) as a gRPC-OK reply. Hyperswitch persists that on the attempt and returns it to the SDK, which reads the error block as a failed payment. For merchant `gooutdoors` this left 13 authorized 3DS payments uncaptured in 7 days; the same payments on the direct path capture at 92%.
- **Cybersource, PSync with an empty `connector_transaction_id`** (redirect return racing the webhook-driven Authorize): the empty string was wrapped as `ResponseId::ConnectorTransactionId("")`, so the connector's own missing-id check did not fire and UCS called `tss/v2/transactions/` with an empty path segment, producing an HTML 404 that the kill switch counts as `connector_outcome`.

### Changes

1. `ValidationTrait::validate_psync_reference_id` (moved from `ConnectorValidation`, same default: a connector transaction id is required). The four existing connector overrides move to their `ValidationTrait` impls unchanged.
2. `PaymentService::get` calls it after building `PaymentFlowData` and before router data. On failure it returns a no-op reply without calling the connector: gRPC OK, `PAYMENT_STATUS_UNSPECIFIED`, no `error`, `connector_transaction_id` and `merchant_transaction_id` echoed. The rejection reason is logged at info level.
3. `PaymentsSyncData::foreign_try_from(PaymentServiceGetRequest)` maps an empty `connector_transaction_id` to `ResponseId::NoResponseId`.

### Why a no-op reply rather than a gRPC error

UCS is stateless and cannot return the caller's current status, so it cannot literally "skip and keep status". A gRPC error would surface to the merchant as a failed sync (hyperswitch's `psync_gateway` returns any `payment_get` error to the caller), which is the symptom being fixed. Hyperswitch already maps `PaymentStatus::Unspecified` to "keep the previous attempt status" and writes no error when the reply carries none, so the no-op reply reproduces the direct path's skip with no hyperswitch change and no connector knowledge outside UCS.

## Motivation and Context

Prod evidence, merchant `gooutdoors` on Adyen, 7 days: 13 payments authorized through UCS whose browser force sync received `HE_00`, 0 captured; 68 whose force sync stayed on the direct path, 62 captured. Cybersource `flowbird`: 5 PSync 404s from empty transaction ids on 2026-09-09, all counted as kill switch failures.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

tested locally

<img width="1249" height="319" alt="image" src="https://github.com/user-attachments/assets/0475dd94-b8df-44db-95a8-08bc1ec2d7a6" />

got no error field
Only attempt status as unspecified, hyperswitch can use previous status

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code


