### PR TITLE
feat(connector): [Worldpayraft] wire-format fixes, Void reversal, and external 3DS passthrough

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use common_enums::CurrencyUnit;
 use common_utils::{
-    consts, errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
+    errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
 };
 use domain_types::{
     connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},
@@ -153,6 +153,14 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
         )])
     }
 
+    /// Transport-level failures only.
+    ///
+    /// Worldpay RAFT answers HTTP 200 for approvals, declines and validation errors alike
+    /// and signals the outcome in the body, so a payment decline never reaches this method
+    /// — it is surfaced by the per-flow response transformers instead. A non-2xx here means
+    /// a licence, routing or platform problem, which RAFT returns as an unwrapped
+    /// `{"fault": {...}}` body. A wrapped `{"<operation>response": {...}}` body is still
+    /// accepted, because none of the RAFT error fields live at the JSON root.
     fn build_error_response(
         &self,
         res: Response,
@@ -169,27 +177,7 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
 
         with_error_response_body!(event_builder, response);
 
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code: response.return_code.unwrap_or_else(|| {
-                response
-                    .response_code
-                    .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string())
-            }),
-            message: response
-                .reason_code
-                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: None,
-            attempt_status: None,
-            connector_transaction_id: None,
-            network_decline_code: None,
-            network_advice_code: None,
-            network_error_message: None,
-            raw_connector_response: None,
-            raw_connector_request: None,
-            typed_connector_response: None,
-            typed_connector_request: None,
-        })
+        Ok(response.to_error_response(res.status_code))
     }
 }
 
@@ -264,19 +252,22 @@ macros::macro_connector_implementation!(
         ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::IntegrationError> {
             self.build_headers(req)
         }
+        /// Capture mode is expressed by endpoint choice — RAFT has no `capture=true` field.
+        /// Automatic (and `SequentialAutomatic`) capture goes to the purchase endpoint;
+        /// manual capture goes to the auth-only endpoint and is finalised by a completion.
         fn get_url(
             &self,
             req: &RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, errors::IntegrationError> {
-            use domain_types::payment_method_data::PaymentMethodData;
             let base_url = self.connector_base_url_payments(req);
-            let is_debit = matches!(
-                &req.request.payment_method_data,
-                PaymentMethodData::Card(c) if c.card_type.as_deref()
-                    .map(|t| t.eq_ignore_ascii_case(worldpayraft::CARD_TYPE_DEBIT))
-                    .unwrap_or(false)
-            );
-            let path = if is_debit { "debit/preauth" } else { "credit/authorization" };
+            let is_debit = worldpayraft::is_debit_card(&req.request.payment_method_data);
+            let is_auto_capture = worldpayraft::resolve_auto_capture(&req.request)?;
+            let path = match (is_debit, is_auto_capture) {
+                (false, true) => "credit/purchase",
+                (false, false) => "credit/authorization",
+                (true, true) => "debit/purchase",
+                (true, false) => "debit/preauth",
+            };
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -325,8 +316,8 @@ macros::macro_connector_implementation!(
                         ..Default::default()
                     },
                 })?;
-            let (is_debit, _, _, _) = worldpayraft::parse_connector_transaction_id(&connector_txn_id);
-            let path = if is_debit { "debit/completion" } else { "credit/completion" };
+            let reference = worldpayraft::WorldpayraftTransactionReference::parse(&connector_txn_id)?;
+            let path = if reference.is_debit { "debit/completion" } else { "credit/completion" };
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -365,8 +356,10 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<Refund, RefundFlowData, RefundsData, RefundsResponseData>,
         ) -> CustomResult<String, errors::IntegrationError> {
             let base_url = self.connector_base_url_refunds(req);
-            let (is_debit, _, _, _) = worldpayraft::parse_connector_transaction_id(&req.request.connector_transaction_id);
-            let path = if is_debit { "debit/refund" } else { "credit/refund" };
+            let reference = worldpayraft::WorldpayraftTransactionReference::parse(
+                &req.request.connector_transaction_id,
+            )?;
+            let path = if reference.is_debit { "debit/refund" } else { "credit/refund" };
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -438,12 +431,20 @@ macros::macro_connector_implementation!(
         ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::IntegrationError> {
             self.build_headers(req)
         }
+        /// A merchant-initiated transaction is routed by capture mode just like an
+        /// Authorize. RAFT has no MIT-specific endpoint; the MIT signalling lives in
+        /// `ProcFlagsIndicators` and `TerminalData.POSEnvironment`.
         fn get_url(
             &self,
             req: &RouterDataV2<RepeatPayment, PaymentFlowData, RepeatPaymentData<T>, PaymentsResponseData>,
         ) -> CustomResult<String, errors::IntegrationError> {
             let base_url = self.connector_base_url_payments(req);
-            Ok(format!("{base_url}/credit/authorization"))
+            let path = if worldpayraft::resolve_repeat_auto_capture(&req.request)? {
+                "credit/purchase"
+            } else {
+                "credit/authorization"
+            };
+            Ok(format!("{base_url}/{path}"))
         }
     }
 );

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
@@ -511,9 +511,6 @@ crate::connectors::macros::macro_connector_flow_status_impls!(
         CreateConnectorCustomer,
         GetConnectorCustomer,
         MandateRevoke,
-        Authenticate,
-        PostAuthenticate,
-        PreAuthenticate,
         PaymentMethodToken,
         PSync,
         RSync,
@@ -524,6 +521,16 @@ crate::connectors::macros::macro_connector_flow_status_impls!(
     ],
     not_supported: [
         Accept,
+        // Worldpay Native RAFT performs no authentication step of its own: there is no 3DS
+        // initiation, lookup, challenge, device-data-collection, method-URL or
+        // authentication-result path among the 17 credit or 14 debit endpoints. It is
+        // external-3DS passthrough only — the merchant (or Hyperswitch's own authentication
+        // service) authenticates elsewhere and hands the cryptogram, ECI and DS transaction
+        // id to Authorize inside `E-commerceData`. There is no API to implement these
+        // against, so they are not_supported rather than merely not_implemented.
+        Authenticate,
+        PostAuthenticate,
+        PreAuthenticate,
         DefendDispute,
         IncrementalAuthorization,
         SubmitEvidence,

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft.rs
@@ -7,10 +7,10 @@ use common_utils::{
     errors::CustomResult, events, ext_traits::ByteSliceExt, types::StringMajorUnit,
 };
 use domain_types::{
-    connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},
+    connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{
-        PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
-        RefundFlowData, RefundsData, RefundsResponseData, RepeatPaymentData,
+        PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
+        PaymentsResponseData, RefundFlowData, RefundsData, RefundsResponseData, RepeatPaymentData,
         SetupMandateRequestData,
     },
     errors,
@@ -32,7 +32,8 @@ use transformers::{
     WorldpayraftAuthorizeRequest, WorldpayraftAuthorizeResponse, WorldpayraftCaptureRequest,
     WorldpayraftCaptureResponse, WorldpayraftRefundRequest, WorldpayraftRefundResponse,
     WorldpayraftRepeatPaymentRequest, WorldpayraftRepeatPaymentResponse,
-    WorldpayraftSetupMandateRequest, WorldpayraftSetupMandateResponse,
+    WorldpayraftSetupMandateRequest, WorldpayraftSetupMandateResponse, WorldpayraftVoidRequest,
+    WorldpayraftVoidResponse,
 };
 
 use crate::{connectors::macros, types::ResponseRouterData, utils, with_error_response_body};
@@ -60,6 +61,12 @@ macros::create_all_prerequisites!(
             request_body: WorldpayraftCaptureRequest,
             response_body: WorldpayraftCaptureResponse,
             router_data: RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>,
+        ),
+        (
+            flow: Void,
+            request_body: WorldpayraftVoidRequest,
+            response_body: WorldpayraftVoidResponse,
+            router_data: RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
         ),
         (
             flow: Refund,
@@ -262,12 +269,8 @@ macros::macro_connector_implementation!(
             let base_url = self.connector_base_url_payments(req);
             let is_debit = worldpayraft::is_debit_card(&req.request.payment_method_data);
             let is_auto_capture = worldpayraft::resolve_auto_capture(&req.request)?;
-            let path = match (is_debit, is_auto_capture) {
-                (false, true) => "credit/purchase",
-                (false, false) => "credit/authorization",
-                (true, true) => "debit/purchase",
-                (true, false) => "debit/preauth",
-            };
+            let path = worldpayraft::WorldpayraftOriginalOperation::from_parts(is_debit, is_auto_capture)
+                .path();
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -317,7 +320,55 @@ macros::macro_connector_implementation!(
                     },
                 })?;
             let reference = worldpayraft::WorldpayraftTransactionReference::parse(&connector_txn_id)?;
-            let path = if reference.is_debit { "debit/completion" } else { "credit/completion" };
+            let path = if reference.is_debit() { "debit/completion" } else { "credit/completion" };
+            Ok(format!("{base_url}/{path}"))
+        }
+    }
+);
+
+// ===== VOID TRAIT MARKER =====
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::PaymentVoidV2 for Worldpayraft<T>
+{
+}
+
+// =============================================================================
+// VOID FLOW IMPLEMENTATION
+// =============================================================================
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Worldpayraft,
+    curl_request: Json(WorldpayraftVoidRequest),
+    curl_response: WorldpayraftVoidResponse,
+    flow_name: Void,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentVoidData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::IntegrationError> {
+            self.build_headers(req)
+        }
+        /// Native RAFT publishes **no** void, reversal or cancel endpoint for cards. A void
+        /// is the original financial message re-POSTed to the endpoint that served it, with
+        /// `AuthorizationType: "RV"`. That endpoint is recovered from the operation code
+        /// carried in the first segment of the composite `connector_transaction_id` — the
+        /// same reference Capture and Refund route on — so no second lookup mechanism and no
+        /// invented path is involved.
+        fn get_url(
+            &self,
+            req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ) -> CustomResult<String, errors::IntegrationError> {
+            let base_url = self.connector_base_url_payments(req);
+            let reference = worldpayraft::WorldpayraftTransactionReference::parse(
+                &req.request.connector_transaction_id,
+            )?;
+            let path = reference.operation.path();
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -359,7 +410,7 @@ macros::macro_connector_implementation!(
             let reference = worldpayraft::WorldpayraftTransactionReference::parse(
                 &req.request.connector_transaction_id,
             )?;
-            let path = if reference.is_debit { "debit/refund" } else { "credit/refund" };
+            let path = if reference.is_debit() { "debit/refund" } else { "credit/refund" };
             Ok(format!("{base_url}/{path}"))
         }
     }
@@ -457,7 +508,6 @@ crate::connectors::macros::macro_connector_flow_status_impls!(
     generic_type: T,
     [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
     not_implemented: [
-        Void,
         CreateConnectorCustomer,
         GetConnectorCustomer,
         MandateRevoke,

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
@@ -4,11 +4,11 @@ use common_utils::{
     types::{MinorUnit, StringMajorUnit},
 };
 use domain_types::{
-    connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},
+    connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate, Void},
     connector_types::{
-        MandateReference, MandateReferenceId, PaymentFlowData, PaymentsAuthorizeData,
-        PaymentsCaptureData, PaymentsResponseData, RefundFlowData, RefundsData,
-        RefundsResponseData, RepeatPaymentData, ResponseId, SetupMandateRequestData,
+        MandateReference, MandateReferenceId, PaymentFlowData, PaymentVoidData,
+        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, RefundFlowData,
+        RefundsData, RefundsResponseData, RepeatPaymentData, ResponseId, SetupMandateRequestData,
     },
     errors,
     payment_method_data::{Card, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
@@ -29,10 +29,14 @@ use crate::{connectors::worldpayraft::WorldpayraftRouterData, types::ResponseRou
 /// Card type identifier as received in `PaymentMethodData` (compared case-insensitively).
 pub(super) const CARD_TYPE_DEBIT: &str = "debit";
 
-/// Prefix embedded in `connector_transaction_id` to identify debit transactions.
-const TXN_TYPE_DEBIT: &str = "D";
-/// Prefix embedded in `connector_transaction_id` to identify credit transactions.
-const TXN_TYPE_CREDIT: &str = "C";
+/// First segment of `connector_transaction_id` — original operation `POST /credit/authorization`.
+const TXN_OP_CREDIT_AUTH: &str = "C";
+/// First segment of `connector_transaction_id` — original operation `POST /credit/purchase`.
+const TXN_OP_CREDIT_PURCHASE: &str = "CP";
+/// First segment of `connector_transaction_id` — original operation `POST /debit/preauth`.
+const TXN_OP_DEBIT_PREAUTH: &str = "D";
+/// First segment of `connector_transaction_id` — original operation `POST /debit/purchase`.
+const TXN_OP_DEBIT_PURCHASE: &str = "DP";
 /// Number of `|`-separated segments in the composite `connector_transaction_id`.
 const TXN_REFERENCE_SEGMENTS: usize = 6;
 
@@ -114,6 +118,65 @@ pub enum WorldpayraftFlag {
     Yes,
     #[serde(rename = "N")]
     No,
+}
+
+/// `AuthorizationType` — the closed two-value set that changes the disposition of an
+/// otherwise ordinary financial message.
+///
+/// Verbatim from the specification: *"Provides a means for the transaction disposition to be
+/// changed from standard authorization to forced conditions. Valid Values: FP - Force Post
+/// (Host Capture Advice completions, credit card completions, etc.); RV - Reversal"*.
+/// `maxLength: 2`, request only, and absent altogether on a normal auth or sale.
+///
+/// `RV` is the **entire** void mechanism: Native RAFT publishes no `/credit/void`,
+/// `/credit/reversal`, `/credit/cancel`, `/debit/void` or `/debit/reversal` endpoint, so a
+/// void is the original message re-POSTed to the original path with this field set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum WorldpayraftAuthorizationType {
+    /// `FP` — Force Post.
+    #[serde(rename = "FP")]
+    ForcePost,
+    /// `RV` — Reversal. Set on a void.
+    #[serde(rename = "RV")]
+    Reversal,
+}
+
+impl WorldpayraftAuthorizationType {
+    /// The literal that goes on the wire.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ForcePost => "FP",
+            Self::Reversal => "RV",
+        }
+    }
+}
+
+impl TryFrom<&str> for WorldpayraftAuthorizationType {
+    type Error = error_stack::Report<errors::IntegrationError>;
+
+    /// Rejects anything outside the published pair. Worldpay silently books an
+    /// unrecognised `AuthorizationType` as a plain authorization, which on a void would
+    /// charge the cardholder a second time instead of releasing the hold.
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            value if value == Self::ForcePost.as_str() => Ok(Self::ForcePost),
+            value if value == Self::Reversal.as_str() => Ok(Self::Reversal),
+            other => Err(error_stack::report!(
+                errors::IntegrationError::InvalidDataFormat {
+                    field_name: "AuthorizationType",
+                    context: errors::IntegrationErrorContext {
+                        additional_context: Some(format!(
+                            "Worldpay RAFT publishes exactly two AuthorizationType values, \
+                             {:?} (Force Post) and {:?} (Reversal); got {other:?}",
+                            Self::ForcePost.as_str(),
+                            Self::Reversal.as_str(),
+                        )),
+                        ..Default::default()
+                    },
+                }
+            )),
+        }
+    }
 }
 
 /// `CardVerificationData.Cvv2Cvc2CIDIndicator` — the CVV2/CVC2/CID **presence** indicator.
