### PR TITLE
fix(ucs): map not-supported errors to gRPC InvalidArgument

### DIFF
--- a/crates/common/ucs_env/src/error.rs
+++ b/crates/common/ucs_env/src/error.rs
@@ -148,9 +148,10 @@ trait ToGrpcStatus {
     fn to_grpc_status_unlogged(&self) -> Status;
 }
 
-/// `invalid_argument` — caller sent a missing or invalid field in this request (UCS is stateless;
-///   every required ID/field must be supplied by the caller on every call).
-/// `unimplemented` — the flow or payment method is not implemented, or not enabled for this connector.
+/// `invalid_argument` — caller sent a missing or invalid field in this request, or asked for a
+///   payment method the connector does not support (UCS is stateless; every required ID/field
+///   must be supplied by the caller on every call).
+/// `unimplemented` — the flow is not implemented, or not enabled for this connector.
 /// `failed_precondition` — connector/merchant configuration problem; not a client credential failure.
 /// `unauthenticated` — credential / auth resolution failure.
 /// `internal` — UCS machinery failure (encoding, URL building, serialization); caller cannot fix.
@@ -185,9 +186,10 @@ impl ToGrpcStatus for IntegrationError {
             | Self::MissingConnectorMandateMetadata { .. }
             | Self::MissingConnectorRelatedTransactionID { .. }
             // Caller supplied a field value that exceeds the connector's length limit.
-            | Self::MaxFieldLengthViolated { .. } => Status::with_details(tonic::Code::InvalidArgument, msg, buf.into()),
+            | Self::MaxFieldLengthViolated { .. }
+            // The connector does not support this payment method or request.
+            | Self::NotSupported { .. } => Status::with_details(tonic::Code::InvalidArgument, msg, buf.into()),
             Self::FlowNotSupported { .. }
-            | Self::NotSupported { .. }
             | Self::CaptureMethodNotSupported { .. }
             | Self::NotImplemented(..) => Status::with_details(tonic::Code::Unimplemented, msg, buf.into()),
             Self::InvalidConnectorConfig { .. }


### PR DESCRIPTION
## Description

Map the `NotSupported` integration error to gRPC `InvalidArgument` (3) instead of `Unimplemented` (12). A request for a payment method the connector does not support is a client request issue, and this makes the wire status match the HTTP 400 mapping on the Hyperswitch side.

`FlowNotSupported`, `CaptureMethodNotSupported`, and `NotImplemented` keep `Unimplemented`.

## Motivation and Context

When a connector refuses a request before calling the processor, the error is a `NotSupported` integration error. UCS returned it with the same gRPC status as `NotImplemented`, so the two classes could not be told apart on the wire. Hyperswitch maps not-supported refusals to HTTP 400 and not-implemented refusals to HTTP 501 (companion PR: https://github.com/juspay/hyperswitch/pull/14187); this change makes the gRPC status match that split.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

Ran a worldpayxml payment with a payment method the connector does not support (`card_with_no_cvc`) through the local stack.

- UCS gRPC status: `InvalidArgument` (3) with `error_code: NOT_SUPPORTED` (previously `Unimplemented` (12)).
- Hyperswitch response: HTTP 400

```json
{
  "error": {
    "type": "invalid_request",
    "message": "Payment method type not supported",
    "code": "IR_19",
    "reason": "Selected payment method is not supported by worldpayxml"
  }
}
```

- The failed attempt is recorded: `payment_attempt.status = failure`, `error_code = IR_19`, `payment_intent.status = failed` (payment `pay_oB2AGR7sFVZ5jYQ1zump`).
- A not-implemented refusal (stripe, same request) still returns `Unimplemented` (12) on the wire and HTTP 501 `IR_00` on the Hyperswitch side.
