### PR TITLE
fix(grpc): surface full error context in the converged UCS error log

### DIFF
--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -1,7 +1,8 @@
 use common_enums::KafkaClientError;
 use common_utils::errors::ErrorSwitch;
 use domain_types::errors::{
-    ApiClientError, ConnectorError, ConnectorFlowError, IntegrationError, WebhookError,
+    doc_url_for_error_code, ApiClientError, ConnectorError, ConnectorFlowError, IntegrationError,
+    WebhookError,
 };
 use error_stack::Report;
 use tonic::Status;
@@ -31,7 +32,7 @@ where
 }
 
 /// Failures in the gRPC plumbing itself, raised before request transformation.
-#[derive(Debug, Clone, PartialEq, thiserror::Error, strum::AsRefStr)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error, strum::AsRefStr, serde::Serialize)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum InternalError {
     #[error("Extensions missing from gRPC request")]
@@ -82,6 +83,30 @@ impl GrpcError {
             Self::Connector(e) => e.http_status_code(),
             _ => None,
         }
+    }
+
+    /// The wrapped leaf error as JSON, for the single converged error log in
+    /// [`IntoGrpcStatus::into_grpc_status`]. Reflects whatever the real error types declare —
+    /// no hand-picked field list — so new fields show up with no change here.
+    ///
+    /// Uses `hyperswitch_masking::masked_serialize`, not `serde_json::to_value`: `Secret`
+    /// fields (e.g. `ErrorResponse::raw_connector_response`) serialize exposed by default, and
+    /// this is the crate's own masked path, same as every other nested `Secret` in the codebase.
+    fn error_detail(&self) -> serde_json::Value {
+        let serialized = match self {
+            Self::Integration(e) => hyperswitch_masking::masked_serialize(e),
+            Self::Connector(e) => hyperswitch_masking::masked_serialize(e),
+            Self::ApiClient(e) => hyperswitch_masking::masked_serialize(e),
+            // `common_enums::KafkaClientError` only derives `Serialize` under its `deja`
+            // feature, which this crate does not enable; fall back to `Display`.
+            Self::KafkaClient(e) => Ok(serde_json::Value::String(e.to_string())),
+            Self::Webhook(e) => hyperswitch_masking::masked_serialize(e),
+            Self::Internal(e) => hyperswitch_masking::masked_serialize(e),
+        };
+
+        serialized.unwrap_or_else(
+            |err| serde_json::json!({ "error_serialization_failed": err.to_string() }),
+        )
     }
 }
 
@@ -322,6 +347,9 @@ impl IntoGrpcStatus for Report<GrpcError> {
             error_code = %context.error_code(),
             http_status_code = ?context.http_status_code(),
             grpc_code_name = ?status.code(),
+            client_error_message = %status.message(),
+            doc_url = ?doc_url_for_error_code(context.error_code()),
+            error_detail = %context.error_detail(),
         );
         status
     }

--- a/crates/types-traits/domain_types/src/errors.rs
+++ b/crates/types-traits/domain_types/src/errors.rs
@@ -6,7 +6,7 @@ use common_enums;
 use common_utils::errors::ErrorSwitch;
 use error_stack::Report;
 // use api_models::errors::types::{ Extra};
-#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr)]
+#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr, serde::Serialize)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ApiClientError {
     #[error("Header map construction failed")]