@@ -524,11 +587,13 @@ fn reject_unsupported_capture_method(
 /// as structured `connector_metadata` for observability and webhook correlation.
 ///
 /// Wire format (six `|`-separated segments, none of which can contain `|`):
-/// `{C|D}|{APITransactionID}|{LocalDateTime}|{authorized minor amount}|{AuthorizationNumber}|{RetrievalREFNumber}`
+/// `{C|CP|D|DP}|{APITransactionID}|{LocalDateTime}|{authorized minor amount}|{AuthorizationNumber}|{RetrievalREFNumber}`
 #[derive(Debug, Clone)]
 pub(super) struct WorldpayraftTransactionReference {
-    /// Routes the follow-up to `/debit/*` instead of `/credit/*`.
-    pub is_debit: bool,
+    /// The endpoint the original message used. A completion or refund only needs the
+    /// credit/debit half of it; a **reversal needs all of it**, because it has to be
+    /// re-POSTed to that exact endpoint.
+    pub operation: WorldpayraftOriginalOperation,
     /// The `APITransactionID` **sent** on the original message; replayed verbatim.
     pub api_transaction_id: String,
     /// The merchant-local timestamp recorded for the original message and replayed on
@@ -550,16 +615,91 @@ pub(super) struct WorldpayraftTransactionReference {
     pub retrieval_ref_number: Option<String>,
 }
 
+/// The financial operation a transaction was created by, and therefore the endpoint any
+/// follow-up to it has to use.
+///
+/// Native RAFT has no void endpoint at all: a void is the **same message re-POSTed to the
+/// same path** with `AuthorizationType: "RV"`. `PaymentVoidData` carries nothing but
+/// `connector_transaction_id`, so the endpoint has to travel inside it — which is why this
+/// is the first segment of the composite reference rather than a bare credit/debit flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorldpayraftOriginalOperation {
+    /// `POST /credit/authorization`, wrapper `creditauth` — manual-capture credit auth.
+    CreditAuth,
+    /// `POST /credit/purchase`, wrapper `creditpurchase` — auto-capture credit sale.
+    CreditPurchase,
+    /// `POST /debit/preauth`, wrapper `debitpreauth` — manual-capture debit auth.
+    DebitPreauth,
+    /// `POST /debit/purchase`, wrapper `debitpurchase` — auto-capture debit sale.
+    DebitPurchase,
+}
+
+impl WorldpayraftOriginalOperation {
+    /// Selects the operation from the two facts an authorize-family wrapper key carries.
+    pub(super) fn from_parts(is_debit: bool, is_auto_capture: bool) -> Self {
+        match (is_debit, is_auto_capture) {
+            (false, false) => Self::CreditAuth,
+            (false, true) => Self::CreditPurchase,
+            (true, false) => Self::DebitPreauth,
+            (true, true) => Self::DebitPurchase,
+        }
+    }
+
+    /// The code written into the first segment of `connector_transaction_id`.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CreditAuth => TXN_OP_CREDIT_AUTH,
+            Self::CreditPurchase => TXN_OP_CREDIT_PURCHASE,
+            Self::DebitPreauth => TXN_OP_DEBIT_PREAUTH,
+            Self::DebitPurchase => TXN_OP_DEBIT_PURCHASE,
+        }
+    }
+
+    /// `true` for the `/debit/*` family, which mirrors every credit endpoint but carries
+    /// no `POSEnvironment`, no `AddressVerificationData` and no `*SpecificData` blocks.
+    pub(super) fn is_debit(self) -> bool {
+        match self {
+            Self::DebitPreauth | Self::DebitPurchase => true,
+            Self::CreditAuth | Self::CreditPurchase => false,
+        }
+    }
+
+    /// The path this operation is served on, relative to the RAFT base URL. It is also the
+    /// path a **reversal** of such a transaction has to be re-POSTed to.
+    pub(super) fn path(self) -> &'static str {
+        match self {
+            Self::CreditAuth => "credit/authorization",
+            Self::CreditPurchase => "credit/purchase",
+            Self::DebitPreauth => "debit/preauth",
+            Self::DebitPurchase => "debit/purchase",
+        }
+    }
+}
+
+impl TryFrom<&str> for WorldpayraftOriginalOperation {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            TXN_OP_CREDIT_AUTH => Ok(Self::CreditAuth),
+            TXN_OP_CREDIT_PURCHASE => Ok(Self::CreditPurchase),
+            TXN_OP_DEBIT_PREAUTH => Ok(Self::DebitPreauth),
+            TXN_OP_DEBIT_PURCHASE => Ok(Self::DebitPurchase),
+            _ => Err(()),
+        }
+    }
+}
+
 impl WorldpayraftTransactionReference {
+    /// `true` when the follow-up belongs on the `/debit/*` endpoint family.
+    pub(super) fn is_debit(&self) -> bool {
+        self.operation.is_debit()
+    }
+
     fn encode(&self) -> String {
-        let prefix = if self.is_debit {
-            TXN_TYPE_DEBIT
-        } else {
-            TXN_TYPE_CREDIT
-        };
         format!(
             "{}|{}|{}|{}|{}|{}",
-            prefix,
+            self.operation.as_str(),
             self.api_transaction_id,
             self.local_date_time,
             self.authorized_minor_amount
@@ -577,7 +717,7 @@ impl WorldpayraftTransactionReference {
                 context: errors::IntegrationErrorContext {
                     additional_context: Some(format!(
                         "Worldpay RAFT expects the composite reference \
-                         '[C|D]|APITransactionID|LocalDateTime|authorized_minor_amount|\
+                         '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|\
                          AuthorizationNumber|RetrievalREFNumber', got {raw:?}"
                     )),
                     ..Default::default()
@@ -589,11 +729,8 @@ impl WorldpayraftTransactionReference {
         if segments.len() != TXN_REFERENCE_SEGMENTS {
             return Err(invalid());
         }
-        let is_debit = match segments[0] {
-            TXN_TYPE_DEBIT => true,
-            TXN_TYPE_CREDIT => false,
-            _ => return Err(invalid()),
-        };
+        let operation =
+            WorldpayraftOriginalOperation::try_from(segments[0]).map_err(|()| invalid())?;
         if segments[1].is_empty() || segments[2].is_empty() {
             return Err(invalid());
         }
@@ -603,7 +740,7 @@ impl WorldpayraftTransactionReference {
         };
 
         Ok(Self {
-            is_debit,
+            operation,
             api_transaction_id: segments[1].to_string(),
             local_date_time: segments[2].to_string(),
             authorized_minor_amount,
@@ -648,6 +785,14 @@ pub struct WorldpayraftAmounts {
     /// was approved for. **Required** on `creditcompletion` / `debitcompletion`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preauthorized_amount: Option<StringMajorUnit>,
+    /// `MiscAmountsBalances.DispensedAmount` — **partial reversals only**. Verbatim:
+    /// *"This is the amount authorized for settlement. It is used in reversal processing to
+    /// indicate the actual amount remaining after the reversal. By default, Worldpay assumes
+    /// the reversal is a full reversal, so this field is only necessary where the reversal
+    /// amount is different than the original transaction amount."* Omitted everywhere else,
+    /// so a full reversal stays a full reversal.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispensed_amount: Option<StringMajorUnit>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1101,6 +1246,27 @@ impl WorldpayraftResponseInner {
         }
     }
 
+    /// The `AttemptStatus` for a declined **reversal**.
+    ///
+    /// The sibling of [`Self::payment_decline_status`] for the void flow. It honours the
+    /// same two non-terminal `ResponseCode`s, but a void has no cardholder-authentication
+    /// step, so `003 HONOR WITH ID` — the issuer asking for the message to be re-presented
+    /// with an identification — maps to `VoidInitiated` here rather than to
+    /// `AuthenticationPending`. Everything else, `002 VOID UNSUCCESSFUL` and
+    /// `051 UNABLE TO LOCATE A MATCHING ORIGINAL TRANSACTION` included, is a terminal
+    /// `VoidFailed`: the hold is still in place.
+    fn void_decline_status(&self) -> AttemptStatus {
+        if self.return_code != RETURN_CODE_SUCCESS {
+            return AttemptStatus::VoidFailed;
+        }
+        match self.response_code.as_deref() {
+            Some(RESPONSE_CODE_HONOR_WITH_ID) | Some(RESPONSE_CODE_REQUEST_IN_PROGRESS) => {
+                AttemptStatus::VoidInitiated
+            }
+            _ => AttemptStatus::VoidFailed,
+        }
+    }
+
     /// The terminal `RefundStatus` for a declined refund message.
     fn refund_decline_status(&self) -> RefundStatus {
         if self.return_code == RETURN_CODE_SUCCESS
@@ -1142,7 +1308,8 @@ impl WorldpayraftResponseInner {
         serde_json::json!({
             "api_transaction_id": reference.api_transaction_id,
             "local_date_time": reference.local_date_time,
-            "is_debit": reference.is_debit,
+            "original_operation": reference.operation.path(),
+            "is_debit": reference.is_debit(),
             "authorized_minor_amount": reference.authorized_minor_amount,
             "authorization_number": reference.authorization_number,
             "retrieval_ref_number": reference.retrieval_ref_number,
@@ -1168,14 +1335,14 @@ impl WorldpayraftResponseInner {
     /// numbers Worldpay returned.
     fn to_transaction_reference(
         &self,
-        is_debit: bool,
+        operation: WorldpayraftOriginalOperation,
         api_transaction_id: String,
         local_date_time: String,
         authorized_minor_amount: Option<i64>,
     ) -> WorldpayraftTransactionReference {
         let trace = self.reference_trace_numbers.as_ref();
         WorldpayraftTransactionReference {
-            is_debit,
+            operation,
             api_transaction_id,
             local_date_time,
             authorized_minor_amount,
@@ -1497,6 +1664,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             misc_amounts_balances: WorldpayraftAmounts {
                 transaction_amount,
                 preauthorized_amount: None,
+                dispensed_amount: None,
             },
             card_info: WorldpayraftCardInfo {
                 pan: card.card_number.clone(),
@@ -1573,7 +1741,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         }
 
         let reference = inner.to_transaction_reference(
-            is_debit,
+            WorldpayraftOriginalOperation::from_parts(is_debit, is_auto_capture),
             api_transaction_id,
             get_local_datetime(),
             authorized_minor_amount,
@@ -1745,6 +1913,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             misc_amounts_balances: WorldpayraftAmounts {
                 transaction_amount,
                 preauthorized_amount: Some(preauthorized_amount),
+                dispensed_amount: None,
             },
             reference_trace_numbers: reference.follow_up_trace_numbers(),
             world_pay_merchant_id: auth.merchant_id,
@@ -1752,7 +1921,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             local_date_time: reference.local_date_time.clone(),
         };
 
-        Ok(if reference.is_debit {
+        Ok(if reference.is_debit() {
             Self::Debit {
                 debitcompletion: inner,
             }
@@ -1820,6 +1989,308 @@ impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
             }),
             resource_common_data: PaymentFlowData {
                 status: AttemptStatus::Charged,
+                ..item.router_data.resource_common_data
+            },
+            ..item.router_data
+        })
+    }
+}
+
+// =============================================================================
+// VOID (reversal)
+// =============================================================================
+
+/// Inner fields for a reversal.
+///
+/// There is no reversal *operation* in Native RAFT — this is the ordinary financial
+/// message for whichever endpoint the original transaction used (`creditauth`,
+/// `creditpurchase`, `debitpreauth`, `debitpurchase`), reduced to the members a reversal
+/// needs and flagged with `AuthorizationType: "RV"`. No `CardInfo` is sent: the reversal is
+/// matched on `APITransactionID`, so re-transmitting the PAN would put card data on the wire
+/// for no benefit.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftReversalInner {
+    /// `AuthorizationType` — always `RV`. This single member is the whole void mechanism.
+    pub authorization_type: WorldpayraftAuthorizationType,
+    /// `MiscAmountsBalances` — `TransactionAmount` is the **original** transaction's amount,
+    /// and `DispensedAmount` the amount left standing after a partial reversal.
+    pub misc_amounts_balances: WorldpayraftAmounts,
+    /// `ReferenceTraceNumbers` — the secondary matching keys (`AuthorizationNumber`,
+    /// `RetrievalREFNumber`) received on the original response, replayed here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
+    #[serde(rename = "WorldPayMerchantID")]
+    pub world_pay_merchant_id: Secret<String>,
+    /// The **original** transaction's `APITransactionID`, replayed verbatim. This is how
+    /// RAFT matches a reversal to its original; a freshly generated id comes back as
+    /// `ResponseCode 051 UNABLE TO LOCATE A MATCHING ORIGINAL TRANSACTION`.
+    #[serde(rename = "APITransactionID")]
+    pub api_transaction_id: String,
+    /// The `LocalDateTime` recorded for the original transaction, replayed as the secondary
+    /// matching key.
+    pub local_date_time: String,
+}
+
+/// Outer wrapper for a void. The key — and therefore the endpoint — is whichever the
+/// original transaction used, recovered from the composite `connector_transaction_id`.
+///
+/// | original | re-POST to | wrapper |
+/// |---|---|---|
+/// | `/credit/authorization` | `POST /credit/authorization` | `creditauth` |
+/// | `/credit/purchase` | `POST /credit/purchase` | `creditpurchase` |
+/// | `/debit/preauth` | `POST /debit/preauth` | `debitpreauth` |
+/// | `/debit/purchase` | `POST /debit/purchase` | `debitpurchase` |
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum WorldpayraftVoidRequest {
+    CreditAuth {
+        creditauth: WorldpayraftReversalInner,
+    },
+    CreditPurchase {
+        creditpurchase: WorldpayraftReversalInner,
+    },
+    DebitPreauth {
+        debitpreauth: WorldpayraftReversalInner,
+    },
+    DebitPurchase {
+        debitpurchase: WorldpayraftReversalInner,
+    },
+}
+
+/// A reversal answers on the same response wrapper as the operation it re-sent.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorldpayraftVoidResponse {
+    CreditAuth {
+        creditauthresponse: WorldpayraftResponseInner,
+    },
+    CreditPurchase {
+        creditpurchaseresponse: WorldpayraftResponseInner,
+    },
+    DebitPreauth {
+        debitpreauthresponse: WorldpayraftResponseInner,
+    },
+    DebitPurchase {
+        debitpurchaseresponse: WorldpayraftResponseInner,
+    },
+}
+
+impl WorldpayraftVoidResponse {
+    fn inner(&self) -> &WorldpayraftResponseInner {
+        match self {
+            Self::CreditAuth {
+                creditauthresponse: inner,
+            }
+            | Self::CreditPurchase {
+                creditpurchaseresponse: inner,
+            }
+            | Self::DebitPreauth {
+                debitpreauthresponse: inner,
+            }
+            | Self::DebitPurchase {
+                debitpurchaseresponse: inner,
+            } => inner,
+        }
+    }
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        WorldpayraftRouterData<
+            RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+            T,
+        >,
+    > for WorldpayraftVoidRequest
+{
+    type Error = error_stack::Report<errors::IntegrationError>;
+
+    /// **Amounts.** The specification is explicit that a reversal carries the *original*
+    /// transaction's `TransactionAmount`, and that a partial reversal expresses itself with
+    /// `DispensedAmount` — "the actual amount remaining after the reversal" — rather than by
+    /// shrinking `TransactionAmount`. The original amount is taken from the composite
+    /// `connector_transaction_id`, the only channel that reaches the Void flow, so the
+    /// figure sent is the one that was actually approved rather than one reconstructed by
+    /// the caller.
+    ///
+    /// `PaymentVoidData::amount` is therefore read as *how much of the original to release*:
+    /// absent or equal to the original means a full reversal and `DispensedAmount` is
+    /// omitted, less than the original leaves `original - amount` standing, and more than the
+    /// original is refused rather than clamped.
+    ///
+    /// `PaymentVoidData::currency` is required because `TransactionAmount` is a major-unit
+    /// string (`ddddddddd.cc`) and neither the composite reference nor the Void flow's
+    /// `PaymentFlowData` (whose `amount` is `None` by construction) carries a currency to
+    /// scale the stored minor amount with.
+    fn try_from(
+        item: WorldpayraftRouterData<
+            RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+        let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
+
+        let reference =
+            WorldpayraftTransactionReference::parse(&router_data.request.connector_transaction_id)?;
+
+        let original_minor_amount = reference.authorized_minor_amount.ok_or_else(|| {
+            error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                field_name: "TransactionAmount",
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(
+                        "A Worldpay RAFT reversal carries the amount of the transaction being \
+                         reversed, and the connector transaction reference records no original \
+                         amount for this transaction"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            })
+        })?;
+
+        let currency = router_data.request.currency.ok_or_else(|| {
+            error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                field_name: "currency",
+                context: errors::IntegrationErrorContext {
+                    suggested_action: Some(
+                        "Send PaymentServiceVoidRequest.amount with the original payment's \
+                         currency (the Money message carries both minor_amount and currency)"
+                            .to_string(),
+                    ),
+                    additional_context: Some(
+                        "Worldpay RAFT requires MiscAmountsBalances.TransactionAmount on a \
+                         reversal as a major-unit string, and the Void flow's PaymentFlowData \
+                         carries no amount to take a currency from"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            })
+        })?;
+
+        let convert = |minor: i64, what: &str| {
+            item.connector
+                .amount_converter
+                .convert(MinorUnit::new(minor), currency)
+                .change_context(errors::IntegrationError::AmountConversionFailed {
+                    context: errors::IntegrationErrorContext {
+                        additional_context: Some(format!(
+                            "Worldpay RAFT requires the reversal {what} in major currency units"
+                        )),
+                        ..Default::default()
+                    },
+                })
+        };
+
+        let transaction_amount = convert(original_minor_amount, "TransactionAmount")?;
+
+        let dispensed_amount = match router_data.request.amount {
+            Some(requested) => {
+                let requested_minor = requested.get_amount_as_i64();
+                if requested_minor > original_minor_amount {
+                    return Err(error_stack::report!(
+                        errors::IntegrationError::InvalidDataFormat {
+                            field_name: "amount",
+                            context: errors::IntegrationErrorContext {
+                                additional_context: Some(format!(
+                                    "Worldpay RAFT cannot reverse more than the original \
+                                     transaction: asked to reverse {requested_minor} minor units \
+                                     of a transaction authorized for {original_minor_amount}"
+                                )),
+                                ..Default::default()
+                            },
+                        }
+                    ));
+                }
+                let remaining = original_minor_amount - requested_minor;
+                // A full reversal is the RAFT default; DispensedAmount exists only to say
+                // how much is left standing, so it is sent only when something is.
+                if remaining > 0 {
+                    Some(convert(remaining, "DispensedAmount")?)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+
+        let inner = WorldpayraftReversalInner {
+            authorization_type: WorldpayraftAuthorizationType::Reversal,
+            misc_amounts_balances: WorldpayraftAmounts {
+                transaction_amount,
+                preauthorized_amount: None,
+                dispensed_amount,
+            },
+            reference_trace_numbers: reference.follow_up_trace_numbers(),
+            world_pay_merchant_id: auth.merchant_id,
+            api_transaction_id: reference.api_transaction_id.clone(),
+            local_date_time: reference.local_date_time.clone(),
+        };
+
+        // `ReversalAdviceReasonCd` is deliberately not sent. Its published values are
+        // 000 Normal Reversal, 002 Timeout, 003 Syntax, 005 Clerk Cancel, 006 Customer
+        // Cancel and 010 Previously Authorized; `PaymentVoidData::cancellation_reason` is a
+        // free-text string with no defined vocabulary, so nothing can be mapped onto that
+        // set without guessing. The field is optional and Worldpay defaults it to
+        // 000 Normal Reversal, which is exactly what a UCS-initiated void is.
+        Ok(match reference.operation {
+            WorldpayraftOriginalOperation::CreditAuth => Self::CreditAuth { creditauth: inner },
+            WorldpayraftOriginalOperation::CreditPurchase => Self::CreditPurchase {
+                creditpurchase: inner,
+            },
+            WorldpayraftOriginalOperation::DebitPreauth => Self::DebitPreauth {
+                debitpreauth: inner,
+            },
+            WorldpayraftOriginalOperation::DebitPurchase => Self::DebitPurchase {
+                debitpurchase: inner,
+            },
+        })
+    }
+}
+
+impl TryFrom<ResponseRouterData<WorldpayraftVoidResponse, Self>>
+    for RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<WorldpayraftVoidResponse, Self>,
+    ) -> Result<Self, Self::Error> {
+        let inner = item.response.inner();
+
+        if !inner.is_success() {
+            let status = inner.void_decline_status();
+            return Ok(Self {
+                response: Err(inner.to_error_response(item.http_code, FlowStatus::Payment(status))),
+                resource_common_data: PaymentFlowData {
+                    status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
+
+        // The composite reference is preserved unchanged: a reversal mints no new
+        // transaction, and a partial reversal leaves the remainder addressable.
+        Ok(Self {
+            response: Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(
+                    item.router_data.request.connector_transaction_id.clone(),
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: inner.network_transaction_id(),
+                network_txn_link_id: inner.transaction_link_id(),
+                connector_response_reference_id: inner.api_transaction_id.clone(),
+                incremental_authorization_allowed: None,
+                splits: None,
+                status_code: item.http_code,
+                payment_account_reference: inner.payment_account_reference(),
+            }),
+            resource_common_data: PaymentFlowData {
+                status: AttemptStatus::Voided,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1926,6 +2397,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             misc_amounts_balances: WorldpayraftAmounts {
                 transaction_amount,
                 preauthorized_amount: None,
+                dispensed_amount: None,
             },
             reference_trace_numbers: reference.follow_up_trace_numbers(),
             world_pay_merchant_id: auth.merchant_id,
@@ -1933,7 +2405,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             local_date_time: reference.local_date_time.clone(),
         };
 
-        Ok(if reference.is_debit {
+        Ok(if reference.is_debit() {
             Self::Debit { debitrefund: inner }
         } else {
             Self::Credit {
@@ -1985,7 +2457,7 @@ impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
             },
         })?;
         let refund_reference = inner.to_transaction_reference(
-            reference.is_debit,
+            reference.operation,
             reference.api_transaction_id.clone(),
             reference.local_date_time.clone(),
             reference.authorized_minor_amount,
@@ -2152,10 +2624,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 })
             })?;
 
-        // Tokenization is always a credit-path operation and carries no amount, so the
-        // composite reference has no PreauthorizedAmount to record.
+        // Tokenization is neither an authorization nor a sale: it is not reversible and
+        // carries no amount, so the reference records the credit-path auth operation purely
+        // so the composite id keeps its shape, with no PreauthorizedAmount.
         let reference = inner.to_transaction_reference(
-            false,
+            WorldpayraftOriginalOperation::CreditAuth,
             truncate_api_transaction_id(
                 &item
                     .router_data
@@ -2515,6 +2988,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             misc_amounts_balances: WorldpayraftAmounts {
                 transaction_amount,
                 preauthorized_amount: None,
+                dispensed_amount: None,
             },
             card_info,
             encryption_token_data,
@@ -2581,8 +3055,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             });
         }
 
+        // A merchant-initiated transaction is credit-only, and the wrapper key that came
+        // back says whether it was booked as a sale or as an auth to be completed later.
         let reference = inner.to_transaction_reference(
-            false,
+            WorldpayraftOriginalOperation::from_parts(false, is_auto_capture),
             truncate_api_transaction_id(
                 &item
                     .router_data

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
@@ -37,8 +37,12 @@ const TXN_OP_CREDIT_PURCHASE: &str = "CP";
 const TXN_OP_DEBIT_PREAUTH: &str = "D";
 /// First segment of `connector_transaction_id` — original operation `POST /debit/purchase`.
 const TXN_OP_DEBIT_PURCHASE: &str = "DP";
-/// Number of `|`-separated segments in the composite `connector_transaction_id`.
-const TXN_REFERENCE_SEGMENTS: usize = 6;
+/// Number of `|`-separated segments in the composite `connector_transaction_id` as it was
+/// minted before the e-commerce indicator travelled with it. Still accepted, so every id
+/// already issued keeps parsing with exactly the meaning it had.
+const TXN_REFERENCE_SEGMENTS_LEGACY: usize = 6;
+/// Number of `|`-separated segments in the current composite `connector_transaction_id`.
+const TXN_REFERENCE_SEGMENTS: usize = 10;
 
 /// `ReturnCode` value meaning "the message itself was processed" (operation level).
 const RETURN_CODE_SUCCESS: &str = "0000";
@@ -62,8 +66,6 @@ const ENTRY_MODE_ECOMM: &str = "E-COMM";
 const POS_CONDITION_CODE_ECOMM: &str = "59";
 /// `TerminalData.TerminalEntryCap` — not applicable for e-commerce.
 const TERMINAL_ENTRY_CAP_DEFAULT: &str = "0";
-/// `E-commerceData.E-commerceIndicator` `07` — e-commerce, no 3-D Secure.
-const ECOMMERCE_INDICATOR_ECOMM_NO_3DS: &str = "07";
 
 // =============================================================================
 // AUTH TYPE
@@ -175,6 +177,253 @@ impl TryFrom<&str> for WorldpayraftAuthorizationType {
                     },
                 }
             )),
+        }
+    }
+}
+
+/// `E-commerceData.E-commerceIndicator` — the closed ten-value set that every electronic
+/// commerce transaction must carry. Verbatim from the specification: *"All electronic
+/// commerce transactions must include this field to indicate the type of transaction being
+/// performed. It can also be used to distinguish various types of Bill Payment
+/// transactions."* `maxLength: 2`.
+///
+/// This is **not** the raw network ECI. Worldpay normalises across the schemes: `05` means
+/// fully authenticated and `06` attempted whatever the brand, whereas Mastercard's own ECI
+/// set is `02`/`01`/`00` for the same three outcomes. [`Self::from_network_eci`] does that
+/// translation.
+///
+/// Note that `07` is **not** "3DS authenticated" — it explicitly says the transaction went
+/// through *neither* Verified by Visa *nor* Mastercard SecureCode. An earlier revision of
+/// this connector hardcoded `07` on every transaction and labelled it authenticated, which
+/// both mislabelled genuinely authenticated payments and threw away the recurring /
+/// installment signalling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum WorldpayraftEcommerceIndicator {
+    /// `01` — Single transaction; the default for bill payments.
+    #[serde(rename = "01")]
+    SingleTransaction,
+    /// `02` — Recurring Transaction. A subsequent payment in an established series.
+    #[serde(rename = "02")]
+    RecurringTransaction,
+    /// `03` — Installment Payment.
+    #[serde(rename = "03")]
+    InstallmentPayment,
+    /// `05` — Verified by Visa authenticated / MasterCard SecureCode with AAV data /
+    /// Discover with CAVV data. Fully authenticated; liability shifted.
+    #[serde(rename = "05")]
+    Authenticated,
+    /// `06` — Verified by Visa attempts processing / MasterCard SecureCode with or without
+    /// AAV data / Discover with or without CAVV data. Authentication was attempted but the
+    /// issuer did not (or could not) authenticate.
+    #[serde(rename = "06")]
+    AttemptedAuthentication,
+    /// `07` — eCommerce, but neither Verified by Visa nor MasterCard SecureCode. Plain
+    /// unauthenticated e-commerce.
+    #[serde(rename = "07")]
+    NotAuthenticated,
+    /// `08` — the cardholder's payment card data was transmitted to the merchant using no
+    /// security method.
+    #[serde(rename = "08")]
+    NoSecurityMethod,
+    /// `09` — used by non-U.S. merchants to designate Secure Electronic Transaction (SET)
+    /// purchases.
+    #[serde(rename = "09")]
+    SecureElectronicTransaction,
+    /// `10` — Recurring transaction (first transaction of a recurring payment series).
+    #[serde(rename = "10")]
+    RecurringFirstOfSeries,
+    /// `20` — Token Initiated (American Express only).
+    #[serde(rename = "20")]
+    TokenInitiated,
+}
+
+impl WorldpayraftEcommerceIndicator {
+    /// The literal that goes on the wire.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SingleTransaction => "01",
+            Self::RecurringTransaction => "02",
+            Self::InstallmentPayment => "03",
+            Self::Authenticated => "05",
+            Self::AttemptedAuthentication => "06",
+            Self::NotAuthenticated => "07",
+            Self::NoSecurityMethod => "08",
+            Self::SecureElectronicTransaction => "09",
+            Self::RecurringFirstOfSeries => "10",
+            Self::TokenInitiated => "20",
+        }
+    }
+
+    /// `true` for the two indicators that assert a 3-D Secure outcome. `3dSecureData` may
+    /// only accompany one of these: the cryptogram is what makes the transaction
+    /// authenticated, so presenting it under any other indicator contradicts itself and
+    /// RAFT rejects the pairing.
+    fn carries_authentication(self) -> bool {
+        match self {
+            Self::Authenticated | Self::AttemptedAuthentication => true,
+            Self::SingleTransaction
+            | Self::RecurringTransaction
+            | Self::InstallmentPayment
+            | Self::NotAuthenticated
+            | Self::NoSecurityMethod
+            | Self::SecureElectronicTransaction
+            | Self::RecurringFirstOfSeries
+            | Self::TokenInitiated => false,
+        }
+    }
+
+    /// Translate the **network** ECI returned by the external 3-D Secure service into the
+    /// RAFT indicator.
+    ///
+    /// Mastercard and Maestro publish `02` authenticated / `01` attempted / `00` not
+    /// authenticated; Visa, American Express and Discover publish `05` / `06` / `07`.
+    /// `E-commerceIndicator` always speaks the Visa-shaped set, so a Mastercard ECI has to
+    /// be converted rather than copied. Anything outside the two published sets is refused:
+    /// guessing here either forfeits a liability shift that was earned or claims one that
+    /// was not.
+    fn from_network_eci(
+        eci: &str,
+        brand: Option<WorldpayraftCardBrand>,
+    ) -> Result<Self, error_stack::Report<errors::IntegrationError>> {
+        let mapped = match brand {
+            Some(WorldpayraftCardBrand::Mastercard) => match eci {
+                "02" => Some(Self::Authenticated),
+                "01" => Some(Self::AttemptedAuthentication),
+                "00" => Some(Self::NotAuthenticated),
+                _ => None,
+            },
+            Some(WorldpayraftCardBrand::Visa)
+            | Some(WorldpayraftCardBrand::Amex)
+            | Some(WorldpayraftCardBrand::Discover)
+            | None => match eci {
+                "05" => Some(Self::Authenticated),
+                "06" => Some(Self::AttemptedAuthentication),
+                "07" => Some(Self::NotAuthenticated),
+                _ => None,
+            },
+        };
+        mapped.ok_or_else(|| {
+            error_stack::report!(errors::IntegrationError::InvalidDataFormat {
+                field_name: "authentication_data.eci",
+                context: errors::IntegrationErrorContext {
+                    suggested_action: Some(
+                        "Send the ECI the 3-D Secure server returned: 02/01/00 for \
+                         Mastercard and Maestro, 05/06/07 for Visa, American Express and \
+                         Discover"
+                            .to_string(),
+                    ),
+                    additional_context: Some(format!(
+                        "Worldpay RAFT E-commerceIndicator cannot be derived from network ECI \
+                         {eci:?} on card brand {brand:?}"
+                    )),
+                    ..Default::default()
+                },
+            })
+        })
+    }
+
+    /// Translate the 3-D Secure `transStatus` into the RAFT indicator. Used when the
+    /// authentication result carries no ECI of its own.
+    ///
+    /// Only `Y` (authenticated) and `A` (attempts processing / proof of attempted
+    /// authentication) assert an authentication to the network. Every other status —
+    /// denied, not performed, rejected, still-challenging or informational — means no
+    /// authentication was obtained, which is exactly what `07` says.
+    fn from_transaction_status(status: &common_enums::TransactionStatus) -> Self {
+        match status {
+            common_enums::TransactionStatus::Success => Self::Authenticated,
+            common_enums::TransactionStatus::NotVerified => Self::AttemptedAuthentication,
+            common_enums::TransactionStatus::Failure
+            | common_enums::TransactionStatus::VerificationNotPerformed
+            | common_enums::TransactionStatus::Rejected
+            | common_enums::TransactionStatus::ChallengeRequired
+            | common_enums::TransactionStatus::ChallengeRequiredDecoupledAuthentication
+            | common_enums::TransactionStatus::InformationOnly => Self::NotAuthenticated,
+        }
+    }
+}
+
+impl From<common_enums::MitCategory> for WorldpayraftEcommerceIndicator {
+    /// The indicator for a merchant-initiated transaction.
+    ///
+    /// `02 Recurring Transaction` and `03 Installment Payment` name exactly the two
+    /// scheduled MIT shapes. An unscheduled card-on-file payment, and a resubmission of a
+    /// declined one, are neither — they are ordinary unauthenticated e-commerce, which is
+    /// what `07` says. `10` ("first transaction of a recurring payment series") belongs to
+    /// the cardholder-initiated transaction that establishes the series, never to a repeat
+    /// of it.
+    fn from(category: common_enums::MitCategory) -> Self {
+        match category {
+            common_enums::MitCategory::Recurring => Self::RecurringTransaction,
+            common_enums::MitCategory::Installment => Self::InstallmentPayment,
+            common_enums::MitCategory::Unscheduled | common_enums::MitCategory::Resubmission => {
+                Self::NotAuthenticated
+            }
+        }
+    }
+}
+
+impl TryFrom<&str> for WorldpayraftEcommerceIndicator {
+    type Error = error_stack::Report<errors::IntegrationError>;
+
+    /// Rejects anything outside the published ten values.
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        [
+            Self::SingleTransaction,
+            Self::RecurringTransaction,
+            Self::InstallmentPayment,
+            Self::Authenticated,
+            Self::AttemptedAuthentication,
+            Self::NotAuthenticated,
+            Self::NoSecurityMethod,
+            Self::SecureElectronicTransaction,
+            Self::RecurringFirstOfSeries,
+            Self::TokenInitiated,
+        ]
+        .into_iter()
+        .find(|candidate| candidate.as_str() == value)
+        .ok_or_else(|| {
+            error_stack::report!(errors::IntegrationError::InvalidDataFormat {
+                field_name: "E-commerceIndicator",
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(format!(
+                        "Worldpay RAFT publishes ten E-commerceIndicator values \
+                         (01, 02, 03, 05, 06, 07, 08, 09, 10, 20); got {value:?}"
+                    )),
+                    ..Default::default()
+                },
+            })
+        })
+    }
+}
+
+/// `E-commerceData.3DSecureProgramProtocol` — the version of the 3-D Secure program the
+/// authentication was performed under. Verbatim: *"This value contains the current version
+/// of 3D secure software being used. Refer to the Mastercard processing specifications for
+/// a full list of valid values. Common values: 1 - 3D Secure Version 1.0 (3DS 1.0);
+/// 2 - EMV 3D Secure (3DS 2.0)"*. `maxLength: 1`, request only, credit only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum WorldpayraftThreeDsProgramProtocol {
+    /// `1` — 3-D Secure Version 1.0.
+    #[serde(rename = "1")]
+    ThreeDsOne,
+    /// `2` — EMV 3-D Secure (3DS 2.x).
+    #[serde(rename = "2")]
+    EmvThreeDs,
+}
+
+impl TryFrom<&common_utils::types::SemanticVersion> for WorldpayraftThreeDsProgramProtocol {
+    type Error = ();
+
+    /// The published set names only the major version. Mastercard may add values, so a
+    /// major version outside `1`/`2` is reported as unmappable and the caller omits the
+    /// optional field rather than asserting a protocol RAFT never defined — the same
+    /// treatment [`WorldpayraftSubsequentTransactionReasonCode`] gets.
+    fn try_from(version: &common_utils::types::SemanticVersion) -> Result<Self, Self::Error> {
+        match version.get_major() {
+            1 => Ok(Self::ThreeDsOne),
+            2 => Ok(Self::EmvThreeDs),
+            _ => Err(()),
         }
     }
 }
@@ -479,6 +728,31 @@ fn response_code_meaning(code: &str) -> Option<&'static str> {
     }
 }
 
+/// Published meaning of an `E-commerceData.3dSecureResult` (response only). The set is
+/// closed at fourteen values plus the documented empty string ("not set"); an unrecognised
+/// value returns `None` and is still surfaced verbatim in `connector_metadata`, exactly as
+/// [`return_code_meaning`] and [`response_code_meaning`] do for their codes.
+fn three_ds_result_meaning(code: &str) -> Option<&'static str> {
+    match code {
+        "" => Some("NOT SET"),
+        "0" => Some("CAVV AUTH RESULTS INVALID"),
+        "1" => Some("CAVV AUTH RESULTS FAILED"),
+        "2" => Some("CAVV AUTH RESULTS PASSED"),
+        "3" => Some("CAVV ATTEMPT PASSED"),
+        "4" => Some("CAVV ATTEMPT FAILED"),
+        "5" => Some("NOT APPLICABLE"),
+        "6" => Some("ISSUER NOT PARTICIPATING"),
+        "7" => Some("FAILED VALIDATION (US)"),
+        "8" => Some("PASSED VALIDATION (US)"),
+        "9" => Some("FAILED VALID. ACS U/A"),
+        "A" => Some("PASSED VALID. ACS U/A"),
+        "B" => Some("PASSED VALID. INFO ONLY"),
+        "C" => Some("ATTEMPT BYPASSED (NO KEY)"),
+        "D" => Some("AUTH BYPASSED (NO KEYS)"),
+        _ => None,
+    }
+}
+
 // =============================================================================
 // SHARED HELPERS
 // =============================================================================
@@ -571,6 +845,210 @@ fn reject_unsupported_capture_method(
 }
 
 // =============================================================================
+// EXTERNAL 3-D SECURE PASSTHROUGH
+// =============================================================================
+
+/// `3dSecureData` `maxLength`.
+const THREE_DS_DATA_MAX_LENGTH: usize = 100;
+
+/// Pad a base64 value out to a length which is a multiple of 4 with `=`.
+///
+/// Required verbatim by `3dSecureData`: *"All data is expected to be base64 encoded. If
+/// multiple base64 fields are concatenated, they must each be padded out to a length which
+/// is a multiple of 4 with equal signs."* Without it the reader cannot tell where the CAVV
+/// ends and the XID begins.
+fn pad_base64(value: &str) -> String {
+    match value.len() % 4 {
+        0 => value.to_string(),
+        remainder => format!("{value}{}", "=".repeat(4 - remainder)),
+    }
+}
+
+/// Choose the `E-commerceIndicator` for an authorize-family message.
+///
+/// With no external authentication result the payment is plain unauthenticated e-commerce,
+/// which is precisely what `07` means. With one, the network ECI is authoritative because
+/// it is the artefact that actually travels to the scheme; `transStatus` is the fallback
+/// for authentication results that carry no ECI. A result carrying neither is refused
+/// rather than quietly downgraded — a caller that sends `authentication_data` is asserting
+/// an authentication happened, and silently reporting it as unauthenticated would forfeit
+/// the liability shift it paid for.
+fn resolve_ecommerce_indicator(
+    authentication_data: Option<&domain_types::router_request_types::AuthenticationData>,
+    brand: Option<WorldpayraftCardBrand>,
+) -> Result<WorldpayraftEcommerceIndicator, error_stack::Report<errors::IntegrationError>> {
+    let Some(authentication_data) = authentication_data else {
+        return Ok(WorldpayraftEcommerceIndicator::NotAuthenticated);
+    };
+    match (
+        authentication_data.eci.as_deref(),
+        authentication_data.trans_status.as_ref(),
+    ) {
+        (Some(eci), _) => WorldpayraftEcommerceIndicator::from_network_eci(eci, brand),
+        (None, Some(trans_status)) => Ok(WorldpayraftEcommerceIndicator::from_transaction_status(
+            trans_status,
+        )),
+        (None, None) => Err(error_stack::report!(
+            errors::IntegrationError::MissingRequiredField {
+                field_name: "authentication_data.eci",
+                context: errors::IntegrationErrorContext {
+                    suggested_action: Some(
+                        "Send authentication_data.eci (or authentication_data.trans_status) \
+                         alongside the cryptogram, or omit authentication_data entirely for an \
+                         unauthenticated payment"
+                            .to_string(),
+                    ),
+                    additional_context: Some(
+                        "Worldpay RAFT derives E-commerceData.E-commerceIndicator from the \
+                         external 3-D Secure result and has no other source for it"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            }
+        )),
+    }
+}
+
+/// The `E-commerceIndicator` for a merchant-initiated repeat payment.
+///
+/// A caller that does not classify the schedule has told us nothing that distinguishes the
+/// payment from ordinary unauthenticated e-commerce, which is what `07` means — the same
+/// reading `TerminalData.POSEnvironment` already takes of an unclassified MIT.
+fn repeat_payment_ecommerce_indicator(
+    mit_category: Option<&common_enums::MitCategory>,
+) -> WorldpayraftEcommerceIndicator {
+    mit_category
+        .cloned()
+        .map(WorldpayraftEcommerceIndicator::from)
+        .unwrap_or(WorldpayraftEcommerceIndicator::NotAuthenticated)
+}
+
+/// Assemble `E-commerceData.3dSecureData` — the base64 cryptogram bundle.
+///
+/// Per brand: *"Visa - CAVV + XID (optional); MasterCard - AAV; Discover - CAVV; American
+/// Express - AEVV + XID (optional)"*. Only Visa and American Express take the XID, so the
+/// other two brands get the cryptogram on its own. UCS models the XID as
+/// `threeds_server_transaction_id`, matching the other external-3DS connectors here.
+///
+/// `05` asserts "authenticated **with** AAV/CAVV data", so a missing cryptogram under that
+/// indicator is an error rather than an omission. `06` is published as "with or without AAV
+/// data", so an attempt with no cryptogram legitimately sends none.
+fn build_three_ds_data(
+    authentication_data: &domain_types::router_request_types::AuthenticationData,
+    brand: Option<WorldpayraftCardBrand>,
+    indicator: WorldpayraftEcommerceIndicator,
+) -> Result<Option<Secret<String>>, error_stack::Report<errors::IntegrationError>> {
+    let cryptogram = match (
+        authentication_data.cavv.as_ref(),
+        indicator == WorldpayraftEcommerceIndicator::Authenticated,
+    ) {
+        (Some(cavv), _) => pad_base64(cavv.peek()),
+        (None, true) => {
+            return Err(error_stack::report!(
+                errors::IntegrationError::MissingRequiredField {
+                    field_name: "authentication_data.cavv",
+                    context: errors::IntegrationErrorContext {
+                        suggested_action: Some(
+                            "Send the CAVV/AAV/AEVV the 3-D Secure server returned, or send the \
+                             attempts ECI if the issuer did not authenticate"
+                                .to_string(),
+                        ),
+                        additional_context: Some(
+                            "Worldpay RAFT E-commerceIndicator 05 means 'authenticated with AAV \
+                             / CAVV data'; the cryptogram belongs in E-commerceData.3dSecureData"
+                                .to_string(),
+                        ),
+                        ..Default::default()
+                    },
+                }
+            ))
+        }
+        (None, false) => return Ok(None),
+    };
+
+    if cryptogram.len() > THREE_DS_DATA_MAX_LENGTH {
+        return Err(error_stack::report!(
+            errors::IntegrationError::InvalidDataFormat {
+                field_name: "authentication_data.cavv",
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(format!(
+                        "Worldpay RAFT E-commerceData.3dSecureData has maxLength \
+                         {THREE_DS_DATA_MAX_LENGTH}; the base64 cryptogram alone is {} characters",
+                        cryptogram.len()
+                    )),
+                    ..Default::default()
+                },
+            }
+        ));
+    }
+
+    let xid = match brand {
+        Some(WorldpayraftCardBrand::Visa) | Some(WorldpayraftCardBrand::Amex) => {
+            authentication_data.threeds_server_transaction_id.as_deref()
+        }
+        Some(WorldpayraftCardBrand::Mastercard) | Some(WorldpayraftCardBrand::Discover) | None => {
+            None
+        }
+    };
+
+    let bundle = match xid {
+        Some(xid) => {
+            let combined = format!("{cryptogram}{}", pad_base64(xid));
+            // The XID is published as optional on both brands that accept it, so a bundle
+            // that will not fit keeps the cryptogram — which carries the liability shift —
+            // rather than being truncated into an unverifiable value.
+            if combined.len() > THREE_DS_DATA_MAX_LENGTH {
+                cryptogram
+            } else {
+                combined
+            }
+        }
+        None => cryptogram,
+    };
+
+    Ok(Some(Secret::new(bundle)))
+}
+
+/// Build the whole request-side `E-commerceData` block for an authorize-family message.
+///
+/// `is_debit` gates the two members the `/debit/*` schemas do not publish:
+/// `E-commerceData` there is exactly `{E-commerceIndicator, 3dSecureData}`.
+fn build_ecommerce_data(
+    authentication_data: Option<&domain_types::router_request_types::AuthenticationData>,
+    brand: Option<WorldpayraftCardBrand>,
+    is_debit: bool,
+) -> Result<WorldpayraftEcommerceData, error_stack::Report<errors::IntegrationError>> {
+    let ecommerce_indicator = resolve_ecommerce_indicator(authentication_data, brand)?;
+
+    // The cryptogram and the 3DS provenance fields only make sense under an indicator that
+    // asserts an authentication; RAFT rejects `3dSecureData` presented under any other.
+    let authentication_data =
+        authentication_data.filter(|_| ecommerce_indicator.carries_authentication());
+
+    let three_ds_data = match authentication_data {
+        Some(authentication_data) => {
+            build_three_ds_data(authentication_data, brand, ecommerce_indicator)?
+        }
+        None => None,
+    };
+
+    Ok(WorldpayraftEcommerceData {
+        ecommerce_indicator,
+        three_ds_data,
+        three_ds_program_protocol: (!is_debit)
+            .then_some(authentication_data)
+            .flatten()
+            .and_then(|authentication_data| authentication_data.message_version.as_ref())
+            .and_then(|version| WorldpayraftThreeDsProgramProtocol::try_from(version).ok()),
+        three_ds_directory_server_transaction_id: (!is_debit)
+            .then_some(authentication_data)
+            .flatten()
+            .and_then(|authentication_data| authentication_data.ds_trans_id.clone()),
+    })
+}
+
+// =============================================================================
 // COMPOSITE CONNECTOR TRANSACTION ID
 // =============================================================================
 
@@ -586,8 +1064,12 @@ fn reject_unsupported_capture_method(
 /// reaches a follow-up flow. The same record is *also* published on the authorize response
 /// as structured `connector_metadata` for observability and webhook correlation.
 ///
-/// Wire format (six `|`-separated segments, none of which can contain `|`):
-/// `{C|CP|D|DP}|{APITransactionID}|{LocalDateTime}|{authorized minor amount}|{AuthorizationNumber}|{RetrievalREFNumber}`
+/// Wire format (ten `|`-separated segments, none of which can contain `|`):
+/// `{C|CP|D|DP}|{APITransactionID}|{LocalDateTime}|{authorized minor amount}|{AuthorizationNumber}|{RetrievalREFNumber}|{E-commerceIndicator}|{ReturnE-commerceIndicator}|{ReturnUCAFIndicator}|{ReturnEcommerceSecurityLevelIndicator}`
+///
+/// The first six segments are the original format and keep their exact meanings; a
+/// six-segment id minted before the e-commerce members travelled with it still parses, with
+/// the four new fields absent.
 #[derive(Debug, Clone)]
 pub(super) struct WorldpayraftTransactionReference {
     /// The endpoint the original message used. A completion or refund only needs the
@@ -613,6 +1095,22 @@ pub(super) struct WorldpayraftTransactionReference {
     /// `ReferenceTraceNumbers.RetrievalREFNumber` from the original response — the
     /// request-side lifecycle trace id, used as a secondary matching key.
     pub retrieval_ref_number: Option<String>,
+    /// `E-commerceData.E-commerceIndicator` as **sent** on the original message. Every
+    /// e-commerce message must carry the indicator, follow-ups included, and the follow-up
+    /// flows have no other channel to learn it. `None` only for a reference minted by an
+    /// operation that has no `E-commerceData` at all (tokenization) or by the pre-3DS
+    /// six-segment format.
+    pub ecommerce_indicator: Option<WorldpayraftEcommerceIndicator>,
+    /// `E-commerceData.ReturnE-commerceIndicator` from the original response — the ECI the
+    /// network settled on after a downgrade. `None` when the network left the acquirer's
+    /// indicator alone, which is the ordinary case.
+    pub return_ecommerce_indicator: Option<WorldpayraftEcommerceIndicator>,
+    /// `E-commerceData.ReturnUCAFIndicator` from the original response, replayed on
+    /// follow-ups for settlement.
+    pub return_ucaf_indicator: Option<String>,
+    /// `E-commerceData.ReturnEcommerceSecurityLevelIndicator` from the original response,
+    /// replayed on follow-ups for settlement.
+    pub return_ecommerce_security_level_indicator: Option<String>,
 }
 
 /// The financial operation a transaction was created by, and therefore the endpoint any
@@ -698,7 +1196,7 @@ impl WorldpayraftTransactionReference {
 
     fn encode(&self) -> String {
         format!(
-            "{}|{}|{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             self.operation.as_str(),
             self.api_transaction_id,
             self.local_date_time,
@@ -707,9 +1205,23 @@ impl WorldpayraftTransactionReference {
                 .unwrap_or_default(),
             self.authorization_number.as_deref().unwrap_or_default(),
             self.retrieval_ref_number.as_deref().unwrap_or_default(),
+            self.ecommerce_indicator
+                .map(WorldpayraftEcommerceIndicator::as_str)
+                .unwrap_or_default(),
+            self.return_ecommerce_indicator
+                .map(WorldpayraftEcommerceIndicator::as_str)
+                .unwrap_or_default(),
+            self.return_ucaf_indicator.as_deref().unwrap_or_default(),
+            self.return_ecommerce_security_level_indicator
+                .as_deref()
+                .unwrap_or_default(),
         )
     }
 
+    /// Accepts the ten-segment format and the original six-segment one. A six-segment id
+    /// was minted before the e-commerce members travelled with the reference, so its four
+    /// missing fields are genuinely unknown rather than defaulted: the follow-up simply
+    /// sends no `E-commerceData`, as it did before.
     pub(super) fn parse(raw: &str) -> Result<Self, error_stack::Report<errors::IntegrationError>> {
         let invalid = || {
             error_stack::report!(errors::IntegrationError::InvalidDataFormat {
@@ -718,7 +1230,10 @@ impl WorldpayraftTransactionReference {
                     additional_context: Some(format!(
                         "Worldpay RAFT expects the composite reference \
                          '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|\
-                         AuthorizationNumber|RetrievalREFNumber', got {raw:?}"
+                         AuthorizationNumber|RetrievalREFNumber|E-commerceIndicator|\
+                         ReturnE-commerceIndicator|ReturnUCAFIndicator|\
+                         ReturnEcommerceSecurityLevelIndicator' (or its original six-segment \
+                         form), got {raw:?}"
                     )),
                     ..Default::default()
                 },
@@ -726,26 +1241,69 @@ impl WorldpayraftTransactionReference {
         };
 
         let segments: Vec<&str> = raw.splitn(TXN_REFERENCE_SEGMENTS, '|').collect();
-        if segments.len() != TXN_REFERENCE_SEGMENTS {
+        if segments.len() != TXN_REFERENCE_SEGMENTS
+            && segments.len() != TXN_REFERENCE_SEGMENTS_LEGACY
+        {
             return Err(invalid());
         }
-        let operation =
-            WorldpayraftOriginalOperation::try_from(segments[0]).map_err(|()| invalid())?;
-        if segments[1].is_empty() || segments[2].is_empty() {
-            return Err(invalid());
-        }
-        let authorized_minor_amount = match segments[3] {
-            "" => None,
-            amount => Some(amount.parse::<i64>().map_err(|_| invalid())?),
+        let segment = |index: usize| segments.get(index).copied();
+        let required = |index: usize| segment(index).filter(|value| !value.is_empty());
+
+        let operation = WorldpayraftOriginalOperation::try_from(segment(0).ok_or_else(invalid)?)
+            .map_err(|()| invalid())?;
+        let api_transaction_id = required(1).ok_or_else(invalid)?.to_string();
+        let local_date_time = required(2).ok_or_else(invalid)?.to_string();
+        let authorized_minor_amount = match required(3) {
+            None => None,
+            Some(amount) => Some(amount.parse::<i64>().map_err(|_| invalid())?),
+        };
+        // A stored indicator that no longer parses would silently mislabel the follow-up's
+        // authentication state, so it is rejected rather than dropped.
+        let indicator = |index: usize| match required(index) {
+            None => Ok(None),
+            Some(value) => WorldpayraftEcommerceIndicator::try_from(value).map(Some),
         };
 
         Ok(Self {
             operation,
-            api_transaction_id: segments[1].to_string(),
-            local_date_time: segments[2].to_string(),
+            api_transaction_id,
+            local_date_time,
             authorized_minor_amount,
-            authorization_number: non_empty(segments[4]),
-            retrieval_ref_number: non_empty(segments[5]),
+            authorization_number: segment(4).and_then(non_empty),
+            retrieval_ref_number: segment(5).and_then(non_empty),
+            ecommerce_indicator: indicator(6)?,
+            return_ecommerce_indicator: indicator(7)?,
+            return_ucaf_indicator: segment(8).and_then(non_empty),
+            return_ecommerce_security_level_indicator: segment(9).and_then(non_empty),
+        })
+    }
+
+    /// The `E-commerceData` a follow-up message (completion, refund, reversal) carries.
+    ///
+    /// `None` when the original reference recorded no indicator — a tokenization reference,
+    /// or one in the pre-3DS six-segment format — because the block's only required member
+    /// would then have to be invented.
+    ///
+    /// The `Return*` members exist on the `/credit/*` schemas alone: `/debit/*`
+    /// `E-commerceData` is exactly `{E-commerceIndicator, 3dSecureData}`, so a debit
+    /// follow-up carries the indicator by itself.
+    fn follow_up_ecommerce_data(&self) -> Option<WorldpayraftFollowUpEcommerceData> {
+        let is_credit = !self.is_debit();
+        self.ecommerce_indicator.map(|sent| {
+            WorldpayraftFollowUpEcommerceData {
+                // What the transaction actually settled under: the network's value when it
+                // changed the indicator, otherwise the one the original message carried.
+                ecommerce_indicator: self.return_ecommerce_indicator.unwrap_or(sent),
+                return_ecommerce_indicator: is_credit
+                    .then_some(self.return_ecommerce_indicator)
+                    .flatten(),
+                return_ucaf_indicator: is_credit
+                    .then_some(self.return_ucaf_indicator.clone())
+                    .flatten(),
+                return_ecommerce_security_level_indicator: is_credit
+                    .then_some(self.return_ecommerce_security_level_indicator.clone())
+                    .flatten(),
+            }
         })
     }
 
@@ -848,10 +1406,94 @@ pub struct WorldpayraftTerminalData {
     pub pos_environment: Option<WorldpayraftPosEnvironment>,
 }
 
+/// Request-side `E-commerceData` for an authorize-family message.
+///
+/// RAFT runs **no** authentication of its own — there is no 3DS initiate, lookup, challenge
+/// or method endpoint in any of the 17 credit or 14 debit paths. Everything 3-D Secure
+/// about a RAFT payment is these fields, carrying a result some other party produced.
+///
+/// There is no separate `CAVV`, `XID`, `AAV`, `UCAF` or `ECI` request member: the
+/// cryptogram bundle is `3dSecureData` and the ECI is `E-commerceIndicator`.
+///
+/// The `/debit/*` schemas expose only `E-commerceIndicator` and `3dSecureData`; the last two
+/// members here exist on the `/credit/*` schemas alone and are left unset for debit.
 #[derive(Debug, Serialize)]
 pub struct WorldpayraftEcommerceData {
+    /// `E-commerceData.E-commerceIndicator`.
     #[serde(rename = "E-commerceIndicator")]
-    pub ecommerce_indicator: String,
+    pub ecommerce_indicator: WorldpayraftEcommerceIndicator,
+    /// `E-commerceData.3dSecureData`, `maxLength: 100` — the base64 cryptogram bundle.
+    /// Verbatim: *"Visa - CAVV + XID (optional); MasterCard - AAV; Discover - CAVV;
+    /// American Express - AEVV + XID (optional)"*, each concatenated element padded to a
+    /// length which is a multiple of 4 with equal signs.
+    ///
+    /// The description of `CardInfo.PAN` points a network-token cryptogram at a field
+    /// called `PaymentNetworkAuthenticationCryptogram`; no such field exists anywhere in
+    /// either specification. The real one is `E-commerceData.PaymentTokenAuthenticationCryptogram`,
+    /// which is not modelled here because the Authorize flow only accepts a raw card and so
+    /// never has a network-token cryptogram to put in it.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "3dSecureData")]
+    pub three_ds_data: Option<Secret<String>>,
+    /// `E-commerceData.3DSecureProgramProtocol` — credit only.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "3DSecureProgramProtocol"
+    )]
+    pub three_ds_program_protocol: Option<WorldpayraftThreeDsProgramProtocol>,
+    /// `E-commerceData.3DSecureDirectoryServerTransactionID`, `maxLength: 36` — the
+    /// dsTransID minted by the directory server during authentication. Credit only.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "3DSecureDirectoryServerTransactionID"
+    )]
+    pub three_ds_directory_server_transaction_id: Option<String>,
+}
+
+/// Request-side `E-commerceData` for a **follow-up** message — completion, refund or
+/// reversal.
+///
+/// `E-commerceIndicator` is required on every e-commerce message, follow-ups included, so
+/// the indicator the authorization went out with is replayed here. The three `Return*`
+/// members are bidirectional, not response-only: they appear in the request schema of
+/// `creditauth`, `creditpurchase`, `creditcompletion` and `creditrefund` alike, and the
+/// specification says of them *"For follow up messages such as completions and reversals,
+/// Worldpay will attempt to retrieve the original value, but this data can be sent back up
+/// to ensure it is logged for settlement reasons."*
+///
+/// `ReturnUCAFAAVData` is deliberately **not** echoed. It is the UCAF/AAV cardholder
+/// authentication cryptogram; the only channel that reaches a follow-up flow is the
+/// persisted `connector_transaction_id`, and a cryptogram does not belong in a stored
+/// identifier. Worldpay retrieves the original itself, as the same sentence says.
+///
+/// The `/debit/*` schemas carry no `Return*` member at all, so all three stay unset there.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftFollowUpEcommerceData {
+    /// `E-commerceData.E-commerceIndicator` — the indicator the transaction settled under:
+    /// whatever the network returned in `ReturnE-commerceIndicator`, else the value the
+    /// original message was sent with.
+    #[serde(rename = "E-commerceIndicator")]
+    pub ecommerce_indicator: WorldpayraftEcommerceIndicator,
+    /// `E-commerceData.ReturnE-commerceIndicator` — sent only when the network actually
+    /// changed the indicator on the original authorization.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "ReturnE-commerceIndicator"
+    )]
+    pub return_ecommerce_indicator: Option<WorldpayraftEcommerceIndicator>,
+    /// `E-commerceData.ReturnUCAFIndicator`, `maxLength: 1`.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "ReturnUCAFIndicator"
+    )]
+    pub return_ucaf_indicator: Option<String>,
+    /// `E-commerceData.ReturnEcommerceSecurityLevelIndicator`, `maxLength: 2` — the
+    /// security protocol / cardholder authentication (SLI) value actually presented to the
+    /// network.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "ReturnEcommerceSecurityLevelIndicator"
+    )]
+    pub return_ecommerce_security_level_indicator: Option<String>,
 }
 
 /// Request-side `ReferenceTraceNumbers`.
@@ -1066,6 +1708,31 @@ pub struct WorldpayraftDiscResponseData {
     pub disc_transaction_id: Option<String>,
 }
 
+/// Response-side `E-commerceData`.
+///
+/// The credit responses carry the whole block; the debit responses carry `3dSecureResult`
+/// alone, which is why every member is optional.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftEcommerceResponseData {
+    /// `3dSecureResult` — how the network graded the cryptogram. Response only.
+    #[serde(rename = "3dSecureResult")]
+    pub three_ds_result: Option<String>,
+    /// `ReturnE-commerceIndicator` — the ECI after any network downgrade. Absent when the
+    /// network left the indicator the acquirer sent alone.
+    #[serde(rename = "ReturnE-commerceIndicator")]
+    pub return_ecommerce_indicator: Option<String>,
+    /// `ReturnUCAFIndicator` — the UCAF indicator after any network downgrade.
+    #[serde(rename = "ReturnUCAFIndicator")]
+    pub return_ucaf_indicator: Option<String>,
+    /// `ReturnEcommerceSecurityLevelIndicator` — the SLI Worldpay presented to the network.
+    #[serde(rename = "ReturnEcommerceSecurityLevelIndicator")]
+    pub return_ecommerce_security_level_indicator: Option<String>,
+    /// `ReturnUCAFAAVData` — the UCAF/AAV value Worldpay presented to the network. A
+    /// cardholder authentication cryptogram, so it stays wrapped and is never persisted.
+    #[serde(rename = "ReturnUCAFAAVData")]
+    pub return_ucaf_aav_data: Option<Secret<String>>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorldpayraftEncryptionTokenData {
     #[serde(rename = "TokenizedPAN")]
@@ -1106,6 +1773,10 @@ pub struct WorldpayraftResponseInner {
     #[serde(rename = "DiscSpecificData")]
     pub disc_specific_data: Option<WorldpayraftDiscResponseData>,
     pub encryption_token_data: Option<WorldpayraftEncryptionTokenData>,
+    /// `E-commerceData` — the 3-D Secure outcome as the network graded it, plus the
+    /// indicators to replay on follow-up messages.
+    #[serde(rename = "E-commerceData")]
+    pub ecommerce_data: Option<WorldpayraftEcommerceResponseData>,
     /// `APITransactionID` — echoed back, left zero-padded to 16 characters.
     #[serde(rename = "APITransactionID")]
     pub api_transaction_id: Option<String>,
@@ -1305,8 +1976,22 @@ impl WorldpayraftResponseInner {
         reference: &WorldpayraftTransactionReference,
     ) -> serde_json::Value {
         let trace = self.reference_trace_numbers.as_ref();
+        let ecommerce = self.ecommerce_data.as_ref();
+        let three_ds_result = ecommerce.and_then(|data| data.three_ds_result.as_deref());
         serde_json::json!({
             "api_transaction_id": reference.api_transaction_id,
+            "ecommerce_indicator": reference.ecommerce_indicator
+                .map(WorldpayraftEcommerceIndicator::as_str),
+            // Verbatim, so a downgraded indicator Worldpay reports in an unrecognised shape
+            // is still visible even though it is not replayed on follow-ups.
+            "return_ecommerce_indicator": ecommerce
+                .and_then(|data| data.return_ecommerce_indicator.clone()),
+            "return_ucaf_indicator": ecommerce
+                .and_then(|data| data.return_ucaf_indicator.clone()),
+            "return_ecommerce_security_level_indicator": ecommerce
+                .and_then(|data| data.return_ecommerce_security_level_indicator.clone()),
+            "three_ds_result": three_ds_result,
+            "three_ds_result_meaning": three_ds_result.and_then(three_ds_result_meaning),
             "local_date_time": reference.local_date_time,
             "original_operation": reference.operation.path(),
             "is_debit": reference.is_debit(),
@@ -1333,14 +2018,19 @@ impl WorldpayraftResponseInner {
 
     /// Rebuild the composite reference from the values that were **sent** plus the trace
     /// numbers Worldpay returned.
+    ///
+    /// `ecommerce_indicator` is what the original request **sent** — RAFT does not echo it,
+    /// and it is required again on every follow-up message.
     fn to_transaction_reference(
         &self,
         operation: WorldpayraftOriginalOperation,
         api_transaction_id: String,
         local_date_time: String,
         authorized_minor_amount: Option<i64>,
+        ecommerce_indicator: Option<WorldpayraftEcommerceIndicator>,
     ) -> WorldpayraftTransactionReference {
         let trace = self.reference_trace_numbers.as_ref();
+        let ecommerce = self.ecommerce_data.as_ref();
         WorldpayraftTransactionReference {
             operation,
             api_transaction_id,
@@ -1352,6 +2042,20 @@ impl WorldpayraftResponseInner {
             retrieval_ref_number: trace
                 .and_then(|t| t.retrieval_ref_number.clone())
                 .and_then(|value| non_empty(value.trim())),
+            ecommerce_indicator,
+            // A downgraded indicator Worldpay reports in a shape this connector does not
+            // recognise is not stored — the follow-up then replays what was actually sent,
+            // which is known to be true — but the raw value is surfaced verbatim in
+            // `connector_metadata` so nothing is lost.
+            return_ecommerce_indicator: ecommerce
+                .and_then(|data| data.return_ecommerce_indicator.as_deref())
+                .and_then(|value| WorldpayraftEcommerceIndicator::try_from(value).ok()),
+            return_ucaf_indicator: ecommerce
+                .and_then(|data| data.return_ucaf_indicator.as_deref())
+                .and_then(non_empty),
+            return_ecommerce_security_level_indicator: ecommerce
+                .and_then(|data| data.return_ecommerce_security_level_indicator.as_deref())
+                .and_then(non_empty),
         }
     }
 }
@@ -1660,6 +2364,16 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 .connector_request_reference_id,
         );
 
+        // RAFT runs no authentication step of its own — it is external-3DS passthrough
+        // only. Whatever result the merchant (or Hyperswitch's own authentication service)
+        // obtained elsewhere arrives as `authentication_data`, and both the indicator and
+        // the cryptogram are derived from it instead of being hardcoded.
+        let ecommerce_data = build_ecommerce_data(
+            router_data.request.authentication_data.as_ref(),
+            WorldpayraftCardBrand::resolve(card),
+            is_debit,
+        )?;
+
         let inner = WorldpayraftCardAuthInner {
             misc_amounts_balances: WorldpayraftAmounts {
                 transaction_amount,
@@ -1678,9 +2392,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 terminal_entry_cap: TERMINAL_ENTRY_CAP_DEFAULT.to_string(),
                 pos_environment,
             },
-            ecommerce_data: WorldpayraftEcommerceData {
-                ecommerce_indicator: ECOMMERCE_INDICATOR_ECOMM_NO_3DS.to_string(),
-            },
+            ecommerce_data,
             proc_flags_indicators,
             world_pay_merchant_id: auth.merchant_id,
             api_transaction_id,
@@ -1740,11 +2452,36 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             });
         }
 
+        // RAFT never echoes `E-commerceIndicator`, yet every follow-up message — completion,
+        // refund, reversal — has to carry it again. It is recomputed here from the same
+        // request fields the outbound message was built from, exactly as
+        // `APITransactionID` is, and travels on the composite reference.
+        let card_brand = match &item.router_data.request.payment_method_data {
+            PaymentMethodData::Card(card) => WorldpayraftCardBrand::resolve(card),
+            _ => None,
+        };
+        let ecommerce_indicator = resolve_ecommerce_indicator(
+            item.router_data.request.authentication_data.as_ref(),
+            card_brand,
+        )
+        .change_context(errors::ConnectorError::ResponseHandlingFailed {
+            context: errors::ResponseTransformationErrorContext {
+                http_status_code: Some(item.http_code),
+                additional_context: Some(
+                    "Worldpay RAFT approved the authorization but its E-commerceIndicator could \
+                     no longer be derived, leaving no indicator for the completion, refund or \
+                     reversal to replay"
+                        .to_string(),
+                ),
+            },
+        })?;
+
         let reference = inner.to_transaction_reference(
             WorldpayraftOriginalOperation::from_parts(is_debit, is_auto_capture),
             api_transaction_id,
             get_local_datetime(),
             authorized_minor_amount,
+            Some(ecommerce_indicator),
         );
         let status = if is_auto_capture {
             AttemptStatus::Charged
@@ -1788,6 +2525,11 @@ pub struct WorldpayraftCompletionInner {
     pub misc_amounts_balances: WorldpayraftAmounts,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
+    /// `E-commerceData` — the indicator the original authorization settled under, plus the
+    /// network's `Return*` values. Every e-commerce message must carry the indicator, and
+    /// Worldpay logs the `Return*` members from a follow-up for settlement.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "E-commerceData")]
+    pub ecommerce_data: Option<WorldpayraftFollowUpEcommerceData>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     /// The **original** authorization's `APITransactionID`, replayed verbatim.
@@ -1916,6 +2658,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 dispensed_amount: None,
             },
             reference_trace_numbers: reference.follow_up_trace_numbers(),
+            ecommerce_data: reference.follow_up_ecommerce_data(),
             world_pay_merchant_id: auth.merchant_id,
             api_transaction_id: reference.api_transaction_id.clone(),
             local_date_time: reference.local_date_time.clone(),
@@ -1969,7 +2712,6 @@ impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
                          transaction reference is no longer available"
                             .to_string(),
                     ),
-                    ..Default::default()
                 },
             })?;
 
@@ -2020,6 +2762,11 @@ pub struct WorldpayraftReversalInner {
     /// `RetrievalREFNumber`) received on the original response, replayed here.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
+    /// `E-commerceData` — the indicator the original authorization settled under, plus the
+    /// network's `Return*` values. Every e-commerce message must carry the indicator, and
+    /// Worldpay logs the `Return*` members from a follow-up for settlement.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "E-commerceData")]
+    pub ecommerce_data: Option<WorldpayraftFollowUpEcommerceData>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     /// The **original** transaction's `APITransactionID`, replayed verbatim. This is how
@@ -2223,6 +2970,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 dispensed_amount,
             },
             reference_trace_numbers: reference.follow_up_trace_numbers(),
+            ecommerce_data: reference.follow_up_ecommerce_data(),
             world_pay_merchant_id: auth.merchant_id,
             api_transaction_id: reference.api_transaction_id.clone(),
             local_date_time: reference.local_date_time.clone(),
@@ -2309,6 +3057,11 @@ pub struct WorldpayraftRefundInner {
     pub misc_amounts_balances: WorldpayraftAmounts,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
+    /// `E-commerceData` — the indicator the original authorization settled under, plus the
+    /// network's `Return*` values. Every e-commerce message must carry the indicator, and
+    /// Worldpay logs the `Return*` members from a follow-up for settlement.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "E-commerceData")]
+    pub ecommerce_data: Option<WorldpayraftFollowUpEcommerceData>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     /// The **original** payment's `APITransactionID`, replayed so Worldpay can match the
@@ -2400,6 +3153,7 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 dispensed_amount: None,
             },
             reference_trace_numbers: reference.follow_up_trace_numbers(),
+            ecommerce_data: reference.follow_up_ecommerce_data(),
             world_pay_merchant_id: auth.merchant_id,
             api_transaction_id: reference.api_transaction_id.clone(),
             local_date_time: reference.local_date_time.clone(),
@@ -2453,7 +3207,6 @@ impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
                     "Worldpay RAFT refund could not re-encode its connector transaction reference"
                         .to_string(),
                 ),
-                ..Default::default()
             },
         })?;
         let refund_reference = inner.to_transaction_reference(
@@ -2461,6 +3214,9 @@ impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
             reference.api_transaction_id.clone(),
             reference.local_date_time.clone(),
             reference.authorized_minor_amount,
+            // A refund inherits the e-commerce indicator of the payment it reverses; the
+            // refund message itself is not separately authenticated.
+            reference.ecommerce_indicator,
         );
 
         Ok(Self {
@@ -2619,7 +3375,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                              EncryptionTokenData.TokenizedPAN to store as the mandate reference"
                                 .to_string(),
                         ),
-                        ..Default::default()
                     },
                 })
             })?;
