### PR TITLE
feat: add generated connector sanity layer

### DIFF
--- a/crates/grpc-server/grpc-server/Cargo.toml
+++ b/crates/grpc-server/grpc-server/Cargo.toml
@@ -101,6 +101,7 @@ serial_test = "3.2.0"
 default = []
 kafka = ["tracing-kafka", "common_utils/kafka"]
 connector-request-kafka = ["dep:connector_request_kafka", "external-services/connector-request-kafka"]
+connector-sanity-layer = []
 # Push gRPC metrics over OTLP to an OpenTelemetry Collector, in addition to the
 # Prometheus /metrics scrape endpoint.
 otel = ["ucs_env/otel", "external-services/otel"]

--- a/crates/grpc-server/grpc-server/src/app.rs
+++ b/crates/grpc-server/grpc-server/src/app.rs
@@ -29,6 +29,27 @@ use crate::{
     utils,
 };
 
+type SanityLayer<S> = crate::sanity_layer::SanityLayer<S>;
+type CompositePaymentsService = composite_service::payments::Payments<
+    crate::server::payments::Payments,
+    crate::server::payments::MerchantAuthentication,
+    crate::server::payments::Customer,
+    crate::server::refunds::Refunds,
+    crate::server::payments::PaymentMethodAuthentication,
+>;
+type CompositeEventService = composite_service::events::CompositeEvents<
+    crate::server::events::EventServiceImpl,
+    crate::server::payments::MerchantAuthentication,
+>;
+type CompositePaymentMethodService = composite_service::payment_methods::PaymentMethods<
+    crate::server::payments::PaymentMethod,
+    crate::server::payments::MerchantAuthentication,
+>;
+type CompositeFrmService = composite_service::frm::Frm<
+    crate::server::frm::FraudAndRiskManagement,
+    crate::server::payments::MerchantAuthentication,
+>;
+
 /// # Panics
 ///
 /// Will panic if redis connection establishment fails or signal handling fails
