### PR TITLE
fix(worldpayxml): surface approval code as auth_code, not network_txn_id

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -18,7 +18,7 @@ use domain_types::{
     payment_method_data::{
         Card, GpayTokenizationData, PaymentMethodData, PaymentMethodDataTypes, WalletData,
     },
-    router_data::{ConnectorSpecificConfig, ErrorResponse, FlowStatus},
+    router_data::{ConnectorResponseData, ConnectorSpecificConfig, ErrorResponse, FlowStatus},
     router_data_v2::RouterDataV2,
     router_response_types::{RedirectForm, Response},
 };
@@ -32,6 +32,26 @@ use super::{
     WorldpayxmlRouterData,
 };
 use crate::{types::ResponseRouterData, utils};
+
+/// Worldpay's `AuthorisationId` is the issuer approval code, not a scheme
+/// network transaction id. Surface it as the connector-response `auth_code`
+/// (mirroring the hyperswitch direct path); it must never go into
+/// `network_txn_id`, which is reserved for the scheme transaction identifier.
+fn get_worldpayxml_auth_code(
+    payment: &responses::WorldpayxmlPayment,
+    payment_method_type: Option<common_enums::PaymentMethodType>,
+) -> Option<ConnectorResponseData> {
+    payment
+        .authorisation_id
+        .as_ref()
+        .and_then(|auth_id| auth_id.id.clone())
+        .map(|auth_code| {
+            ConnectorResponseData::with_auth_code(
+                auth_code,
+                payment_method_type.unwrap_or(common_enums::PaymentMethodType::Card),
+            )
+        })
+}
 use common_utils::{errors::CustomResult, pii::SecretSerdeValue};
 
 const API_VERSION: &str = "1.4";
@@ -2276,10 +2296,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             redirection_data: None,
             mandate_reference: get_worldpayxml_mandate_reference(order_status, payment),
             connector_metadata: None,
-            network_txn_id: payment
-                .authorisation_id
-                .as_ref()
-                .and_then(|auth_id| auth_id.id.clone()),
+            network_txn_id: None,
             network_txn_link_id: None,
             connector_response_reference_id: Some(order_status.order_code.clone()),
             incremental_authorization_allowed: None,
@@ -2291,6 +2308,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response: get_worldpayxml_auth_code(
+                    payment,
+                    router_data.resource_common_data.payment_method_type,
+                ),
                 ..router_data.resource_common_data.clone()
             },
             response: Ok(payments_response_data),
@@ -2422,10 +2443,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             redirection_data: None,
             mandate_reference: get_worldpayxml_mandate_reference(order_status, payment),
             connector_metadata: None,
-            network_txn_id: payment
-                .authorisation_id
-                .as_ref()
-                .and_then(|auth_id| auth_id.id.clone()),
+            network_txn_id: None,
             network_txn_link_id: None,
             connector_response_reference_id: Some(order_status.order_code.clone()),
             incremental_authorization_allowed: None,
@@ -2437,6 +2455,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response: get_worldpayxml_auth_code(
+                    payment,
+                    router_data.resource_common_data.payment_method_type,
+                ),
                 ..router_data.resource_common_data.clone()
             },
             response: Ok(payments_response_data),
@@ -2564,10 +2586,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
             redirection_data: None,
             mandate_reference: get_worldpayxml_mandate_reference(order_status, payment),
             connector_metadata: None,
-            network_txn_id: payment
-                .authorisation_id
-                .as_ref()
-                .and_then(|auth_id| auth_id.id.clone()),
+            network_txn_id: None,
             network_txn_link_id: None,
             connector_response_reference_id: Some(order_status.order_code.clone()),
             incremental_authorization_allowed: None,