@@ -2636,6 +3391,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                     .connector_request_reference_id,
             ),
             get_local_datetime(),
+            None,
+            // `tokenize` has no `E-commerceData` member at all, so there is no indicator to
+            // record and nothing for a follow-up to replay.
             None,
         );
 
@@ -2999,7 +3757,13 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 pos_environment: Some(pos_environment),
             },
             ecommerce_data: WorldpayraftEcommerceData {
-                ecommerce_indicator: ECOMMERCE_INDICATOR_ECOMM_NO_3DS.to_string(),
+                ecommerce_indicator: repeat_payment_ecommerce_indicator(mit_category.as_ref()),
+                // A merchant-initiated transaction has no cardholder present to
+                // authenticate, so it carries no 3-D Secure artefacts of its own; the
+                // original CIT's authentication is what the stored credential rests on.
+                three_ds_data: None,
+                three_ds_program_protocol: None,
+                three_ds_directory_server_transaction_id: None,
             },
             proc_flags_indicators: WorldpayraftProcFlagsIndicators {
                 mastercard_advice_code_indicator: Some(WorldpayraftFlag::Yes),
@@ -3067,6 +3831,9 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             ),
             get_local_datetime(),
             Some(item.router_data.request.minor_amount.get_amount_as_i64()),
+            Some(repeat_payment_ecommerce_indicator(
+                item.router_data.request.mit_category.as_ref(),
+            )),
         );
 
         Ok(Self {

--- a/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs
@@ -1,5 +1,8 @@
-use crate::types::ResponseRouterData;
-use common_enums::{AttemptStatus, RefundStatus};
+use common_enums::{AttemptStatus, CardNetwork, RefundStatus};
+use common_utils::{
+    consts,
+    types::{MinorUnit, StringMajorUnit},
+};
 use domain_types::{
     connector_flow::{Authorize, Capture, Refund, RepeatPayment, SetupMandate},
     connector_types::{
@@ -9,44 +12,54 @@ use domain_types::{
     },
     errors,
     payment_method_data::{Card, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber},
-    router_data::ConnectorSpecificConfig,
+    router_data::{ConnectorSpecificConfig, ErrorResponse, FlowStatus},
     router_data_v2::RouterDataV2,
+    utils::{get_card_issuer, CardIssuer},
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
-use crate::connectors::worldpayraft::WorldpayraftRouterData;
+use crate::{connectors::worldpayraft::WorldpayraftRouterData, types::ResponseRouterData};
 
 // =============================================================================
 // CONSTANTS
 // =============================================================================
 
-/// Card type identifier as received in PaymentMethodData (case-insensitive comparison via eq_ignore_ascii_case).
+/// Card type identifier as received in `PaymentMethodData` (compared case-insensitively).
 pub(super) const CARD_TYPE_DEBIT: &str = "debit";
 
-/// Prefix embedded in connector_transaction_id to identify debit transactions.
-pub(super) const TXN_TYPE_DEBIT: &str = "D";
-/// Prefix embedded in connector_transaction_id to identify credit transactions.
-pub(super) const TXN_TYPE_CREDIT: &str = "C";
+/// Prefix embedded in `connector_transaction_id` to identify debit transactions.
+const TXN_TYPE_DEBIT: &str = "D";
+/// Prefix embedded in `connector_transaction_id` to identify credit transactions.
+const TXN_TYPE_CREDIT: &str = "C";
+/// Number of `|`-separated segments in the composite `connector_transaction_id`.
+const TXN_REFERENCE_SEGMENTS: usize = 6;
 
-/// Worldpay RAFT operation-level success code (ReturnCode).
+/// `ReturnCode` value meaning "the message itself was processed" (operation level).
 const RETURN_CODE_SUCCESS: &str = "0000";
-/// Worldpay RAFT issuer-level success code (ResponseCode).
-const RESPONSE_CODE_SUCCESS: &str = "000";
+/// `ResponseCode` value meaning "approved" (issuer level).
+const RESPONSE_CODE_APPROVED: &str = "000";
+/// `ResponseCode` `010` — PARTIAL APPROVAL. The spec classifies this as an approval,
+/// not a decline; the approved amount is echoed in `MiscAmountsBalances.OriginalAuthAmount`.
+const RESPONSE_CODE_PARTIAL_APPROVAL: &str = "010";
+/// `ResponseCode` `003` — HONOR WITH ID. Manual review, not a terminal decline.
+const RESPONSE_CODE_HONOR_WITH_ID: &str = "003";
+/// `ResponseCode` `114` — REQUEST IN PROGRESS. Non-terminal; the outcome is not yet known.
+const RESPONSE_CODE_REQUEST_IN_PROGRESS: &str = "114";
 
-/// E-commerce channel entry mode.
+/// Separator joining `McrdBanknetREFNUM` and `McrdBanknetSettleDate` inside the single
+/// `network_txn_id` string. Neither field can contain `:` (both are numeric).
+const MCRD_NTID_SEPARATOR: char = ':';
+
+/// `TerminalData.EntryMode` for an e-commerce channel transaction.
 const ENTRY_MODE_ECOMM: &str = "E-COMM";
-/// POS condition code for e-commerce.
+/// `TerminalData.POSConditionCode` for an e-commerce channel transaction.
 const POS_CONDITION_CODE_ECOMM: &str = "59";
-/// Terminal entry capability (not applicable for e-commerce).
+/// `TerminalData.TerminalEntryCap` — not applicable for e-commerce.
 const TERMINAL_ENTRY_CAP_DEFAULT: &str = "0";
-/// E-commerce indicator: 3DS authenticated.
-const ECOMMERCE_INDICATOR_SECURE: &str = "07";
-/// CVV2/CVC2 indicator: value provided.
-const CVV_INDICATOR_PRESENT: &str = "0";
-/// Flag value indicating yes/enabled for proc flag fields.
-const MIT_YES: &str = "Y";
+/// `E-commerceData.E-commerceIndicator` `07` — e-commerce, no 3-D Secure.
+const ECOMMERCE_INDICATOR_ECOMM_NO_3DS: &str = "07";
 
 // =============================================================================
 // AUTH TYPE
@@ -77,7 +90,13 @@ impl TryFrom<&ConnectorSpecificConfig> for WorldpayraftAuthType {
             }),
             _ => Err(error_stack::report!(
                 errors::IntegrationError::FailedToObtainAuthType {
-                    context: errors::IntegrationErrorContext::default()
+                    context: errors::IntegrationErrorContext {
+                        additional_context: Some(
+                            "Worldpay RAFT expects ConnectorSpecificConfig::Worldpayraft { license, merchant_id }"
+                                .to_string(),
+                        ),
+                        ..Default::default()
+                    }
                 }
             )),
         }
@@ -85,27 +104,323 @@ impl TryFrom<&ConnectorSpecificConfig> for WorldpayraftAuthType {
 }
 
 // =============================================================================
-// ERROR RESPONSE
+// CLOSED VALUE SETS
 // =============================================================================
 
-/// Worldpay RAFT error response body.
+/// The `Y`/`N` flag shape used by every `ProcFlagsIndicators` member.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum WorldpayraftFlag {
+    #[serde(rename = "Y")]
+    Yes,
+    #[serde(rename = "N")]
+    No,
+}
+
+/// `CardVerificationData.Cvv2Cvc2CIDIndicator` — the CVV2/CVC2/CID **presence** indicator.
 ///
-/// The API always returns HTTP 200. To detect errors, check:
-/// - `ReturnCode` != "0000"  → operation-level failure
-/// - `ResponseCode` != "000" → soft decline / issuer decline
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftErrorResponse {
-    pub return_code: Option<String>,
-    pub reason_code: Option<String>,
-    pub response_code: Option<String>,
+/// Note the polarity: `1` means the value IS present, `0` means it was bypassed or not
+/// given. (An earlier revision of this connector had these two inverted.)
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum WorldpayraftCvvIndicator {
+    /// `0` — the CVV2/CVC2/CID value was bypassed or not given.
+    #[serde(rename = "0")]
+    BypassedOrNotGiven,
+    /// `1` — the CVV2/CVC2/CID value is present.
+    #[serde(rename = "1")]
+    Present,
+    /// `2` — the CVV2/CVC2/CID value is illegible.
+    #[serde(rename = "2")]
+    Illegible,
+    /// `9` — the CVV2/CVC2/CID value is not on the card.
+    #[serde(rename = "9")]
+    NotOnCard,
+}
+
+/// `TerminalData.POSEnvironment` — the stored-credential / credential-on-file indicator.
+///
+/// Request-only and credit-only: `POSEnvironment` does not exist in the debit spec.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum WorldpayraftPosEnvironment {
+    /// `C` — Credential on File transaction.
+    #[serde(rename = "C")]
+    CredentialOnFile,
+    /// `I` — Installment transaction for Visa.
+    #[serde(rename = "I")]
+    Installment,
+    /// `R` — Recurring for Visa/Discover, Standing Order for Mastercard (amount may vary).
+    #[serde(rename = "R")]
+    Recurring,
+    /// `S` — Subscription for Mastercard, Recurring for Visa/Discover (fixed amount).
+    #[serde(rename = "S")]
+    Subscription,
+    /// `U` — Unscheduled card on file (merchant-initiated).
+    #[serde(rename = "U")]
+    UnscheduledCardOnFile,
+}
+
+impl From<common_enums::MitCategory> for WorldpayraftPosEnvironment {
+    fn from(category: common_enums::MitCategory) -> Self {
+        match category {
+            common_enums::MitCategory::Installment => Self::Installment,
+            common_enums::MitCategory::Recurring => Self::Subscription,
+            common_enums::MitCategory::Unscheduled => Self::UnscheduledCardOnFile,
+            // A retry of a previously declined MIT re-uses the stored credential without
+            // establishing a new schedule, so the generic credential-on-file value applies.
+            common_enums::MitCategory::Resubmission => Self::CredentialOnFile,
+        }
+    }
+}
+
+/// `*SubsequentTransactionReasonCode` — the identical nine-value enum carried by all four
+/// `*SpecificData` objects. Request only, `maxLength: 2`.
+///
+/// The published set has no value for a scheduled recurring / installment / unscheduled
+/// card-on-file MIT, so this connector only emits the one value it can derive without
+/// inventing a meaning: `Resubmission`, for `MitCategory::Resubmission`.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum WorldpayraftSubsequentTransactionReasonCode {
+    /// `13` — Below floor limit.
+    #[serde(rename = "13")]
+    BelowFloorLimit,
+    /// `17` — VRU Approved.
+    #[serde(rename = "17")]
+    VruApproved,
+    /// `40` — Incremental Authorization.
+    #[serde(rename = "40")]
+    IncrementalAuthorization,
+    /// `41` — Resubmission.
+    #[serde(rename = "41")]
+    Resubmission,
+    /// `42` — Delayed Charge.
+    #[serde(rename = "42")]
+    DelayedCharge,
+    /// `43` — Reauthorization.
+    #[serde(rename = "43")]
+    Reauthorization,
+    /// `44` — No Show.
+    #[serde(rename = "44")]
+    NoShow,
+    /// `45` — Deferred Authorization.
+    #[serde(rename = "45")]
+    DeferredAuthorization,
+    /// `50` — Offline Chip Approval.
+    #[serde(rename = "50")]
+    OfflineChipApproval,
+}
+
+impl TryFrom<common_enums::MitCategory> for WorldpayraftSubsequentTransactionReasonCode {
+    type Error = ();
+
+    fn try_from(category: common_enums::MitCategory) -> Result<Self, Self::Error> {
+        match category {
+            common_enums::MitCategory::Resubmission => Ok(Self::Resubmission),
+            // No published RAFT reason code describes a scheduled recurring, installment or
+            // unscheduled card-on-file MIT; the field is optional, so it is omitted instead.
+            common_enums::MitCategory::Installment
+            | common_enums::MitCategory::Recurring
+            | common_enums::MitCategory::Unscheduled => Err(()),
+        }
+    }
+}
+
+/// The four card networks for which Native RAFT publishes a network transaction id.
+///
+/// None of the four `*SpecificData` objects exists in the debit spec, so NTIDs are a
+/// credit-path concept only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorldpayraftCardBrand {
+    Visa,
+    Mastercard,
+    Amex,
+    Discover,
+}
+
+impl WorldpayraftCardBrand {
+    fn from_card_network(network: &CardNetwork) -> Option<Self> {
+        match network {
+            CardNetwork::Visa => Some(Self::Visa),
+            CardNetwork::Mastercard | CardNetwork::Maestro => Some(Self::Mastercard),
+            CardNetwork::AmericanExpress => Some(Self::Amex),
+            CardNetwork::Discover => Some(Self::Discover),
+            CardNetwork::JCB
+            | CardNetwork::DinersClub
+            | CardNetwork::CartesBancaires
+            | CardNetwork::UnionPay
+            | CardNetwork::Interac
+            | CardNetwork::RuPay
+            | CardNetwork::Star
+            | CardNetwork::Pulse
+            | CardNetwork::Accel
+            | CardNetwork::Nyce
+            | CardNetwork::Prop
+            | CardNetwork::PrivateLabel
+            | CardNetwork::Dinacard => None,
+        }
+    }
+
+    fn from_card_issuer(issuer: CardIssuer) -> Option<Self> {
+        match issuer {
+            CardIssuer::Visa => Some(Self::Visa),
+            CardIssuer::Master | CardIssuer::Maestro => Some(Self::Mastercard),
+            CardIssuer::AmericanExpress => Some(Self::Amex),
+            CardIssuer::Discover => Some(Self::Discover),
+            CardIssuer::DinersClub
+            | CardIssuer::JCB
+            | CardIssuer::CarteBlanche
+            | CardIssuer::CartesBancaires
+            | CardIssuer::UnionPay => None,
+        }
+    }
+
+    /// Resolve the brand for the per-brand NTID echo. The caller-supplied `card_network`
+    /// is authoritative; when it is absent the brand is derived from the PAN's BIN range
+    /// using the shared `domain_types::utils::get_card_issuer` helper.
+    fn resolve<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>(
+        card: &Card<T>,
+    ) -> Option<Self> {
+        card.card_network
+            .as_ref()
+            .and_then(Self::from_card_network)
+            .or_else(|| {
+                get_card_issuer(card.card_number.peek())
+                    .ok()
+                    .and_then(Self::from_card_issuer)
+            })
+    }
+}
+
+// =============================================================================
+// RESPONSE CODE TABLES
+// =============================================================================
+
+/// Published meaning of a `ReturnCode` (operation level). The set is closed at four values.
+fn return_code_meaning(code: &str) -> Option<&'static str> {
+    match code {
+        "0000" => Some("SUCCESSFUL"),
+        "0004" => Some("EDIT ERROR ON INPUT"),
+        "0008" => Some("LOGIC ERROR"),
+        "0012" => Some("SYSTEM ISSUE"),
+        _ => None,
+    }
+}
+
+/// Published meaning of a `ResponseCode` (issuer / decision level).
+///
+/// The set is explicitly open — "Worldpay can add response codes at any time. Any response
+/// code not recognized should be treated as a decline" — so this is a lookup returning
+/// `None` for an unknown code rather than an enum.
+fn response_code_meaning(code: &str) -> Option<&'static str> {
+    match code {
+        "000" => Some("APPROVE"),
+        "001" => Some("REFER TO ISSUER"),
+        "002" => Some("VOID UNSUCCESSFUL"),
+        "003" => Some("HONOR WITH ID"),
+        "004" => Some("CARD EXPIRED"),
+        "005" => Some("DO NOT HONOR"),
+        "006" => Some("PIN TRY LIMIT EXCEEDED"),
+        "007" => Some("INVALID MERCHANT ID"),
+        "008" => Some("INVALID AMOUNT"),
+        "009" => Some("INVALID ACCOUNT"),
+        "010" => Some("PARTIAL APPROVAL"),
+        "011" => Some("INVALID TRANSACTION"),
+        "012" => Some("INVALID PIN"),
+        "013" => Some("INVALID CARD SECURITY CODE"),
+        "014" => Some("NETWORK UNAVAILABLE"),
+        "015" => Some("INVALID CURRENCY CODE"),
+        "016" => Some("DECLINE - PICK UP CARD"),
+        "017" => Some("DECLINE - PICK UP CARD - FRAUD"),
+        "018" => Some("INVALID CARD NUMBER"),
+        "019" => Some("SUSPECTED FRAUD - CALL CENTER"),
+        "020" => Some("RESTRICTED CARD"),
+        "021" => Some("DECLINE - PICK UP LOST CARD"),
+        "022" => Some("DECLINE - PICK UP STOLEN CARD"),
+        "023" => Some("DECLINED - OVER LIMIT - ACCOUNT"),
+        "024" => Some("INVALID TERMINAL ID"),
+        "025" => Some("DO NOT HONOR - SUSPECTED FRAUD"),
+        "026" => Some("EXCEEDS WITHDRAWAL LIMIT"),
+        "027" => Some("NO DATA AVAILABLE"),
+        "028" => Some("SECURITY VIOLATION"),
+        "029" => Some("ORIGINAL AMOUNT INCORRECT"),
+        "030" => Some("FORMAT ERROR"),
+        "031" => Some("EXCEEDS WITHDRAWAL COUNT LIMIT"),
+        "032" => Some("HARD CAPTURE"),
+        "033" => Some("RESPONSE RECEIVED TOO LATE"),
+        "034" => Some("UNABLE TO ROUTE TRANSACTION"),
+        "035" => Some("DECLINED - TRANSACTION IN VIOLATION OF LAW"),
+        "036" => Some("DUPLICATE REQUEST"),
+        "037" => Some("DUPLICATE REVERSAL"),
+        "038" => Some("NO SUCH ISSUER"),
+        "039" => Some("INSUFFICIENT FUNDS"),
+        "040" => Some("EXCEEDS PURCHASE LIMITS"),
+        "041" => Some("RE-ENTER"),
+        "042" => Some("CALL CENTER"),
+        "043" => Some("ENTER DOB AND RE-SEND"),
+        "044" => Some("CAN'T CONVERT CHECK"),
+        "045" => Some("INVALID DATE"),
+        "046" => Some("CRYPTOGRAPHIC ERROR FOUND IN PIN OR CVV"),
+        "047" => Some("TIME LIMIT FOR A PRE-AUTH IS TOO LONG"),
+        "048" => Some("SYSTEM MALFUNCTION"),
+        "049" => Some("PIN MISSING"),
+        "050" => Some("SWITCH COMMUNICATION ERROR"),
+        "051" => Some("UNABLE TO LOCATE A MATCHING ORIGINAL TRANSACTION"),
+        "052" => Some("CARD NOT ACTIVATED YET"),
+        "053" => Some("CARD ALREADY ACTIVATED"),
+        "054" => Some("VELOCITY: EXCEEDS COUNT"),
+        "055" => Some("VELOCITY: EXCEEDS AMOUNT"),
+        "056" => Some("VELOCITY: EXCEEDS COUNT AND AMOUNT"),
+        "057" => Some("VELOCITY: VELOCITY NEGATIVE"),
+        "058" => Some("VELOCITY: VELOCITY FRAUD RECORD"),
+        "059" => Some("VELOCITY: NO ZIP CODE MATCH"),
+        "060" => Some("CARD ESCHEATED"),
+        "061" => Some("MERCHANT DEPLETED"),
+        "062" => Some("FRAUD SYSTEM DETECTED UNUSUAL ACTIVITY"),
+        "063" => Some("EMV MISSING OR INVALID TAG DATA"),
+        "064" => Some("LINE TYPE NOT VALID FOR THIS TERMINAL"),
+        "065" => Some("DECRYPTION/TOKENIZATION ERROR"),
+        "066" => Some("REGISTRATION EVENT"),
+        "067" => Some("APPLICATION TRANSACTION COUNTER ERROR"),
+        "068" => Some("CARDHOLDER VERIFICATION FAILURE - TVR"),
+        "069" => Some("ERROR IDENTIFYING CHIP APPLICATION"),
+        "070" => Some("MAC NOT DETECTED"),
+        "071" => Some("INTERNAL MAC PROCESSING ERROR"),
+        "072" => Some("INVALID MAC DETECTED"),
+        "073" => Some("DECRYPTION NOT POSSIBLE - MERCHANT"),
+        "074" => Some("DECRYPTION NOT POSSIBLE - WORLDPAY"),
+        "075" => Some("PROBLEM CALLING ENCRYPTION"),
+        "076" => Some("MALFORMED MESSAGE RECEIVED"),
+        "077" => Some("POSSIBLE DECRYPTION FAILURE"),
+        "078" => Some("DETOKENIZATION FAILED"),
+        "079" => Some("LOW TOKEN CONVERSION ERROR"),
+        "080" => Some("RESERVED"),
+        "100" => Some("IDEMPOTENCY DETECTED A DUPLICATE REQUEST BUT THERE WAS A MESSAGE TYPE MISMATCH BETWEEN WHAT IT LOCATED AND WHAT WAS SENT IN"),
+        "101" => Some("A REQUEST FOR PINLESS CONVERSION FAILED TO FIND A VALID ROUTING OPTION"),
+        "102" => Some("ACCOUNT CLOSED"),
+        "103" => Some("TRANSACTION FEE NOT PERMITTED OR INVALID"),
+        "104" => Some("CASH BACK REQUEST EXCEEDS ISSUER LIMIT"),
+        "105" => Some("UNABLE TO LOCATE PREVIOUS TRANSACTION"),
+        "106" => Some("PREVIOUS TRANSACTION LOCATED, BUT DATA INCONSISTENT"),
+        "107" => Some("DECLINED FIRST USE OF CARD"),
+        "108" => Some("TRANSACTION AMOUNT EXCEEDS PREAUTHORIZED AMOUNT"),
+        "109" => Some("STOP PAYMENT ORDER"),
+        "110" => Some("EXPIRATION DATE MISMATCH"),
+        "111" => Some("STALE DATED TRANSACTION"),
+        "112" => Some("INVALID ADDRESS VERIFICATION INFORMATION"),
+        "113" => Some("CUTOFF IS IN PROGRESS"),
+        "114" => Some("REQUEST IN PROGRESS"),
+        "115" => Some("INFORMATION NOT ON FILE"),
+        "116" => Some("TOKEN LOOKUP FAILURE"),
+        "117" => Some("CARDHOLDER DOES NOT PARTICIPATE IN ATTEMPTED PRODUCT"),
+        "118" => Some("SPECIAL CONDITIONS"),
+        "550" => Some("TRANSACTION DECLINED BY FRAUDSIGHT"),
+        _ => None,
+    }
 }
 
 // =============================================================================
 // SHARED HELPERS
 // =============================================================================
 
