### PR TITLE
fix(ucs): record euler-assigned api_tag on outgoing golden log span

### DIFF
--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -747,7 +747,9 @@ where
     let start = tokio::time::Instant::now();
     tracing::Span::current().record(
         "api_tag",
-        api_tag.as_deref().unwrap_or(event_params.flow_name.as_str()),
+        api_tag
+            .as_deref()
+            .unwrap_or(event_params.flow_name.as_str()),
     );
     let proxy_name = event_params.proxy_name.unwrap_or("primary");
     let transport_type = connector.get_transport_type();

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -711,6 +711,7 @@ pub struct EventProcessingParams<'a> {
         response.error_message = Empty,
         response.status_code = Empty,
         res_code = Empty,
+        api_tag = Empty,
         message_ = "Golden Log Line (outgoing)",
         // `latency` is the pre-existing human-readable string; `latency_ms` is the same
         // duration as a plain number of milliseconds, for numeric downstream consumers.
@@ -744,6 +745,10 @@ where
         + GetFlowStatus,
 {
     let start = tokio::time::Instant::now();
+    tracing::Span::current().record(
+        "api_tag",
+        api_tag.as_deref().unwrap_or(event_params.flow_name.as_str()),
+    );
     let proxy_name = event_params.proxy_name.unwrap_or("primary");
     let transport_type = connector.get_transport_type();
     #[cfg(feature = "log-transformations")]

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -566,7 +566,7 @@ where
                         }
                     }
 
-                    if let Some(evt) = event.as_deref_mut() {
+                    if let Some(evt) = event {
                         evt.set_error_response(&error_response);
                         let mut json_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
                         if let Some(error_data) = &evt.error {

--- a/crates/common/external-services/src/service.rs
+++ b/crates/common/external-services/src/service.rs
@@ -566,7 +566,7 @@ where
                         }
                     }
 
-                    if let Some(evt) = event {
+                    if let Some(evt) = event.as_deref_mut() {
                         evt.set_error_response(&error_response);
                         let mut json_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
                         if let Some(error_data) = &evt.error {


### PR DESCRIPTION
## Problem

The `api_tag` value (from euler's `x-config-override`, e.g. `psync = "GW_TXN_SYNC"`) was resolved and passed into `execute_connector_processing_step` but never written to the tracing span. LP read the `flow` span field instead, producing the internal UCS flow name (`Psync`, `Authorize`, etc.) rather than the euler-assigned API tag (`GW_TXN_SYNC`, etc.). This caused `api_details.api_tag` to be wrong in outgoing golden log lines.

## Fix

Added `api_tag = Empty` to the `#[tracing::instrument]` fields of `execute_connector_processing_step` and record the value at function entry, falling back to the flow name when no `api_tag` override is set:

```rust
tracing::Span::current().record(
    "api_tag",
    api_tag.as_deref().unwrap_or(event_params.flow_name.as_str()),
);
```

This is paired with a hyperswitch-infra change (raised separately) that updates `[log.fields.outgoing]` to read `api_details.api_tag` from the new `api_tag` span field instead of `flow`.

## Verification

Ran the server locally with `log-transformations` feature and `psync = "GW_TXN_SYNC"` configured. A Stripe psync request confirmed `api_tag: "GW_TXN_SYNC"` in the golden log span context (previously showed the internal flow name `Psync`).

## Files Changed

- `crates/common/external-services/src/service.rs` — add `api_tag` instrument field and record it at function entry