@@ -2579,6 +2598,10 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
         Ok(Self {
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response: get_worldpayxml_auth_code(
+                    payment,
+                    router_data.resource_common_data.payment_method_type,
+                ),
                 ..router_data.resource_common_data.clone()
             },
             response: Ok(payments_response_data),
@@ -2908,10 +2931,7 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlTransactionResponse, Self>
                     redirection_data: None,
                     mandate_reference: None,
                     connector_metadata: None,
-                    network_txn_id: payment
-                        .authorisation_id
-                        .as_ref()
-                        .and_then(|auth_id| auth_id.id.clone()),
+                    network_txn_id: None,
                     network_txn_link_id: None,
                     connector_response_reference_id: Some(order_status.order_code.clone()),
                     incremental_authorization_allowed: None,
@@ -2923,6 +2943,10 @@ impl TryFrom<ResponseRouterData<responses::WorldpayxmlTransactionResponse, Self>
                 Ok(Self {
                     resource_common_data: PaymentFlowData {
                         status,
+                        connector_response: get_worldpayxml_auth_code(
+                            payment,
+                            router_data.resource_common_data.payment_method_type,
+                        ),
                         ..router_data.resource_common_data.clone()
                     },
                     response: Ok(payments_response_data),

--- a/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayxml/transformers.rs
@@ -33,10 +33,6 @@ use super::{
 };
 use crate::{types::ResponseRouterData, utils};
 
-/// Worldpay's `AuthorisationId` is the issuer approval code, not a scheme
-/// network transaction id. Surface it as the connector-response `auth_code`
-/// (mirroring the hyperswitch direct path); it must never go into
-/// `network_txn_id`, which is reserved for the scheme transaction identifier.
 fn get_worldpayxml_auth_code(
     payment: &responses::WorldpayxmlPayment,
     payment_method_type: Option<common_enums::PaymentMethodType>,


### PR DESCRIPTION
## Description

Over UCS, worldpayxml returned Worldpay's approval code in the wrong field:

- `auth_code` was null — the direct path returns the approval code there.
- `network_transaction_id` was populated with that approval code, where the direct path returns null. It's not a network transaction id, so it could be misused for NTI-based MITs.

This moves the approval code to `auth_code` and sets `network_transaction_id` to null, matching the direct path. Affects the authorize, setup-mandate, repeat, and sync responses.

## Motivation and Context

A merchant comparing the UCS path against the direct path found `auth_code` missing and `network_transaction_id` wrongly populated. The mis-mapping was introduced in #2122.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

worldpayxml card authorization over UCS (added `worldpayxml` to `ucs_only_connectors` so the router tunnels through Prism). The `connector_response` now carries `auth_code` and top-level `network_transaction_id` is null, matching the direct path. Before this fix, `auth_code` was null and `network_transaction_id` held the approval code.

<details><summary><b>Request</b></summary>

```sh
curl -X POST 'http://localhost:8080/payments' -H 'Content-Type: application/json' -H 'api-key: ****' -d '{"amount": 1000, "currency": "USD", "confirm": true, "capture_method": "automatic", "authentication_type": "no_three_ds", "return_url": "https://google.com", "connector": ["worldpayxml"], "customer_id": "wpxml_test", "email": "hello@gmail.com", "setup_future_usage": "off_session", "customer_acceptance": {"acceptance_type": "online", "accepted_at": "1963-05-03T04:07:52.723Z", "online": {"ip_address": "192.168.1.1", "user_agent": "test"}}, "billing": {"address": {"zip": "94122", "country": "US", "first_name": "John", "last_name": "Doe", "line1": "1467", "city": "San Francisco", "state": "CA"}}, "payment_method": "card", "payment_method_type": "credit", "payment_method_data": {"card": {"card_number": "4242424242424242", "card_exp_month": "12", "card_exp_year": "30", "card_cvc": "123", "card_holder_name": "John Doe"}}}'
```
</details>

<details><summary><b>Response</b> — <code>succeeded</code>, <code>connector_response.auth_code</code> set, <code>network_transaction_id: null</code></summary>

```json
{
  "payment_id": "pay_jHFLZ3fYH2DbXadE4sUx",
  "merchant_id": "cyMerchant_804d6aef",
  "status": "succeeded",
  "amount": 1000,
  "net_amount": 1000,
  "shipping_cost": null,
  "amount_capturable": 0,
  "amount_received": 1000,
  "processor_merchant_id": "cyMerchant_804d6aef",
  "initiator": null,
  "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fS1BPUG9hMmFwaWdKbWo0Y1phNWEscHVibGlzaGFibGVfa2V5PXBrX2Rldl82OWYyMjRhYTFhNWI0YjhmOTI4ZTk5ODUwOGZlOTJiNixjbGllbnRfc2VjcmV0PXBheV9qSEZMWjNmWUgyRGJYYWRFNHNVeF9zZWNyZXRfanNFeUJDU3BxUFZOQVlHblVXTXYsY3VzdG9tZXJfaWQ9d3B4bWxfdGVzdCxjbGllbnRfc2Vzc2lvbl9pZD1jbGllbnRfc2Vzc19CVTBaWnZvcGNqUWdJVU45dTlwQyxwYXltZW50X2lkPXBheV9qSEZMWjNmWUgyRGJYYWRFNHNVeA==",
  "connector": "worldpayxml",
  "state_metadata": null,
  "client_secret": "****",
  "created": "2026-09-09T16:20:45.618Z",
  "modified_at": "2026-09-09T16:20:46.749Z",
  "connector_customer_id": null,
  "currency": "USD",
  "customer_id": "wpxml_test",
  "customer": {
    "id": "wpxml_test",
    "name": null,
    "email": "hello@gmail.com",
    "phone": null,
    "phone_country_code": null,
    "customer_document_details": null
  },
  "description": null,
  "refunds": null,
  "disputes": null,
  "mandate_id": null,
  "mandate_data": null,
  "setup_future_usage": "off_session",
  "off_session": null,
  "capture_on": null,
  "capture_method": "automatic",
  "payment_method": "card",
  "payment_method_data": {
    "card": {
      "last4": "4242",
      "card_type": "CREDIT",
      "card_subtype": null,
      "card_segment_type": null,
      "funding_source": null,
      "card_network": "Visa",
      "card_issuer": "STRIPE PAYMENTS UK LIMITED",
      "card_issuing_country": "UNITEDKINGDOM",
      "card_isin": "424242",
      "card_extended_bin": null,
      "card_exp_month": "12",
      "card_exp_year": "30",
      "card_holder_name": "John Doe",
      "payment_checks": null,
      "authentication_data": null,
      "auth_code": "734576"
    },
    "billing": null
  },
  "payment_token": "****",
  "shipping": null,
  "billing": {
    "address": {
      "city": "San Francisco",
      "country": "US",
      "line1": "1467",
      "line2": null,
      "line3": null,
      "zip": "94122",
      "state": "CA",
      "first_name": "John",
      "last_name": "Doe",
      "origin_zip": null
    },
    "phone": null,
    "email": null
  },
  "order_details": null,
  "email": "hello@gmail.com",
  "name": null,
  "phone": null,
  "return_url": "https://google.com/",
  "authentication_type": "no_three_ds",
  "statement_descriptor_name": null,
  "statement_descriptor_suffix": null,
  "next_action": null,
  "cancellation_reason": null,
  "error_code": null,
  "error_message": null,
  "unified_code": null,
  "unified_message": null,
  "error_details": null,
  "payment_experience": null,
  "payment_method_type": "credit",
  "connector_label": null,
  "business_country": null,
  "business_label": null,
  "business_sub_label": null,
  "allowed_payment_method_types": null,
  "manual_retry_allowed": null,
  "connector_transaction_id": "pay_jHFLZ3fYH2DbXadE4sUx_1",
  "frm_message": null,
  "metadata": null,
  "connector_metadata": null,
  "connector_response_metadata": null,
  "feature_metadata": {
    "redirect_response": null,
    "search_tags": null,
    "apple_pay_recurring_details": null,
    "pix_additional_details": null,
    "boleto_additional_details": null,
    "pix_automatico_additional_details": null,
    "finix_additional_details": null
  },
  "reference_id": "pay_jHFLZ3fYH2DbXadE4sUx_1",
  "payment_link": null,
  "profile_id": "pro_KPOPoa2apigJmj4cZa5a",
  "surcharge_details": null,
  "applied_offer": null,
  "attempt_count": 1,
  "merchant_decision": null,
  "merchant_connector_id": "mca_eo1BqcEgYLxzQIFplVwF",
  "incremental_authorization_allowed": false,
  "authorization_count": null,
  "incremental_authorizations": null,
  "external_authentication_details": null,
  "external_3ds_authentication_attempted": false,
  "expires_on": "2026-09-09T16:35:45.618Z",
  "fingerprint": null,
  "fingerprint_type": null,
  "browser_info": null,
  "payment_channel": null,
  "payment_method_id": "pm_nzRLXogwXuAD7sUf996q",
  "network_transaction_id": null,
  "payment_account_reference": null,
  "network_transaction_link_id": null,
  "payment_method_status": "active",
  "updated": "2026-09-09T16:20:46.749Z",
  "split_payments": null,
  "frm_metadata": null,
  "extended_authorization_applied": null,
  "extended_authorization_last_applied_at": null,
  "request_extended_authorization": null,
  "capture_before": null,
  "merchant_order_reference_id": null,
  "order_tax_amount": null,
  "connector_mandate_id": "J0U3P9Z8W9H8X6D",
  "card_discovery": "manual",
  "force_3ds_challenge": false,
  "force_3ds_challenge_trigger": false,
  "issuer_error_code": null,
  "issuer_error_message": null,
  "is_iframe_redirection_enabled": null,
  "whole_connector_response": null,
  "enable_partial_authorization": null,
  "enable_overcapture": null,
  "is_overcapture_enabled": null,
  "network_details": null,
  "is_stored_credential": null,
  "mit_category": null,
  "billing_descriptor": null,
  "is_account_funded_transaction": null,
  "recipient_details": null,
  "tokenization": null,
  "partner_merchant_identifier_details": null,
  "payment_method_tokenization_details": {
    "payment_method_id": "pm_nzRLXogwXuAD7sUf996q",
    "payment_method_status": "active",
    "psp_tokenization": false,
    "network_tokenization": false,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "is_eligible_for_mit_payment": false
  },
  "installment_options": null,
  "installment_data": null,
  "sender_payment_instrument_id": null
}
```
</details>