-/// Returns the current UTC datetime formatted as "YYYY-MM-DDTHH:MM:SS".
+/// Returns the current UTC datetime formatted as `YYYY-MM-DDTHH:MM:SS` (`LocalDateTime`).
 fn get_local_datetime() -> String {
     let now = common_utils::date_time::now().assume_utc();
     format!(
@@ -119,64 +434,220 @@ fn get_local_datetime() -> String {
     )
 }
 
-/// Truncates a string to at most 16 characters (APITransactionID max length).
+/// Truncates a string to at most 16 characters (`APITransactionID` `maxLength`).
 fn truncate_api_transaction_id(id: &str) -> String {
     id.chars().take(16).collect()
 }
 
-/// Derive a 6-digit numeric SystemTraceNumber from an arbitrary ID string.
-///
-/// Takes the last 6 numeric characters from the string. If fewer than
-/// 6 numeric characters exist, pads with zeros on the left.
-fn derive_system_trace_number(id: &str) -> String {
-    let digits: String = id.chars().filter(|c| c.is_ascii_digit()).collect();
-    let len = digits.len();
-    if len >= 6 {
-        digits[len - 6..].to_string()
-    } else {
-        format!("{:0>6}", digits)
-    }
+/// `true` when the card is flagged as a debit card, which routes the request onto the
+/// `/debit/*` family of endpoints.
+pub(super) fn is_debit_card<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+>(
+    payment_method_data: &PaymentMethodData<T>,
+) -> bool {
+    matches!(
+        payment_method_data,
+        PaymentMethodData::Card(card) if card.card_type.as_deref()
+            .is_some_and(|card_type| card_type.eq_ignore_ascii_case(CARD_TYPE_DEBIT))
+    )
 }
 
-/// Parse a connector_transaction_id that encodes card type + auth trace numbers.
+/// Decide between the auto-capture endpoint (`/credit/purchase`, `/debit/purchase`) and the
+/// auth-only endpoint (`/credit/authorization`, `/debit/preauth`).
 ///
-/// New format: `"{prefix}|{AuthorizationNumber}|{RetrievalREFNumber}|{SystemTraceNumber}"`
-/// where prefix is `TXN_TYPE_CREDIT` ("C") or `TXN_TYPE_DEBIT` ("D").
-///
-/// Legacy format (backwards compat, treated as credit):
-/// `"{AuthorizationNumber}|{RetrievalREFNumber}|{SystemTraceNumber}"`
-///
-/// Returns `(is_debit, authorization_number, retrieval_ref_number, system_trace_number)`.
-pub(super) fn parse_connector_transaction_id(id: &str) -> (bool, &str, &str, &str) {
-    let mut iter = id.splitn(4, '|');
-    match (iter.next(), iter.next(), iter.next(), iter.next()) {
-        (Some(prefix), Some(auth_num), Some(retrieval_ref), Some(sys_trace)) => {
-            (prefix == TXN_TYPE_DEBIT, auth_num, retrieval_ref, sys_trace)
-        }
-        (Some(auth_num), Some(retrieval_ref), Some(sys_trace), None) => {
-            // Legacy format without prefix — treat as credit
-            (false, auth_num, retrieval_ref, sys_trace)
-        }
-        _ => (false, id, "", ""),
-    }
+/// Delegates to the shared [`PaymentsAuthorizeData::is_auto_capture`] helper, which maps
+/// `Automatic | SequentialAutomatic | None` to `true` and `Manual` to `false`.
+/// `ManualMultiple` and `Scheduled` have no RAFT endpoint and are rejected up front rather
+/// than silently falling through to the auth-only path.
+pub(super) fn resolve_auto_capture<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+>(
+    request: &PaymentsAuthorizeData<T>,
+) -> Result<bool, error_stack::Report<errors::IntegrationError>> {
+    reject_unsupported_capture_method(request.capture_method)?;
+    Ok(request.is_auto_capture())
 }
 
-/// Derive AttemptStatus for Authorize and Capture flows.
-///
-/// - `ReturnCode == RETURN_CODE_SUCCESS` AND `ResponseCode == RESPONSE_CODE_SUCCESS` → success
-/// - Anything else → Failure
-fn map_payment_status(return_code: &str, response_code: &str) -> bool {
-    return_code == RETURN_CODE_SUCCESS && response_code == RESPONSE_CODE_SUCCESS
+/// The RepeatPayment counterpart of [`resolve_auto_capture`]. A merchant-initiated
+/// transaction is still a purchase or an auth-only message, chosen the same way.
+pub(super) fn resolve_repeat_auto_capture<
+    T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
+>(
+    request: &RepeatPaymentData<T>,
+) -> Result<bool, error_stack::Report<errors::IntegrationError>> {
+    reject_unsupported_capture_method(request.capture_method)?;
+    Ok(request.is_auto_capture())
+}
+
+/// `ManualMultiple` and `Scheduled` have no RAFT endpoint. Rejecting them here keeps
+/// `is_auto_capture()` — which reports both as "not automatic" — from silently routing
+/// them onto the auth-only path.
+fn reject_unsupported_capture_method(
+    capture_method: Option<common_enums::CaptureMethod>,
+) -> Result<(), error_stack::Report<errors::IntegrationError>> {
+    match capture_method {
+        Some(common_enums::CaptureMethod::ManualMultiple)
+        | Some(common_enums::CaptureMethod::Scheduled) => Err(error_stack::report!(
+            errors::IntegrationError::CaptureMethodNotSupported {
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(format!(
+                        "Worldpay RAFT expresses capture mode by endpoint choice and has no \
+                         endpoint for capture_method {capture_method:?}; only Automatic, \
+                         SequentialAutomatic and Manual are supported"
+                    )),
+                    ..Default::default()
+                },
+            }
+        )),
+        Some(common_enums::CaptureMethod::Automatic)
+        | Some(common_enums::CaptureMethod::SequentialAutomatic)
+        | Some(common_enums::CaptureMethod::Manual)
+        | None => Ok(()),
+    }
 }
 
 // =============================================================================
-// SHARED STRUCTS
+// COMPOSITE CONNECTOR TRANSACTION ID
+// =============================================================================
+
+/// Everything a follow-up message (capture, refund, reversal) needs in order to be matched
+/// back to its original transaction by Worldpay.
+///
+/// **Why this is packed into `connector_transaction_id` rather than `connector_metadata`:**
+/// RAFT matches follow-ups on the *request-side* `APITransactionID` that the acquirer sent
+/// on the original message — not on anything Worldpay mints — and it additionally requires
+/// the original `LocalDateTime` and, for `creditcompletion`, the originally authorized
+/// amount as `PreauthorizedAmount`. `PaymentsCaptureData` and `RefundsData` carry no
+/// `connector_metadata` field, so `connector_transaction_id` is the only channel that
+/// reaches a follow-up flow. The same record is *also* published on the authorize response
+/// as structured `connector_metadata` for observability and webhook correlation.
+///
+/// Wire format (six `|`-separated segments, none of which can contain `|`):
+/// `{C|D}|{APITransactionID}|{LocalDateTime}|{authorized minor amount}|{AuthorizationNumber}|{RetrievalREFNumber}`
+#[derive(Debug, Clone)]
+pub(super) struct WorldpayraftTransactionReference {
+    /// Routes the follow-up to `/debit/*` instead of `/credit/*`.
+    pub is_debit: bool,
+    /// The `APITransactionID` **sent** on the original message; replayed verbatim.
+    pub api_transaction_id: String,
+    /// The merchant-local timestamp recorded for the original message and replayed on
+    /// every follow-up.
+    ///
+    /// RAFT does not echo `LocalDateTime`, and `RouterDataV2` does not carry the serialized
+    /// request into the response transformer, so this is regenerated when the original
+    /// response is handled — one round trip after the value that actually went on the wire.
+    /// `APITransactionID` is the primary matching key; `LocalDateTime` is secondary.
+    pub local_date_time: String,
+    /// The originally authorized amount in minor units, needed as `PreauthorizedAmount`.
+    /// Empty for operations that carry no amount (tokenization).
+    pub authorized_minor_amount: Option<i64>,
+    /// `ReferenceTraceNumbers.AuthorizationNumber` from the original response — the 6-char
+    /// issuer approval code, used as a secondary matching key.
+    pub authorization_number: Option<String>,
+    /// `ReferenceTraceNumbers.RetrievalREFNumber` from the original response — the
+    /// request-side lifecycle trace id, used as a secondary matching key.
+    pub retrieval_ref_number: Option<String>,
+}
+
+impl WorldpayraftTransactionReference {
+    fn encode(&self) -> String {
+        let prefix = if self.is_debit {
+            TXN_TYPE_DEBIT
+        } else {
+            TXN_TYPE_CREDIT
+        };
+        format!(
+            "{}|{}|{}|{}|{}|{}",
+            prefix,
+            self.api_transaction_id,
+            self.local_date_time,
+            self.authorized_minor_amount
+                .map(|amount| amount.to_string())
+                .unwrap_or_default(),
+            self.authorization_number.as_deref().unwrap_or_default(),
+            self.retrieval_ref_number.as_deref().unwrap_or_default(),
+        )
+    }
+
+    pub(super) fn parse(raw: &str) -> Result<Self, error_stack::Report<errors::IntegrationError>> {
+        let invalid = || {
+            error_stack::report!(errors::IntegrationError::InvalidDataFormat {
+                field_name: "connector_transaction_id",
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(format!(
+                        "Worldpay RAFT expects the composite reference \
+                         '[C|D]|APITransactionID|LocalDateTime|authorized_minor_amount|\
+                         AuthorizationNumber|RetrievalREFNumber', got {raw:?}"
+                    )),
+                    ..Default::default()
+                },
+            })
+        };
+
+        let segments: Vec<&str> = raw.splitn(TXN_REFERENCE_SEGMENTS, '|').collect();
+        if segments.len() != TXN_REFERENCE_SEGMENTS {
+            return Err(invalid());
+        }
+        let is_debit = match segments[0] {
+            TXN_TYPE_DEBIT => true,
+            TXN_TYPE_CREDIT => false,
+            _ => return Err(invalid()),
+        };
+        if segments[1].is_empty() || segments[2].is_empty() {
+            return Err(invalid());
+        }
+        let authorized_minor_amount = match segments[3] {
+            "" => None,
+            amount => Some(amount.parse::<i64>().map_err(|_| invalid())?),
+        };
+
+        Ok(Self {
+            is_debit,
+            api_transaction_id: segments[1].to_string(),
+            local_date_time: segments[2].to_string(),
+            authorized_minor_amount,
+            authorization_number: non_empty(segments[4]),
+            retrieval_ref_number: non_empty(segments[5]),
+        })
+    }
+
+    /// The request-side `ReferenceTraceNumbers` for a follow-up message. Only real values
+    /// received from Worldpay are replayed; `None` when neither is known, so the object is
+    /// omitted rather than sent with empty strings.
+    fn follow_up_trace_numbers(&self) -> Option<WorldpayraftRequestTraceNumbers> {
+        if self.authorization_number.is_none() && self.retrieval_ref_number.is_none() {
+            return None;
+        }
+        Some(WorldpayraftRequestTraceNumbers {
+            retrieval_ref_number: self.retrieval_ref_number.clone(),
+            authorization_number: self.authorization_number.clone(),
+            economically_related_link_id: None,
+        })
+    }
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+// =============================================================================
+// SHARED REQUEST STRUCTS
 // =============================================================================
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftAmounts {
-    pub transaction_amount: common_utils::types::StringMajorUnit,
+    /// `MiscAmountsBalances.TransactionAmount` — required on every financial operation.
+    pub transaction_amount: StringMajorUnit,
+    /// `MiscAmountsBalances.PreauthorizedAmount` — the amount the original authorization
+    /// was approved for. **Required** on `creditcompletion` / `debitcompletion`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preauthorized_amount: Option<StringMajorUnit>,
 }
 
 #[derive(Debug, Serialize)]
@@ -189,12 +660,26 @@ pub struct WorldpayraftCardInfo<
     pub expiration_date: Secret<String>,
 }
 
+/// `CardInfo` for flows that carry an already-materialised PAN or network token string
+/// rather than a generic `RawCardNumber<T>`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftPlainCardInfo {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "PAN")]
+    pub pan: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_date: Option<Secret<String>>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct WorldpayraftCardVerificationData {
+    /// `CardVerificationData.Cvv2Cvc2CIDIndicator` — presence indicator (`1` = present).
     #[serde(rename = "Cvv2Cvc2CIDIndicator")]
-    pub cvv_indicator: String,
-    #[serde(rename = "CVV2CVC2")]
-    pub cvv2_cvc2: Secret<String>,
+    pub cvv_indicator: WorldpayraftCvvIndicator,
+    /// `CardVerificationData.Cvv2Cvc2CIDValue` — the security code itself, `maxLength: 4`.
+    /// (There is no field named `CVV2CVC2` anywhere in the Native RAFT specifications.)
+    #[serde(rename = "Cvv2Cvc2CIDValue")]
+    pub cvv2_cvc2_cid_value: Secret<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -212,6 +697,10 @@ pub struct WorldpayraftTerminalData {
     #[serde(rename = "POSConditionCode")]
     pub pos_condition_code: String,
     pub terminal_entry_cap: String,
+    /// `TerminalData.POSEnvironment` — stored-credential indicator. Request-only and
+    /// credit-only; omitted for one-off payments and for every `/debit/*` endpoint.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "POSEnvironment")]
+    pub pos_environment: Option<WorldpayraftPosEnvironment>,
 }
 
 #[derive(Debug, Serialize)]
@@ -220,17 +709,563 @@ pub struct WorldpayraftEcommerceData {
     pub ecommerce_indicator: String,
 }
 
+/// Request-side `ReferenceTraceNumbers`.
+///
+/// `SystemTraceNumber` is deliberately absent: the spec declares it response-only
+/// ("This value will be generated by Worldpay") and it is not in the request schema of any
+/// credit or debit operation.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftRequestTraceNumbers {
-    pub system_trace_number: String,
+    /// `RetrievalREFNumber` — merchant-generated lifecycle id, `maxLength: 12`. Worldpay
+    /// generates one when the acquirer omits it, so it is only sent on a follow-up, where
+    /// the value received on the original response is replayed.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "RetrievalREFNumber")]
+    pub retrieval_ref_number: Option<String>,
+    /// `AuthorizationNumber` — the 6-char **issuer approval code** from the original
+    /// response. Never a connector transaction id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_number: Option<String>,
+    /// `EconomicallyRelatedLinkID` — request only, `maxLength: 36`. Carries the
+    /// Mastercard/Maestro `TransactionLinkID` received on the original CIT so the network
+    /// can tie a subsequent merchant-initiated transaction back to it.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "EconomicallyRelatedLinkID"
+    )]
+    pub economically_related_link_id: Option<String>,
+}
+
+/// Request-side `ProcFlagsIndicators` — only the members this connector sets.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftProcFlagsIndicators {
+    /// `MastercardAdviceCodeIndicator` — opt-in for
+    /// `McrdSpecificData.MastercardMerchantAdviceCode`. Without it the advice code is
+    /// never returned. Credit-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mastercard_advice_code_indicator: Option<WorldpayraftFlag>,
+    /// `CardholderInitiatedTransaction` — the CIT that establishes a stored credential.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cardholder_initiated_transaction: Option<WorldpayraftFlag>,
+    /// `MerchantInitiatedTransaction` — required on every MIT.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant_initiated_transaction: Option<WorldpayraftFlag>,
+    /// `RecurringBillPay` — the transaction is a recurring bill payment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurring_bill_pay: Option<WorldpayraftFlag>,
+}
+
+/// Request-side `VisaSpecificData` — the NTID echo on a subsequent MIT.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftVisaRequestData {
+    /// `VisaTransactionId`, `maxLength: 15` — the reference number assigned by Visa on the
+    /// original CIT.
+    #[serde(rename = "VisaTransactionId")]
+    pub visa_transaction_id: String,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "VisaSubsequentTransactionReasonCode"
+    )]
+    pub visa_subsequent_transaction_reason_code:
+        Option<WorldpayraftSubsequentTransactionReasonCode>,
+}
+
+/// Request-side `McrdSpecificData` — the NTID echo on a subsequent MIT.
+///
+/// Mastercard requires **both** Banknet fields; the reference number alone is not enough.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftMcrdRequestData {
+    /// `McrdBanknetREFNUM`, `maxLength: 9`. The all-uppercase `REFNUM` is the spec spelling.
+    #[serde(rename = "McrdBanknetREFNUM")]
+    pub mcrd_banknet_refnum: String,
+    /// `McrdBanknetSettleDate`, `maxLength: 4`, `MMDD`.
+    #[serde(rename = "McrdBanknetSettleDate")]
+    pub mcrd_banknet_settle_date: String,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "McrdSubsequentTransactionReasonCode"
+    )]
+    pub mcrd_subsequent_transaction_reason_code:
+        Option<WorldpayraftSubsequentTransactionReasonCode>,
+}
+
+/// Request-side `AmexSpecificData` — the NTID echo on a subsequent MIT.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftAmexRequestData {
+    /// `AmexTransactionId`, `maxLength: 15`.
+    #[serde(rename = "AmexTransactionId")]
+    pub amex_transaction_id: String,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "AmexSubsequentTransactionReasonCode"
+    )]
+    pub amex_subsequent_transaction_reason_code:
+        Option<WorldpayraftSubsequentTransactionReasonCode>,
+}
+
+/// Request-side `DiscSpecificData` — the NTID echo on a subsequent MIT.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftDiscRequestData {
+    /// `DiscTransactionId`, `maxLength: 15`.
+    #[serde(rename = "DiscTransactionId")]
+    pub disc_transaction_id: String,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "DiscSubsequentTransactionReasonCode"
+    )]
+    pub disc_subsequent_transaction_reason_code:
+        Option<WorldpayraftSubsequentTransactionReasonCode>,
+}
+
+/// The per-brand `*SpecificData` blocks that carry the network transaction id on a
+/// subsequent merchant-initiated transaction. Exactly one is populated.
+#[derive(Debug, Default, Serialize)]
+pub struct WorldpayraftBrandRequestData {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "VisaSpecificData")]
+    pub visa_specific_data: Option<WorldpayraftVisaRequestData>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "McrdSpecificData")]
+    pub mcrd_specific_data: Option<WorldpayraftMcrdRequestData>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "AmexSpecificData")]
+    pub amex_specific_data: Option<WorldpayraftAmexRequestData>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "DiscSpecificData")]
+    pub disc_specific_data: Option<WorldpayraftDiscRequestData>,
+}
+
+/// `EncryptionTokenData` on a request — carries a stored Worldpay token.
+#[derive(Debug, Serialize)]
+pub struct WorldpayraftEncryptionTokenRequestData {
+    /// `TokenizedPAN` — a Worldpay token goes here, **not** in `CardInfo.PAN`.
+    #[serde(rename = "TokenizedPAN")]
+    pub tokenized_pan: Secret<String>,
+}
+
+// =============================================================================
+// SHARED RESPONSE STRUCTS
+// =============================================================================
+
+/// `ErrorInformation` — present when `ReturnCode` is a non-zero (edit/logic) error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftErrorInformation {
+    /// `FieldInError` — the field flagged in error during transaction processing.
+    pub field_in_error: Option<String>,
+    /// `ErrorText` — the portion of the field data detected as being in error.
+    pub error_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftResponseTraceNumbers {
+    /// `AuthorizationNumber` — 6-char issuer approval code.
+    pub authorization_number: Option<String>,
+    #[serde(rename = "RetrievalREFNumber")]
+    pub retrieval_ref_number: Option<String>,
+    /// `SystemTraceNumber` — Worldpay-generated, response only. Persisted for reporting
+    /// and webhook correlation; never echoed on a request.
+    pub system_trace_number: Option<String>,
+    /// `NetworkTraceNumber` — the trace number used between Worldpay and the network.
+    pub network_trace_number: Option<String>,
+    /// `NetworkRefNumber` — the retrieval reference number used between Worldpay and the
+    /// network.
+    pub network_ref_number: Option<String>,
+    /// `TransactionLinkID` — Mastercard/Maestro lifecycle id.
+    #[serde(rename = "TransactionLinkID")]
+    pub transaction_link_id: Option<String>,
+    /// `PaymentAcctREFNumber` — the PAR (Payment Account Reference).
+    #[serde(rename = "PaymentAcctREFNumber")]
+    pub payment_acct_ref_number: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftResponseAmounts {
+    /// `OriginalAuthAmount` — on a partial approval (`ResponseCode 010`) this is the amount
+    /// actually authorized.
+    pub original_auth_amount: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftVisaResponseData {
+    /// `VisaTransactionId` — Visa's network transaction id.
+    #[serde(rename = "VisaTransactionId")]
+    pub visa_transaction_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftMcrdResponseData {
+    /// `McrdBanknetREFNUM` — Mastercard Banknet Reference Number.
+    #[serde(rename = "McrdBanknetREFNUM")]
+    pub mcrd_banknet_refnum: Option<String>,
+    /// `McrdBanknetSettleDate` — Mastercard settlement date, `MMDD`.
+    #[serde(rename = "McrdBanknetSettleDate")]
+    pub mcrd_banknet_settle_date: Option<String>,
+    /// `MastercardMerchantAdviceCode` — DE48 SE84 merchant advice code. Response-only,
+    /// Mastercard-only, credit-only, and returned **only** when the request carried
+    /// `ProcFlagsIndicators.MastercardAdviceCodeIndicator = "Y"`.
+    #[serde(rename = "MastercardMerchantAdviceCode")]
+    pub mastercard_merchant_advice_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftAmexResponseData {
+    /// `AmexTransactionId` — American Express network transaction id.
+    #[serde(rename = "AmexTransactionId")]
+    pub amex_transaction_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftDiscResponseData {
+    /// `DiscTransactionId` — Discover reference number.
+    #[serde(rename = "DiscTransactionId")]
+    pub disc_transaction_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftEncryptionTokenData {
+    #[serde(rename = "TokenizedPAN")]
+    pub tokenized_pan: Option<String>,
+    #[serde(rename = "PAN-Last4")]
+    pub pan_last4: Option<String>,
+}
+
+/// The body of any Native RAFT financial or tokenization response.
+///
+/// Every RAFT response is wrapped in a single operation key (`creditauthresponse`,
+/// `creditpurchaseresponse`, …) and the payloads are structurally identical supersets of
+/// one another, so one struct serves every flow. Only `ReturnCode` is required by the
+/// spec; everything else — `ResponseCode` included — can be absent when the message was
+/// rejected before it reached the issuer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WorldpayraftResponseInner {
+    /// `ReturnCode` — operation level. Any non-`0000` value means the message failed.
+    pub return_code: String,
+    /// `ReasonCode` — an opaque internal pinpoint code with no published enumeration.
+    /// Never surfaced as the merchant-facing message.
+    pub reason_code: Option<String>,
+    /// `ResponseCode` — issuer / decision level. Absent when `ReturnCode != "0000"`.
+    pub response_code: Option<String>,
+    /// `ReturnText` — the human-readable failure description. Present only when
+    /// `ReturnCode` is non-zero.
+    pub return_text: Option<String>,
+    pub error_information: Option<WorldpayraftErrorInformation>,
+    pub reference_trace_numbers: Option<WorldpayraftResponseTraceNumbers>,
+    pub misc_amounts_balances: Option<WorldpayraftResponseAmounts>,
+    #[serde(rename = "VisaSpecificData")]
+    pub visa_specific_data: Option<WorldpayraftVisaResponseData>,
+    #[serde(rename = "McrdSpecificData")]
+    pub mcrd_specific_data: Option<WorldpayraftMcrdResponseData>,
+    #[serde(rename = "AmexSpecificData")]
+    pub amex_specific_data: Option<WorldpayraftAmexResponseData>,
+    #[serde(rename = "DiscSpecificData")]
+    pub disc_specific_data: Option<WorldpayraftDiscResponseData>,
+    pub encryption_token_data: Option<WorldpayraftEncryptionTokenData>,
+    /// `APITransactionID` — echoed back, left zero-padded to 16 characters.
+    #[serde(rename = "APITransactionID")]
+    pub api_transaction_id: Option<String>,
+}
+
+impl WorldpayraftResponseInner {
+    /// `ReturnCode == "0000"` AND `ResponseCode` is an approval (`000`, or `010` partial).
+    fn is_success(&self) -> bool {
+        self.return_code == RETURN_CODE_SUCCESS
+            && matches!(
+                self.response_code.as_deref(),
+                Some(RESPONSE_CODE_APPROVED) | Some(RESPONSE_CODE_PARTIAL_APPROVAL)
+            )
+    }
+
+    /// `ErrorResponse.code`: the issuer decision code when the message reached the issuer,
+    /// otherwise the operation-level `ReturnCode`.
+    fn error_code(&self) -> String {
+        self.response_code
+            .as_deref()
+            .filter(|code| !code.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                if self.return_code.is_empty() {
+                    consts::NO_ERROR_CODE.to_string()
+                } else {
+                    self.return_code.clone()
+                }
+            })
+    }
+
+    /// `ErrorResponse.message` / `network_error_message`: `ReturnText` when Worldpay sent
+    /// one, otherwise the published meaning of the code that failed. `ReasonCode` is never
+    /// used here — it has no published enumeration.
+    fn error_message(&self) -> String {
+        self.return_text
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.response_code
+                    .as_deref()
+                    .and_then(response_code_meaning)
+                    .map(str::to_string)
+            })
+            .or_else(|| return_code_meaning(&self.return_code).map(str::to_string))
+            .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string())
+    }
+
+    /// `ErrorResponse.reason`: the `ErrorInformation` pair when present — that is the only
+    /// field that pinpoints the offending request data — else the opaque `ReasonCode`.
+    fn error_reason(&self) -> Option<String> {
+        match self.error_information.as_ref() {
+            Some(info) => match (info.field_in_error.as_deref(), info.error_text.as_deref()) {
+                (Some(field), Some(text)) => Some(format!("{field}: {text}")),
+                (Some(field), None) => Some(field.to_string()),
+                (None, Some(text)) => Some(text.to_string()),
+                (None, None) => self.reason_code.clone(),
+            },
+            None => self.reason_code.clone(),
+        }
+    }
+
+    /// `McrdSpecificData.MastercardMerchantAdviceCode` — the Mastercard retry advice code.
+    fn network_advice_code(&self) -> Option<String> {
+        self.mcrd_specific_data
+            .as_ref()
+            .and_then(|mcrd| mcrd.mastercard_merchant_advice_code.clone())
+    }
+
+    /// The network transaction id for a future MIT, in brand precedence order
+    /// (Visa → Mastercard → Amex → Discover).
+    ///
+    /// Mastercard is the exception to "one id": a subsequent MIT must echo **both**
+    /// `McrdBanknetREFNUM` and `McrdBanknetSettleDate`, and `network_txn_id` is a single
+    /// string. The two are therefore joined as `<McrdBanknetREFNUM>:<McrdBanknetSettleDate>`
+    /// and split apart again when the MIT request is built. Both also appear separately in
+    /// `connector_metadata`.
+    fn network_transaction_id(&self) -> Option<String> {
+        self.visa_specific_data
+            .as_ref()
+            .and_then(|visa| visa.visa_transaction_id.clone())
+            .or_else(|| {
+                self.mcrd_specific_data.as_ref().and_then(|mcrd| {
+                    match (
+                        mcrd.mcrd_banknet_refnum.as_deref(),
+                        mcrd.mcrd_banknet_settle_date.as_deref(),
+                    ) {
+                        (Some(refnum), Some(settle_date)) => {
+                            Some(format!("{refnum}{MCRD_NTID_SEPARATOR}{settle_date}"))
+                        }
+                        // A Banknet reference number without its settlement date cannot be
+                        // replayed on a Mastercard MIT, so it is not offered as an NTID.
+                        (Some(_), None) | (None, Some(_)) | (None, None) => None,
+                    }
+                })
+            })
+            .or_else(|| {
+                self.amex_specific_data
+                    .as_ref()
+                    .and_then(|amex| amex.amex_transaction_id.clone())
+            })
+            .or_else(|| {
+                self.disc_specific_data
+                    .as_ref()
+                    .and_then(|disc| disc.disc_transaction_id.clone())
+            })
+    }
+
+    /// `ReferenceTraceNumbers.TransactionLinkID` — the Mastercard/Maestro lifecycle id.
+    fn transaction_link_id(&self) -> Option<String> {
+        self.reference_trace_numbers
+            .as_ref()
+            .and_then(|trace| trace.transaction_link_id.clone())
+    }
+
+    /// `ReferenceTraceNumbers.PaymentAcctREFNumber` — the PAR.
+    fn payment_account_reference(&self) -> Option<String> {
+        self.reference_trace_numbers
+            .as_ref()
+            .and_then(|trace| trace.payment_acct_ref_number.clone())
+    }
+
+    /// The terminal `AttemptStatus` for a declined payment-side message.
+    ///
+    /// `terminal` is the flow-appropriate hard-failure status; two `ResponseCode`s are
+    /// explicitly non-terminal and override it.
+    fn payment_decline_status(&self, terminal: AttemptStatus) -> AttemptStatus {
+        if self.return_code != RETURN_CODE_SUCCESS {
+            // The message was rejected before the issuer saw it: correctable and terminal
+            // for this attempt.
+            return terminal;
+        }
+        match self.response_code.as_deref() {
+            Some(RESPONSE_CODE_HONOR_WITH_ID) => AttemptStatus::AuthenticationPending,
+            Some(RESPONSE_CODE_REQUEST_IN_PROGRESS) => AttemptStatus::Pending,
+            _ => terminal,
+        }
+    }
+
+    /// The terminal `RefundStatus` for a declined refund message.
+    fn refund_decline_status(&self) -> RefundStatus {
+        if self.return_code == RETURN_CODE_SUCCESS
+            && self.response_code.as_deref() == Some(RESPONSE_CODE_REQUEST_IN_PROGRESS)
+        {
+            RefundStatus::Pending
+        } else {
+            RefundStatus::Failure
+        }
+    }
+
+    /// Build the `ErrorResponse` for a body-level decline. RAFT answers HTTP 200 for
+    /// approvals, declines and validation errors alike, so this — not
+    /// `build_error_response` — is where every payment failure is surfaced.
+    fn to_error_response(&self, status_code: u16, attempt_status: FlowStatus) -> ErrorResponse {
+        ErrorResponse {
+            status_code,
+            code: self.error_code(),
+            message: self.error_message(),
+            reason: self.error_reason(),
+            attempt_status: Some(attempt_status),
+            connector_transaction_id: self.api_transaction_id.clone(),
+            // The issuer decision code is the closest thing RAFT publishes to a raw
+            // network decline code.
+            network_decline_code: self.response_code.clone(),
+            network_advice_code: self.network_advice_code(),
+            network_error_message: Some(self.error_message()),
+            ..Default::default()
+        }
+    }
+
+    /// The structured record of everything worth persisting from this response, published
+    /// as `connector_metadata` for observability, reconciliation and webhook correlation.
+    fn to_connector_metadata(
+        &self,
+        reference: &WorldpayraftTransactionReference,
+    ) -> serde_json::Value {
+        let trace = self.reference_trace_numbers.as_ref();
+        serde_json::json!({
+            "api_transaction_id": reference.api_transaction_id,
+            "local_date_time": reference.local_date_time,
+            "is_debit": reference.is_debit,
+            "authorized_minor_amount": reference.authorized_minor_amount,
+            "authorization_number": reference.authorization_number,
+            "retrieval_ref_number": reference.retrieval_ref_number,
+            "system_trace_number": trace.and_then(|t| t.system_trace_number.clone()),
+            "network_trace_number": trace.and_then(|t| t.network_trace_number.clone()),
+            "network_ref_number": trace.and_then(|t| t.network_ref_number.clone()),
+            "transaction_link_id": self.transaction_link_id(),
+            "payment_acct_ref_number": self.payment_account_reference(),
+            "visa_transaction_id": self.visa_specific_data.as_ref()
+                .and_then(|v| v.visa_transaction_id.clone()),
+            "mcrd_banknet_ref_num": self.mcrd_specific_data.as_ref()
+                .and_then(|m| m.mcrd_banknet_refnum.clone()),
+            "mcrd_banknet_settle_date": self.mcrd_specific_data.as_ref()
+                .and_then(|m| m.mcrd_banknet_settle_date.clone()),
+            "amex_transaction_id": self.amex_specific_data.as_ref()
+                .and_then(|a| a.amex_transaction_id.clone()),
+            "disc_transaction_id": self.disc_specific_data.as_ref()
+                .and_then(|d| d.disc_transaction_id.clone()),
+        })
+    }
+
+    /// Rebuild the composite reference from the values that were **sent** plus the trace
+    /// numbers Worldpay returned.
+    fn to_transaction_reference(
+        &self,
+        is_debit: bool,
+        api_transaction_id: String,
+        local_date_time: String,
+        authorized_minor_amount: Option<i64>,
+    ) -> WorldpayraftTransactionReference {
+        let trace = self.reference_trace_numbers.as_ref();
+        WorldpayraftTransactionReference {
+            is_debit,
+            api_transaction_id,
+            local_date_time,
+            authorized_minor_amount,
+            authorization_number: trace
+                .and_then(|t| t.authorization_number.clone())
+                .and_then(|value| non_empty(value.trim())),
+            retrieval_ref_number: trace
+                .and_then(|t| t.retrieval_ref_number.clone())
+                .and_then(|value| non_empty(value.trim())),
+        }
+    }
+}
+
+// =============================================================================
+// TRANSPORT-LEVEL ERROR RESPONSE
+// =============================================================================
+
+/// `{"fault": {...}}` — the shape RAFT returns for a transport / licence problem.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorldpayraftFault {
+    #[serde(rename = "faultType")]
+    pub fault_type: Option<String>,
+    #[serde(rename = "faultDescription")]
+    pub fault_description: Option<String>,
+}
+
+/// A RAFT error body.
+///
+/// Business failures are wrapped in the operation key (`{"creditauthresponse": {…}}`), so
+/// nothing useful lives at the JSON root — a deserializer that reads `ReturnCode` from the
+/// root fails on every RAFT response. Transport failures use a different, unwrapped shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorldpayraftErrorResponse {
+    Fault {
+        fault: WorldpayraftFault,
+    },
+    /// The single-entry `{"<operation>response": {…}}` envelope, keyed by whichever
+    /// operation was called.
+    Wrapped(std::collections::HashMap<String, WorldpayraftResponseInner>),
+}
+
+impl WorldpayraftErrorResponse {
+    /// Build an `ErrorResponse` from whichever shape came back.
+    ///
+    /// `attempt_status` is never left unset: a 5xx leaves the payment state genuinely
+    /// unknown, so it stays non-terminal, while a 4xx (licence, routing) means the
+    /// transaction never happened.
+    pub fn to_error_response(&self, status_code: u16) -> ErrorResponse {
+        let attempt_status = if status_code >= 500 {
+            FlowStatus::Payment(AttemptStatus::Pending)
+        } else {
+            FlowStatus::Payment(AttemptStatus::Failure)
+        };
+        match self {
+            Self::Wrapped(envelope) => match envelope.values().next() {
+                Some(inner) => inner.to_error_response(status_code, attempt_status),
+                None => ErrorResponse {
+                    status_code,
+                    code: consts::NO_ERROR_CODE.to_string(),
+                    message: consts::NO_ERROR_MESSAGE.to_string(),
+                    reason: Some("Worldpay RAFT returned an empty response envelope".to_string()),
+                    attempt_status: Some(attempt_status),
+                    ..Default::default()
+                },
+            },
+            Self::Fault { fault } => ErrorResponse {
+                status_code,
+                code: fault
+                    .fault_type
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+                message: fault
+                    .fault_description
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+                reason: fault.fault_type.clone(),
+                attempt_status: Some(attempt_status),
+                ..Default::default()
+            },
+        }
+    }
 }
 
 // =============================================================================
 // AUTHORIZE REQUEST
 // =============================================================================
 
-/// Inner fields shared by both creditauth and debitpreauth requests.
+/// Inner fields shared by the four authorize-family operations
+/// (`creditpurchase`, `creditauth`, `debitpurchase`, `debitpreauth`).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftCardAuthInner<
@@ -245,7 +1280,8 @@ pub struct WorldpayraftCardAuthInner<
     pub terminal_data: WorldpayraftTerminalData,
     #[serde(rename = "E-commerceData")]
     pub ecommerce_data: WorldpayraftEcommerceData,
-    pub reference_trace_numbers: WorldpayraftRequestTraceNumbers,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proc_flags_indicators: Option<WorldpayraftProcFlagsIndicators>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     #[serde(rename = "APITransactionID")]
@@ -253,68 +1289,68 @@ pub struct WorldpayraftCardAuthInner<
     pub local_date_time: String,
 }
 
-/// Outer wrapper for authorize requests.
+/// Outer wrapper for authorize requests. The wrapper key names the endpoint:
 ///