@@ -66,7 +66,7 @@ impl ApiError {
 
 /// Fields used when mapping request-phase connector errors to gRPC `IntegrationError`.
 /// Does not depend on generated proto types.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct IntegrationErrorContext {
     /// Human-readable remediation (maps to `IntegrationError.suggested_action`).
     pub suggested_action: Option<String>,
@@ -82,7 +82,7 @@ pub struct IntegrationErrorContext {
 ///
 /// For rare cases (e.g. HTTP status unknown **and** [`Self::additional_context`] set), build
 /// [`ConnectorError`] with a struct literal instead of adding more constructor helpers.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct ResponseTransformationErrorContext {
     /// HTTP status from the connector response when known.
     pub http_status_code: Option<u16>,
@@ -110,7 +110,7 @@ pub fn combine_error_message_with_context(
 /// - proto → domain (`ForeignTryFrom`)
 /// - domain → connector bytes (`build_request_v2`)
 /// - request building variants from `ApiClientError` (`HeaderMapConstruction`, etc.)
-#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr)]
+#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr, serde::Serialize)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum IntegrationError {
     #[error("Error while obtaining URL for the integration")]
@@ -366,7 +366,7 @@ impl ErrorSwitch<grpc_api_types::payments::IntegrationError> for IntegrationErro
 /// Errors that occur on the response side of a connector call:
 /// - UCS-side: connector bytes → domain (`handle_response_v2`), domain → proto (`generate_payment_*_response`)
 /// - Connector-side: connector returned a 4xx/5xx HTTP error response (parsed by `get_error_response_v2` / `get_5xx_error_response`)
-#[derive(Debug, thiserror::Error, Clone, strum::AsRefStr)]
+#[derive(Debug, thiserror::Error, Clone, strum::AsRefStr, serde::Serialize)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ConnectorError {
     #[error("Failed to deserialize connector response")]
@@ -635,7 +635,7 @@ impl ForeignFrom<&ErrorResponse> for Option<grpc_api_types::payments::ErrorInfo>
 }
 
 /// Errors that occur during webhook processing
-#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr)]
+#[derive(Debug, thiserror::Error, PartialEq, Clone, strum::AsRefStr, serde::Serialize)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum WebhookError {
     #[error("Webhooks not implemented for this connector ({operation})")]


### PR DESCRIPTION
## Description

`IntoGrpcStatus for Report<GrpcError>::into_grpc_status` (`crates/common/ucs_env/src/error.rs`) is the single place every gRPC-boundary error is logged. It emitted only `error` (the `Report` debug — error-stack renders each frame's `Display`, not the context structs), `error_code`, `http_status_code`, `grpc_code_name`. None of the structured detail already sent to the caller in the `IntegrationError` / `ConnectorError` proto reached the logs.

### Changes

- `#[derive(serde::Serialize)]` added to `IntegrationError`, `ConnectorError`, `IntegrationErrorContext`, `ResponseTransformationErrorContext`, `ApiClientError`, `WebhookError` (`domain_types::errors`) and `InternalError` (`ucs_env::error`). `ErrorResponse` already derived it.
- `GrpcError::error_detail(&self) -> serde_json::Value` — serializes whichever leaf error is wrapped via **`hyperswitch_masking::masked_serialize`**, not `serde_json::to_value`. This was deliberate, not the first attempt: `Secret`'s plain `Serialize` impl exposes the raw value by default (verified against the crate source — masking only applies to `Debug`), so a naive `to_value` on a `ConnectorErrorResponse` would put `ErrorResponse::raw_connector_response` / `raw_connector_request` in plaintext into this log. `masked_serialize` is the crate's own masked path and redacts every nested `Secret` generically — same mechanism used for any other `Secret` field in this codebase, no field-name denylist to maintain.
- `KafkaClientError` (`common_enums`) only derives `Serialize` under its `deja` feature, which this crate doesn't enable — falls back to its `Display` string rather than pulling that feature in for one log line.
- `logger::error!` gains `client_error_message` (from `status.message()` — the exact string the caller receives), `doc_url` (from `doc_url_for_error_code`), and `error_detail` (the masked JSON, logged as a compact string via `Value`'s `Display`).

**No existing log field is renamed or removed.** Purely additive, two files.

## Motivation and Context

Alerting on UCS gRPC errors currently has to work off `error_code` + the generic `Display` message; the connector's own reason / network advice code is only in the proto sent downstream, never in our logs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

tested locally
<img width="1268" height="355" alt="image" src="https://github.com/user-attachments/assets/4066093c-133e-4cfc-872c-adbf4815635b" />



## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code