@@ -103,37 +124,24 @@ pub async fn server_builder(config: configs::Config) -> Result<(), Configuration
 
 pub struct Service {
     pub health_check_service: crate::server::health_check::HealthCheck,
-    pub composite_payments_service: composite_service::payments::Payments<
-        crate::server::payments::Payments,
-        crate::server::payments::MerchantAuthentication,
-        crate::server::payments::Customer,
-        crate::server::refunds::Refunds,
-        crate::server::payments::PaymentMethodAuthentication,
-    >,
-    pub composite_event_service: composite_service::events::CompositeEvents<
-        crate::server::events::EventServiceImpl,
-        crate::server::payments::MerchantAuthentication,
-    >,
-    pub composite_payment_method_service: composite_service::payment_methods::PaymentMethods<
-        crate::server::payments::PaymentMethod,
-        crate::server::payments::MerchantAuthentication,
-    >,
-    pub composite_frm_service: composite_service::frm::Frm<
-        crate::server::frm::FraudAndRiskManagement,
-        crate::server::payments::MerchantAuthentication,
-    >,
-    pub payments_service: crate::server::payments::Payments,
-    pub refunds_service: crate::server::refunds::Refunds,
-    pub disputes_service: crate::server::disputes::Disputes,
-    pub recurring_payment_service: crate::server::payments::RecurringPayments,
-    pub event_service: crate::server::events::EventServiceImpl,
-    pub payment_method_service: crate::server::payments::PaymentMethod,
-    pub merchant_authentication_service: crate::server::payments::MerchantAuthentication,
-    pub customer_service: crate::server::payments::Customer,
-    pub payment_method_authentication_service: crate::server::payments::PaymentMethodAuthentication,
-    pub payouts_service: crate::server::payouts::Payouts,
-    pub surcharges_service: crate::server::surcharges::Surcharges,
-    pub frm_service: crate::server::frm::FraudAndRiskManagement,
+    pub composite_payments_service: SanityLayer<CompositePaymentsService>,
+    pub composite_event_service: SanityLayer<CompositeEventService>,
+    pub composite_payment_method_service: SanityLayer<CompositePaymentMethodService>,
+    pub composite_frm_service: SanityLayer<CompositeFrmService>,
+    pub payments_service: SanityLayer<crate::server::payments::Payments>,
+    pub refunds_service: SanityLayer<crate::server::refunds::Refunds>,
+    pub disputes_service: SanityLayer<crate::server::disputes::Disputes>,
+    pub recurring_payment_service: SanityLayer<crate::server::payments::RecurringPayments>,
+    pub event_service: SanityLayer<crate::server::events::EventServiceImpl>,
+    pub payment_method_service: SanityLayer<crate::server::payments::PaymentMethod>,
+    pub merchant_authentication_service:
+        SanityLayer<crate::server::payments::MerchantAuthentication>,
+    pub customer_service: SanityLayer<crate::server::payments::Customer>,
+    pub payment_method_authentication_service:
+        SanityLayer<crate::server::payments::PaymentMethodAuthentication>,
+    pub payouts_service: SanityLayer<crate::server::payouts::Payouts>,
+    pub surcharges_service: SanityLayer<crate::server::surcharges::Surcharges>,
+    pub frm_service: SanityLayer<crate::server::frm::FraudAndRiskManagement>,
 }
 
 impl Service {
@@ -198,23 +206,30 @@ impl Service {
 
         Self {
             health_check_service: crate::server::health_check::HealthCheck,
-            composite_payments_service,
-            composite_event_service,
-            composite_payment_method_service,
-            composite_frm_service,
-            payments_service,
-            refunds_service,
-            disputes_service: crate::server::disputes::Disputes,
-            recurring_payment_service: crate::server::payments::RecurringPayments,
-            event_service,
-            payment_method_service,
-            merchant_authentication_service,
-            customer_service,
-            payment_method_authentication_service:
+            composite_payments_service: crate::sanity_layer::wrap(composite_payments_service),
+            composite_event_service: crate::sanity_layer::wrap(composite_event_service),
+            composite_payment_method_service: crate::sanity_layer::wrap(
+                composite_payment_method_service,
+            ),
+            composite_frm_service: crate::sanity_layer::wrap(composite_frm_service),
+            payments_service: crate::sanity_layer::wrap(payments_service),
+            refunds_service: crate::sanity_layer::wrap(refunds_service),
+            disputes_service: crate::sanity_layer::wrap(crate::server::disputes::Disputes),
+            recurring_payment_service: crate::sanity_layer::wrap(
+                crate::server::payments::RecurringPayments,
+            ),
+            event_service: crate::sanity_layer::wrap(event_service),
+            payment_method_service: crate::sanity_layer::wrap(payment_method_service),
+            merchant_authentication_service: crate::sanity_layer::wrap(
+                merchant_authentication_service,
+            ),
+            customer_service: crate::sanity_layer::wrap(customer_service),
+            payment_method_authentication_service: crate::sanity_layer::wrap(
                 crate::server::payments::PaymentMethodAuthentication,
-            payouts_service: crate::server::payouts::Payouts,
-            surcharges_service: crate::server::surcharges::Surcharges,
-            frm_service: crate::server::frm::FraudAndRiskManagement,
+            ),
+            payouts_service: crate::sanity_layer::wrap(crate::server::payouts::Payouts),
+            surcharges_service: crate::sanity_layer::wrap(crate::server::surcharges::Surcharges),
+            frm_service: crate::sanity_layer::wrap(crate::server::frm::FraudAndRiskManagement),
         }
     }
 

--- a/crates/grpc-server/grpc-server/src/http/state.rs
+++ b/crates/grpc-server/grpc-server/src/http/state.rs
@@ -20,40 +20,47 @@ type CompositeFrmService = composite_service::frm::Frm<
     crate::server::frm::FraudAndRiskManagement,
     crate::server::payments::MerchantAuthentication,
 >;
+type SanityLayer<S> = crate::sanity_layer::SanityLayer<S>;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub composite_payments_service: CompositePaymentsService,
-    pub composite_event_service: CompositeEventService,
-    pub composite_payment_method_service: CompositePaymentMethodService,
-    pub composite_frm_service: CompositeFrmService,
-    pub payments_service: crate::server::payments::Payments,
-    pub refunds_service: crate::server::refunds::Refunds,
-    pub disputes_service: crate::server::disputes::Disputes,
-    pub recurring_payment_service: crate::server::payments::RecurringPayments,
-    pub event_service: crate::server::events::EventServiceImpl,
-    pub payment_method_service: crate::server::payments::PaymentMethod,
-    pub merchant_authentication_service: crate::server::payments::MerchantAuthentication,
-    pub customer_service: crate::server::payments::Customer,
-    pub payment_method_authentication_service: crate::server::payments::PaymentMethodAuthentication,
+    pub composite_payments_service: SanityLayer<CompositePaymentsService>,
+    pub composite_event_service: SanityLayer<CompositeEventService>,
+    pub composite_payment_method_service: SanityLayer<CompositePaymentMethodService>,
+    pub composite_frm_service: SanityLayer<CompositeFrmService>,
+    pub payments_service: SanityLayer<crate::server::payments::Payments>,
+    pub refunds_service: SanityLayer<crate::server::refunds::Refunds>,
+    pub disputes_service: SanityLayer<crate::server::disputes::Disputes>,
+    pub recurring_payment_service: SanityLayer<crate::server::payments::RecurringPayments>,
+    pub event_service: SanityLayer<crate::server::events::EventServiceImpl>,
+    pub payment_method_service: SanityLayer<crate::server::payments::PaymentMethod>,
+    pub merchant_authentication_service:
+        SanityLayer<crate::server::payments::MerchantAuthentication>,
+    pub customer_service: SanityLayer<crate::server::payments::Customer>,
+    pub payment_method_authentication_service:
+        SanityLayer<crate::server::payments::PaymentMethodAuthentication>,
 }
 
 #[allow(clippy::too_many_arguments)]
 impl AppState {
     pub fn new(
-        composite_payments_service: CompositePaymentsService,
-        composite_event_service: CompositeEventService,
-        composite_payment_method_service: CompositePaymentMethodService,
-        composite_frm_service: CompositeFrmService,
-        payments_service: crate::server::payments::Payments,
-        refund_service: crate::server::refunds::Refunds,
-        dispute_service: crate::server::disputes::Disputes,
-        recurring_payment_service: crate::server::payments::RecurringPayments,
-        event_service: crate::server::events::EventServiceImpl,
-        payment_method_service: crate::server::payments::PaymentMethod,
-        merchant_authentication_service: crate::server::payments::MerchantAuthentication,
-        customer_service: crate::server::payments::Customer,
-        payment_method_authentication_service: crate::server::payments::PaymentMethodAuthentication,
+        composite_payments_service: SanityLayer<CompositePaymentsService>,
+        composite_event_service: SanityLayer<CompositeEventService>,
+        composite_payment_method_service: SanityLayer<CompositePaymentMethodService>,
+        composite_frm_service: SanityLayer<CompositeFrmService>,
+        payments_service: SanityLayer<crate::server::payments::Payments>,
+        refund_service: SanityLayer<crate::server::refunds::Refunds>,
+        dispute_service: SanityLayer<crate::server::disputes::Disputes>,
+        recurring_payment_service: SanityLayer<crate::server::payments::RecurringPayments>,
+        event_service: SanityLayer<crate::server::events::EventServiceImpl>,
+        payment_method_service: SanityLayer<crate::server::payments::PaymentMethod>,
+        merchant_authentication_service: SanityLayer<
+            crate::server::payments::MerchantAuthentication,
+        >,
+        customer_service: SanityLayer<crate::server::payments::Customer>,
+        payment_method_authentication_service: SanityLayer<
+            crate::server::payments::PaymentMethodAuthentication,
+        >,
     ) -> Self {
         Self {
             composite_payments_service,

--- a/crates/grpc-server/grpc-server/src/lib.rs
+++ b/crates/grpc-server/grpc-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config_overrides;
 pub mod http;
 pub mod metrics;
 pub mod request;
+pub mod sanity_layer;
 pub mod server;
 pub mod types;
 pub mod utils;

--- a/crates/grpc-server/grpc-server/src/sanity_layer.rs
+++ b/crates/grpc-server/grpc-server/src/sanity_layer.rs
@@ -1,0 +1,149 @@
+//! Connector-specific request sanity logic.
+//!
+//! The typed service wrappers are generated in `grpc-api-types` from the
+//! protobuf descriptor set. This module only supplies the runtime sanitizer:
+//! 1. resolve which connector this request is for (reusing the same
+//!    resolution every other flow already relies on), then
+//! 2. dispatch to that connector's own sanity step, if one is registered.
+
+#[cfg(feature = "connector-sanity-layer")]
+use grpc_api_types::auto_populate::{
+    PopulateOsBasedReturnUrl, RequestSanitizer, SanityLayer as GeneratedSanityLayer,
+};
+#[cfg(feature = "connector-sanity-layer")]
+use grpc_api_types::payments::OsBasedReturnUrl;
+#[cfg(feature = "connector-sanity-layer")]
+use std::collections::HashMap;
+#[cfg(feature = "connector-sanity-layer")]
+use tonic::metadata::{MetadataMap, MetadataValue};
+
+#[cfg(feature = "connector-sanity-layer")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ConnectorSanitizer;
+
+#[cfg(feature = "connector-sanity-layer")]
+pub type SanityLayer<S> = GeneratedSanityLayer<S, ConnectorSanitizer>;
+
+#[cfg(not(feature = "connector-sanity-layer"))]
+pub type SanityLayer<S> = S;
+
+#[cfg(feature = "connector-sanity-layer")]
+pub fn wrap<S>(inner: S) -> SanityLayer<S> {
+    GeneratedSanityLayer::new(inner, ConnectorSanitizer)
+}
+
+#[cfg(not(feature = "connector-sanity-layer"))]
+pub fn wrap<S>(inner: S) -> SanityLayer<S> {
+    inner
+}
+
+#[cfg(feature = "connector-sanity-layer")]
+impl RequestSanitizer for ConnectorSanitizer {
+    fn sanitize<T: PopulateOsBasedReturnUrl>(&self, metadata: &mut MetadataMap, req: &mut T) {
+        if is_plaid_request(metadata) {
+            plaid_sanity(metadata, req);
+        }
+    }
+}
+
+/// Plaid's dashboard config (sent via `x-connector-config`) may carry
+/// Euler-only redirect keys that UCS's typed `PlaidConfig` proto message
+/// doesn't declare. Read those keys from the raw header JSON, populate the
+/// request field, then strip them before downstream typed config parsing.
+#[cfg(feature = "connector-sanity-layer")]
+fn plaid_sanity<T: PopulateOsBasedReturnUrl>(metadata: &mut MetadataMap, req: &mut T) {
+    if let Some(os_based_return_url) = plaid_os_based_return_url(metadata) {
+        tracing::debug!(
+            map_keys = ?os_based_return_url.return_url_map.keys().collect::<Vec<_>>(),
+            "populating os_based_return_url map extracted from raw Plaid config"
+        );
+        req.populate_os_based_return_url(os_based_return_url);
+    }
+
+    clean_plaid_config_header(metadata);
+}
+
+#[cfg(feature = "connector-sanity-layer")]
+fn is_plaid_request(metadata: &MetadataMap) -> bool {
+    metadata
+        .get(common_utils::consts::X_AUTHENTICATOR_CONNECTOR_NAME)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("plaid"))
+        || raw_plaid_config(metadata).is_some()
+}
+
+#[cfg(feature = "connector-sanity-layer")]
+fn raw_plaid_config(metadata: &MetadataMap) -> Option<serde_json::Value> {
+    let header_value = metadata
+        .get(common_utils::consts::X_CONNECTOR_CONFIG)?
+        .to_str()
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_str(header_value).ok()?;
+    let config = json.get("config")?;
+    config.get("Plaid").or_else(|| config.get("plaid")).cloned()
+}
+
+#[cfg(feature = "connector-sanity-layer")]
+fn clean_plaid_config_header(metadata: &mut MetadataMap) {
+    let Some(header_str) = metadata
+        .get(common_utils::consts::X_CONNECTOR_CONFIG)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return;
+    };
+
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(header_str) else {
+        return;
+    };
+
+    let Some(config) = json
+        .get_mut("config")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    let Some(mut plaid_config) = config.remove("Plaid").or_else(|| config.remove("plaid")) else {
+        return;
+    };
+
+    if let Some(plaid_config) = plaid_config.as_object_mut() {
+        plaid_config.remove("ios_redirect_uri");
+        plaid_config.remove("android_package_name");
+        plaid_config.remove("web_redirect_uri");
+    }
+
+    config.insert("Plaid".to_string(), plaid_config);
+
+    let Ok(header_value) = serde_json::to_string(&json) else {
+        return;
+    };
+    let Ok(header_value) = MetadataValue::try_from(header_value.as_str()) else {
+        return;
+    };
+
+    metadata.insert(common_utils::consts::X_CONNECTOR_CONFIG, header_value);
+}
+
+#[cfg(feature = "connector-sanity-layer")]
+fn plaid_os_based_return_url(metadata: &MetadataMap) -> Option<OsBasedReturnUrl> {
+    let plaid_config = raw_plaid_config(metadata)?;
+    let return_url_map = [
+        ("ios_redirect_uri", "ios_redirect_uri"),
+        ("android_package_name", "android_package_name"),
+        ("web_redirect_uri", "web_redirect_uri"),
+    ]
+    .into_iter()
+    .filter_map(|(os, config_key)| {
+        plaid_config
+            .get(config_key)
+            .and_then(serde_json::Value::as_str)
+            .map(|value| (os.to_string(), value.to_string()))
+    })
+    .collect::<HashMap<_, _>>();
+
+    (!return_url_map.is_empty()).then_some(OsBasedReturnUrl {
+        os_type: String::new(),
+        return_url_map,
+    })
+}

--- a/crates/types-traits/grpc-api-types/Cargo.toml
+++ b/crates/types-traits/grpc-api-types/Cargo.toml
@@ -23,5 +23,6 @@ hyperswitch_masking = { version = "0.0.1", default-features = false, features = 
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 heck = "0.5.0"
 g2h = { git = "https://github.com/juspay/g2h", rev = "399d5257744cabffe88d9871a1192eacbbe9f484" }

--- a/crates/types-traits/grpc-api-types/build.rs
+++ b/crates/types-traits/grpc-api-types/build.rs
@@ -1,6 +1,11 @@
 use std::{env, path::PathBuf};
 
+#[path = "codegen/auto_populate.rs"]
+mod auto_populate;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=codegen/auto_populate.rs");
+
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
     // Create the bridge generator with string enums
@@ -74,6 +79,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/frm.proto",
         ],
         &["proto"],
+    )?;
+
+    // Second codegen pass: read back the descriptor set just written above
+    // and generate the `populate_<field>` trait impls (see
+    // `codegen/auto_populate.rs` for the field -> setter declarations).
+    let descriptor_bytes = std::fs::read(out_dir.join("connector_service_descriptor.bin"))?;
+    let descriptor_set =
+        <prost_types::FileDescriptorSet as prost::Message>::decode(descriptor_bytes.as_slice())?;
+    let auto_populate_generated = auto_populate::generate(&descriptor_set);
+    std::fs::write(
+        out_dir.join("auto_populate_generated.rs"),
+        auto_populate_generated,
     )?;
 
     // prost_build::Config::new()