-/// Credit cards use `{ "creditauth": { ... } }` → POST /credit/authorization
-/// Debit cards use  `{ "debitpreauth": { ... } }` → POST /debit/preauth
+/// | capture | card   | endpoint                 | wrapper        |
+/// |---------|--------|--------------------------|----------------|
+/// | auto    | credit | `POST /credit/purchase`  | `creditpurchase` |
+/// | manual  | credit | `POST /credit/authorization` | `creditauth` |
+/// | auto    | debit  | `POST /debit/purchase`   | `debitpurchase` |
+/// | manual  | debit  | `POST /debit/preauth`    | `debitpreauth` |
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum WorldpayraftAuthorizeRequest<
     T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize,
 > {
-    Credit {
+    CreditPurchase {
+        creditpurchase: WorldpayraftCardAuthInner<T>,
+    },
+    CreditAuth {
         creditauth: WorldpayraftCardAuthInner<T>,
     },
-    Debit {
+    DebitPurchase {
+        debitpurchase: WorldpayraftCardAuthInner<T>,
+    },
+    DebitPreauth {
         debitpreauth: WorldpayraftCardAuthInner<T>,
     },
 }
 
-// =============================================================================
-// AUTHORIZE RESPONSE
-// =============================================================================
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftResponseTraceNumbers {
-    pub authorization_number: Option<String>,
-    #[serde(rename = "RetrievalREFNumber")]
-    pub retrieval_ref_number: Option<String>,
-    pub system_trace_number: Option<String>,
-    pub network_ref_number: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct WorldpayraftEncryptionTokenData {
-    #[serde(rename = "TokenizedPAN")]
-    pub tokenized_pan: Option<String>,
-    #[serde(rename = "PAN-Last4")]
-    pub pan_last4: Option<String>,
-}
-
-/// Inner fields shared by creditauthresponse and debitpreauthresponse.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftCardAuthResponseInner {
-    pub return_code: String,
-    pub reason_code: Option<String>,
-    pub response_code: String,
-    pub reference_trace_numbers: Option<WorldpayraftResponseTraceNumbers>,
-    #[serde(rename = "APITransactionID")]
-    pub api_transaction_id: Option<String>,
-    pub encryption_token_data: Option<WorldpayraftEncryptionTokenData>,
-}
-
-/// Outer wrapper for authorize responses.
+/// Outer wrapper for authorize responses, one variant per authorize-family endpoint.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorldpayraftAuthorizeResponse {
-    Credit {
-        creditauthresponse: WorldpayraftCardAuthResponseInner,
+    CreditPurchase {
+        creditpurchaseresponse: WorldpayraftResponseInner,
     },
-    Debit {
-        debitpreauthresponse: WorldpayraftCardAuthResponseInner,
+    CreditAuth {
+        creditauthresponse: WorldpayraftResponseInner,
     },
+    DebitPurchase {
+        debitpurchaseresponse: WorldpayraftResponseInner,
+    },
+    DebitPreauth {
+        debitpreauthresponse: WorldpayraftResponseInner,
+    },
+}
+
+impl WorldpayraftAuthorizeResponse {
+    /// `(inner, is_debit, is_auto_capture)` — the wrapper key identifies the endpoint that
+    /// answered, and therefore both the card family and the capture mode.
+    fn parts(&self) -> (&WorldpayraftResponseInner, bool, bool) {
+        match self {
+            Self::CreditPurchase {
+                creditpurchaseresponse,
+            } => (creditpurchaseresponse, false, true),
+            Self::CreditAuth { creditauthresponse } => (creditauthresponse, false, false),
+            Self::DebitPurchase {
+                debitpurchaseresponse,
+            } => (debitpurchaseresponse, true, true),
+            Self::DebitPreauth {
+                debitpreauthresponse,
+            } => (debitpreauthresponse, true, false),
+        }
+    }
 }
 
 // =============================================================================
@@ -348,7 +1384,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
-
         let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
 
         let transaction_amount = item
@@ -380,11 +1415,8 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             }
         };
 
-        let is_debit = card
-            .card_type
-            .as_deref()
-            .map(|t| t.eq_ignore_ascii_case(CARD_TYPE_DEBIT))
-            .unwrap_or(false);
+        let is_debit = is_debit_card(&router_data.request.payment_method_data);
+        let is_auto_capture = resolve_auto_capture(&router_data.request)?;
 
         let expiration_date = card.get_expiry_date_as_yymm().change_context(
             errors::IntegrationError::InvalidDataFormat {
@@ -398,48 +1430,74 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             },
         )?;
 
-        let card_verification_data = {
-            let cvv_str = card.card_cvc.peek();
-            if !cvv_str.is_empty() {
-                Some(WorldpayraftCardVerificationData {
-                    cvv_indicator: CVV_INDICATOR_PRESENT.to_string(),
-                    cvv2_cvc2: card.card_cvc.clone(),
-                })
-            } else {
-                None
-            }
+        // `Cvv2Cvc2CIDIndicator` is a presence indicator: "1" when a value accompanies it.
+        // When no CVC was collected the whole `CardVerificationData` object is omitted.
+        let card_verification_data = if card.card_cvc.peek().is_empty() {
+            None
+        } else {
+            Some(WorldpayraftCardVerificationData {
+                cvv_indicator: WorldpayraftCvvIndicator::Present,
+                cvv2_cvc2_cid_value: card.card_cvc.clone(),
+            })
         };
 
-        // AVS is only sent for credit cards (debit doesn't support it)
+        // AVS is only sent for credit cards (debit does not carry AddressVerificationData).
         let address_verification_data = if is_debit {
             None
         } else {
-            let billing = router_data.resource_common_data.get_optional_billing();
-            if let Some(billing_addr) = billing {
-                let zip = billing_addr.address.as_ref().and_then(|a| a.zip.clone());
-                let address_line = billing_addr.address.as_ref().and_then(|a| a.line1.clone());
-                if zip.is_some() || address_line.is_some() {
-                    Some(WorldpayraftAddressVerificationData {
-                        avs_zip_code: zip,
-                        avs_address: address_line,
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+            router_data
+                .resource_common_data
+                .get_optional_billing()
+                .and_then(|billing| billing.address.as_ref())
+                .and_then(|address| {
+                    let avs_zip_code = address.zip.clone();
+                    let avs_address = address.line1.clone();
+                    if avs_zip_code.is_none() && avs_address.is_none() {
+                        None
+                    } else {
+                        Some(WorldpayraftAddressVerificationData {
+                            avs_zip_code,
+                            avs_address,
+                        })
+                    }
+                })
         };
 
-        let payment_id = &router_data
-            .resource_common_data
-            .connector_request_reference_id;
-        let system_trace_number = derive_system_trace_number(payment_id);
-        let api_transaction_id = truncate_api_transaction_id(payment_id);
-        let local_date_time = get_local_datetime();
+        // `POSEnvironment` is request-only and credit-only. A payment that is establishing
+        // a credential for later merchant-initiated use is flagged as credential-on-file.
+        let is_storing_credential =
+            router_data.request.setup_future_usage == Some(common_enums::FutureUsage::OffSession);
+        let pos_environment = if is_debit || !is_storing_credential {
+            None
+        } else {
+            Some(WorldpayraftPosEnvironment::CredentialOnFile)
+        };
+
+        // `MastercardAdviceCodeIndicator` is what opts this transaction into receiving
+        // `McrdSpecificData.MastercardMerchantAdviceCode` on a decline. Credit only — the
+        // debit spec has no advice code at all.
+        let proc_flags_indicators = if is_debit && !is_storing_credential {
+            None
+        } else {
+            Some(WorldpayraftProcFlagsIndicators {
+                mastercard_advice_code_indicator: (!is_debit).then_some(WorldpayraftFlag::Yes),
+                cardholder_initiated_transaction: is_storing_credential
+                    .then_some(WorldpayraftFlag::Yes),
+                ..Default::default()
+            })
+        };
+
+        let api_transaction_id = truncate_api_transaction_id(
+            &router_data
+                .resource_common_data
+                .connector_request_reference_id,
+        );
 
         let inner = WorldpayraftCardAuthInner {
-            misc_amounts_balances: WorldpayraftAmounts { transaction_amount },
+            misc_amounts_balances: WorldpayraftAmounts {
+                transaction_amount,
+                preauthorized_amount: None,
+            },
             card_info: WorldpayraftCardInfo {
                 pan: card.card_number.clone(),
                 expiration_date,
@@ -450,25 +1508,29 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 entry_mode: ENTRY_MODE_ECOMM.to_string(),
                 pos_condition_code: POS_CONDITION_CODE_ECOMM.to_string(),
                 terminal_entry_cap: TERMINAL_ENTRY_CAP_DEFAULT.to_string(),
+                pos_environment,
             },
             ecommerce_data: WorldpayraftEcommerceData {
-                ecommerce_indicator: ECOMMERCE_INDICATOR_SECURE.to_string(),
+                ecommerce_indicator: ECOMMERCE_INDICATOR_ECOMM_NO_3DS.to_string(),
             },
-            reference_trace_numbers: WorldpayraftRequestTraceNumbers {
-                system_trace_number,
-            },
+            proc_flags_indicators,
             world_pay_merchant_id: auth.merchant_id,
             api_transaction_id,
-            local_date_time,
+            local_date_time: get_local_datetime(),
         };
 
-        if is_debit {
-            Ok(Self::Debit {
+        Ok(match (is_debit, is_auto_capture) {
+            (false, true) => Self::CreditPurchase {
+                creditpurchase: inner,
+            },
+            (false, false) => Self::CreditAuth { creditauth: inner },
+            (true, true) => Self::DebitPurchase {
+                debitpurchase: inner,
+            },
+            (true, false) => Self::DebitPreauth {
                 debitpreauth: inner,
-            })
-        } else {
-            Ok(Self::Credit { creditauth: inner })
-        }
+            },
+        })
     }
 }
 
@@ -485,52 +1547,56 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     fn try_from(
         item: ResponseRouterData<WorldpayraftAuthorizeResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let (is_debit, inner) = match &item.response {
-            WorldpayraftAuthorizeResponse::Credit { creditauthresponse } => {
-                (false, creditauthresponse)
-            }
-            WorldpayraftAuthorizeResponse::Debit {
-                debitpreauthresponse,
-            } => (true, debitpreauthresponse),
-        };
+        let (inner, is_debit, is_auto_capture) = item.response.parts();
 
-        let status = if map_payment_status(&inner.return_code, &inner.response_code) {
+        // Replay-critical values: what UCS *sent*, not what came back, is the matching key.
+        let api_transaction_id = truncate_api_transaction_id(
+            &item
+                .router_data
+                .resource_common_data
+                .connector_request_reference_id,
+        );
+        let authorized_minor_amount = inner
+            .is_success()
+            .then(|| item.router_data.request.minor_amount.get_amount_as_i64());
+
+        if !inner.is_success() {
+            let status = inner.payment_decline_status(AttemptStatus::AuthorizationFailed);
+            return Ok(Self {
+                response: Err(inner.to_error_response(item.http_code, FlowStatus::Payment(status))),
+                resource_common_data: PaymentFlowData {
+                    status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
+
+        let reference = inner.to_transaction_reference(
+            is_debit,
+            api_transaction_id,
+            get_local_datetime(),
+            authorized_minor_amount,
+        );
+        let status = if is_auto_capture {
+            AttemptStatus::Charged
+        } else {
             AttemptStatus::Authorized
-        } else {
-            AttemptStatus::Failure
         };
-
-        // Encode card type prefix so downstream flows can route correctly
-        // Format: "{C|D}|{AuthorizationNumber}|{RetrievalREFNumber}|{SystemTraceNumber}"
-        let prefix = if is_debit {
-            TXN_TYPE_DEBIT
-        } else {
-            TXN_TYPE_CREDIT
-        };
-        let connector_transaction_id = inner
-            .reference_trace_numbers
-            .as_ref()
-            .map(|trace| {
-                let auth_num = trace.authorization_number.as_deref().unwrap_or("");
-                let retrieval_ref = trace.retrieval_ref_number.as_deref().unwrap_or("");
-                let sys_trace = trace.system_trace_number.as_deref().unwrap_or("");
-                format!("{prefix}|{auth_num}|{retrieval_ref}|{sys_trace}")
-            })
-            .unwrap_or_default();
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
+                resource_id: ResponseId::ConnectorTransactionId(reference.encode()),
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
-                network_txn_id: None,
-                network_txn_link_id: None,
+                connector_metadata: Some(inner.to_connector_metadata(&reference)),
+                network_txn_id: inner.network_transaction_id(),
+                network_txn_link_id: inner.transaction_link_id(),
                 connector_response_reference_id: inner.api_transaction_id.clone(),
                 incremental_authorization_allowed: None,
                 splits: None,
                 status_code: item.http_code,
-                payment_account_reference: None,
+                payment_account_reference: inner.payment_account_reference(),
             }),
             resource_common_data: PaymentFlowData {
                 status,
@@ -542,36 +1608,31 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 }
 
 // =============================================================================
-// CAPTURE REQUEST
+// CAPTURE
 // =============================================================================
 
-/// Trace numbers carried in the Capture request body.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftCaptureTraceNumbers {
-    pub authorization_number: String,
-    #[serde(rename = "RetrievalREFNumber")]
-    pub retrieval_ref_number: String,
-    pub system_trace_number: String,
-}
-
-/// Inner fields shared by creditcompletion and debitcompletion requests.
+/// Inner fields for `creditcompletion` / `debitcompletion`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftCompletionInner {
+    /// `MiscAmountsBalances` — `PreauthorizedAmount` is **required** here alongside
+    /// `TransactionAmount`; a completion without it cannot be matched to its preauth.
     pub misc_amounts_balances: WorldpayraftAmounts,
-    pub reference_trace_numbers: WorldpayraftCaptureTraceNumbers,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
+    /// The **original** authorization's `APITransactionID`, replayed verbatim.
     #[serde(rename = "APITransactionID")]
     pub api_transaction_id: String,
+    /// The `LocalDateTime` recorded for the original authorization, replayed here.
     pub local_date_time: String,
 }
 
 /// Outer wrapper for capture requests.
 ///
-/// Credit: `{ "creditcompletion": { ... } }` → POST /credit/completion
-/// Debit:  `{ "debitcompletion": { ... } }` → POST /debit/completion
+/// Credit: `{ "creditcompletion": { … } }` → `POST /credit/completion`
+/// Debit:  `{ "debitcompletion": { … } }` → `POST /debit/completion`
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum WorldpayraftCaptureRequest {
@@ -583,37 +1644,29 @@ pub enum WorldpayraftCaptureRequest {
     },
 }
 
-// =============================================================================
-// CAPTURE RESPONSE
-// =============================================================================
-
-/// Inner fields shared by creditcompletionresponse and debitcompletionresponse.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftCompletionResponseInner {
-    pub return_code: String,
-    pub reason_code: Option<String>,
-    pub response_code: String,
-    pub reference_trace_numbers: Option<WorldpayraftCaptureTraceNumbers>,
-    #[serde(rename = "APITransactionID")]
-    pub api_transaction_id: Option<String>,
-}
-
-/// Outer wrapper for capture responses.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorldpayraftCaptureResponse {
     Credit {
-        creditcompletionresponse: WorldpayraftCompletionResponseInner,
+        creditcompletionresponse: WorldpayraftResponseInner,
     },
     Debit {
-        debitcompletionresponse: WorldpayraftCompletionResponseInner,
+        debitcompletionresponse: WorldpayraftResponseInner,
     },
 }
 
-// =============================================================================
-// TryFrom: RouterDataV2 → WorldpayraftCaptureRequest
-// =============================================================================
+impl WorldpayraftCaptureResponse {
+    fn inner(&self) -> &WorldpayraftResponseInner {
+        match self {
+            Self::Credit {
+                creditcompletionresponse,
+            } => creditcompletionresponse,
+            Self::Debit {
+                debitcompletionresponse,
+            } => debitcompletionresponse,
+        }
+    }
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -632,8 +1685,11 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
-
         let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
+
+        let reference = WorldpayraftTransactionReference::parse(
+            &router_data.request.get_connector_transaction_id()?,
+        )?;
 
         let transaction_amount = item
             .connector
@@ -652,58 +1708,61 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 },
             })?;
 
-        let connector_txn_id = router_data.request.get_connector_transaction_id()?;
-        let (is_debit, auth_num, retrieval_ref, sys_trace) =
-            parse_connector_transaction_id(&connector_txn_id);
-
-        if auth_num.is_empty() && retrieval_ref.is_empty() {
-            return Err(error_stack::report!(
-                errors::IntegrationError::InvalidDataFormat {
-                    field_name: "connector_transaction_id",
-                    context: errors::IntegrationErrorContext {
-                        additional_context: Some(format!(
-                            "Expected format: [C|D]|AuthorizationNumber|RetrievalREFNumber|SystemTraceNumber, got: {connector_txn_id}"
-                        )),
-                        ..Default::default()
-                    },
-                }
-            ));
-        }
-
-        let api_transaction_id = truncate_api_transaction_id(
-            &router_data
-                .resource_common_data
-                .connector_request_reference_id,
-        );
-        let local_date_time = get_local_datetime();
+        // `PreauthorizedAmount` is what the original authorization was approved for; it is
+        // carried on the composite connector_transaction_id because `PaymentsCaptureData`
+        // has no channel for connector metadata.
+        let authorized_minor_amount = reference.authorized_minor_amount.ok_or_else(|| {
+            error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                field_name: "PreauthorizedAmount",
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(
+                        "The originally authorized amount is required on a Worldpay RAFT \
+                         completion and is not present in the connector transaction reference"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            })
+        })?;
+        let preauthorized_amount = item
+            .connector
+            .amount_converter
+            .convert(
+                MinorUnit::new(authorized_minor_amount),
+                router_data.request.currency,
+            )
+            .change_context(errors::IntegrationError::AmountConversionFailed {
+                context: errors::IntegrationErrorContext {
+                    additional_context: Some(
+                        "Worldpay RAFT requires PreauthorizedAmount in major currency units"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            })?;
 
         let inner = WorldpayraftCompletionInner {
-            misc_amounts_balances: WorldpayraftAmounts { transaction_amount },
-            reference_trace_numbers: WorldpayraftCaptureTraceNumbers {
-                authorization_number: auth_num.to_string(),
-                retrieval_ref_number: retrieval_ref.to_string(),
-                system_trace_number: sys_trace.to_string(),
+            misc_amounts_balances: WorldpayraftAmounts {
+                transaction_amount,
+                preauthorized_amount: Some(preauthorized_amount),
             },
+            reference_trace_numbers: reference.follow_up_trace_numbers(),
             world_pay_merchant_id: auth.merchant_id,
-            api_transaction_id,
-            local_date_time,
+            api_transaction_id: reference.api_transaction_id.clone(),
+            local_date_time: reference.local_date_time.clone(),
         };
 
-        if is_debit {
-            Ok(Self::Debit {
+        Ok(if reference.is_debit {
+            Self::Debit {
                 debitcompletion: inner,
-            })
+            }
         } else {
-            Ok(Self::Credit {
+            Self::Credit {
                 creditcompletion: inner,
-            })
-        }
+            }
+        })
     }
 }
-
-// =============================================================================
-// TryFrom: WorldpayraftCaptureResponse → RouterDataV2
-// =============================================================================
 
 impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
     for RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>
@@ -713,27 +1772,37 @@ impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
     fn try_from(
         item: ResponseRouterData<WorldpayraftCaptureResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let inner = match &item.response {
-            WorldpayraftCaptureResponse::Credit {
-                creditcompletionresponse,
-            } => creditcompletionresponse,
-            WorldpayraftCaptureResponse::Debit {
-                debitcompletionresponse,
-            } => debitcompletionresponse,
-        };
+        let inner = item.response.inner();
 
-        let status = if map_payment_status(&inner.return_code, &inner.response_code) {
-            AttemptStatus::Charged
-        } else {
-            AttemptStatus::Failure
-        };
+        if !inner.is_success() {
+            let status = inner.payment_decline_status(AttemptStatus::CaptureFailed);
+            return Ok(Self {
+                response: Err(inner.to_error_response(item.http_code, FlowStatus::Payment(status))),
+                resource_common_data: PaymentFlowData {
+                    status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
 
-        // Preserve the original composite connector_transaction_id from the Authorize flow
-        // so downstream flows (refund) can still use the stored trace numbers.
-        let connector_transaction_id = match &item.router_data.request.connector_transaction_id {
-            ResponseId::ConnectorTransactionId(txn_id) => txn_id.clone(),
-            _ => String::new(),
-        };
+        // Preserve the composite reference from the authorize leg so a later refund still
+        // has the original APITransactionID, LocalDateTime and trace numbers.
+        let connector_transaction_id = item
+            .router_data
+            .request
+            .get_connector_transaction_id()
+            .change_context(errors::ConnectorError::ResponseHandlingFailed {
+                context: errors::ResponseTransformationErrorContext {
+                    http_status_code: Some(item.http_code),
+                    additional_context: Some(
+                        "Worldpay RAFT completion succeeded but the originating connector \
+                         transaction reference is no longer available"
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
+            })?;
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
@@ -741,16 +1810,16 @@ impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
-                network_txn_id: None,
-                network_txn_link_id: None,
+                network_txn_id: inner.network_transaction_id(),
+                network_txn_link_id: inner.transaction_link_id(),
                 connector_response_reference_id: inner.api_transaction_id.clone(),
                 incremental_authorization_allowed: None,
                 splits: None,
                 status_code: item.http_code,
-                payment_account_reference: None,
+                payment_account_reference: inner.payment_account_reference(),
             }),
             resource_common_data: PaymentFlowData {
-                status,
+                status: AttemptStatus::Charged,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -759,36 +1828,26 @@ impl TryFrom<ResponseRouterData<WorldpayraftCaptureResponse, Self>>
 }
 
 // =============================================================================
-// REFUND REQUEST
+// REFUND
 // =============================================================================
 
-/// Trace numbers carried in the Refund request body.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRefundTraceNumbers {
-    pub authorization_number: String,
-    #[serde(rename = "RetrievalREFNumber")]
-    pub retrieval_ref_number: String,
-    pub system_trace_number: String,
-}
-
-/// Inner fields shared by creditrefund and debitrefund requests.
+/// Inner fields for `creditrefund` / `debitrefund`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftRefundInner {
     pub misc_amounts_balances: WorldpayraftAmounts,
-    pub reference_trace_numbers: WorldpayraftRefundTraceNumbers,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
+    /// The **original** payment's `APITransactionID`, replayed so Worldpay can match the
+    /// refund back to it.
     #[serde(rename = "APITransactionID")]
     pub api_transaction_id: String,
+    /// The `LocalDateTime` recorded for the original payment, replayed for the same reason.
     pub local_date_time: String,
 }
 
-/// Outer wrapper for refund requests.
-///
-/// Credit: `{ "creditrefund": { ... } }` → POST /credit/refund
-/// Debit:  `{ "debitrefund": { ... } }` → POST /debit/refund
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum WorldpayraftRefundRequest {
@@ -800,45 +1859,29 @@ pub enum WorldpayraftRefundRequest {
     },
 }
 
-// =============================================================================
-// REFUND RESPONSE
-// =============================================================================
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRefundResponseTraceNumbers {
-    pub authorization_number: Option<String>,
-    #[serde(rename = "RetrievalREFNumber")]
-    pub retrieval_ref_number: Option<String>,
-}
-
-/// Inner fields shared by creditrefundresponse and debitrefundresponse.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRefundResponseInner {
-    pub return_code: String,
-    pub reason_code: Option<String>,
-    pub response_code: String,
-    #[serde(rename = "APITransactionID")]
-    pub api_transaction_id: Option<String>,
-    pub reference_trace_numbers: Option<WorldpayraftRefundResponseTraceNumbers>,
-}
-
-/// Outer wrapper for refund responses.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorldpayraftRefundResponse {
     Credit {
-        creditrefundresponse: WorldpayraftRefundResponseInner,
+        creditrefundresponse: WorldpayraftResponseInner,
     },
     Debit {
-        debitrefundresponse: WorldpayraftRefundResponseInner,
+        debitrefundresponse: WorldpayraftResponseInner,
     },
 }
 
-// =============================================================================
-// TryFrom: RouterDataV2 → WorldpayraftRefundRequest
-// =============================================================================
+impl WorldpayraftRefundResponse {
+    fn inner(&self) -> &WorldpayraftResponseInner {
+        match self {
+            Self::Credit {
+                creditrefundresponse,
+            } => creditrefundresponse,
+            Self::Debit {
+                debitrefundresponse,
+            } => debitrefundresponse,
+        }
+    }
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -857,8 +1900,10 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
-
         let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
+
+        let reference =
+            WorldpayraftTransactionReference::parse(&router_data.request.connector_transaction_id)?;
 
         let transaction_amount = item
             .connector
@@ -877,52 +1922,26 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 },
             })?;
 
-        let connector_txn_id = &router_data.request.connector_transaction_id;
-        let (is_debit, auth_num, retrieval_ref, sys_trace) =
-            parse_connector_transaction_id(connector_txn_id);
-
-        if auth_num.is_empty() && retrieval_ref.is_empty() {
-            return Err(error_stack::report!(
-                errors::IntegrationError::InvalidDataFormat {
-                    field_name: "connector_transaction_id",
-                    context: errors::IntegrationErrorContext {
-                        additional_context: Some(format!(
-                            "Expected format: [C|D]|AuthorizationNumber|RetrievalREFNumber|SystemTraceNumber, got: {connector_txn_id}"
-                        )),
-                        ..Default::default()
-                    },
-                }
-            ));
-        }
-
-        let api_transaction_id = truncate_api_transaction_id(&router_data.request.refund_id);
-        let local_date_time = get_local_datetime();
-
         let inner = WorldpayraftRefundInner {
-            misc_amounts_balances: WorldpayraftAmounts { transaction_amount },
-            reference_trace_numbers: WorldpayraftRefundTraceNumbers {
-                authorization_number: auth_num.to_string(),
-                retrieval_ref_number: retrieval_ref.to_string(),
-                system_trace_number: sys_trace.to_string(),
+            misc_amounts_balances: WorldpayraftAmounts {
+                transaction_amount,
+                preauthorized_amount: None,
             },
+            reference_trace_numbers: reference.follow_up_trace_numbers(),
             world_pay_merchant_id: auth.merchant_id,
-            api_transaction_id,
-            local_date_time,
+            api_transaction_id: reference.api_transaction_id.clone(),
+            local_date_time: reference.local_date_time.clone(),
         };
 
-        if is_debit {
-            Ok(Self::Debit { debitrefund: inner })
+        Ok(if reference.is_debit {
+            Self::Debit { debitrefund: inner }
         } else {
-            Ok(Self::Credit {
+            Self::Credit {
                 creditrefund: inner,
-            })
-        }
+            }
+        })
     }
 }
-
-// =============================================================================
-// TryFrom: WorldpayraftRefundResponse → RouterDataV2
-// =============================================================================
 
 impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
     for RouterDataV2<Refund, RefundFlowData, RefundsData, RefundsResponseData>
@@ -932,41 +1951,55 @@ impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
     fn try_from(
         item: ResponseRouterData<WorldpayraftRefundResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let inner = match &item.response {
-            WorldpayraftRefundResponse::Credit {
-                creditrefundresponse,
-            } => creditrefundresponse,
-            WorldpayraftRefundResponse::Debit {
-                debitrefundresponse,
-            } => debitrefundresponse,
-        };
+        let inner = item.response.inner();
 
-        let refund_status = if inner.return_code == RETURN_CODE_SUCCESS
-            && inner.response_code == RESPONSE_CODE_SUCCESS
-        {
-            RefundStatus::Success
-        } else {
-            RefundStatus::Failure
-        };
+        if !inner.is_success() {
+            let refund_status = inner.refund_decline_status();
+            return Ok(Self {
+                response: Err(
+                    inner.to_error_response(item.http_code, FlowStatus::Refund(refund_status))
+                ),
+                resource_common_data: RefundFlowData {
+                    status: refund_status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
 
-        // connector_refund_id: prefer AuthorizationNumber from response trace numbers,
-        // fall back to APITransactionID
-        let connector_refund_id = inner
-            .reference_trace_numbers
-            .as_ref()
-            .and_then(|t| t.authorization_number.clone())
-            .or_else(|| inner.api_transaction_id.clone())
-            .unwrap_or_default();
+        // The refund is identified by the same composite reference shape as the payment, so
+        // the trace numbers minted for the refund leg travel with it. `AuthorizationNumber`
+        // is deliberately not used as the id: it is a 6-char issuer approval code and is
+        // not unique across transactions.
+        let reference = WorldpayraftTransactionReference::parse(
+            &item.router_data.request.connector_transaction_id,
+        )
+        .change_context(errors::ConnectorError::ResponseHandlingFailed {
+            context: errors::ResponseTransformationErrorContext {
+                http_status_code: Some(item.http_code),
+                additional_context: Some(
+                    "Worldpay RAFT refund could not re-encode its connector transaction reference"
+                        .to_string(),
+                ),
+                ..Default::default()
+            },
+        })?;
+        let refund_reference = inner.to_transaction_reference(
+            reference.is_debit,
+            reference.api_transaction_id.clone(),
+            reference.local_date_time.clone(),
+            reference.authorized_minor_amount,
+        );
 
         Ok(Self {
             response: Ok(RefundsResponseData {
-                connector_refund_id,
-                refund_status,
+                connector_refund_id: refund_reference.encode(),
+                refund_status: RefundStatus::Success,
                 status_code: item.http_code,
                 acquirer_reference_number: None,
             }),
             resource_common_data: RefundFlowData {
-                status: refund_status,
+                status: RefundStatus::Success,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -975,23 +2008,13 @@ impl TryFrom<ResponseRouterData<WorldpayraftRefundResponse, Self>>
 }
 
 // =============================================================================
-// SETUPMANDATE REQUEST
+// SETUP MANDATE (card tokenization)
 // =============================================================================
-// Worldpay RAFT card tokenization endpoint: POST /tokenization/token
-// Stores a card PAN as a TokenizedPAN which is returned as the mandate reference.
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftSetupMandateCardInfo {
-    #[serde(rename = "PAN")]
-    pub pan: Secret<String>,
-    pub expiration_date: Secret<String>,
-}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftSetupMandateInner {
-    pub card_info: WorldpayraftSetupMandateCardInfo,
+    pub card_info: WorldpayraftPlainCardInfo,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     #[serde(rename = "APITransactionID")]
@@ -999,52 +2022,17 @@ pub struct WorldpayraftSetupMandateInner {
     pub local_date_time: String,
 }
 
-/// Wrapper for the tokenize request body.
+/// Wrapper for the `tokenize` request body → `POST /tokenization/token`.
 #[derive(Debug, Serialize)]
 pub struct WorldpayraftSetupMandateRequest {
     pub tokenize: WorldpayraftSetupMandateInner,
 }
 
-// =============================================================================
-// SETUPMANDATE RESPONSE
-// =============================================================================
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct WorldpayraftSetupMandateTokenData {
-    #[serde(rename = "TokenizedPAN")]
-    pub tokenized_pan: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftSetupMandateTraceNumbers {
-    pub authorization_number: Option<String>,
-    #[serde(rename = "RetrievalREFNumber")]
-    pub retrieval_ref_number: Option<String>,
-    pub system_trace_number: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftSetupMandateResponseInner {
-    pub return_code: String,
-    pub reason_code: Option<String>,
-    pub response_code: String,
-    pub encryption_token_data: Option<WorldpayraftSetupMandateTokenData>,
-    pub reference_trace_numbers: Option<WorldpayraftSetupMandateTraceNumbers>,
-    #[serde(rename = "APITransactionID")]
-    pub api_transaction_id: Option<String>,
-}
-
-/// Wrapper for the tokenizeresponse body.
+/// Wrapper for the `tokenizeresponse` body.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WorldpayraftSetupMandateResponse {
-    pub tokenizeresponse: WorldpayraftSetupMandateResponseInner,
+    pub tokenizeresponse: WorldpayraftResponseInner,
 }
-
-// =============================================================================
-// TryFrom: RouterDataV2 → WorldpayraftSetupMandateRequest
-// =============================================================================
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1073,7 +2061,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
-
         let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
 
         let card: &Card<T> = match &router_data.request.payment_method_data {
@@ -1101,31 +2088,23 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
             },
         )?;
 
-        let pan = Secret::new(card.card_number.peek().to_string());
-
-        let payment_id = &router_data
-            .resource_common_data
-            .connector_request_reference_id;
-        let api_transaction_id = truncate_api_transaction_id(payment_id);
-        let local_date_time = get_local_datetime();
-
         Ok(Self {
             tokenize: WorldpayraftSetupMandateInner {
-                card_info: WorldpayraftSetupMandateCardInfo {
-                    pan,
-                    expiration_date,
+                card_info: WorldpayraftPlainCardInfo {
+                    pan: Some(Secret::new(card.card_number.peek().to_string())),
+                    expiration_date: Some(expiration_date),
                 },
                 world_pay_merchant_id: auth.merchant_id,
-                api_transaction_id,
-                local_date_time,
+                api_transaction_id: truncate_api_transaction_id(
+                    &router_data
+                        .resource_common_data
+                        .connector_request_reference_id,
+                ),
+                local_date_time: get_local_datetime(),
             },
         })
     }
 }
-
-// =============================================================================
-// TryFrom: WorldpayraftSetupMandateResponse → RouterDataV2
-// =============================================================================
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<ResponseRouterData<WorldpayraftSetupMandateResponse, Self>>
@@ -1141,57 +2120,73 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     fn try_from(
         item: ResponseRouterData<WorldpayraftSetupMandateResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let response = &item.response.tokenizeresponse;
+        let inner = &item.response.tokenizeresponse;
 
-        let status = if map_payment_status(&response.return_code, &response.response_code) {
-            AttemptStatus::Charged
-        } else {
-            AttemptStatus::Failure
-        };
+        if !inner.is_success() {
+            let status = inner.payment_decline_status(AttemptStatus::Failure);
+            return Ok(Self {
+                response: Err(inner.to_error_response(item.http_code, FlowStatus::Payment(status))),
+                resource_common_data: PaymentFlowData {
+                    status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
 
-        let tokenized_pan = response
+        let tokenized_pan = inner
             .encryption_token_data
             .as_ref()
-            .and_then(|etd| etd.tokenized_pan.clone());
+            .and_then(|token_data| token_data.tokenized_pan.clone())
+            .ok_or_else(|| {
+                error_stack::report!(errors::ConnectorError::ResponseHandlingFailed {
+                    context: errors::ResponseTransformationErrorContext {
+                        http_status_code: Some(item.http_code),
+                        additional_context: Some(
+                            "Worldpay RAFT tokenizeresponse approved but carried no \
+                             EncryptionTokenData.TokenizedPAN to store as the mandate reference"
+                                .to_string(),
+                        ),
+                        ..Default::default()
+                    },
+                })
+            })?;
 
-        let mandate_reference = tokenized_pan.as_ref().map(|pan| {
-            Box::new(MandateReference {
-                connector_mandate_id: Some(pan.clone()),
-                payment_method_id: None,
-                connector_mandate_request_reference_id: None,
-                mandate_metadata: None,
-            })
-        });
-
-        // connector_transaction_id = "C|{AuthorizationNumber}|{RetrievalREFNumber}|{SystemTraceNumber}"
-        // SetupMandate is always treated as a credit-path operation
-        let connector_transaction_id = response
-            .reference_trace_numbers
-            .as_ref()
-            .map(|trace| {
-                let auth_num = trace.authorization_number.as_deref().unwrap_or("");
-                let retrieval_ref = trace.retrieval_ref_number.as_deref().unwrap_or("");
-                let sys_trace = trace.system_trace_number.as_deref().unwrap_or("");
-                format!("{TXN_TYPE_CREDIT}|{auth_num}|{retrieval_ref}|{sys_trace}")
-            })
-            .unwrap_or_default();
+        // Tokenization is always a credit-path operation and carries no amount, so the
+        // composite reference has no PreauthorizedAmount to record.
+        let reference = inner.to_transaction_reference(
+            false,
+            truncate_api_transaction_id(
+                &item
+                    .router_data
+                    .resource_common_data
+                    .connector_request_reference_id,
+            ),
+            get_local_datetime(),
+            None,
+        );
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
+                resource_id: ResponseId::ConnectorTransactionId(reference.encode()),
                 redirection_data: None,
-                mandate_reference,
-                connector_metadata: None,
-                network_txn_id: None,
-                network_txn_link_id: None,
-                connector_response_reference_id: response.api_transaction_id.clone(),
+                mandate_reference: Some(Box::new(MandateReference {
+                    connector_mandate_id: Some(tokenized_pan),
+                    payment_method_id: None,
+                    connector_mandate_request_reference_id: None,
+                    mandate_metadata: None,
+                })),
+                connector_metadata: Some(inner.to_connector_metadata(&reference)),
+                network_txn_id: inner.network_transaction_id(),
+                network_txn_link_id: inner.transaction_link_id(),
+                connector_response_reference_id: inner.api_transaction_id.clone(),
                 incremental_authorization_allowed: None,
                 splits: None,
                 status_code: item.http_code,
-                payment_account_reference: None,
+                payment_account_reference: inner.payment_account_reference(),
             }),
             resource_common_data: PaymentFlowData {
-                status,
+                status: AttemptStatus::Charged,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1200,38 +2195,29 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
 }
 
 // =============================================================================
-// REPEAT PAYMENT REQUEST
+// REPEAT PAYMENT (merchant-initiated transaction)
 // =============================================================================
-// Worldpay RAFT MIT using stored TokenizedPAN via POST /credit/authorization
-// with MIT flags.
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRepeatProcFlags {
-    pub merchant_initiated_transaction: String,
-    pub recurring_bill_pay: Option<String>,
-}
-
-/// CardInfo for RepeatPayment — uses a plain Secret<String> PAN (the stored TokenizedPAN),
-/// not a generic RawCardNumber<T>.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRepeatCardInfo {
-    #[serde(rename = "PAN")]
-    pub pan: Secret<String>,
-    pub expiration_date: Secret<String>,
-}
-
+/// Inner fields for a merchant-initiated `creditauth`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct WorldpayraftRepeatCreditAuth {
     pub misc_amounts_balances: WorldpayraftAmounts,
-    pub card_info: WorldpayraftRepeatCardInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_info: Option<WorldpayraftPlainCardInfo>,
+    /// A stored Worldpay token belongs in `EncryptionTokenData.TokenizedPAN`, not in
+    /// `CardInfo.PAN`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encryption_token_data: Option<WorldpayraftEncryptionTokenRequestData>,
     pub terminal_data: WorldpayraftTerminalData,
     #[serde(rename = "E-commerceData")]
     pub ecommerce_data: WorldpayraftEcommerceData,
-    pub proc_flags_indicators: WorldpayraftRepeatProcFlags,
-    pub reference_trace_numbers: WorldpayraftRequestTraceNumbers,
+    pub proc_flags_indicators: WorldpayraftProcFlagsIndicators,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_trace_numbers: Option<WorldpayraftRequestTraceNumbers>,
+    /// The per-brand `*SpecificData` blocks carrying the network transaction id.
+    #[serde(flatten)]
+    pub brand_data: WorldpayraftBrandRequestData,
     #[serde(rename = "WorldPayMerchantID")]
     pub world_pay_merchant_id: Secret<String>,
     #[serde(rename = "APITransactionID")]
@@ -1239,32 +2225,42 @@ pub struct WorldpayraftRepeatCreditAuth {
     pub local_date_time: String,
 }
 
-/// Wrapper for the creditauth request body (RepeatPayment).
+/// Outer wrapper for the merchant-initiated request. Capture mode picks the endpoint
+/// exactly as it does on Authorize: `POST /credit/purchase` for an auto-captured MIT,
+/// `POST /credit/authorization` for one that will be completed separately.
 #[derive(Debug, Serialize)]
-pub struct WorldpayraftRepeatPaymentRequest {
-    pub creditauth: WorldpayraftRepeatCreditAuth,
-}
-
-/// RepeatPayment response — same outer shape as credit authorize.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WorldpayraftRepeatPaymentResponseInner {
-    pub return_code: String,
-    pub reason_code: Option<String>,
-    pub response_code: String,
-    pub reference_trace_numbers: Option<WorldpayraftResponseTraceNumbers>,
-    #[serde(rename = "APITransactionID")]
-    pub api_transaction_id: Option<String>,
+#[serde(untagged)]
+pub enum WorldpayraftRepeatPaymentRequest {
+    CreditPurchase {
+        creditpurchase: WorldpayraftRepeatCreditAuth,
+    },
+    CreditAuth {
+        creditauth: WorldpayraftRepeatCreditAuth,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorldpayraftRepeatPaymentResponse {
-    pub creditauthresponse: WorldpayraftRepeatPaymentResponseInner,
+#[serde(untagged)]
+pub enum WorldpayraftRepeatPaymentResponse {
+    CreditPurchase {
+        creditpurchaseresponse: WorldpayraftResponseInner,
+    },
+    CreditAuth {
+        creditauthresponse: WorldpayraftResponseInner,
+    },
 }
 
-// =============================================================================
-// TryFrom: RouterDataV2 → WorldpayraftRepeatPaymentRequest
-// =============================================================================
+impl WorldpayraftRepeatPaymentResponse {
+    /// `(inner, is_auto_capture)` — the wrapper key identifies which endpoint answered.
+    fn parts(&self) -> (&WorldpayraftResponseInner, bool) {
+        match self {
+            Self::CreditPurchase {
+                creditpurchaseresponse,
+            } => (creditpurchaseresponse, true),
+            Self::CreditAuth { creditauthresponse } => (creditauthresponse, false),
+        }
+    }
+}
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<
@@ -1293,7 +2289,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
         >,
     ) -> Result<Self, Self::Error> {
         let router_data = &item.router_data;
-
         let auth = WorldpayraftAuthType::try_from(&router_data.connector_config)?;
 
         let transaction_amount = item
@@ -1313,74 +2308,255 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 },
             })?;
 
-        let tokenized_pan = match &router_data.request.mandate_reference {
-            MandateReferenceId::ConnectorMandateId(connector_mandate_ref) => connector_mandate_ref
-                .get_connector_mandate_id()
-                .ok_or_else(|| {
-                    error_stack::report!(errors::IntegrationError::MissingRequiredField {
-                        field_name: "connector_mandate_id",
+        let card = match &router_data.request.payment_method_data {
+            PaymentMethodData::Card(card) => Some(card),
+            _ => None,
+        };
+
+        // Worldpay explicitly recommends a non-empty `CardInfo.ExpirationDate` on every
+        // token-initiated transaction, and Discover requires it.
+        let expiration_date = match card {
+            Some(card) => Some(card.get_expiry_date_as_yymm().change_context(
+                errors::IntegrationError::InvalidDataFormat {
+                    field_name: "card.card_exp_year / card.card_exp_month",
+                    context: errors::IntegrationErrorContext {
+                        additional_context: Some(
+                            "Worldpay RAFT expects card expiry in YYMM format".to_string(),
+                        ),
+                        ..Default::default()
+                    },
+                },
+            )?),
+            None => None,
+        };
+
+        let mit_category = router_data.request.mit_category.clone();
+        let subsequent_reason_code = mit_category.clone().and_then(|category| {
+            WorldpayraftSubsequentTransactionReasonCode::try_from(category).ok()
+        });
+
+        // Each mandate flavour selects a different credential carrier:
+        // - ConnectorMandateId  → a Worldpay token in `EncryptionTokenData.TokenizedPAN`
+        // - NetworkMandateId    → raw card in `CardInfo.PAN` + the scheme NTID echo
+        // - NetworkTokenWithNTI → network token in `CardInfo.PAN` + the scheme NTID echo
+        let (card_info, encryption_token_data, network_transaction_id, transaction_link_id) =
+            match &router_data.request.mandate_reference {
+                MandateReferenceId::ConnectorMandateId(connector_mandate_ref) => {
+                    let tokenized_pan = connector_mandate_ref
+                        .get_connector_mandate_id()
+                        .ok_or_else(|| {
+                            error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                                field_name: "connector_mandate_id",
+                                context: errors::IntegrationErrorContext {
+                                    additional_context: Some(
+                                        "Worldpay RAFT RepeatPayment requires the stored \
+                                         TokenizedPAN as the connector mandate id"
+                                            .to_string(),
+                                    ),
+                                    ..Default::default()
+                                },
+                            })
+                        })?;
+                    (
+                        expiration_date
+                            .clone()
+                            .map(|expiry| WorldpayraftPlainCardInfo {
+                                pan: None,
+                                expiration_date: Some(expiry),
+                            }),
+                        Some(WorldpayraftEncryptionTokenRequestData {
+                            tokenized_pan: Secret::new(tokenized_pan),
+                        }),
+                        None,
+                        None,
+                    )
+                }
+                MandateReferenceId::NetworkMandateId(network_mandate) => {
+                    let card = card.ok_or_else(|| {
+                        error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                            field_name: "payment_method_data.card",
+                            context: errors::IntegrationErrorContext {
+                                additional_context: Some(
+                                    "A Worldpay RAFT network-transaction-id MIT is a raw-card \
+                                     message: the card must accompany the NTID"
+                                        .to_string(),
+                                ),
+                                ..Default::default()
+                            },
+                        })
+                    })?;
+                    (
+                        Some(WorldpayraftPlainCardInfo {
+                            pan: Some(Secret::new(card.card_number.peek().to_string())),
+                            expiration_date: expiration_date.clone(),
+                        }),
+                        None,
+                        Some(network_mandate.network_transaction_id.clone()),
+                        network_mandate.transaction_link_id.clone(),
+                    )
+                }
+                MandateReferenceId::NetworkTokenWithNTI(network_token) => {
+                    let card = card.ok_or_else(|| {
+                        error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                            field_name: "payment_method_data.card",
+                            context: errors::IntegrationErrorContext {
+                                additional_context: Some(
+                                    "A Worldpay RAFT network-token MIT carries the network token \
+                                     in CardInfo.PAN; no card data was supplied"
+                                        .to_string(),
+                                ),
+                                ..Default::default()
+                            },
+                        })
+                    })?;
+                    (
+                        Some(WorldpayraftPlainCardInfo {
+                            pan: Some(Secret::new(card.card_number.peek().to_string())),
+                            expiration_date: expiration_date.clone(),
+                        }),
+                        None,
+                        Some(network_token.network_transaction_id.clone()),
+                        network_token.transaction_link_id.clone(),
+                    )
+                }
+            };
+
+        // Echo the network transaction id in the block belonging to the card's own brand.
+        // RAFT has no generic NetworkTransactionId field.
+        let brand_data = match (&network_transaction_id, card) {
+            (None, _) => WorldpayraftBrandRequestData::default(),
+            (Some(ntid), card) => {
+                let brand = card
+                    .and_then(WorldpayraftCardBrand::resolve)
+                    .ok_or_else(|| {
+                        error_stack::report!(errors::IntegrationError::MissingRequiredField {
+                        field_name: "payment_method_data.card.card_network",
                         context: errors::IntegrationErrorContext {
                             additional_context: Some(
-                                "Worldpay RAFT RepeatPayment requires a stored TokenizedPAN as the connector mandate ID".to_string(),
+                                "Worldpay RAFT carries the network transaction id in a per-brand \
+                                 object (VisaSpecificData / McrdSpecificData / AmexSpecificData / \
+                                 DiscSpecificData); the card brand could not be determined"
+                                    .to_string(),
                             ),
                             ..Default::default()
                         },
                     })
-                })?,
-            MandateReferenceId::NetworkMandateId(_)
-            | MandateReferenceId::NetworkTokenWithNTI(_) => {
-                return Err(error_stack::report!(
-                    errors::IntegrationError::NotImplemented(
-                        "Only ConnectorMandateId is supported for Worldpay RAFT RepeatPayment"
-                            .to_string(),
-                        errors::IntegrationErrorContext::default(),
-                    )
-                ))
+                    })?;
+                match brand {
+                    WorldpayraftCardBrand::Visa => WorldpayraftBrandRequestData {
+                        visa_specific_data: Some(WorldpayraftVisaRequestData {
+                            visa_transaction_id: ntid.clone(),
+                            visa_subsequent_transaction_reason_code: subsequent_reason_code,
+                        }),
+                        ..Default::default()
+                    },
+                    WorldpayraftCardBrand::Mastercard => {
+                        // Mastercard needs BOTH Banknet fields; the reference number on its
+                        // own is not sufficient. The settlement date travels with the NTID
+                        // as `<McrdBanknetREFNUM>:<McrdBanknetSettleDate>`.
+                        let (banknet_ref, settle_date) =
+                            ntid.split_once(MCRD_NTID_SEPARATOR).ok_or_else(|| {
+                                error_stack::report!(errors::IntegrationError::InvalidDataFormat {
+                                    field_name: "mandate_reference.network_transaction_id",
+                                    context: errors::IntegrationErrorContext {
+                                        additional_context: Some(format!(
+                                            "A Mastercard MIT needs both McrdBanknetREFNUM \
+                                                 and McrdBanknetSettleDate (MMDD); Worldpay RAFT \
+                                                 stores them as '<REFNUM>:<MMDD>', got {ntid:?}"
+                                        )),
+                                        ..Default::default()
+                                    },
+                                })
+                            })?;
+                        WorldpayraftBrandRequestData {
+                            mcrd_specific_data: Some(WorldpayraftMcrdRequestData {
+                                mcrd_banknet_refnum: banknet_ref.to_string(),
+                                mcrd_banknet_settle_date: settle_date.to_string(),
+                                mcrd_subsequent_transaction_reason_code: subsequent_reason_code,
+                            }),
+                            ..Default::default()
+                        }
+                    }
+                    WorldpayraftCardBrand::Amex => WorldpayraftBrandRequestData {
+                        amex_specific_data: Some(WorldpayraftAmexRequestData {
+                            amex_transaction_id: ntid.clone(),
+                            amex_subsequent_transaction_reason_code: subsequent_reason_code,
+                        }),
+                        ..Default::default()
+                    },
+                    WorldpayraftCardBrand::Discover => WorldpayraftBrandRequestData {
+                        disc_specific_data: Some(WorldpayraftDiscRequestData {
+                            disc_transaction_id: ntid.clone(),
+                            disc_subsequent_transaction_reason_code: subsequent_reason_code,
+                        }),
+                        ..Default::default()
+                    },
+                }
             }
         };
 
-        let payment_id = &router_data
-            .resource_common_data
-            .connector_request_reference_id;
-        let system_trace_number = derive_system_trace_number(payment_id);
-        let api_transaction_id = truncate_api_transaction_id(payment_id);
-        let local_date_time = get_local_datetime();
+        // The Mastercard/Maestro lifecycle id received on the original CIT is resent on the
+        // MIT as `ReferenceTraceNumbers.EconomicallyRelatedLinkID`.
+        let reference_trace_numbers =
+            transaction_link_id.map(|link_id| WorldpayraftRequestTraceNumbers {
+                retrieval_ref_number: None,
+                authorization_number: None,
+                economically_related_link_id: Some(link_id),
+            });
 
-        Ok(Self {
-            creditauth: WorldpayraftRepeatCreditAuth {
-                misc_amounts_balances: WorldpayraftAmounts { transaction_amount },
-                card_info: WorldpayraftRepeatCardInfo {
-                    pan: Secret::new(tokenized_pan),
-                    // RepeatPayment does not carry raw expiry; use a placeholder.
-                    // Worldpay RAFT uses the stored token which already embeds expiry.
-                    expiration_date: Secret::new(String::new()),
-                },
-                terminal_data: WorldpayraftTerminalData {
-                    entry_mode: ENTRY_MODE_ECOMM.to_string(),
-                    pos_condition_code: POS_CONDITION_CODE_ECOMM.to_string(),
-                    terminal_entry_cap: TERMINAL_ENTRY_CAP_DEFAULT.to_string(),
-                },
-                ecommerce_data: WorldpayraftEcommerceData {
-                    ecommerce_indicator: ECOMMERCE_INDICATOR_SECURE.to_string(),
-                },
-                proc_flags_indicators: WorldpayraftRepeatProcFlags {
-                    merchant_initiated_transaction: MIT_YES.to_string(),
-                    recurring_bill_pay: Some(MIT_YES.to_string()),
-                },
-                reference_trace_numbers: WorldpayraftRequestTraceNumbers {
-                    system_trace_number,
-                },
-                world_pay_merchant_id: auth.merchant_id,
-                api_transaction_id,
-                local_date_time,
+        // Every MIT must carry a stored-credential indicator; an unscheduled card-on-file
+        // MIT is the shape UCS models when the caller does not classify the schedule.
+        let pos_environment = mit_category
+            .clone()
+            .map(WorldpayraftPosEnvironment::from)
+            .unwrap_or(WorldpayraftPosEnvironment::UnscheduledCardOnFile);
+
+        let inner = WorldpayraftRepeatCreditAuth {
+            misc_amounts_balances: WorldpayraftAmounts {
+                transaction_amount,
+                preauthorized_amount: None,
             },
+            card_info,
+            encryption_token_data,
+            terminal_data: WorldpayraftTerminalData {
+                entry_mode: ENTRY_MODE_ECOMM.to_string(),
+                pos_condition_code: POS_CONDITION_CODE_ECOMM.to_string(),
+                terminal_entry_cap: TERMINAL_ENTRY_CAP_DEFAULT.to_string(),
+                pos_environment: Some(pos_environment),
+            },
+            ecommerce_data: WorldpayraftEcommerceData {
+                ecommerce_indicator: ECOMMERCE_INDICATOR_ECOMM_NO_3DS.to_string(),
+            },
+            proc_flags_indicators: WorldpayraftProcFlagsIndicators {
+                mastercard_advice_code_indicator: Some(WorldpayraftFlag::Yes),
+                cardholder_initiated_transaction: None,
+                merchant_initiated_transaction: Some(WorldpayraftFlag::Yes),
+                recurring_bill_pay: matches!(
+                    mit_category,
+                    Some(common_enums::MitCategory::Recurring)
+                )
+                .then_some(WorldpayraftFlag::Yes),
+            },
+            reference_trace_numbers,
+            brand_data,
+            world_pay_merchant_id: auth.merchant_id,
+            api_transaction_id: truncate_api_transaction_id(
+                &router_data
+                    .resource_common_data
+                    .connector_request_reference_id,
+            ),
+            local_date_time: get_local_datetime(),
+        };
+
+        Ok(if resolve_repeat_auto_capture(&router_data.request)? {
+            Self::CreditPurchase {
+                creditpurchase: inner,
+            }
+        } else {
+            Self::CreditAuth { creditauth: inner }
         })
     }
 }
-
-// =============================================================================
-// TryFrom: WorldpayraftRepeatPaymentResponse → RouterDataV2
-// =============================================================================
 
 impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
     TryFrom<ResponseRouterData<WorldpayraftRepeatPaymentResponse, Self>>
@@ -1391,42 +2567,52 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     fn try_from(
         item: ResponseRouterData<WorldpayraftRepeatPaymentResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let response = &item.response.creditauthresponse;
+        let (inner, is_auto_capture) = item.response.parts();
 
-        let status = if map_payment_status(&response.return_code, &response.response_code) {
-            AttemptStatus::Charged
-        } else {
-            AttemptStatus::Failure
-        };
+        if !inner.is_success() {
+            let status = inner.payment_decline_status(AttemptStatus::Failure);
+            return Ok(Self {
+                response: Err(inner.to_error_response(item.http_code, FlowStatus::Payment(status))),
+                resource_common_data: PaymentFlowData {
+                    status,
+                    ..item.router_data.resource_common_data
+                },
+                ..item.router_data
+            });
+        }
 
-        // RepeatPayment is always credit; encode with TXN_TYPE_CREDIT prefix
-        let connector_transaction_id = response
-            .reference_trace_numbers
-            .as_ref()
-            .map(|trace| {
-                let auth_num = trace.authorization_number.as_deref().unwrap_or("");
-                let retrieval_ref = trace.retrieval_ref_number.as_deref().unwrap_or("");
-                let sys_trace = trace.system_trace_number.as_deref().unwrap_or("");
-                format!("{TXN_TYPE_CREDIT}|{auth_num}|{retrieval_ref}|{sys_trace}")
-            })
-            .unwrap_or_default();
+        let reference = inner.to_transaction_reference(
+            false,
+            truncate_api_transaction_id(
+                &item
+                    .router_data
+                    .resource_common_data
+                    .connector_request_reference_id,
+            ),
+            get_local_datetime(),
+            Some(item.router_data.request.minor_amount.get_amount_as_i64()),
+        );
 
         Ok(Self {
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
+                resource_id: ResponseId::ConnectorTransactionId(reference.encode()),
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
-                network_txn_id: None,
-                network_txn_link_id: None,
-                connector_response_reference_id: response.api_transaction_id.clone(),
+                connector_metadata: Some(inner.to_connector_metadata(&reference)),
+                network_txn_id: inner.network_transaction_id(),
+                network_txn_link_id: inner.transaction_link_id(),
+                connector_response_reference_id: inner.api_transaction_id.clone(),
                 incremental_authorization_allowed: None,
                 splits: None,
                 status_code: item.http_code,
-                payment_account_reference: None,
+                payment_account_reference: inner.payment_account_reference(),
             }),
             resource_common_data: PaymentFlowData {
-                status,
+                status: if is_auto_capture {
+                    AttemptStatus::Charged
+                } else {
+                    AttemptStatus::Authorized
+                },
                 ..item.router_data.resource_common_data
             },
             ..item.router_data

--- a/crates/internal/integration-tests/src/connector_specs/worldpayraft/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/worldpayraft/specs.json
@@ -3,6 +3,7 @@
   "supported_suites": [
     "PaymentService/Authorize",
     "PaymentService/Capture",
+    "PaymentService/Void",
     "PaymentService/Refund",
     "PaymentService/SetupRecurring",
     "RecurringPaymentService/Charge"

--- a/data/field_probe/worldpayraft.json
+++ b/data/field_probe/worldpayraft.json
@@ -3,8 +3,8 @@
   "flows": {
     "authenticate": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: authenticate flow for worldpayraft"
+        "status": "not_supported",
+        "error": "authenticate flow not supported by worldpayraft connector"
       }
     },
     "authorize": {
@@ -487,7 +487,7 @@
     "capture": {
       "default": {
         "status": "error",
-        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber|E-commerceIndicator|ReturnE-commerceIndicator|ReturnUCAFIndicator|ReturnEcommerceSecurityLevelIndicator' (or its original six-segment form), got \"probe_connector_txn_001\""
       }
     },
     "create_client_authentication_token": {
@@ -584,14 +584,14 @@
     },
     "post_authenticate": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: post_authenticate flow for worldpayraft"
+        "status": "not_supported",
+        "error": "post_authenticate flow not supported by worldpayraft connector"
       }
     },
     "pre_authenticate": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: pre_authenticate flow for worldpayraft"
+        "status": "not_supported",
+        "error": "pre_authenticate flow not supported by worldpayraft connector"
       }
     },
     "proxy_authorize": {
@@ -720,7 +720,7 @@
     "refund": {
       "default": {
         "status": "error",
-        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber|E-commerceIndicator|ReturnE-commerceIndicator|ReturnUCAFIndicator|ReturnEcommerceSecurityLevelIndicator' (or its original six-segment form), got \"probe_connector_txn_001\""
       }
     },
     "refund_get": {
@@ -798,7 +798,7 @@
     "void": {
       "default": {
         "status": "error",
-        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber|E-commerceIndicator|ReturnE-commerceIndicator|ReturnUCAFIndicator|ReturnEcommerceSecurityLevelIndicator' (or its original six-segment form), got \"probe_connector_txn_001\""
       }
     }
   }

--- a/data/field_probe/worldpayraft.json
+++ b/data/field_probe/worldpayraft.json
@@ -121,14 +121,14 @@
           "return_url": "https://example.com/return"
         },
         "sample": {
-          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/authorization",
+          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/purchase",
           "method": "Post",
           "headers": {
             "authorization": "VANTIV license=\"probe_key\"",
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"creditauth\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"CardInfo\":{\"PAN\":\"4111111111111111\",\"ExpirationDate\":\"3003\"},\"CardVerificationData\":{\"Cvv2Cvc2CIDIndicator\":\"0\",\"CVV2CVC2\":\"737\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ReferenceTraceNumbers\":{\"SystemTraceNumber\":\"000001\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_txn_001\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
+          "body": "{\"creditpurchase\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"CardInfo\":{\"PAN\":\"4111111111111111\",\"ExpirationDate\":\"3003\"},\"CardVerificationData\":{\"Cvv2Cvc2CIDIndicator\":\"1\",\"Cvv2Cvc2CIDValue\":\"737\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ProcFlagsIndicators\":{\"MastercardAdviceCodeIndicator\":\"Y\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_txn_001\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
         }
       },
       "CashappQr": {
@@ -486,25 +486,8 @@
     },
     "capture": {
       "default": {
-        "status": "supported",
-        "proto_request": {
-          "merchant_capture_id": "probe_capture_001",
-          "connector_transaction_id": "probe_connector_txn_001",
-          "amount_to_capture": {
-            "minor_amount": 1000,
-            "currency": "USD"
-          }
-        },
-        "sample": {
-          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/completion",
-          "method": "Post",
-          "headers": {
-            "authorization": "VANTIV license=\"probe_key\"",
-            "content-type": "application/json",
-            "via": "HyperSwitch"
-          },
-          "body": "{\"creditcompletion\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"ReferenceTraceNumbers\":{\"AuthorizationNumber\":\"probe_connector_txn_001\",\"RetrievalREFNumber\":\"\",\"SystemTraceNumber\":\"\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_capture_00\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
-        }
+        "status": "error",
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
       }
     },
     "create_client_authentication_token": {
@@ -636,14 +619,14 @@
           "return_url": "https://example.com/return"
         },
         "sample": {
-          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/authorization",
+          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/purchase",
           "method": "Post",
           "headers": {
             "authorization": "VANTIV license=\"probe_key\"",
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"creditauth\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"CardInfo\":{\"PAN\":\"{{$card_number}}\",\"ExpirationDate\":\"3003\"},\"CardVerificationData\":{\"Cvv2Cvc2CIDIndicator\":\"0\",\"CVV2CVC2\":\"{{$card_cvc}}\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ReferenceTraceNumbers\":{\"SystemTraceNumber\":\"000001\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_proxy_txn_\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
+          "body": "{\"creditpurchase\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"CardInfo\":{\"PAN\":\"{{$card_number}}\",\"ExpirationDate\":\"3003\"},\"CardVerificationData\":{\"Cvv2Cvc2CIDIndicator\":\"1\",\"Cvv2Cvc2CIDValue\":\"{{$card_cvc}}\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ProcFlagsIndicators\":{\"MastercardAdviceCodeIndicator\":\"Y\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_proxy_txn_\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
         }
       }
     },
@@ -712,14 +695,14 @@
           "off_session": true
         },
         "sample": {
-          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/authorization",
+          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/purchase",
           "method": "Post",
           "headers": {
             "authorization": "VANTIV license=\"probe_key\"",
             "content-type": "application/json",
             "via": "HyperSwitch"
           },
-          "body": "{\"creditauth\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"CardInfo\":{\"PAN\":\"probe-mandate-123\",\"ExpirationDate\":\"\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ProcFlagsIndicators\":{\"MerchantInitiatedTransaction\":\"Y\",\"RecurringBillPay\":\"Y\"},\"ReferenceTraceNumbers\":{\"SystemTraceNumber\":\"000000\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
+          "body": "{\"creditpurchase\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"EncryptionTokenData\":{\"TokenizedPAN\":\"probe-mandate-123\"},\"TerminalData\":{\"EntryMode\":\"E-COMM\",\"POSConditionCode\":\"59\",\"TerminalEntryCap\":\"0\",\"POSEnvironment\":\"U\"},\"E-commerceData\":{\"E-commerceIndicator\":\"07\"},\"ProcFlagsIndicators\":{\"MastercardAdviceCodeIndicator\":\"Y\",\"MerchantInitiatedTransaction\":\"Y\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
         }
       }
     },
@@ -736,27 +719,8 @@
     },
     "refund": {
       "default": {
-        "status": "supported",
-        "proto_request": {
-          "merchant_refund_id": "probe_refund_001",
-          "connector_transaction_id": "probe_connector_txn_001",
-          "payment_amount": 1000,
-          "refund_amount": {
-            "minor_amount": 1000,
-            "currency": "USD"
-          },
-          "reason": "customer_request"
-        },
-        "sample": {
-          "url": "https://ws-cert.vantiv.com/merchant/servicing/apitransactions/NativeRaftApi/v1/credit/refund",
-          "method": "Post",
-          "headers": {
-            "authorization": "VANTIV license=\"probe_key\"",
-            "content-type": "application/json",
-            "via": "HyperSwitch"
-          },
-          "body": "{\"creditrefund\":{\"MiscAmountsBalances\":{\"TransactionAmount\":\"10.00\"},\"ReferenceTraceNumbers\":{\"AuthorizationNumber\":\"probe_connector_txn_001\",\"RetrievalREFNumber\":\"\",\"SystemTraceNumber\":\"\"},\"WorldPayMerchantID\":\"probe_key\",\"APITransactionID\":\"probe_refund_001\",\"LocalDateTime\":\"2020-01-01T00:00:00+00:00\"}}"
-        }
+        "status": "error",
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
       }
     },
     "refund_get": {
@@ -833,8 +797,8 @@
     },
     "void": {
       "default": {
-        "status": "not_implemented",
-        "error": "This feature is not implemented: void flow for worldpayraft"
+        "status": "error",
+        "error": "Invalid data format: connector_transaction_id. Worldpay RAFT expects the composite reference '[C|CP|D|DP]|APITransactionID|LocalDateTime|authorized_minor_amount|AuthorizationNumber|RetrievalREFNumber', got \"probe_connector_txn_001\""
       }
     }
   }

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -257,7 +257,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Volt](connectors/volt.md) | ✓ | ⚠ | x | x | x | ✓ | x | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Wellsfargo](connectors/wellsfargo.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | x | ✓ | ✓ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Worldpay](connectors/worldpay.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | ✓ | ⚠ | ⚠ | ? | ⚠ | ✓ | ⚠ | ✓ | x | ✓ | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ? | ⚠ | ? | x | ⚠ | x | x | ⚠ | ⚠ | x |
-| [Worldpayraft](connectors/worldpayraft.md) | ⚠ | ⚠ | x | ✓ | ⚠ | ✓ | x | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
+| [Worldpayraft](connectors/worldpayraft.md) | ⚠ | ? | x | ? | ⚠ | ? | x | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Worldpayvantiv](connectors/worldpayvantiv.md) | ✓ | ✓ | ✓ | ✓ | x | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Worldpayxml](connectors/worldpayxml.md) | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | x | x | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ | x |
 | [Xendit](connectors/xendit.md) | ✓ | ⚠ | x | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -257,7 +257,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Volt](connectors/volt.md) | ✓ | ⚠ | x | x | x | ✓ | x | ⚠ | ⚠ | x | ⚠ | x | ⚠ | ⚠ | ⚠ | x | x | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Wellsfargo](connectors/wellsfargo.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | x | ✓ | ✓ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Worldpay](connectors/worldpay.md) | ✓ | ✓ | ⚠ | ✓ | x | ✓ | ✓ | ⚠ | ⚠ | ? | ⚠ | ✓ | ⚠ | ✓ | x | ✓ | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ? | ⚠ | ? | x | ⚠ | x | x | ⚠ | ⚠ | x |
-| [Worldpayraft](connectors/worldpayraft.md) | ⚠ | ? | x | ? | ⚠ | ? | x | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |
+| [Worldpayraft](connectors/worldpayraft.md) | ⚠ | ? | x | ? | ⚠ | ? | x | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Worldpayvantiv](connectors/worldpayvantiv.md) | ✓ | ✓ | ✓ | ✓ | x | ✓ | ✓ | ⚠ | ⚠ | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Worldpayxml](connectors/worldpayxml.md) | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | x | x | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ | x |
 | [Xendit](connectors/xendit.md) | ✓ | ⚠ | x | ✓ | ⚠ | ✓ | x | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | x | x | ⚠ | ⚠ | x |

--- a/docs-generated/connectors/worldpayraft.md
+++ b/docs-generated/connectors/worldpayraft.md
@@ -127,38 +127,16 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py#L176) · [JavaScript](../../examples/worldpayraft/worldpayraft.js) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L98) · [Rust](../../examples/worldpayraft/worldpayraft.rs#L224)
-
-### Card Payment (Authorize + Capture)
-
-Two-step card payment. First authorize, then capture. Use when you need to verify funds before finalizing.
-
-**Response status handling:**
-
-| Status | Recommended action |
-|--------|-------------------|
-| `AUTHORIZED` | Funds reserved — proceed to Capture to settle |
-| `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
-| `FAILED` | Payment declined — surface error to customer, do not retry without new details |
-
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py#L195) · [JavaScript](../../examples/worldpayraft/worldpayraft.js) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L114) · [Rust](../../examples/worldpayraft/worldpayraft.rs#L240)
-
-### Refund
-
-Return funds to the customer for a completed payment.
-
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py#L220) · [JavaScript](../../examples/worldpayraft/worldpayraft.js) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L136) · [Rust](../../examples/worldpayraft/worldpayraft.rs#L263)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py#L154) · [JavaScript](../../examples/worldpayraft/worldpayraft.js) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L74) · [Rust](../../examples/worldpayraft/worldpayraft.rs#L198)
 
 ## API Reference
 
 | Flow (Service.RPC) | Category | gRPC Request Message |
 |--------------------|----------|----------------------|
 | [PaymentService.Authorize](#paymentserviceauthorize) | Payments | `PaymentServiceAuthorizeRequest` |
-| [PaymentService.Capture](#paymentservicecapture) | Payments | `PaymentServiceCaptureRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
 | [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
-| [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 
 ### Payments
@@ -294,18 +272,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L255) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L157) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
-
-#### PaymentService.Capture
-
-Finalize an authorized payment by transferring funds. Captures the authorized amount to complete the transaction and move funds to your merchant account.
-
-| | Message |
-|---|---------|
-| **Request** | `PaymentServiceCaptureRequest` |
-| **Response** | `PaymentServiceCaptureResponse` |
-
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L264) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L169) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L179) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L89) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -316,7 +283,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L273) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L179) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L188) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L101) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
 
 #### PaymentService.ProxySetupRecurring
 
@@ -327,18 +294,7 @@ Setup recurring mandate using vault-aliased card data.
 | **Request** | `PaymentServiceProxySetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L282) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L208) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
-
-#### PaymentService.Refund
-
-Process a partial or full refund for a captured payment. Returns funds to the customer when goods are returned or services are cancelled.
-
-| | Message |
-|---|---------|
-| **Request** | `PaymentServiceRefundRequest` |
-| **Response** | `RefundResponse` |
-
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L300) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L271) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L197) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L130) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
 
 #### PaymentService.SetupRecurring
 
@@ -349,7 +305,7 @@ Configure a payment method for recurring billing. Sets up the mandate and paymen
 | **Request** | `PaymentServiceSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L309) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L281) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L215) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L193) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
 
 ### Mandates
 
@@ -362,4 +318,4 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L291) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L240) · [Rust](../../examples/worldpayraft/worldpayraft.rs)
+**Examples:** [Python](../../examples/worldpayraft/worldpayraft.py) · [TypeScript](../../examples/worldpayraft/worldpayraft.ts#L206) · [Kotlin](../../examples/worldpayraft/worldpayraft.kt#L162) · [Rust](../../examples/worldpayraft/worldpayraft.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -905,9 +905,9 @@ examples_python: examples/worldpay/worldpay.py
 ## Worldpayraft
 connector_id: worldpayraft
 doc: docs/connectors/worldpayraft.md
-scenarios: checkout_autocapture, checkout_card, refund
+scenarios: checkout_autocapture
 payment_methods: Card
-flows: authorize, capture, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, setup_recurring
+flows: authorize, proxy_authorize, proxy_setup_recurring, recurring_charge, setup_recurring
 examples_python: examples/worldpayraft/worldpayraft.py
 
 ## Worldpayvantiv

--- a/examples/worldpayraft/worldpayraft.kt
+++ b/examples/worldpayraft/worldpayraft.kt
@@ -26,7 +26,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.WorldpayraftConfig
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "setup_recurring")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "setup_recurring")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -69,30 +69,6 @@ private fun buildAuthorizeRequest(captureMethodStr: String): PaymentServiceAutho
     }.build()
 }
 
-private fun buildCaptureRequest(connectorTransactionIdStr: String): PaymentServiceCaptureRequest {
-    return PaymentServiceCaptureRequest.newBuilder().apply {
-        merchantCaptureId = "probe_capture_001"  // Identification.
-        connectorTransactionId = connectorTransactionIdStr
-        amountToCaptureBuilder.apply {  // Capture Details.
-            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
-            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
-    }.build()
-}
-
-private fun buildRefundRequest(connectorTransactionIdStr: String): PaymentServiceRefundRequest {
-    return PaymentServiceRefundRequest.newBuilder().apply {
-        merchantRefundId = "probe_refund_001"  // Identification.
-        connectorTransactionId = connectorTransactionIdStr
-        paymentAmount = 1000L  // Amount Information.
-        refundAmountBuilder.apply {
-            minorAmount = 1000L  // Amount in minor units (e.g., 1000 = $10.00).
-            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
-        reason = "customer_request"  // Reason for the refund.
-    }.build()
-}
-
 // Scenario: One-step Payment (Authorize + Capture)
 // Simple payment that authorizes and captures in one call. Use for immediate charges.
 fun processCheckoutAutocapture(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
@@ -109,50 +85,6 @@ fun processCheckoutAutocapture(txnId: String, config: ConnectorConfig = _default
     return mapOf("status" to authorizeResponse.status.name, "transactionId" to authorizeResponse.connectorTransactionId, "error" to authorizeResponse.error)
 }
 
-// Scenario: Card Payment (Authorize + Capture)
-// Two-step card payment. First authorize, then capture. Use when you need to verify funds before finalizing.
-fun processCheckoutCard(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
-    val paymentClient = PaymentClient(config)
-
-    // Step 1: Authorize — reserve funds on the payment method
-    val authorizeResponse = paymentClient.authorize(buildAuthorizeRequest("MANUAL"))
-
-    when (authorizeResponse.status.name) {
-        "FAILED"  -> throw RuntimeException("Payment failed: ${authorizeResponse.error.unifiedDetails.message}")
-        "PENDING" -> return mapOf("status" to "PENDING")  // await webhook before proceeding
-    }
-
-    // Step 2: Capture — settle the reserved funds
-    val captureResponse = paymentClient.capture(buildCaptureRequest(authorizeResponse.connectorTransactionId ?: ""))
-
-    if (captureResponse.status.name == "FAILED")
-        throw RuntimeException("Capture failed: ${captureResponse.error.unifiedDetails.message}")
-
-    return mapOf("status" to captureResponse.status.name, "transactionId" to authorizeResponse.connectorTransactionId, "error" to authorizeResponse.error)
-}
-
-// Scenario: Refund
-// Return funds to the customer for a completed payment.
-fun processRefund(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
-    val paymentClient = PaymentClient(config)
-
-    // Step 1: Authorize — reserve funds on the payment method
-    val authorizeResponse = paymentClient.authorize(buildAuthorizeRequest("AUTOMATIC"))
-
-    when (authorizeResponse.status.name) {
-        "FAILED"  -> throw RuntimeException("Payment failed: ${authorizeResponse.error.unifiedDetails.message}")
-        "PENDING" -> return mapOf("status" to "PENDING")  // await webhook before proceeding
-    }
-
-    // Step 2: Refund — return funds to the customer
-    val refundResponse = paymentClient.refund(buildRefundRequest(authorizeResponse.connectorTransactionId ?: ""))
-
-    if (refundResponse.status.name == "FAILED")
-        throw RuntimeException("Refund failed: ${refundResponse.error.unifiedDetails.message}")
-
-    return mapOf("status" to refundResponse.status.name, "error" to refundResponse.error)
-}
-
 // Flow: PaymentService.Authorize (Card)
 fun authorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val client = PaymentClient(config)
@@ -163,16 +95,6 @@ fun authorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
         "PENDING" -> println("Pending — await webhook before proceeding")
         else      -> println("Authorized: ${response.connectorTransactionId}")
     }
-}
-
-// Flow: PaymentService.Capture
-fun capture(txnId: String, config: ConnectorConfig = _defaultConfig) {
-    val client = PaymentClient(config)
-    val request = buildCaptureRequest("probe_connector_txn_001")
-    val response = client.capture(request)
-    if (response.status.name == "FAILED")
-        throw RuntimeException("Capture failed: ${response.error.unifiedDetails.message}")
-    println("Done: ${response.status.name}")
 }
 
 // Flow: PaymentService.ProxyAuthorize
@@ -267,16 +189,6 @@ fun recurringCharge(txnId: String, config: ConnectorConfig = _defaultConfig) {
     println("Done: ${response.status.name}")
 }
 
-// Flow: PaymentService.Refund
-fun refund(txnId: String, config: ConnectorConfig = _defaultConfig) {
-    val client = PaymentClient(config)
-    val request = buildRefundRequest("probe_connector_txn_001")
-    val response = client.refund(request)
-    if (response.status.name == "FAILED")
-        throw RuntimeException("Refund failed: ${response.error.unifiedDetails.message}")
-    println("Done: ${response.status.name}")
-}
-
 // Flow: PaymentService.SetupRecurring
 fun setupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig) {
     val client = PaymentClient(config)
@@ -322,15 +234,11 @@ fun main(args: Array<String>) {
     val flow = args.firstOrNull() ?: "processCheckoutAutocapture"
     when (flow) {
         "processCheckoutAutocapture" -> processCheckoutAutocapture(txnId)
-        "processCheckoutCard" -> processCheckoutCard(txnId)
-        "processRefund" -> processRefund(txnId)
         "authorize" -> authorize(txnId)
-        "capture" -> capture(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
         "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "recurringCharge" -> recurringCharge(txnId)
-        "refund" -> refund(txnId)
         "setupRecurring" -> setupRecurring(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, authorize, capture, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, setupRecurring")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, authorize, proxyAuthorize, proxySetupRecurring, recurringCharge, setupRecurring")
     }
 }

--- a/examples/worldpayraft/worldpayraft.py
+++ b/examples/worldpayraft/worldpayraft.py
@@ -11,7 +11,7 @@ from payments import PaymentClient
 from payments import RecurringPaymentClient
 from payments.generated import sdk_config_pb2, payment_pb2, events_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "capture", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "setup_recurring"]
+SUPPORTED_FLOWS = ["authorize", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "setup_recurring"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -49,16 +49,6 @@ def _build_authorize_request(capture_method: str):
         ),
         auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),  # Authentication Details.
         return_url="https://example.com/return",  # URLs for Redirection and Webhooks.