--- a/crates/types-traits/grpc-api-types/codegen/auto_populate.md
+++ b/crates/types-traits/grpc-api-types/codegen/auto_populate.md
@@ -1,0 +1,372 @@
+# Auto Populate Codegen Design
+
+This document explains the decisions behind `auto_populate.rs`, which generates typed request-population traits and service wrappers from the compiled protobuf descriptor set.
+
+## Goal
+
+Some sanity-layer values are known at runtime, but only some protobuf request types have the destination field. Application code should be able to say “populate this field if this request supports it” without maintaining a manual list of request structs.
+
+The protobuf schema is the source of truth:
+
+- If a request message contains the configured field, generated code should populate it.
+- If a request message does not contain the field, generated code should no-op.
+- If a new RPC method uses a request containing the field, rebuilding should pick it up automatically.
+- Business code should not know which request/message types support the field.
+
+## Why Use `FileDescriptorSet`
+
+`prost-build` already produces a `FileDescriptorSet` during protobuf compilation. That descriptor contains:
+
+- protobuf packages
+- services
+- RPC methods
+- method input/output message types
+- message fields
+- field shapes, including `optional`, `repeated`, message type, and oneof metadata
+
+Using this descriptor avoids runtime protobuf reflection and avoids hand-maintained mappings such as:
+
+```rust
+os_based_return_url => [
+    MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest,
+    AuthenticatorClientAuthenticationContext,
+]
+```
+
+The generator reads the descriptor at build time and emits normal Rust code into `OUT_DIR`.
+
+## Why Limit To The `types` Package
+
+The generator intentionally processes only the protobuf package named `types`.
+
+Reasoning:
+
+- UCS request/response structs are generated under `crate::payments`.
+- Other descriptor packages, such as health/reflection, are not request-domain types.
+- Generating implementations for external packages would create invalid Rust paths or unnecessary trait impls.
+
+This is controlled by:
+
+```rust
+const SUPPORTED_PACKAGE: &str = "types";
+const SUPPORTED_PACKAGE_MODULE: &str = "crate::payments";
+```
+
+If another generated module/package needs this mechanism later, the generator should be extended deliberately instead of assuming all descriptor packages map to `crate::payments`.
+
+## Developer-Written Contract: `FIELD_SPECS`
+
+`FIELD_SPECS` is the only hand-written field declaration surface.
+
+For each field, the developer writes:
+
+- protobuf field name
+- generated trait name
+- generated method name
+- Rust value type
+- setter body for optional fields
+- setter body for non-optional singular fields
+
+Example:
+
+```rust
+FieldSpec {
+    field_name: "os_based_return_url",
+    trait_name: "PopulateOsBasedReturnUrl",
+    method_name: "populate_os_based_return_url",
+    value_type: "crate::payments::OsBasedReturnUrl",
+    when_optional_body: "...",
+    when_required_body: "...",
+}
+```
+
+The developer does not list request/message types. The descriptor decides where the field exists.
+
+## Why Setter Bodies Are Shape-Based
+
+Different proto field shapes generate different Rust field types:
+
+- `optional SomeMessage field = 1;` becomes `Option<SomeMessage>`
+- `SomeMessage field = 1;` becomes `SomeMessage`
+- `repeated SomeMessage field = 1;` becomes `Vec<SomeMessage>`
+
+So the setter cannot be one generic assignment for every shape.
+
+The current contract supports:
+
+- `when_optional_body`
+- `when_required_body`
+
+`repeated` is intentionally rejected with a generated `compile_error!`. This is safer than silently picking behavior for a shape that has not been designed.
+
+## Current `os_based_return_url` Semantics
+
+`os_based_return_url` is optional on the request context, but if it is present, `os_type` must already be present in practice.
+
+The generated setter follows that rule:
+
+- It does not create `os_based_return_url` if the request did not send it.
+- It preserves the request-provided `os_type`.
+- It only fills `return_url_map` when `os_type` is non-empty.
+
+This keeps responsibility split cleanly:
+
+- caller/request provides the selected OS
+- sanity layer provides the configured URL map
+- downstream logic can choose from the map using the request OS
+
+## Request Discovery
+
+`request_message_names` walks:
+
+```text
+FileDescriptorSet
+  -> file[]
+  -> service[]
+  -> method[]
+  -> input_type
+```
+
+This means “request type” is defined as “a message used as an RPC input type”, not by naming convention.
+
+This avoids fragile assumptions like:
+
+- message name ends with `Request`
+- message belongs to a specific file
+- service is manually listed
+
+If a new method is added to an existing service, the generator sees the new method from the descriptor and emits wrapper code for it.
+
+## Message Field Discovery
+
+`message_index` builds a map:
+
+```text
+top-level message name -> DescriptorProto
+```
+
+Then the generator checks whether each message either:
+
+- directly contains the configured field, or
+- can reach the configured field through nested message fields
+
+This is needed for request shapes like:
+
+```proto
+message MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest {
+  oneof domain_context {
+    AuthenticatorClientAuthenticationContext authenticator = 8;
+  }
+}
+
+message AuthenticatorClientAuthenticationContext {
+  optional OsBasedReturnUrl os_based_return_url = 8;
+}
+```
+
+The top-level request does not directly contain `os_based_return_url`, but it can reach it through the `authenticator` oneof variant.
+
+## Why Generate No-Ops
+
+Every request message gets an implementation for the configured populate trait.
+
+If the field is not present and cannot be reached through nested messages, the implementation is:
+
+```rust
+let _ = value;
+```
+
+Reasoning:
+
+- generic business/sanity code can call the populate method on any request type
+- unsupported request types naturally do nothing
+- the caller does not branch on request type
+- adding a new request type does not require implementing a trait manually
+
+## Nested Message Delegation
+
+If a top-level request does not directly contain the field but has a nested message that can contain it, generated code delegates to the nested message.
+
+For normal optional message fields, the generated shape is:
+
+```rust
+if let Some(inner) = self.some_context.as_mut() {
+    inner.populate_os_based_return_url(value);
+} else {
+    let _ = value;
+}
+```
+
+If the nested message is absent, the setter no-ops. The generator does not create missing nested contexts because that would require business rules the schema alone cannot provide.
+
+## Oneof Delegation
+
+For oneof fields, the generator emits a `match` over every oneof variant that can reach the target field.
+
+This matters because more than one oneof variant may contain similarly named fields. The generator must not select only the first matching variant.
+
+For `os_based_return_url`, only the `Authenticator` variant currently matches. The generated logic is equivalent to:
+
+```rust
+match self.domain_context.as_mut() {
+    Some(DomainContext::Authenticator(inner)) => {
+        inner.populate_os_based_return_url(value);
+    }
+    _ => {
+        let _ = value;
+    }
+}
+```
+
+This preserves the oneof selected by the caller and only mutates the active variant.
+
+## Service Wrapper Generation
+
+The generator also emits a generic `SanityLayer<S, Z>` wrapper.
+
+For each supported tonic service, it generates:
+
+```rust
+impl<S, Z> SomeService for SanityLayer<S, Z>
+where
+    S: SomeService,
+    Z: RequestSanitizer,
+{
+    async fn some_method(&self, request: tonic::Request<RequestType>) -> Result<...> {
+        let (mut metadata, extensions, mut message) = request.into_parts();
+        self.sanitizer.sanitize(&mut metadata, &mut message);
+        let request = tonic::Request::from_parts(metadata, extensions, message);
+        self.inner.some_method(request).await
+    }
+}
+```
+
+Reasoning:
+
+- sanity runs before the real handler
+- no flow handler file needs to be modified
+- HTTP handlers that call the same service object also pass through the wrapper
+- metadata can be cleaned before downstream typed header parsing
+- the typed request body can be mutated before business logic sees it
+
+## Why Runtime Use Is Feature-Gated
+
+The generated wrapper exists so the sanity layer can run before every typed RPC handler. That is useful for Euler/Plaid compatibility, but it should not affect the normal UCS path unless explicitly enabled.
+
+`grpc-server` therefore uses a Cargo feature:
+
+```bash
+cargo run -p grpc-server --features connector-sanity-layer
+```
+
+When `connector-sanity-layer` is enabled:
+
+- `crate::sanity_layer::wrap(service)` returns the generated `SanityLayer`
+- every wrapped service method calls the sanitizer before the real handler
+- Plaid redirect keys can be moved from raw metadata into the typed request
+
+When `connector-sanity-layer` is disabled:
+
+- `crate::sanity_layer::wrap(service)` returns the original service
+- there is no generated wrapper in the runtime call path
+- normal UCS behavior is unchanged
+
+This keeps integration code stable while avoiding runtime overhead for builds that do not need the compatibility layer.
+
+## Runtime Responsibility
+
+The generated code does not know Plaid, Euler, or merchant-specific config structure.
+
+Runtime connector-specific code lives in `grpc-server/src/sanity_layer.rs`.
+
+For Plaid, that runtime layer:
+
+- identifies Plaid from metadata/raw config
+- reads Euler-only keys from raw `x-connector-config`
+- builds an `OsBasedReturnUrl` value containing `return_url_map`
+- calls `populate_os_based_return_url`
+- removes Euler-only keys from metadata before normal typed config parsing
+
+This keeps generated infrastructure generic and connector-specific policy outside `grpc-api-types`.
+
+## Adding A New Auto-Populated Field
+
+To add another field, add one `FieldSpec`.
+
+Required information:
+
+- `field_name`: exact proto field name
+- `trait_name`: generated Rust trait name
+- `method_name`: generated Rust method name
+- `value_type`: Rust type passed to the setter
+- `when_optional_body`: assignment logic for `optional` proto fields
+- `when_required_body`: assignment logic for non-optional singular proto fields
+
+No request/message list is needed.
+
+After adding the spec:
+
+1. Add the field to the relevant `.proto` messages.
+2. Run the build.
+3. The generated file in `OUT_DIR` will include trait impls for every matching message.
+4. Runtime sanity code can call the generated method generically.
+
+## What Happens When New Proto Is Added
+
+New method in an existing service:
+
+- automatically appears in the descriptor
+- generated `SanityLayer` gets a wrapper method
+- request type gets populate trait impls
+
+New request message used by an existing/new method:
+
+- automatically appears as a method input type
+- gets no-op or real setter based on its fields
+
+New service:
+
+- generated code can emit an implementation for it
+- the server composition root still needs to wrap/register the service with `crate::sanity_layer::wrap`
+
+This is the remaining explicit integration point because service construction/registration is application wiring, not protobuf type generation.
+
+## Failure Modes
+
+Unsupported repeated target field:
+
+- generated code emits `compile_error!`
+- reason: repeated-field merge semantics are business-specific
+
+Unsupported repeated nested path:
+
+- generated code emits `compile_error!`
+- reason: choosing which element to mutate is business-specific
+
+Missing nested context:
+
+- generated code no-ops
+- reason: creating missing domain context would require business logic
+
+Unknown package/module:
+
+- ignored unless it is `types`
+- reason: only `types` currently maps to `crate::payments`
+
+Malformed raw connector config at runtime:
+
+- Plaid sanity extraction no-ops
+- downstream normal validation still handles typed config errors
+
+## Why This Is Not Runtime Reflection
+
+The descriptor is inspected only during Rust build/codegen.
+
+At runtime:
+
+- the service wrapper is normal Rust code
+- setters are normal trait methods
+- matching oneof variants is normal enum matching
+- no protobuf descriptor lookup is needed
+
+This gives the maintainability of descriptor-driven discovery without runtime reflection cost or stringly typed request mutation.