-    )
-
-def _build_capture_request(connector_transaction_id: str):
-    return payment_pb2.PaymentServiceCaptureRequest(
-        merchant_capture_id="probe_capture_001",  # Identification.
-        connector_transaction_id=connector_transaction_id,
-        amount_to_capture=payment_pb2.Money(  # Capture Details.
-            minor_amount=1000,  # Amount in minor units (e.g., 1000 = $10.00).
-            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
-        ),
     )
 
 def _build_proxy_authorize_request():
@@ -132,18 +122,6 @@ def _build_recurring_charge_request():
         off_session=True,  # Behavioral Flags and Preferences.
     )
 
-def _build_refund_request(connector_transaction_id: str):
-    return payment_pb2.PaymentServiceRefundRequest(
-        merchant_refund_id="probe_refund_001",  # Identification.
-        connector_transaction_id=connector_transaction_id,
-        payment_amount=1000,  # Amount Information.
-        refund_amount=payment_pb2.Money(
-            minor_amount=1000,  # Amount in minor units (e.g., 1000 = $10.00).
-            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
-        ),
-        reason="customer_request",  # Reason for the refund.
-    )
-
 def _build_setup_recurring_request():
     return payment_pb2.PaymentServiceSetupRecurringRequest(
         merchant_recurring_payment_id="probe_mandate_001",  # Identification.
@@ -192,56 +170,6 @@ async def process_checkout_autocapture(merchant_transaction_id: str, config: sdk
     return {"status": getattr(authorize_response, "status", ""), "transaction_id": getattr(authorize_response, "connector_transaction_id", ""), "error": getattr(authorize_response, "error", None)}
 
 
-async def process_checkout_card(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Card Payment (Authorize + Capture)
-
-    Two-step card payment. First authorize, then capture. Use when you need to verify funds before finalizing.
-    """
-    payment_client = PaymentClient(config)
-
-    # Step 1: Authorize — reserve funds on the payment method
-    authorize_response = await payment_client.authorize(_build_authorize_request("MANUAL"))
-
-    if authorize_response.status == "FAILED":
-        raise RuntimeError(f"Payment failed: {authorize_response.error}")
-    if authorize_response.status == "PENDING":
-        # Awaiting async confirmation — handle via webhook
-        return {"status": "pending", "transaction_id": authorize_response.connector_transaction_id}
-
-    # Step 2: Capture — settle the reserved funds
-    capture_response = await payment_client.capture(_build_capture_request(authorize_response.connector_transaction_id))
-
-    if capture_response.status == "FAILED":
-        raise RuntimeError(f"Capture failed: {capture_response.error}")
-
-    return {"status": getattr(capture_response, "status", ""), "transaction_id": getattr(authorize_response, "connector_transaction_id", ""), "error": getattr(capture_response, "error", None)}
-
-
-async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Refund
-
-    Return funds to the customer for a completed payment.
-    """
-    payment_client = PaymentClient(config)
-
-    # Step 1: Authorize — reserve funds on the payment method
-    authorize_response = await payment_client.authorize(_build_authorize_request("AUTOMATIC"))
-
-    if authorize_response.status == "FAILED":
-        raise RuntimeError(f"Payment failed: {authorize_response.error}")
-    if authorize_response.status == "PENDING":
-        # Awaiting async confirmation — handle via webhook
-        return {"status": "pending", "transaction_id": authorize_response.connector_transaction_id}
-
-    # Step 2: Refund — return funds to the customer
-    refund_response = await payment_client.refund(_build_refund_request(authorize_response.connector_transaction_id))
-
-    if refund_response.status == "FAILED":
-        raise RuntimeError(f"Refund failed: {refund_response.error}")
-
-    return {"status": getattr(refund_response, "status", ""), "error": getattr(refund_response, "error", None)}
-
-
 async def process_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: PaymentService.Authorize (Card)"""
     payment_client = PaymentClient(config)
@@ -249,15 +177,6 @@ async def process_authorize(merchant_transaction_id: str, config: sdk_config_pb2
     authorize_response = await payment_client.authorize(_build_authorize_request("AUTOMATIC"))
 
     return {"status": authorize_response.status, "transaction_id": authorize_response.connector_transaction_id}
-
-
-async def process_capture(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Flow: PaymentService.Capture"""
-    payment_client = PaymentClient(config)
-
-    capture_response = await payment_client.capture(_build_capture_request("probe_connector_txn_001"))
-
-    return {"status": capture_response.status}
 
 
 async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/worldpayraft/worldpayraft.rs
+++ b/examples/worldpayraft/worldpayraft.rs
@@ -16,11 +16,9 @@ use std::str::FromStr;
 #[allow(dead_code)]
 pub const SUPPORTED_FLOWS: &[&str] = &[
     "authorize",
-    "capture",
     "proxy_authorize",
     "proxy_setup_recurring",
     "recurring_charge",
-    "refund",
     "setup_recurring",
 ];
 
@@ -81,19 +79,6 @@ pub fn build_authorize_request(capture_method: &str) -> PaymentServiceAuthorizeR
         }),
         auth_type: AuthenticationType::NoThreeDs.into(), // Authentication Details.
         return_url: Some("https://example.com/return".to_string()), // URLs for Redirection and Webhooks.
-        ..Default::default()
-    }
-}
-
-pub fn build_capture_request(connector_transaction_id: &str) -> PaymentServiceCaptureRequest {
-    PaymentServiceCaptureRequest {
-        merchant_capture_id: Some("probe_capture_001".to_string()), // Identification.
-        connector_transaction_id: connector_transaction_id.to_string(),
-        amount_to_capture: Some(Money {
-            // Capture Details.
-            minor_amount: 1000, // Amount in minor units (e.g., 1000 = $10.00).
-            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
-        }),
         ..Default::default()
     }
 }
@@ -192,20 +177,6 @@ pub fn build_recurring_charge_request() -> RecurringPaymentServiceChargeRequest 
     }
 }
 
-pub fn build_refund_request(connector_transaction_id: &str) -> PaymentServiceRefundRequest {
-    PaymentServiceRefundRequest {
-        merchant_refund_id: Some("probe_refund_001".to_string()), // Identification.
-        connector_transaction_id: connector_transaction_id.to_string(),
-        payment_amount: 1000, // Amount Information.
-        refund_amount: Some(Money {
-            minor_amount: 1000,             // Amount in minor units (e.g., 1000 = $10.00).
-            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
-        }),
-        reason: Some("customer_request".to_string()), // Reason for the refund.
-        ..Default::default()
-    }
-}
-
 pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
     PaymentServiceSetupRecurringRequest {
         merchant_recurring_payment_id: "probe_mandate_001".to_string(), // Identification.
@@ -277,94 +248,6 @@ pub async fn process_checkout_autocapture(
     ))
 }
 
-// Scenario: Card Payment (Authorize + Capture)
-// Two-step card payment. First authorize, then capture. Use when you need to verify funds before finalizing.
-#[allow(dead_code)]
-pub async fn process_checkout_card(
-    client: &ConnectorClient,
-    _merchant_transaction_id: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    // Step 1: Authorize — reserve funds on the payment method
-    let authorize_response = client
-        .authorize(build_authorize_request("MANUAL"), &HashMap::new(), None)
-        .await?;
-
-    match authorize_response.status() {
-        PaymentStatus::Failure | PaymentStatus::AuthorizationFailed => {
-            return Err(format!("Payment failed: {:?}", authorize_response.error).into())
-        }
-        PaymentStatus::Pending => return Ok("pending — awaiting webhook".to_string()),
-        _ => {}
-    }
-
-    // Step 2: Capture — settle the reserved funds
-    let capture_response = client
-        .capture(
-            build_capture_request(
-                authorize_response
-                    .connector_transaction_id
-                    .as_deref()
-                    .unwrap_or(""),
-            ),
-            &HashMap::new(),
-            None,
-        )
-        .await?;
-
-    if capture_response.status() == PaymentStatus::Failure {
-        return Err(format!("Capture failed: {:?}", capture_response.error).into());
-    }
-
-    Ok(format!(
-        "Payment completed: {}",
-        authorize_response
-            .connector_transaction_id
-            .as_deref()
-            .unwrap_or("")
-    ))
-}
-
-// Scenario: Refund
-// Return funds to the customer for a completed payment.
-#[allow(dead_code)]
-pub async fn process_refund(
-    client: &ConnectorClient,
-    _merchant_transaction_id: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    // Step 1: Authorize — reserve funds on the payment method
-    let authorize_response = client
-        .authorize(build_authorize_request("AUTOMATIC"), &HashMap::new(), None)
-        .await?;
-
-    match authorize_response.status() {
-        PaymentStatus::Failure | PaymentStatus::AuthorizationFailed => {
-            return Err(format!("Payment failed: {:?}", authorize_response.error).into())
-        }
-        PaymentStatus::Pending => return Ok("pending — awaiting webhook".to_string()),
-        _ => {}
-    }
-
-    // Step 2: Refund — return funds to the customer
-    let refund_response = client
-        .refund(
-            build_refund_request(
-                authorize_response
-                    .connector_transaction_id
-                    .as_deref()
-                    .unwrap_or(""),
-            ),
-            &HashMap::new(),
-            None,
-        )
-        .await?;
-
-    if refund_response.status() == RefundStatus::RefundFailure {
-        return Err(format!("Refund failed: {:?}", refund_response.error).into());
-    }
-
-    Ok(format!("Refunded: {:?}", refund_response.status()))
-}
-
 // Flow: PaymentService.Authorize (Card)
 #[allow(dead_code)]
 pub async fn process_authorize(
@@ -384,22 +267,6 @@ pub async fn process_authorize(
             response.connector_transaction_id.as_deref().unwrap_or("")
         )),
     }
-}
-
-// Flow: PaymentService.Capture
-#[allow(dead_code)]
-pub async fn process_capture(
-    client: &ConnectorClient,
-    _merchant_transaction_id: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .capture(
-            build_capture_request("probe_connector_txn_001"),
-            &HashMap::new(),
-            None,
-        )
-        .await?;
-    Ok(format!("status: {:?}", response.status()))
 }
 
 // Flow: PaymentService.ProxyAuthorize
@@ -468,16 +335,13 @@ async fn main() {
         .unwrap_or_else(|| "process_checkout_autocapture".to_string());
     let result: Result<String, Box<dyn std::error::Error>> = match flow.as_str() {
         "process_checkout_autocapture" => process_checkout_autocapture(&client, "order_001").await,
-        "process_checkout_card" => process_checkout_card(&client, "order_001").await,
-        "process_refund" => process_refund(&client, "order_001").await,
         "process_authorize" => process_authorize(&client, "txn_001").await,
-        "process_capture" => process_capture(&client, "txn_001").await,
         "process_proxy_authorize" => process_proxy_authorize(&client, "txn_001").await,
         "process_proxy_setup_recurring" => process_proxy_setup_recurring(&client, "txn_001").await,
         "process_recurring_charge" => process_recurring_charge(&client, "txn_001").await,
         "process_setup_recurring" => process_setup_recurring(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_authorize, process_capture, process_proxy_authorize, process_proxy_setup_recurring, process_recurring_charge, process_setup_recurring", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_authorize, process_proxy_authorize, process_proxy_setup_recurring, process_recurring_charge, process_setup_recurring", flow);
             return;
         }
     };

--- a/examples/worldpayraft/worldpayraft.ts
+++ b/examples/worldpayraft/worldpayraft.ts
@@ -7,7 +7,7 @@
 
 import { PaymentClient, RecurringPaymentClient, types } from 'hyperswitch-prism';
 const { Environment, AcceptanceType, AuthenticationType, CaptureMethod, CardNetwork, Currency, FutureUsage, PaymentMethodType } = types;
-export const SUPPORTED_FLOWS = ["authorize", "capture", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "setup_recurring"];
+export const SUPPORTED_FLOWS = ["authorize", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "setup_recurring"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -46,17 +46,6 @@ function _buildAuthorizeRequest(captureMethod: types.CaptureMethod): types.IPaym
         },
         "authType": AuthenticationType.NO_THREE_DS,  // Authentication Details.
         "returnUrl": "https://example.com/return"  // URLs for Redirection and Webhooks.
-    };
-}
-
-function _buildCaptureRequest(connectorTransactionId: string): types.IPaymentServiceCaptureRequest {
-    return {
-        "merchantCaptureId": "probe_capture_001",  // Identification.
-        "connectorTransactionId": connectorTransactionId,
-        "amountToCapture": {  // Capture Details.
-            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
-            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
     };
 }
 
@@ -133,19 +122,6 @@ function _buildRecurringChargeRequest(): types.IRecurringPaymentServiceChargeReq
     };
 }
 
-function _buildRefundRequest(connectorTransactionId: string): types.IPaymentServiceRefundRequest {
-    return {
-        "merchantRefundId": "probe_refund_001",  // Identification.
-        "connectorTransactionId": connectorTransactionId,
-        "paymentAmount": 1000,  // Amount Information.
-        "refundAmount": {
-            "minorAmount": 1000,  // Amount in minor units (e.g., 1000 = $10.00).
-            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        },
-        "reason": "customer_request"  // Reason for the refund.
-    };
-}
-
 function _buildSetupRecurringRequest(): types.IPaymentServiceSetupRecurringRequest {
     return {
         "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
@@ -199,58 +175,6 @@ async function processCheckoutAutocapture(merchantTransactionId: string, config:
     return { status: authorizeResponse.status, transactionId: authorizeResponse.connectorTransactionId!, error: authorizeResponse.error } as any;
 }
 
-// Card Payment (Authorize + Capture)
-// Two-step card payment. First authorize, then capture. Use when you need to verify funds before finalizing.
-async function processCheckoutCard(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    // Step 1: Authorize — reserve funds on the payment method
-    const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.MANUAL));
-
-    if (authorizeResponse.status === types.PaymentStatus.FAILURE) {
-        throw new Error(`Payment failed: ${JSON.stringify(authorizeResponse.error)}`);
-    }
-    if (authorizeResponse.status === types.PaymentStatus.PENDING) {
-        // Awaiting async confirmation — handle via webhook
-        return { status: 'pending', connectorTransactionId: authorizeResponse.connectorTransactionId };
-    }
-
-    // Step 2: Capture — settle the reserved funds
-    const captureResponse = await paymentClient.capture(_buildCaptureRequest(authorizeResponse.connectorTransactionId!));
-
-    if (captureResponse.status === types.PaymentStatus.FAILURE) {
-        throw new Error(`Capture failed: ${JSON.stringify(captureResponse.error)}`);
-    }
-
-    return { status: captureResponse.status, transactionId: authorizeResponse.connectorTransactionId!, error: authorizeResponse.error } as any;
-}
-
-// Refund
-// Return funds to the customer for a completed payment.
-async function processRefund(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    // Step 1: Authorize — reserve funds on the payment method
-    const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.AUTOMATIC));
-
-    if (authorizeResponse.status === types.PaymentStatus.FAILURE) {
-        throw new Error(`Payment failed: ${JSON.stringify(authorizeResponse.error)}`);
-    }
-    if (authorizeResponse.status === types.PaymentStatus.PENDING) {
-        // Awaiting async confirmation — handle via webhook
-        return { status: 'pending', connectorTransactionId: authorizeResponse.connectorTransactionId };
-    }
-
-    // Step 2: Refund — return funds to the customer
-    const refundResponse = await paymentClient.refund(_buildRefundRequest(authorizeResponse.connectorTransactionId!));
-
-    if (refundResponse.status === types.RefundStatus.REFUND_FAILURE) {
-        throw new Error(`Refund failed: ${JSON.stringify(refundResponse.error)}`);
-    }
-
-    return { status: refundResponse.status, error: refundResponse.error } as any;
-}
-
 // Flow: PaymentService.Authorize (Card)
 async function authorize(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -258,15 +182,6 @@ async function authorize(merchantTransactionId: string, config: types.IConnector
     const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.AUTOMATIC));
 
     return authorizeResponse;
-}
-
-// Flow: PaymentService.Capture
-async function capture(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    const captureResponse = await paymentClient.capture(_buildCaptureRequest('probe_connector_txn_001'));
-
-    return captureResponse;
 }
 
 // Flow: PaymentService.ProxyAuthorize
@@ -296,15 +211,6 @@ async function recurringCharge(merchantTransactionId: string, config: types.ICon
     return recurringResponse;
 }
 
-// Flow: PaymentService.Refund
-async function refund(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    const refundResponse = await paymentClient.refund(_buildRefundRequest('probe_connector_txn_001'));
-
-    return refundResponse;
-}
-
 // Flow: PaymentService.SetupRecurring
 async function setupRecurring(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -317,7 +223,7 @@ async function setupRecurring(merchantTransactionId: string, config: types.IConn
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, authorize, capture, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, setupRecurring, _buildAuthorizeRequest, _buildCaptureRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildSetupRecurringRequest
+    processCheckoutAutocapture, authorize, proxyAuthorize, proxySetupRecurring, recurringCharge, setupRecurring, _buildAuthorizeRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildSetupRecurringRequest
 };
 
 // CLI runner

--- a/grace/scripts/scripts/worldpayraft_mock_server.py
+++ b/grace/scripts/scripts/worldpayraft_mock_server.py
@@ -1,0 +1,912 @@
+#!/usr/bin/env python3
+"""Local mock of the Worldpay **Native RAFT API** v1.35.1 (credit + debit).
+
+Purpose: we have no Worldpay credentials, so this mock is the only way to see
+exactly what the UCS `worldpayraft` connector puts on the wire and to assert it
+against the published OpenAPI specs. Every request is logged verbatim, then run
+through a battery of field-level checks; each check emits an `[OK]` / `[FAIL]`
+line and is accumulated into a report the test harness can pull over HTTP.
+
+Ground truth: `Native Raft Credit API-1.35.1.yaml` / `Native Raft Debit
+API-1.35.1.yaml` (`host: ws-cert.vantiv.com`,
+`basePath: /merchant/servicing/apitransactions/NativeRaftApi/v1`). Every field
+name emitted below was grepped out of those two documents.
+
+Usage
+-----
+    python3 worldpayraft_mock_server.py [port] [license] [merchant_id]
+
+Defaults: port 9098, license `MOCK_LICENSE`, merchant id `MOCK_MERCHANT_ID`.
+Point the connector at `http://127.0.0.1:<port>/merchant/servicing/apitransactions/NativeRaftApi/v1`
+(the base path is optional -- bare `/credit/authorization` is accepted too).
+
+Endpoints and envelope keys (verbatim from the YAMLs)
+----------------------------------------------------
+    POST /credit/purchase        creditpurchase        -> creditpurchaseresponse
+    POST /credit/authorization   creditauth            -> creditauthresponse
+    POST /credit/completion      creditcompletion      -> creditcompletionresponse
+    POST /credit/refund          creditrefund          -> creditrefundresponse
+    POST /credit/balanceinquiry  creditbalanceinquiry  -> creditbalanceinquiryresponse
+    POST /debit/purchase         debitpurchase         -> debitpurchaseresponse
+    POST /debit/preauth          debitpreauth          -> debitpreauthresponse
+    POST /debit/completion       debitcompletion       -> debitcompletionresponse
+    POST /debit/refund           debitrefund           -> debitrefundresponse
+    POST /tokenization/token     tokenize              -> tokenizeresponse
+
+**There is no void/reversal/cancel endpoint for cards.** A Void is the *same*
+message re-sent to the *same* path with `AuthorizationType: "RV"` (optionally
+`ReversalAdviceReasonCd`), carrying the ORIGINAL `APITransactionID`. The mock
+detects `AuthorizationType == "RV"` on any financial path and books it as a
+reversal. `/credit/void`, `/credit/reversal`, `/credit/cancel`, `/credit/inquiry`,
+`/credit/status`, `/debit/void` and `/debit/reversal` are registered only so that
+a connector inventing them gets a loud `[FAIL]` plus the real 404 `NotFoundError`
+body Worldpay would return.
+
+HTTP status
+-----------
+Financial endpoints ALWAYS answer `200`. RAFT signals failure in the body only:
+success is `ReturnCode == "0000"` AND `ResponseCode == "000"` (`"010"` is a
+partial approval). Transport-level 401/404/500 shapes exist but are reserved for
+bad auth / unknown routes, mirroring the specs.
+
+Scripted failure modes
+----------------------
+Keyed off the **last four digits of `CardInfo.PAN`**. For a follow-up message
+that carries no PAN (completion / refund / reversal) the PAN of the remembered
+original transaction is used instead, so a capture of a declined auth declines
+the same way. `UserDefinedData.UserData1 = "FORCE:<code>"` overrides everything.
+
+    ....1111  approve                    ReturnCode 0000 / ResponseCode 000
+    ....0010  partial approval           ResponseCode 010, PartiallyAuthorized=Y,
+                                         OriginalAuthAmount = half the request
+    ....0005  DO NOT HONOR               ResponseCode 005  + advice code 01
+    ....0039  INSUFFICIENT FUNDS         ResponseCode 039  + advice code 02
+    ....0051  NO MATCHING ORIGINAL       ResponseCode 051  + advice code 03
+    ....0004  CARD EXPIRED               ResponseCode 004  + advice code 03
+    ....0013  INVALID CARD SECURITY CODE ResponseCode 013, Cvv2Cvc2CIDResult=N
+    ....0112  INVALID AVS INFORMATION    ResponseCode 112, AVSResult=N
+    ....0550  DECLINED BY FRAUDSIGHT     ResponseCode 550  + advice code 03
+    ....0666  edit error                 ReturnCode 0004 + ErrorInformation
+                                         {FieldInError, ErrorText}, no ResponseCode
+    ....0012  system issue               ReturnCode 0012, no ResponseCode
+
+Note on the enums: `054` is VELOCITY: EXCEEDS COUNT and `051` is UNABLE TO LOCATE
+A MATCHING ORIGINAL TRANSACTION in the real table (`raft_response_codes.json`);
+CARD EXPIRED is `004` and INSUFFICIENT FUNDS is `039`. The mapping above uses the
+real meanings rather than the approximate ones.
+
+Report API
+----------
+    GET  /__report   accumulated findings + per-transaction memory, as JSON
+    POST /__reset    clear findings and the transaction memory
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9098
+LICENSE = sys.argv[2] if len(sys.argv) > 2 else "MOCK_LICENSE"
+MERCHANT_ID = sys.argv[3] if len(sys.argv) > 3 else "MOCK_MERCHANT_ID"
+
+EXPECTED_AUTHORIZATION = 'VANTIV license="%s"' % LICENSE
+BASE_PATH = "/merchant/servicing/apitransactions/NativeRaftApi/v1"
+
+# ---------------------------------------------------------------------------
+# Route table -- request wrapper / response wrapper / message kind.
+# Taken verbatim from `<op>Request.required[0]` and `<op>Response.required[0]`
+# in the credit and debit YAMLs.
+# ---------------------------------------------------------------------------
+
+ROUTES = {
+    "/credit/purchase":       ("creditpurchase",       "creditpurchaseresponse",       "sale"),
+    "/credit/authorization":  ("creditauth",           "creditauthresponse",           "auth"),
+    "/credit/completion":     ("creditcompletion",     "creditcompletionresponse",     "completion"),
+    "/credit/refund":         ("creditrefund",         "creditrefundresponse",         "refund"),
+    "/credit/balanceinquiry": ("creditbalanceinquiry", "creditbalanceinquiryresponse", "inquiry"),
+    "/debit/purchase":        ("debitpurchase",        "debitpurchaseresponse",        "sale"),
+    "/debit/preauth":         ("debitpreauth",         "debitpreauthresponse",         "auth"),
+    "/debit/completion":      ("debitcompletion",      "debitcompletionresponse",      "completion"),
+    "/debit/refund":          ("debitrefund",          "debitrefundresponse",          "refund"),
+    "/tokenization/token":    ("tokenize",             "tokenizeresponse",             "tokenize"),
+}
+
+# Paths a connector might invent. They do NOT exist in any Native RAFT spec.
+PHANTOM_ROUTES = {
+    "/credit/void":     'no such endpoint; a Void is the original message re-sent with AuthorizationType="RV"',
+    "/credit/reversal": 'no such endpoint; a Void is the original message re-sent with AuthorizationType="RV"',
+    "/credit/cancel":   "no such endpoint; only /apm/cancel exists, and that is for alternate payment methods",
+    "/credit/inquiry":  "no such endpoint; /credit/balanceinquiry is a CARD BALANCE inquiry, not a transaction status lookup",
+    "/credit/status":   "no such endpoint; Native RAFT has no transaction-status/PSync operation at all",
+    "/credit/query":    "no such endpoint; Native RAFT has no transaction-status/PSync operation at all",
+    "/debit/void":      'no such endpoint; use the original message with AuthorizationType="RV"',
+    "/debit/reversal":  'no such endpoint; use the original message with AuthorizationType="RV"',
+}
+
+# Legal top-level members of a credit financial request object.
+KNOWN_TOP_LEVEL = {
+    "MiscAmountsBalances", "AccountCodesAndData", "CardInfo", "Multi-clearingData", "EMVData",
+    "AddressVerificationData", "CardVerificationData", "EncryptionTokenData", "DeviceInformation",
+    "PINProcessingData", "TerminalData", "E-commerceData", "BillPaymentData", "GatewayRoutingId",
+    "ProcFlagsIndicators", "VisaSpecificData", "McrdSpecificData", "DiscSpecificData",
+    "AmexSpecificData", "MarketSpecificData", "Duration", "STPData", "MerchantSpecificData",
+    "ReferenceTraceNumbers", "WorldPayMerchantID", "UserDefinedData", "SoftDescriptorData",
+    "WalletId", "OperatorEmployee", "BatchNumber", "CustomerInformation", "PrestigiousPropertyIND",
+    "ReversalAdviceReasonCd", "AlternateMerchantID", "DynamicCurrConvInfo", "Level3Data",
+    "PaymentSenderData", "PrivateLabelData", "AuthorizationType", "APITransactionID",
+    "LocalDateTime", "LodgingData", "VehicleRentalData", "OnlineShipToAddress",
+    "OnlineBillToAddress", "OnlineOrderCustomerData", "SynchronyData", "FisLoyaltyData",
+    "PriorityRouting", "AdditionalFraudData", "BenefitCardServicesData", "EncryptedData",
+    "TraceData", "MastercardDSRPCryptogram", "MastercardRemoteCommerceAcceptorIdentifier",
+    "AdditionalPOSData", "AssuredPaymentsUserAccountData", "AssuredPaymentsPurchaseInformation",
+    "AssuredPaymentsItemData", "AssuredPaymentsGeneralData", "AssuredPaymentsMembershipData",
+    "AssuredSellerData", "AssuredSubscriptionData", "PassengerTransportData",
+    "AirlineItineraryData", "AirlineAncillaryServiceData", "BasketData", "JWTProcessingData",
+    "OnlineShipFromAddress", "OrderShipDate",
+}
+
+# Legal request-side members of the objects UCS actually populates.
+KNOWN_SUBFIELDS = {
+    "CardInfo": {"PAN", "TRACK_2", "TRACK_1", "ExpirationDate", "CardSequenceNumber"},
+    "CardVerificationData": {"Cvv2Cvc2CIDValue", "Cvv2Cvc2CIDIndicator"},
+    "AddressVerificationData": {"AVSZIPCode", "AVSAddress"},
+    "ReferenceTraceNumbers": {
+        "RetrievalREFNumber", "CorrelationID", "AuthorizationNumber", "RefInvoiceNumber",
+        "DraftLocator", "TransactionLinkID", "TaxVATInvoiceNumber", "EconomicallyRelatedLinkID",
+    },
+    "TerminalData": {
+        "EntryMode", "TerminalType", "TerminalNumber", "POSConditionCode", "POSEnvironment",
+        "TerminalEntryCap", "AttendedDevice", "OperatingEnvironment",
+    },
+    "MiscAmountsBalances": {
+        "TransactionAmount", "PreauthorizedAmount", "CashBackAmount", "SurchargeAmount",
+        "ConvenienceFEE", "TIPAmount", "DispensedAmount", "SalesTAXAmount", "CumulativeAmount",
+        "PaymentTrailingAmt", "OPTUMAmount", "GiftCardReloadableAmount",
+        "GiftCardNonReloadableAmount", "InvoiceDiscountAmount", "InvoiceShippingAmount",
+        "OriginalAuthAmount", "AvailableBALFromAcct",
+    },
+}
+
+# Fields the spec declares response-only. Sending them is a bug.
+RESPONSE_ONLY_SUBFIELDS = {
+    "ReferenceTraceNumbers": {
+        "SystemTraceNumber", "NetworkTraceNumber", "NetworkRefNumber", "PaymentAcctREFNumber",
+        "PanReferenceID",
+    },
+    "CardVerificationData": {"Cvv2Cvc2CIDResult"},
+    "AddressVerificationData": {"AVSResult"},
+}
+
+# Wrong field names seen in the wild, mapped to the real spec name.
+LEGACY_ALIASES = {
+    "CardVerificationData": {
+        "CVV2CVC2": "Cvv2Cvc2CIDValue",
+        "CVV2": "Cvv2Cvc2CIDValue",
+        "CVV": "Cvv2Cvc2CIDValue",
+        "CardSecurityCode": "Cvv2Cvc2CIDValue",
+        "CVV2CVC2Indicator": "Cvv2Cvc2CIDIndicator",
+    },
+}
+
+ECI_CODES = {
+    "01": "Single transaction - default for Bill Payments",
+    "02": "Recurring Transaction",
+    "03": "Installment Payment",
+    "05": "VbV authenticated / MC SecureCode with AAV / Discover with CAVV",
+    "06": "VbV attempts processing / MC SecureCode with or without AAV",
+    "07": "eCommerce, but neither Verified by Visa nor MasterCard SecureCode",
+    "08": "No security method",
+    "09": "SET (non-US)",
+    "10": "Recurring, first of a series",
+    "20": "Token Initiated (AMEX only)",
+}
+
+# last-4 of PAN -> (ReturnCode, ResponseCode, ReturnText, MastercardMerchantAdviceCode)
+MAGIC_PANS = {
+    "0010": ("0000", "010", None, None),
+    "0005": ("0000", "005", "DO NOT HONOR", "01"),
+    "0039": ("0000", "039", "INSUFFICIENT FUNDS", "02"),
+    "0051": ("0000", "051", "UNABLE TO LOCATE A MATCHING ORIGINAL TRANSACTION", "03"),
+    "0004": ("0000", "004", "CARD EXPIRED", "03"),
+    "0013": ("0000", "013", "INVALID CARD SECURITY CODE", "01"),
+    "0112": ("0000", "112", "INVALID ADDRESS VERIFICATION INFORMATION", "01"),
+    "0550": ("0000", "550", "TRANSACTION DECLINED BY FRAUDSIGHT", "03"),
+    "0666": ("0004", None, "EDIT ERROR ON INPUT", None),
+    "0012": ("0012", None, "SYSTEM ISSUE", None),
+}
+
+# ---------------------------------------------------------------------------
+# Mutable state: validation findings + remembered transactions
+# ---------------------------------------------------------------------------
+
+FINDINGS = []      # list of dicts, newest last
+TRANSACTIONS = {}  # APITransactionID -> record
+BY_AUTH_NUMBER = {}  # AuthorizationNumber -> APITransactionID
+COUNTERS = {"requests": 0, "OK": 0, "FAIL": 0, "WARN": 0, "INFO": 0}
+SEQ = {"n": 0, "trace": 100000, "auth": 100000, "rrn": 0}
+
+
+def record(level, check, message, ctx):
+    """Append one finding and print it as an [OK]/[FAIL]/[WARN]/[INFO] line."""
+    SEQ["n"] += 1
+    COUNTERS[level] = COUNTERS.get(level, 0) + 1
+    finding = {
+        "seq": SEQ["n"],
+        "at": datetime.now(timezone.utc).isoformat(),
+        "level": level,
+        "check": check,
+        "message": message,
+        "path": ctx.get("path"),
+        "wrapper": ctx.get("wrapper"),
+        "api_transaction_id": ctx.get("api_transaction_id"),
+    }
+    FINDINGS.append(finding)
+    print("[%s] %-28s %s" % (level, check, message), flush=True)
+
+
+def ok(check, message, ctx):
+    record("OK", check, message, ctx)
+
+
+def fail(check, message, ctx):
+    record("FAIL", check, message, ctx)
+
+
+def warn(check, message, ctx):
+    record("WARN", check, message, ctx)
+
+
+def info(check, message, ctx):
+    record("INFO", check, message, ctx)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def obj(body, name):
+    value = body.get(name)
+    return value if isinstance(value, dict) else {}
+
+
+def validate(path, headers, body, req_wrapper, kind, ctx):
+    """Run every check against one decoded request. Returns the operation dict."""
+
+    # --- 1. Authorization header --------------------------------------------
+    got_auth = headers.get("Authorization")
+    if got_auth is None:
+        fail("auth.header.present", "no Authorization header sent; expected %r"
+             % EXPECTED_AUTHORIZATION, ctx)
+    elif got_auth == EXPECTED_AUTHORIZATION:
+        ok("auth.header", "Authorization matches %r" % EXPECTED_AUTHORIZATION, ctx)
+    else:
+        fail("auth.header",
+             "Authorization is %r, expected exactly %r (scheme must be the literal "
+             "'VANTIV', the license quoted, no base64)" % (got_auth, EXPECTED_AUTHORIZATION), ctx)
+
+    ctype = (headers.get("Content-Type") or "").split(";")[0].strip()
+    if ctype == "application/json":
+        ok("http.content_type", "Content-Type: application/json", ctx)
+    else:
+        fail("http.content_type", "Content-Type is %r, spec consumes application/json" % ctype, ctx)
+
+    # --- 2. Envelope wrapper key --------------------------------------------
+    if not isinstance(body, dict):
+        fail("envelope.wrapper", "body is not a JSON object", ctx)
+        return {}
+    keys = list(body.keys())
+    if keys == [req_wrapper]:
+        ok("envelope.wrapper", "body wrapped in the single key %r" % req_wrapper, ctx)
+    elif req_wrapper in body:
+        fail("envelope.wrapper",
+             "wrapper %r present but body also carries extra top-level keys %r; the spec "
+             "declares exactly one root property" % (req_wrapper, [k for k in keys if k != req_wrapper]), ctx)
+    else:
+        fail("envelope.wrapper",
+             "wrong wrapper key: got %r, %s expects %r (response comes back as %r)"
+             % (keys, path, req_wrapper, ROUTES[path][1]), ctx)
+        # Best effort: continue against whatever single object was sent.
+        if len(keys) == 1 and isinstance(body[keys[0]], dict):
+            return validate_operation(path, body[keys[0]], kind, ctx)
+        return {}
+
+    return validate_operation(path, body.get(req_wrapper) or {}, kind, ctx)
+
+
+def validate_operation(path, op, kind, ctx):
+    if not isinstance(op, dict):
+        fail("envelope.wrapper", "wrapper value is not a JSON object", ctx)
+        return {}
+
+    ctx["api_transaction_id"] = op.get("APITransactionID")
+
+    # --- 3. WorldPayMerchantID ----------------------------------------------
+    mid = op.get("WorldPayMerchantID")
+    if mid is None:
+        fail("field.WorldPayMerchantID", "missing; it is a required field on every operation", ctx)
+    elif mid == MERCHANT_ID:
+        ok("field.WorldPayMerchantID", "== %r" % MERCHANT_ID, ctx)
+    else:
+        fail("field.WorldPayMerchantID",
+             "is %r, expected %r -- the connector is probably sending the license/api key "
+             "instead of the merchant id" % (mid, MERCHANT_ID), ctx)
+
+    # --- 4. APITransactionID ------------------------------------------------
+    txn_id = op.get("APITransactionID")
+    if not txn_id:
+        fail("field.APITransactionID",
+             "missing or empty; required on every operation and it is the matching + "
+             "idempotency key", ctx)
+    elif len(str(txn_id)) > 16:
+        fail("field.APITransactionID",
+             "%r is %d chars, maxLength is 16 (Worldpay left zero-pads to a fixed 16)"
+             % (txn_id, len(str(txn_id))), ctx)
+    else:
+        ok("field.APITransactionID", "%r present, %d/16 chars" % (txn_id, len(str(txn_id))), ctx)
+
+    # --- 5. LocalDateTime ---------------------------------------------------
+    ldt = op.get("LocalDateTime")
+    if not ldt:
+        fail("field.LocalDateTime", "missing; required, format YYYY-MM-DDTHH:mm:ss", ctx)
+    else:
+        try:
+            datetime.strptime(str(ldt)[:19], "%Y-%m-%dT%H:%M:%S")
+            if len(str(ldt)) > 19:
+                fail("field.LocalDateTime",
+                     "%r is %d chars, maxLength is 19 -- merchant-local "
+                     "'YYYY-MM-DDTHH:mm:ss' with no timezone suffix" % (ldt, len(str(ldt))), ctx)
+            else:
+                ok("field.LocalDateTime", "%r well formed" % ldt, ctx)
+        except ValueError:
+            fail("field.LocalDateTime", "%r is not YYYY-MM-DDTHH:mm:ss" % ldt, ctx)
+
+    # --- 6. Unknown / misplaced top-level members ---------------------------
+    unknown = [k for k in op if k not in KNOWN_TOP_LEVEL]
+    if unknown:
+        fail("schema.unknown_field",
+             "top-level members not in the spec: %r" % unknown, ctx)
+    else:
+        ok("schema.unknown_field", "all top-level members exist in the spec", ctx)
+
+    for parent, allowed in KNOWN_SUBFIELDS.items():
+        block = obj(op, parent)
+        # Response-only members exist in the spec; they get their own, sharper
+        # finding below rather than being reported as unknown here.
+        allowed = allowed | RESPONSE_ONLY_SUBFIELDS.get(parent, set())
+        strays = [k for k in block if k not in allowed]
+        if strays:
+            aliases = LEGACY_ALIASES.get(parent, {})
+            for stray in strays:
+                if stray in aliases:
+                    fail("schema.legacy_field_name",
+                         "%s.%s is NOT a Native RAFT field -- the spec name is %s.%s "
+                         "(literal '%s' appears 0 times in credit.yaml)"
+                         % (parent, stray, parent, aliases[stray], stray), ctx)
+                else:
+                    fail("schema.unknown_field",
+                         "%s.%s is not in the spec" % (parent, stray), ctx)
+
+    # --- 7. CVV field name and presence indicator ---------------------------
+    cvd = obj(op, "CardVerificationData")
+    cvv_value = cvd.get("Cvv2Cvc2CIDValue")
+    legacy_cvv = next((cvd[k] for k in ("CVV2CVC2", "CVV2", "CVV", "CardSecurityCode")
+                       if k in cvd), None)
+    indicator = cvd.get("Cvv2Cvc2CIDIndicator")
+
+    if cvv_value:
+        ok("cvv.field_name", "CVV carried in the correct field CardVerificationData.Cvv2Cvc2CIDValue", ctx)
+    elif legacy_cvv:
+        fail("cvv.field_name",
+             "CVV carried in a NON-EXISTENT field; Worldpay will silently drop it and the "
+             "transaction will run without CVV verification. Rename to "
+             "CardVerificationData.Cvv2Cvc2CIDValue (maxLength 4)", ctx)
+    elif cvd:
+        warn("cvv.field_name", "CardVerificationData present but carries no CVV value", ctx)
+
+    have_cvv = bool(cvv_value or legacy_cvv)
+    if have_cvv:
+        if indicator == "1":
+            ok("cvv.indicator", 'Cvv2Cvc2CIDIndicator="1" (value is present) matches the CVV sent', ctx)
+        elif indicator == "0":
+            fail("cvv.indicator",
+                 'Cvv2Cvc2CIDIndicator="0" means "the CVV2/CVC2/CID value was BYPASSED or not '
+                 'given", but a CVV value IS being sent -- the indicator is inverted. It must '
+                 'be "1" when a value is present', ctx)
+        elif indicator is None:
+            fail("cvv.indicator",
+                 'a CVV value is sent but Cvv2Cvc2CIDIndicator is missing; it must be "1"', ctx)
+        else:
+            warn("cvv.indicator",
+                 'Cvv2Cvc2CIDIndicator=%r with a CVV present; expected "1" '
+                 '(2=illegible, 9=not on card)' % indicator, ctx)
+    elif indicator not in (None, "0", "9"):
+        warn("cvv.indicator",
+             'Cvv2Cvc2CIDIndicator=%r but no CVV value is being sent' % indicator, ctx)
+
+    # --- 8. SystemTraceNumber must not be sent ------------------------------
+    for parent, banned in RESPONSE_ONLY_SUBFIELDS.items():
+        block = obj(op, parent)
+        for name in banned:
+            if name in block:
+                fail("field.response_only",
+                     "%s.%s is sent on the REQUEST; the spec declares it response-only "
+                     "(%r, value %r) -- Worldpay generates it and returns it, the acquirer "
+                     "must never populate it"
+                     % (parent, name, "generated by Worldpay", block[name]), ctx)
+    rtn = obj(op, "ReferenceTraceNumbers")
+    if "SystemTraceNumber" not in rtn:
+        ok("field.SystemTraceNumber", "not sent on the request (correct: response-only)", ctx)
+
+    # --- 9. Amounts ---------------------------------------------------------
+    amounts = obj(op, "MiscAmountsBalances")
+    txn_amount = amounts.get("TransactionAmount")
+    if kind in ("auth", "sale", "completion", "refund"):
+        if txn_amount in (None, ""):
+            fail("field.TransactionAmount",
+                 "MiscAmountsBalances.TransactionAmount missing; required on every financial "
+                 "operation", ctx)
+        else:
+            ok("field.TransactionAmount", "= %r" % txn_amount, ctx)
+
+    if kind == "completion":
+        preauth = amounts.get("PreauthorizedAmount")
+        if preauth in (None, ""):
+            fail("field.PreauthorizedAmount",
+                 "MiscAmountsBalances.PreauthorizedAmount is MISSING on %s -- the spec marks "
+                 "it REQUIRED on completion ('the acquirer places the amount that the "
+                 "transaction was originally authorized for in this field'). Without it the "
+                 "capture cannot be matched to the preauth" % path, ctx)
+        else:
+            ok("field.PreauthorizedAmount", "= %r on %s" % (preauth, path), ctx)
+            if txn_amount not in (None, "") and str(txn_amount) != str(preauth):
+                info("capture.partial",
+                     "TransactionAmount %r != PreauthorizedAmount %r -> partial capture"
+                     % (txn_amount, preauth), ctx)
+
+    # --- 10. E-commerceIndicator -------------------------------------------
+    ecom = obj(op, "E-commerceData")
+    eci = ecom.get("E-commerceIndicator")
+    if eci is None:
+        warn("field.E-commerceIndicator",
+             "not sent; all e-commerce transactions must include it", ctx)
+    elif eci in ECI_CODES:
+        info("field.E-commerceIndicator",
+             "received %r (%s)%s" % (eci, ECI_CODES[eci],
+                                     " -- note: hardcoded 07 loses 3DS/recurring signalling"
+                                     if eci == "07" else ""), ctx)
+    else:
+        fail("field.E-commerceIndicator",
+             "%r is not a documented ECI value %s" % (eci, sorted(ECI_CODES)), ctx)
+
+    if ecom.get("3dSecureData") and eci not in ("05", "06"):
+        fail("field.E-commerceIndicator",
+             "3dSecureData is present but E-commerceIndicator is %r; an authenticated 3DS "
+             "transaction must be 05 (or 06 for attempts)" % eci, ctx)
+
+    # --- 11. Reversal / follow-up linkage -----------------------------------
+    auth_type = op.get("AuthorizationType")
+    is_reversal = auth_type == "RV"
+    if auth_type is not None and auth_type not in ("FP", "RV"):
+        fail("field.AuthorizationType",
+             "%r is not a documented value; only FP (Force Post) and RV (Reversal) exist"
+             % auth_type, ctx)
+    if is_reversal:
+        ok("void.mechanism",
+             'AuthorizationType="RV" on %s -- correct: there is no void/reversal endpoint, a '
+             "void is the original message re-sent with RV" % path, ctx)
+        rr = op.get("ReversalAdviceReasonCd")
+        if rr is None:
+            info("field.ReversalAdviceReasonCd",
+                 "not sent; Worldpay will default it (000 Normal Reversal)", ctx)
+        elif rr not in ("000", "002", "003", "005", "006", "010"):
+            fail("field.ReversalAdviceReasonCd",
+                 "%r is not a documented value (000/002/003/005/006/010)" % rr, ctx)
+
+    follow_up = kind in ("completion", "refund") or is_reversal
+    if follow_up:
+        check_followup_linkage(op, txn_id, rtn, kind, is_reversal, ctx)
+    elif txn_id:
+        remember(op, txn_id, kind, path, ctx)
+
+    return op
+
+
+def check_followup_linkage(op, txn_id, rtn, kind, is_reversal, ctx):
+    """Did the follow-up reuse the ORIGINAL APITransactionID, as the spec requires?"""
+    label = "reversal" if is_reversal else kind
+    auth_number = rtn.get("AuthorizationNumber")
+
+    if txn_id and txn_id in TRANSACTIONS:
+        original = TRANSACTIONS[txn_id]
+        ok("followup.api_transaction_id",
+           "%s reuses APITransactionID %r from the original %s -- correct, that is how "
+           "Worldpay matches follow-up messages" % (label, txn_id, original["kind"]), ctx)
+        return
+
+    linked = BY_AUTH_NUMBER.get(str(auth_number)) if auth_number else None
+    if linked:
+        fail("followup.api_transaction_id",
+             "%s sent a REGENERATED APITransactionID %r. The original transaction was %r "
+             "(matched via ReferenceTraceNumbers.AuthorizationNumber %r). The spec: 'If you "
+             "are initiating a subsequent message that ties back to an original request, "
+             "provide the APITransactionID of the original transaction.' With a fresh id "
+             "Worldpay cannot match the %s back to the auth"
+             % (label, txn_id, linked, auth_number, label), ctx)
+        return
+
+    if auth_number:
+        warn("followup.api_transaction_id",
+             "%s carries APITransactionID %r which this mock has never seen, and "
+             "AuthorizationNumber %r does not match a remembered authorization either "
+             "(nothing to link it to)" % (label, txn_id, auth_number), ctx)
+    else:
+        fail("followup.api_transaction_id",
+             "%s carries neither a known APITransactionID (%r) nor a "
+             "ReferenceTraceNumbers.AuthorizationNumber -- there is no way for Worldpay to "
+             "match it back to the original transaction" % (label, txn_id), ctx)
+
+    if auth_number and len(str(auth_number)) > 6:
+        fail("field.AuthorizationNumber",
+             "ReferenceTraceNumbers.AuthorizationNumber %r is %d chars, maxLength is 6 "
+             "(it is the 6-char issuer approval code, not a connector transaction id)"
+             % (auth_number, len(str(auth_number))), ctx)
+
+    rrn = rtn.get("RetrievalREFNumber")
+    if rrn == "":
+        fail("field.RetrievalREFNumber",
+             "sent as an empty string; omit the field entirely rather than sending '' "
+             "(Worldpay generates one when the network requires it)", ctx)
+
+
+def remember(op, txn_id, kind, path, ctx):
+    pan = obj(op, "CardInfo").get("PAN") or ""
+    record_ = {
+        "api_transaction_id": txn_id,
+        "kind": kind,
+        "path": path,
+        "pan_last4": str(pan)[-4:],
+        "amount": obj(op, "MiscAmountsBalances").get("TransactionAmount"),
+        "local_date_time": op.get("LocalDateTime"),
+    }
+    TRANSACTIONS[str(txn_id)] = record_
+
+
+# ---------------------------------------------------------------------------
+# Response shaping
+# ---------------------------------------------------------------------------
+
+def brand_of(pan):
+    pan = str(pan or "")
+    if pan.startswith("4"):
+        return "visa"
+    if pan[:2] in ("34", "37"):
+        return "amex"
+    if pan[:4] in ("6011",) or pan[:2] == "65":
+        return "discover"
+    if pan[:2] in ("51", "52", "53", "54", "55"):
+        return "mastercard"
+    if pan[:4].isdigit() and 2221 <= int(pan[:4] or 0) <= 2720:
+        return "mastercard"
+    return "unknown"
+
+
+def next_id(bucket, width):
+    SEQ[bucket] += 1
+    return str(SEQ[bucket])[-width:].rjust(width, "0")
+
+
+def outcome_for(op, txn_id):
+    """Resolve the scripted outcome for this message."""
+    forced = obj(op, "UserDefinedData").get("UserData1") or ""
+    if str(forced).startswith("FORCE:"):
+        code = str(forced).split(":", 1)[1].strip()
+        if code in MAGIC_PANS:
+            return MAGIC_PANS[code]
+        return ("0000", code, None, None)
+
+    pan = obj(op, "CardInfo").get("PAN") or ""
+    last4 = str(pan)[-4:]
+    if not last4 and txn_id and str(txn_id) in TRANSACTIONS:
+        last4 = TRANSACTIONS[str(txn_id)].get("pan_last4") or ""
+    if last4 in MAGIC_PANS:
+        return MAGIC_PANS[last4]
+    return ("0000", "000", None, None)
+
+
+def build_response(path, resp_wrapper, kind, op, ctx):
+    txn_id = op.get("APITransactionID") or ""
+    return_code, response_code, return_text, advice = outcome_for(op, txn_id)
+
+    body = {
+        "ReturnCode": return_code,
+        "ReasonCode": "0000",
+        "APITransactionID": str(txn_id)[:16].rjust(16, "0"),
+    }
+    if return_text and return_code != "0000":
+        body["ReturnText"] = return_text[:60]
+
+    if return_code == "0004":
+        body["ReasonCode"] = "0101"
+        body["ErrorInformation"] = {
+            "FieldInError": "CardVerificationData.Cvv2Cvc2CIDValue",
+            "ErrorText": "NON-NUMERIC",
+        }
+        return {resp_wrapper: body}
+    if return_code == "0012":
+        body["ReasonCode"] = "9999"
+        return {resp_wrapper: body}
+
+    body["ResponseCode"] = response_code
+
+    if kind == "tokenize":
+        body["EncryptionTokenData"] = {
+            "TokenizedPAN": "9%s" % str(obj(op, "CardInfo").get("PAN") or "")[-15:].rjust(15, "0"),
+            "TokenID": "0001",
+        }
+        return {resp_wrapper: body}
+
+    pan = str(obj(op, "CardInfo").get("PAN") or "")
+    amounts = obj(op, "MiscAmountsBalances")
+    amount = amounts.get("TransactionAmount")
+    approved = response_code in ("000", "010")
+
+    misc = {}
+    if response_code == "010":
+        try:
+            misc["OriginalAuthAmount"] = "%.2f" % (float(amount) / 2.0)
+        except (TypeError, ValueError):
+            misc["OriginalAuthAmount"] = amount
+        body["ProcFlagsIndicators"] = {"PartiallyAuthorized": "Y"}
+    elif amount is not None:
+        misc["OriginalAuthAmount"] = amount
+        body["ProcFlagsIndicators"] = {"PartiallyAuthorized": "N"}
+    if misc:
+        body["MiscAmountsBalances"] = misc
+
+    if pan:
+        body["CardInfo"] = {"PAN": ("*" * max(len(pan) - 4, 0)) + pan[-4:], "CardProductCode": "CRD"}
+
+    avs_result = "N" if response_code == "112" else "Y"
+    cvv_result = "N" if response_code == "013" else ("M" if approved else "P")
+    avd = obj(op, "AddressVerificationData")
+    # "Worldpay returns this field in the response message if the authorization
+    # request included AVSZipCode or AVSAddress."
+    if avd.get("AVSZIPCode") or avd.get("AVSAddress") or response_code == "112":
+        body["AddressVerificationData"] = {"AVSResult": avs_result}
+    cvd = obj(op, "CardVerificationData")
+    if cvd:
+        body["CardVerificationData"] = {"Cvv2Cvc2CIDResult": cvv_result}
+
+    eci = obj(op, "E-commerceData").get("E-commerceIndicator")
+    if eci is not None:
+        body["E-commerceData"] = {
+            "ReturnE-commerceIndicator": eci,
+            "3dSecureResult": "2" if eci in ("05", "06") else "5",
+        }
+
+    auth_number = next_id("auth", 6) if approved else "      "
+    trace_number = next_id("trace", 6)
+    SEQ["rrn"] += 1
+    retrieval = "%s%08d" % (datetime.now(timezone.utc).strftime("%y%j")[-4:], SEQ["rrn"])
+    body["ReferenceTraceNumbers"] = {
+        "AuthorizationNumber": auth_number,
+        "RetrievalREFNumber": obj(op, "ReferenceTraceNumbers").get("RetrievalREFNumber") or retrieval,
+        "SystemTraceNumber": trace_number,
+    }
+    correlation = obj(op, "ReferenceTraceNumbers").get("CorrelationID")
+    if correlation:
+        body["ReferenceTraceNumbers"]["CorrelationID"] = correlation
+
+    brand = brand_of(pan) if pan else (
+        TRANSACTIONS.get(str(txn_id), {}).get("brand") or "unknown")
+    if brand == "mastercard":
+        mcrd = {
+            "McrdBanknetREFNUM": trace_number.rjust(9, "0")[-9:],
+            "McrdBanknetSettleDate": datetime.now(timezone.utc).strftime("%m%d"),
+        }
+        if advice and obj(op, "ProcFlagsIndicators").get("MastercardAdviceCodeIndicator") == "Y":
+            mcrd["MastercardMerchantAdviceCode"] = advice
+        elif advice:
+            # Still return it so the error path can be exercised, but say so.
+            mcrd["MastercardMerchantAdviceCode"] = advice
+            info("response.advice_code",
+                 'returning MastercardMerchantAdviceCode=%r even though the request did not set '
+                 'ProcFlagsIndicators.MastercardAdviceCodeIndicator="Y"; the real host would '
+                 "omit it" % advice, ctx)
+        body["McrdSpecificData"] = mcrd
+    elif brand == "visa":
+        body["VisaSpecificData"] = {
+            "VisaTransactionId": trace_number.rjust(15, "0"),
+            "VisaValidationCode": "A1B2",
+            "VisaCardLevelResults": "A ",
+        }
+    elif brand == "amex":
+        body["AmexSpecificData"] = {"AmexTransactionId": trace_number.rjust(15, "0")}
+    elif brand == "discover":
+        body["DiscSpecificData"] = {"DiscTransactionId": trace_number.rjust(15, "0")}
+
+    body["AuthorizationSource"] = "5" if approved else "C"
+
+    if approved and kind in ("auth", "sale") and txn_id:
+        TRANSACTIONS.setdefault(str(txn_id), {})
+        TRANSACTIONS[str(txn_id)].update({
+            "api_transaction_id": txn_id,
+            "kind": kind,
+            "path": path,
+            "pan_last4": pan[-4:],
+            "brand": brand,
+            "amount": amount,
+            "authorization_number": auth_number,
+            "retrieval_ref_number": body["ReferenceTraceNumbers"]["RetrievalREFNumber"],
+            "system_trace_number": trace_number,
+        })
+        BY_AUTH_NUMBER[auth_number] = str(txn_id)
+        # A connector that keeps its own "connector transaction id" will echo it
+        # back on the capture; remember that too so the linkage check can fire.
+        for candidate in (obj(op, "ReferenceTraceNumbers").get("CorrelationID"),
+                          obj(op, "ReferenceTraceNumbers").get("RefInvoiceNumber")):
+            if candidate:
+                BY_AUTH_NUMBER.setdefault(str(candidate), str(txn_id))
+        BY_AUTH_NUMBER.setdefault(str(txn_id), str(txn_id))
+
+    return {resp_wrapper: body}
+
+
+def summary():
+    return {
+        "requests": COUNTERS["requests"],
+        "ok": COUNTERS["OK"],
+        "fail": COUNTERS["FAIL"],
+        "warn": COUNTERS["WARN"],
+        "info": COUNTERS["INFO"],
+        "failed_checks": sorted({f["check"] for f in FINDINGS if f["level"] == "FAIL"}),
+    }
+
+
+def print_summary():
+    s = summary()
+    print("-" * 78, flush=True)
+    print("SUMMARY  requests=%(requests)d  OK=%(ok)d  FAIL=%(fail)d  WARN=%(warn)d  "
+          "INFO=%(info)d" % s, flush=True)
+    for check in s["failed_checks"]:
+        print("  FAILED: %s" % check, flush=True)
+    print("-" * 78, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# HTTP plumbing
+# ---------------------------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args):
+        pass  # superseded by the explicit dump below
+
+    # -- helpers ------------------------------------------------------------
+    def _normalised_path(self):
+        path = self.path.split("?")[0]
+        if path.startswith(BASE_PATH):
+            path = path[len(BASE_PATH):] or "/"
+        return path.rstrip("/") or "/"
+
+    def _send(self, status, payload):
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _dump_request(self, path, raw, body):
+        print("=" * 78, flush=True)
+        print(">>> INBOUND REQUEST  %s %s HTTP/%s" % (self.command, self.path,
+                                                      self.request_version), flush=True)
+        print("--- headers ---", flush=True)
+        for name, value in self.headers.items():
+            print("%s: %s" % (name, value), flush=True)
+        print("--- body (verbatim) ---", flush=True)
+        print(raw.decode("utf-8", "replace") if raw else "<empty>", flush=True)
+        if body is not None:
+            print("--- body (pretty) ---", flush=True)
+            print(json.dumps(body, indent=2, sort_keys=True), flush=True)
+        print("--- validation (route %s) ---" % path, flush=True)
+
+    # -- verbs --------------------------------------------------------------
+    def do_GET(self):
+        path = self._normalised_path()
+        if path == "/__report":
+            self._send(200, {
+                "license_expected": EXPECTED_AUTHORIZATION,
+                "merchant_id_expected": MERCHANT_ID,
+                "summary": summary(),
+                "findings": FINDINGS,
+                "transactions": TRANSACTIONS,
+            })
+            return
+        if path == "/__health":
+            self._send(200, {"status": "ok", "port": PORT})
+            return
+        self._send(404, {"fault": {"faultType": "Server Error Processing Message",
+                                   "faultDescription": "Requested Service does not exist"}})
+
+    def do_POST(self):
+        path = self._normalised_path()
+
+        if path == "/__reset":
+            del FINDINGS[:]
+            TRANSACTIONS.clear()
+            BY_AUTH_NUMBER.clear()
+            for key in COUNTERS:
+                COUNTERS[key] = 0
+            print("=" * 78, flush=True)
+            print(">>> /__reset -- findings and transaction memory cleared", flush=True)
+            self._send(200, {"status": "reset"})
+            return
+
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw.decode() or "{}")
+        except ValueError:
+            body = None
+
+        COUNTERS["requests"] += 1
+        self._dump_request(path, raw, body)
+        ctx = {"path": path, "wrapper": None, "api_transaction_id": None}
+
+        if path in PHANTOM_ROUTES:
+            fail("route.nonexistent",
+                 "POST %s -- %s. Worldpay answers 404 NotFoundError here"
+                 % (path, PHANTOM_ROUTES[path]), ctx)
+            payload = {"fault": {"faultType": "Server Error Processing Message",
+                                 "faultDescription": "Requested Service does not exist"}}
+            self._finish(404, payload)
+            return
+
+        if path not in ROUTES:
+            fail("route.unknown",
+                 "POST %s is not a Native RAFT operation; known routes: %s"
+                 % (path, ", ".join(sorted(ROUTES))), ctx)
+            payload = {"fault": {"faultType": "Server Error Processing Message",
+                                 "faultDescription": "Requested Service does not exist"}}
+            self._finish(404, payload)
+            return
+
+        req_wrapper, resp_wrapper, kind = ROUTES[path]
+        ctx["wrapper"] = req_wrapper
+        ok("route", "POST %s -> %s / %s" % (path, req_wrapper, resp_wrapper), ctx)
+
+        if body is None:
+            fail("http.body", "request body is not valid JSON", ctx)
+            self._finish(200, {resp_wrapper: {
+                "ReturnCode": "0004", "ReasonCode": "0001",
+                "ReturnText": "MALFORMED MESSAGE RECEIVED",
+                "ErrorInformation": {"FieldInError": "body", "ErrorText": "NOT JSON"},
+            }})
+            return
+
+        op = validate(path, self.headers, body, req_wrapper, kind, ctx)
+        payload = build_response(path, resp_wrapper, kind, op, ctx)
+        self._finish(200, payload)
+
+    def _finish(self, status, payload):
+        print("--- response ---", flush=True)
+        print("HTTP %d" % status, flush=True)
+        print(json.dumps(payload, indent=2), flush=True)
+        print_summary()
+        self._send(status, payload)
+
+
+if __name__ == "__main__":
+    print("Worldpay Native RAFT mock listening on "
+          "http://127.0.0.1:%d%s" % (PORT, BASE_PATH), flush=True)
+    print('  expecting Authorization: %s' % EXPECTED_AUTHORIZATION, flush=True)
+    print("  expecting WorldPayMerchantID: %s" % MERCHANT_ID, flush=True)
+    print("  routes: %s" % ", ".join(sorted(ROUTES)), flush=True)
+    print("  report: GET /__report   reset: POST /__reset", flush=True)
+    try:
+        HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+    except KeyboardInterrupt:
+        print_summary()


### PR DESCRIPTION
## Summary

Implement the **Void** flow for the **Worldpayraft** (Worldpay Native RAFT) connector.

Worldpay Native RAFT has **no** void, reversal or cancel endpoint — `grep -E '^  /' credit.yaml` on the official OpenAPI v1.35.1 spec yields 17 paths and none of them is a void. A Void is the **same message re-POSTed to the same financial path as the original**, with `AuthorizationType: "RV"` (the only other legal value is `"FP"`, Force Post), replaying the **original** `APITransactionID` — that is how RAFT matches the reversal back to the original. A fresh id returns `ResponseCode 051 NO MATCHING ORIGINAL`.

## Changes

- `Void` added to `create_all_prerequisites!`, the `PaymentVoidV2` trait marker, a `macro_connector_implementation!` block with `flow_name: Void`, and `Void` removed from the `not_implemented:` list in `macro_connector_flow_status_impls!`.
- **Endpoint selection**: the first segment of the composite `connector_transaction_id` minted by commit `0441b4fa` was widened from a bare credit/debit flag (`C`/`D`) into an operation code — `C` = `/credit/authorization`, `CP` = `/credit/purchase`, `D` = `/debit/preauth`, `DP` = `/debit/purchase` — because a reversal must return to the exact endpoint the original used and `PaymentVoidData` carries nothing but that id. `C`/`D` keep their previous meanings, so nothing already encoded changes meaning. Authorize's `get_url` now shares that one endpoint table instead of a second `match`; Capture and Refund ask the reference's `is_debit()`.
- `WorldpayraftAuthorizationType` (`FP`/`RV`) and `WorldpayraftOriginalOperation` (`C`/`CP`/`D`/`DP`) are enums with `TryFrom`, not magic strings.
- `APITransactionID`, `LocalDateTime` and the `ReferenceTraceNumbers` are replayed through the same `follow_up_trace_numbers()` path Capture and Refund already use.
- **Partial reversal** carries `MiscAmountsBalances.DispensedAmount` (the amount left standing); a full reversal omits it. A request to release more than the original amount is refused.
- `ReversalAdviceReasonCd` is deliberately **not** sent: its published set is `000/002/003/005/006/010` and `PaymentVoidData::cancellation_reason` is free text with no defined vocabulary, so nothing maps onto that set without guessing. Worldpay defaults it to `000 Normal Reversal`, which is what a UCS void is.
- Success maps to `AttemptStatus::Voided`; a decline produces a real `ErrorResponse` with `FlowStatus::Payment(AttemptStatus::VoidFailed)`, matching the per-flow error model commit `0441b4fa` established. `003 HONOR WITH ID` and `114 REQUEST IN PROGRESS` are non-terminal `VoidInitiated`.
- `connector_specs/worldpayraft/specs.json` gains `"PaymentService/Void"` in `supported_suites` (`cargo run --bin check_connector_specs` gates this in CI).

## Files Modified

- `crates/integrations/connector-integration/src/connectors/worldpayraft.rs`
- `crates/integrations/connector-integration/src/connectors/worldpayraft/transformers.rs`
- `crates/internal/integration-tests/src/connector_specs/worldpayraft/specs.json`

## Testing

There are **no real Worldpay credentials**, so this was exercised against a local mock server that validates every request against those same official OpenAPI v1.35.1 schemas. The mock registers `/credit/void`, `/credit/reversal`, `/credit/cancel`, `/debit/void` and `/debit/reversal` as **phantom routes** that return the real Worldpay 404 fault body, so inventing an endpoint fails loudly.

Final mock report: `{"requests": 4, "ok": 48, "fail": 0, "warn": 2, "info": 4, "failed_checks": []}`. The 2 WARNs are a pre-existing, separately-queued `field.E-commerceIndicator` gap on follow-up messages.

## gRPC Test Results

**Status: PASS**

<details>
<summary>grpcurl Authorize + Void calls (credentials redacted)</summary>

Common headers on every call:

```
-H 'x-connector-config: <REDACTED>'
-H 'x-merchant-id: <REDACTED>'  -H 'x-tenant-id: public'
```

**AUTHORIZE #1** — manual capture -> `POST /credit/authorization`

```
grpcurl -plaintext <headers> -H 'x-request-id: wpr_void_man01' \
  -d '{"merchant_transaction_id":"wpr_void_man01","amount":{"minor_amount":2500,"currency":"USD"},"payment_method":{"card":{"card_number":{"value":"<REDACTED>"},"card_exp_month":{"value":"<REDACTED>"},"card_exp_year":{"value":"<REDACTED>"},"card_cvc":{"value":"<REDACTED>"},"card_holder_name":{"value":"John Doe"}}},"capture_method":"MANUAL","address":{"billing_address":{}},"auth_type":"NO_THREE_DS","return_url":"https://example.com/return"}' \
  127.0.0.1:8000 types.PaymentService/Authorize
```

```json
{
  "merchantTransactionId": "00wpr_void_man01",
  "connectorTransactionId": "C|wpr_void_man01|2026-09-09T21:21:50|2500|100006|625200000007",
  "status": "AUTHORIZED",
  "statusCode": 200,
  "networkTransactionId": "000000000100007",
  "connectorReferenceId": "00wpr_void_man01"
}
```

**VOID #1** — full reversal, re-POST to `/credit/authorization`

```
grpcurl -plaintext <headers> -H 'x-request-id: wpr_void_man01' \
  -d '{"merchant_void_id":"wpr_void_man01","connector_transaction_id":"C|wpr_void_man01|2026-09-09T21:21:50|2500|100006|625200000007","cancellation_reason":"requested_by_customer","amount":{"minor_amount":2500,"currency":"USD"}}' \
  127.0.0.1:8000 types.PaymentService/Void
```

```json
{
  "connectorTransactionId": "C|wpr_void_man01|2026-09-09T21:21:50|2500|100006|625200000007",
  "status": "VOIDED",
  "statusCode": 200,
  "merchantVoidId": "00wpr_void_man01",
  "connectorReferenceId": "00wpr_void_man01"
}
```

Body actually put on the wire:

```json
{"creditauth":{"AuthorizationType":"RV","MiscAmountsBalances":{"TransactionAmount":"25.00"},"ReferenceTraceNumbers":{"RetrievalREFNumber":"625200000007","AuthorizationNumber":"100006"},"WorldPayMerchantID":"<REDACTED>","APITransactionID":"wpr_void_man01","LocalDateTime":"2026-09-09T21:21:50"}}
```

**AUTHORIZE #2** — auto capture -> `POST /credit/purchase`

```
grpcurl -plaintext <headers> -H 'x-request-id: wpr_void_auto2' \
  -d '{"merchant_transaction_id":"wpr_void_auto2","amount":{"minor_amount":4000,"currency":"USD"},"payment_method":{"card":{"card_number":{"value":"<REDACTED>"},"card_exp_month":{"value":"<REDACTED>"},"card_exp_year":{"value":"<REDACTED>"},"card_cvc":{"value":"<REDACTED>"},"card_holder_name":{"value":"John Doe"}}},"capture_method":"AUTOMATIC","address":{"billing_address":{}},"auth_type":"NO_THREE_DS","return_url":"https://example.com/return"}' \
  127.0.0.1:8000 types.PaymentService/Authorize
```

```json
{
  "merchantTransactionId": "00wpr_void_auto2",
  "connectorTransactionId": "CP|wpr_void_auto2|2026-09-09T21:21:50|4000|100008|625200000009",
  "status": "CHARGED",
  "statusCode": 200,
  "networkTransactionId": "000000000100009",
  "connectorReferenceId": "00wpr_void_auto2"
}
```

**VOID #2** — partial reversal (release 10.00 of 40.00), re-POST to `/credit/purchase`

```
grpcurl -plaintext <headers> -H 'x-request-id: wpr_void_auto2' \
  -d '{"merchant_void_id":"wpr_void_auto2","connector_transaction_id":"CP|wpr_void_auto2|2026-09-09T21:21:50|4000|100008|625200000009","amount":{"minor_amount":1000,"currency":"USD"}}' \
  127.0.0.1:8000 types.PaymentService/Void
```

```json
{
  "connectorTransactionId": "CP|wpr_void_auto2|2026-09-09T21:21:50|4000|100008|625200000009",
  "status": "VOIDED",
  "statusCode": 200,
  "merchantVoidId": "00wpr_void_auto2",
  "connectorReferenceId": "00wpr_void_auto2"
}
```

Body actually put on the wire:

```json
{"creditpurchase":{"AuthorizationType":"RV","MiscAmountsBalances":{"TransactionAmount":"40.00","DispensedAmount":"30.00"},"ReferenceTraceNumbers":{"RetrievalREFNumber":"625200000009","AuthorizationNumber":"100008"},"WorldPayMerchantID":"<REDACTED>","APITransactionID":"wpr_void_auto2","LocalDateTime":"2026-09-09T21:21:50"}}
```

Mock summary (verbatim):

```json
{"requests": 4, "ok": 48, "fail": 0, "warn": 2, "info": 4, "failed_checks": []}
```

`void.mechanism` findings (verbatim):

```json
{"level":"OK","check":"void.mechanism","message":"AuthorizationType=\"RV\" on /credit/authorization -- correct: there is no void/reversal endpoint, a void is the original message re-sent with RV","path":"/credit/authorization","api_transaction_id":"wpr_void_man01"}
{"level":"OK","check":"void.mechanism","message":"AuthorizationType=\"RV\" on /credit/purchase -- correct: there is no void/reversal endpoint, a void is the original message re-sent with RV","path":"/credit/purchase","api_transaction_id":"wpr_void_auto2"}
```

`followup.api_transaction_id` findings (verbatim):

```json
{"level":"OK","check":"followup.api_transaction_id","message":"reversal reuses APITransactionID 'wpr_void_man01' from the original auth -- correct, that is how Worldpay matches follow-up messages","path":"/credit/authorization","api_transaction_id":"wpr_void_man01"}
{"level":"OK","check":"followup.api_transaction_id","message":"reversal reuses APITransactionID 'wpr_void_auto2' from the original sale -- correct, that is how Worldpay matches follow-up messages","path":"/credit/purchase","api_transaction_id":"wpr_void_auto2"}
```

</details>

## Validation Checklist

- [x] `cargo build` passed with zero errors *(codegen checkpoint)*
- [x] `cargo +nightly fmt --all -- --check` clean *(re-verified in this checkpoint)*
- [x] `cargo clippy -p connector-integration` — 11 warnings, byte-identical to the pre-change baseline (verified by stashing the two connector files and re-running); all pre-existing `indexing_slicing` in `WorldpayraftTransactionReference::parse` and `struct update has no effect`. No new warning from this change. *(codegen checkpoint)*
- [x] `cargo run --bin check_connector_specs` — `All checks passed. OK.` (113/113 connectors, 0 missing suites) *(codegen checkpoint)*
- [x] grpcurl Authorize returned success status (2xx); both Voids returned `VOIDED` / `statusCode 200`
- [x] No credentials in committed source code (full-branch diff scanned; connector reads `Secret<String>` from the request context, mock script uses `MOCK_LICENSE` / `MOCK_MERCHANT_ID` placeholders only)
- [x] Staged file set verified against the manifest in both directions (`git diff --cached --name-only`)

> **Note on this checkpoint's local re-validation**: the build host's root filesystem is currently 100% full (16 MB free of 1.9 TB, consumed by ~600 GB of `target/` dirs across sibling checkouts), so the cargo-based steps could **not** be re-run here — `cargo run --bin check_connector_specs` aborted with `ENOSPC`. The `fmt --check` re-run above succeeded, and the specs change was verified structurally instead (valid JSON; `"PaymentService/Void"` is the exact suite string used by 78 other connectors' `specs.json`). The clippy / `check_connector_specs` results carried above are from the codegen checkpoint that ran before the disk filled. **CI is the authority on all four.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgjSyHoxBWduXou1y4NLKB