--- a/crates/types-traits/grpc-api-types/codegen/auto_populate.rs
+++ b/crates/types-traits/grpc-api-types/codegen/auto_populate.rs
@@ -1,0 +1,385 @@
+//! Descriptor-driven generator for "populate this field if the request has it"
+//! traits.
+//!
+//! Discovery of *which* request messages contain a given field is entirely
+//! derived from the compiled `FileDescriptorSet` (via each service's RPC
+//! input types) — never hand-maintained. The only thing a developer writes
+//! per field is, in `FIELD_SPECS` below, the setter body for each possible
+//! field *shape* (optional vs. plain singular) — not a list of message
+//! types. Adding a new flow whose request contains the field therefore
+//! requires zero changes here; the next build picks it up automatically.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use heck::{ToSnakeCase, ToUpperCamelCase};
+use prost_types::{
+    field_descriptor_proto::{Label, Type},
+    DescriptorProto, FieldDescriptorProto, FileDescriptorSet, ServiceDescriptorProto,
+};
+
+/// Only the `types` package is aliased as `crate::payments` (see `src/lib.rs`);
+/// everything else (e.g. `grpc.health.v1`) is intentionally out of scope for
+/// this generator.
+const SUPPORTED_PACKAGE: &str = "types";
+const SUPPORTED_PACKAGE_MODULE: &str = "crate::payments";
+
+/// The entire developer-facing declaration surface: a field name, and one
+/// setter body per field shape. Nothing about *which messages* have the
+/// field is declared here.
+pub struct FieldSpec {
+    pub field_name: &'static str,
+    pub trait_name: &'static str,
+    pub method_name: &'static str,
+    pub value_type: &'static str,
+    /// Setter body for a field declared with the `optional` keyword
+    /// (prost emits `Option<value_type>`). May reference `req` and `value`.
+    pub when_optional_body: &'static str,
+    /// Setter body for a plain singular field (prost emits `value_type`
+    /// directly, no `Option`). May reference `req` and `value`.
+    pub when_required_body: &'static str,
+}
+
+pub const FIELD_SPECS: &[FieldSpec] = &[
+    FieldSpec {
+        field_name: "os_based_return_url",
+        trait_name: "PopulateOsBasedReturnUrl",
+        method_name: "populate_os_based_return_url",
+        value_type: "crate::payments::OsBasedReturnUrl",
+        when_optional_body: "if let Some(existing) = req.os_based_return_url.as_mut() {\n                if !existing.os_type.is_empty() {\n                    existing.return_url_map = value.return_url_map;\n                }\n            }",
+        when_required_body: "if !req.os_based_return_url.os_type.is_empty() {\n                req.os_based_return_url.return_url_map = value.return_url_map;\n            }",
+    },
+];
+
+/// Every distinct request message name used as an RPC input type across every
+/// service in the descriptor, restricted to `SUPPORTED_PACKAGE`. This is the
+/// authoritative "what counts as a request" list — derived, never maintained
+/// by hand.
+fn request_message_names(descriptor_set: &FileDescriptorSet) -> BTreeSet<String> {
+    descriptor_set
+        .file
+        .iter()
+        .flat_map(|file| file.service.iter())
+        .flat_map(|service| service.method.iter())
+        .filter_map(|method| method.input_type.as_deref())
+        .filter_map(|input_type| {
+            let trimmed = input_type.trim_start_matches('.');
+            let (package, message_name) = trimmed.rsplit_once('.')?;
+            (package == SUPPORTED_PACKAGE).then(|| message_name.to_string())
+        })
+        .collect()
+}
+
+/// Top-level message name -> descriptor, restricted to `SUPPORTED_PACKAGE`.
+fn message_index(descriptor_set: &FileDescriptorSet) -> BTreeMap<String, &DescriptorProto> {
+    descriptor_set
+        .file
+        .iter()
+        .filter(|file| file.package.as_deref() == Some(SUPPORTED_PACKAGE))
+        .flat_map(|file| file.message_type.iter())
+        .filter_map(|message| message.name.clone().map(|name| (name, message)))
+        .collect()
+}
+
+fn message_names(descriptor_set: &FileDescriptorSet) -> BTreeSet<String> {
+    message_index(descriptor_set).into_keys().collect()
+}
+
+fn rust_type_name(proto_name: &str) -> String {
+    proto_name.to_upper_camel_case()
+}
+
+fn find_field<'a>(
+    message: &'a DescriptorProto,
+    field_name: &str,
+) -> Option<&'a FieldDescriptorProto> {
+    message
+        .field
+        .iter()
+        .find(|field| field.name.as_deref() == Some(field_name))
+}
+
+/// For a message that has the field, decide which developer-supplied setter
+/// body applies, based on the field's shape as reported by the descriptor —
+/// never guessed from the message name or type.
+fn setter_body_for(spec: &FieldSpec, field: &FieldDescriptorProto, message_name: &str) -> String {
+    if field.label == Some(Label::Repeated as i32) {
+        return format!(
+            "let _ = value; compile_error!(\"{method}: `{message}.{field_name}` exists but is `repeated`, which this generator does not support — add explicit handling in build/auto_populate.rs\");",
+            method = spec.method_name,
+            message = message_name,
+            field_name = spec.field_name,
+        );
+    }
+
+    let body = if field.proto3_optional == Some(true) {
+        spec.when_optional_body
+    } else {
+        spec.when_required_body
+    };
+    format!("let req = self;\n            {body}")
+}
+
+fn type_name(path: &str) -> Option<&str> {
+    path.trim_start_matches('.')
+        .rsplit_once('.')
+        .map(|(_, name)| name)
+}
+
+fn message_field_type_name(field: &FieldDescriptorProto) -> Option<&str> {
+    (field.r#type == Some(Type::Message as i32))
+        .then(|| field.type_name.as_deref())
+        .flatten()
+        .and_then(type_name)
+}
+
+fn message_contains_field(
+    messages: &BTreeMap<String, &DescriptorProto>,
+    message_name: &str,
+    field_name: &str,
+    seen: &mut BTreeSet<String>,
+) -> bool {
+    if !seen.insert(message_name.to_string()) {
+        return false;
+    }
+
+    let Some(message) = messages.get(message_name) else {
+        return false;
+    };
+
+    find_field(message, field_name).is_some()
+        || message.field.iter().any(|field| {
+            message_field_type_name(field).is_some_and(|child_name| {
+                message_contains_field(messages, child_name, field_name, seen)
+            })
+        })
+}
+
+fn child_contains_field(
+    messages: &BTreeMap<String, &DescriptorProto>,
+    field: &FieldDescriptorProto,
+    field_name: &str,
+) -> bool {
+    message_field_type_name(field).is_some_and(|child_name| {
+        message_contains_field(messages, child_name, field_name, &mut BTreeSet::new())
+    })
+}
+
+fn oneof_name(message: &DescriptorProto, field: &FieldDescriptorProto) -> Option<String> {
+    let index = usize::try_from(field.oneof_index?).ok()?;
+    message
+        .oneof_decl
+        .get(index)?
+        .name
+        .as_deref()
+        .map(ToSnakeCase::to_snake_case)
+}
+
+fn nested_delegate_body(
+    spec: &FieldSpec,
+    messages: &BTreeMap<String, &DescriptorProto>,
+    message_name: &str,
+    message: &DescriptorProto,
+) -> Option<String> {
+    let field = message
+        .field
+        .iter()
+        .find(|field| child_contains_field(messages, field, spec.field_name))?;
+    let child_name = message_field_type_name(field)?;
+
+    if field.oneof_index.is_some() {
+        let oneof_index = field.oneof_index?;
+        let oneof_name = oneof_name(message, field)?;
+        let oneof_module = rust_type_name(message_name).to_snake_case();
+        let oneof_enum_name = message
+            .oneof_decl
+            .get(usize::try_from(oneof_index).ok()?)?
+            .name
+            .as_deref()?
+            .to_upper_camel_case();
+        let arms = message
+            .field
+            .iter()
+            .filter(|field| field.oneof_index == Some(oneof_index))
+            .filter(|field| child_contains_field(messages, field, spec.field_name))
+            .filter_map(|field| {
+                field.name.as_deref().map(|name| {
+                    format!(
+                        "Some({module}::{oneof_module}::{oneof_enum_name}::{variant}(inner)) => {{\n                    inner.{method}(value);\n                }}",
+                        module = SUPPORTED_PACKAGE_MODULE,
+                        oneof_module = oneof_module,
+                        oneof_enum_name = oneof_enum_name,
+                        variant = name.to_upper_camel_case(),
+                        method = spec.method_name,
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+            .join(",\n                ");
+
+        if arms.is_empty() {
+            return None;
+        }
+
+        Some(format!(
+            "match self.{oneof_name}.as_mut() {{\n                {arms},\n                _ => {{\n                    let _ = value;\n                }}\n            }}",
+            oneof_name = oneof_name,
+            arms = arms,
+        ))
+    } else if field.label == Some(Label::Repeated as i32) {
+        Some(format!(
+            "compile_error!(\"{method}: `{message}.{field}` can reach `{target}` through repeated message `{child}`, which this generator does not support yet\");\n            let _ = value;",
+            method = spec.method_name,
+            message = message_name,
+            field = field.name.as_deref().unwrap_or("<unknown>"),
+            target = spec.field_name,
+            child = child_name,
+        ))
+    } else {
+        let field_name = field.name.as_deref()?;
+        Some(format!(
+            "if let Some(inner) = self.{field_name}.as_mut() {{\n                inner.{method}(value);\n            }} else {{\n                let _ = value;\n            }}",
+            field_name = field_name,
+            method = spec.method_name,
+        ))
+    }
+}
+
+fn populate_impl_message_names(descriptor_set: &FileDescriptorSet) -> BTreeSet<String> {
+    let messages = message_index(descriptor_set);
+    let mut names = request_message_names(descriptor_set);
+
+    names.extend(
+        message_names(descriptor_set)
+            .into_iter()
+            .filter(|message_name| {
+                FIELD_SPECS.iter().any(|spec| {
+                    message_contains_field(
+                        &messages,
+                        message_name,
+                        spec.field_name,
+                        &mut BTreeSet::new(),
+                    )
+                })
+            }),
+    );
+
+    names
+}
+
+fn supported_services(descriptor_set: &FileDescriptorSet) -> Vec<&ServiceDescriptorProto> {
+    descriptor_set
+        .file
+        .iter()
+        .filter(|file| file.package.as_deref() == Some(SUPPORTED_PACKAGE))
+        .flat_map(|file| file.service.iter())
+        .filter(|service| service.name.is_some())
+        .collect()
+}
+
+fn generate_sanity_layer(out: &mut String, descriptor_set: &FileDescriptorSet) {
+    let sanitizer_bounds = FIELD_SPECS
+        .iter()
+        .map(|spec| spec.trait_name)
+        .collect::<Vec<_>>()
+        .join(" + ");
+
+    out.push_str("    #[derive(Clone, Copy, Debug, Default)]\n    pub struct NoopSanitizer;\n\n");
+    out.push_str(&format!(
+        "    pub trait RequestSanitizer: Clone + Send + Sync + 'static {{\n        fn sanitize<T: {sanitizer_bounds}>(&self, metadata: &mut tonic::metadata::MetadataMap, request: &mut T);\n    }}\n\n",
+    ));
+    out.push_str(&format!(
+        "    impl RequestSanitizer for NoopSanitizer {{\n        fn sanitize<T: {sanitizer_bounds}>(&self, _metadata: &mut tonic::metadata::MetadataMap, _request: &mut T) {{}}\n    }}\n\n",
+    ));
+    out.push_str(
+        "    #[derive(Clone)]\n    pub struct SanityLayer<S, Z = NoopSanitizer> {\n        pub inner: S,\n        pub sanitizer: Z,\n    }\n\n",
+    );
+    out.push_str(
+        "    impl<S, Z> SanityLayer<S, Z> {\n        pub fn new(inner: S, sanitizer: Z) -> Self {\n            Self { inner, sanitizer }\n        }\n    }\n\n",
+    );
+    out.push_str(
+        "    impl<S> SanityLayer<S, NoopSanitizer> {\n        pub fn noop(inner: S) -> Self {\n            Self { inner, sanitizer: NoopSanitizer }\n        }\n    }\n\n",
+    );
+
+    for service in supported_services(descriptor_set) {
+        let service_name = service.name.as_deref().expect("service name was filtered");
+        let service_module = format!("{}_server", service_name.to_snake_case());
+
+        out.push_str(&format!(
+            "    #[tonic::async_trait]\n    impl<S, Z> {module}::{service} for SanityLayer<S, Z>\n    where\n        S: {module}::{service},\n        Z: RequestSanitizer,\n    {{\n",
+            module = format!("{SUPPORTED_PACKAGE_MODULE}::{service_module}"),
+            service = service_name,
+        ));
+
+        for method in &service.method {
+            let Some(method_name) = method.name.as_deref() else {
+                continue;
+            };
+            let Some(input_type) = method.input_type.as_deref().and_then(type_name) else {
+                continue;
+            };
+            let Some(output_type) = method.output_type.as_deref().and_then(type_name) else {
+                continue;
+            };
+            let rust_method_name = method_name.to_snake_case();
+
+            out.push_str(&format!(
+                "        async fn {method}(\n            &self,\n            request: tonic::Request<{types_module}::{input_type}>,\n        ) -> Result<tonic::Response<{types_module}::{output_type}>, tonic::Status> {{\n            let (mut metadata, extensions, mut message) = request.into_parts();\n            self.sanitizer.sanitize(&mut metadata, &mut message);\n            let request = tonic::Request::from_parts(metadata, extensions, message);\n            self.inner.{method}(request).await\n        }}\n\n",
+                method = rust_method_name,
+                types_module = SUPPORTED_PACKAGE_MODULE,
+                input_type = rust_type_name(input_type),
+                output_type = rust_type_name(output_type),
+            ));
+        }
+
+        out.push_str("    }\n\n");
+    }
+}
+
+pub fn generate(descriptor_set: &FileDescriptorSet) -> String {
+    let messages = message_index(descriptor_set);
+    let message_names = populate_impl_message_names(descriptor_set);
+
+    let mut out = String::new();
+    out.push_str("// GENERATED FILE - DO NOT EDIT MANUALLY\n");
+    out.push_str(
+        "// Generated by codegen/auto_populate.rs from the compiled protobuf descriptor set.\n",
+    );
+    out.push_str("pub mod generated {\n");
+    out.push_str("    #![allow(clippy::all)]\n\n");
+
+    for spec in FIELD_SPECS {
+        out.push_str(&format!(
+            "    pub trait {trait_name} {{\n        fn {method}(&mut self, value: {value_type});\n    }}\n\n",
+            trait_name = spec.trait_name,
+            method = spec.method_name,
+            value_type = spec.value_type,
+        ));
+
+        for message_name in &message_names {
+            let Some(descriptor) = messages.get(message_name) else {
+                continue;
+            };
+
+            let body = match find_field(descriptor, spec.field_name) {
+                Some(field) => setter_body_for(spec, field, message_name),
+                None => nested_delegate_body(spec, &messages, message_name, descriptor)
+                    .unwrap_or_else(|| "let _ = value;".to_string()),
+            };
+
+            out.push_str(&format!(
+                "    impl {trait_name} for {module}::{message} {{\n        fn {method}(&mut self, value: {value_type}) {{\n            {body}\n        }}\n    }}\n\n",
+                trait_name = spec.trait_name,
+                module = SUPPORTED_PACKAGE_MODULE,
+                message = rust_type_name(message_name),
+                method = spec.method_name,
+                value_type = spec.value_type,
+                body = body,
+            ));
+        }
+    }
+
+    generate_sanity_layer(&mut out, descriptor_set);
+
+    out.push_str("}\n");
+    out
+}

--- a/crates/types-traits/grpc-api-types/proto/payment.proto
+++ b/crates/types-traits/grpc-api-types/proto/payment.proto
@@ -3193,6 +3193,11 @@ message PaymentClientAuthenticationContext {
   optional string return_url = 8;
 }
 
+message OsBasedReturnUrl {
+  string os_type = 1;
+  map<string, string> return_url_map = 2;
+}
+
 // Authenticator-specific context for client authentication token creation
 message AuthenticatorClientAuthenticationContext {
   optional string return_url = 1;           // OAuth redirect URL for Link completion
@@ -3206,6 +3211,8 @@ message AuthenticatorClientAuthenticationContext {
   // hosted flow completes (e.g. an Android package name). Sent by merchants
   // integrating from a native app instead of return_url.
   optional string native_app_identifier = 7;
+
+  optional OsBasedReturnUrl os_based_return_url = 8;
 }
 
 // Response message for SDK session

--- a/crates/types-traits/grpc-api-types/src/lib.rs
+++ b/crates/types-traits/grpc-api-types/src/lib.rs
@@ -28,3 +28,8 @@ pub mod surcharge {
 pub mod frm {
     pub use super::types::*;
 }
+
+pub mod auto_populate {
+    include!(concat!(env!("OUT_DIR"), "/auto_populate_generated.rs"));
+    pub use generated::*;
+}

--- a/crates/types-traits/grpc-api-types/tests/auto_populate_test.rs
+++ b/crates/types-traits/grpc-api-types/tests/auto_populate_test.rs
@@ -1,0 +1,63 @@
+//! Proves the descriptor-driven `auto_populate` mechanism end-to-end for
+//! `os_based_return_url`, without any hand-written field -> message mapping.
+
+use grpc_api_types::auto_populate::PopulateOsBasedReturnUrl;
+use grpc_api_types::payments::{
+    merchant_authentication_service_create_client_authentication_token_request,
+    AuthenticatorClientAuthenticationContext,
+    MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest, OsBasedReturnUrl,
+};
+use std::collections::HashMap;
+
+#[test]
+fn populates_nested_os_based_return_url_map_when_context_exists() {
+    let mut req = MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest {
+        domain_context: Some(
+            merchant_authentication_service_create_client_authentication_token_request::DomainContext::Authenticator(
+                AuthenticatorClientAuthenticationContext {
+                    os_based_return_url: Some(OsBasedReturnUrl {
+                        os_type: "ios".to_string(),
+                        return_url_map: HashMap::new(),
+                    }),
+                    ..Default::default()
+                },
+            ),
+        ),
+        ..Default::default()
+    };
+
+    req.populate_os_based_return_url(OsBasedReturnUrl {
+        os_type: String::new(),
+        return_url_map: HashMap::from([
+            ("ios".to_string(), "https://ios.example/return".to_string()),
+            ("android".to_string(), "com.example.android".to_string()),
+            ("web".to_string(), "https://web.example/return".to_string()),
+        ]),
+    });
+
+    let Some(
+        merchant_authentication_service_create_client_authentication_token_request::DomainContext::Authenticator(
+            authenticator,
+        ),
+    ) = req.domain_context
+    else {
+        panic!("expected authenticator context");
+    };
+    let os_based_return_url = authenticator
+        .os_based_return_url
+        .expect("os_based_return_url should still be present");
+
+    assert_eq!(os_based_return_url.os_type, "ios");
+    assert_eq!(
+        os_based_return_url.return_url_map.get("ios"),
+        Some(&"https://ios.example/return".to_string())
+    );
+    assert_eq!(
+        os_based_return_url.return_url_map.get("android"),
+        Some(&"com.example.android".to_string())
+    );
+    assert_eq!(
+        os_based_return_url.return_url_map.get("web"),
+        Some(&"https://web.example/return".to_string())
+    );
+}


### PR DESCRIPTION
## Summary
- Add `OsBasedReturnUrl` and `optional os_based_return_url` to `AuthenticatorClientAuthenticationContext` for Plaid client-auth redirect configuration.
- Add descriptor-driven `auto_populate` codegen that finds request/message types from the protobuf `FileDescriptorSet` and generates typed populate traits plus service wrappers.
- Add a feature-gated `grpc-server` sanity layer for Plaid that reads Euler-only redirect keys from raw `x-connector-config`, populates `os_based_return_url.return_url_map`, and strips those extra keys before downstream typed config parsing.
- Keep normal UCS runtime path untouched unless `connector-sanity-layer` is enabled.

## How it works
At build time, `grpc-api-types` reads the compiled protobuf descriptor set and generates `auto_populate_generated.rs`. For each field declared in `FIELD_SPECS`, the generator emits a trait such as `PopulateOsBasedReturnUrl`. Request messages that directly contain the field get real setter implementations; request messages that do not support it get no-op implementations. Nested and oneof request shapes delegate to the active child context when the field is reachable there.

The generated `SanityLayer<S, Z>` wraps tonic service implementations. Before forwarding to the real handler, it splits the `tonic::Request` into metadata, extensions, and body, lets the sanitizer mutate metadata/body, then rebuilds the request. This lets the Plaid sanity layer both populate the typed request and clean raw metadata before the existing connector config parser runs.

For Plaid, the runtime sanitizer reads these raw config keys when present:
- `ios_redirect_uri`
- `android_package_name`
- `web_redirect_uri`

It builds `OsBasedReturnUrl { os_type: String::new(), return_url_map }` and calls `populate_os_based_return_url`. The generated setter only fills the map when the request already contains `os_based_return_url` with a non-empty `os_type`, preserving the request-provided OS selection.

## Enablement
The runtime wrapper is disabled by default. Enable it when running/building `grpc-server` with:

```bash
cargo run -p grpc-server --features connector-sanity-layer
```

`ServiceType::Grpc` vs `ServiceType::Http` is still selected through config:

```toml
[server]
type = "grpc" # or "http"
```

When the feature is disabled, `crate::sanity_layer::wrap(service)` returns the original service and the generated wrapper is not in the runtime call path. When enabled, it returns the generated `SanityLayer` and sanity runs before handlers for both gRPC and HTTP service calls.

## Validation
Ran:

```bash
cargo fmt -p grpc-api-types -p grpc-server
cargo check -p grpc-server
cargo check -p grpc-server --features connector-sanity-layer
cargo test -p grpc-api-types --test auto_populate_test
cargo build -p grpc-server --features connector-sanity-layer
```

Live gRPC smoke used `types.MerchantAuthenticationService/CreateClientAuthenticationToken` with `x-auth-connector: plaid`, request body containing `authenticator.osBasedReturnUrl.osType = "ios"`, and `x-connector-config` containing the three Euler-only Plaid redirect keys.

Observed expected downstream failure:

```text
InvalidArgument: Missing required field: customer. customer is required for Plaid Link token creation
```

Before that failure, request logs showed the sanity layer populated:

```json
"os_based_return_url": {
  "os_type": "ios",
  "return_url_map": {
    "ios_redirect_uri": "https://merchant.example/plaid-ios-return",
    "android_package_name": "com.example.android",
    "web_redirect_uri": "https://merchant.example/plaid-web-return"
  }
}
```
