### PR TITLE
feat(connector): [Shift4] recurring payments for card, Apple Pay and Google Pay

### DIFF
--- a/crates/integrations/connector-integration/src/connectors/shift4.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4.rs
@@ -55,6 +55,7 @@ pub const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::genera
 pub(crate) mod headers {
     pub(crate) const CONTENT_TYPE: &str = "Content-Type";
     pub(crate) const AUTHORIZATION: &str = "Authorization";
+    pub(crate) const IDEMPOTENCY_KEY: &str = "Idempotency-Key";
 }
 
 // ===== CONNECTOR COMMON IMPLEMENTATION - Must be defined before macros =====
@@ -113,20 +114,29 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize> Conn
 
         let typed =
             macros::serialize_typed_connector_payload(&response, "typed_connector_response");
+        // Shift4's error envelope carries the full decline picture. Dropping the
+        // network fields here would blind smart retry and the GSM error tables:
+        // `adviceCode == "do_not_try_again"` in particular is the merchant advice
+        // code that means "do not schedule a retry for this card".
+        //
+        // `attempt_status` stays `None` deliberately: this method is flow-agnostic
+        // (Refund and RSync route through it too), so stamping a payment status
+        // here would report a hard-declined refund as a terminal payment failure.
+        // Each flow's own transformer sets the concrete status.
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response
                 .error
                 .code
                 .clone()
-                .unwrap_or_else(|| "NO_ERROR_CODE".to_string()),
-            message: response.error.message,
-            reason: None,
+                .unwrap_or_else(|| common_utils::consts::NO_ERROR_CODE.to_string()),
+            message: response.error.message.clone(),
+            reason: Some(response.error.message),
             attempt_status: None,
-            connector_transaction_id: None,
-            network_decline_code: None,
-            network_advice_code: None,
-            network_error_message: None,
+            connector_transaction_id: response.error.charge_id,
+            network_decline_code: response.error.issuer_decline_code,
+            network_advice_code: response.error.network_advice_code,
+            network_error_message: response.error.advice_code,
             typed_connector_response: typed,
             raw_connector_response: None,
             raw_connector_request: None,
@@ -270,7 +280,23 @@ macros::macro_connector_implementation!(
             req: &RouterDataV2<Authorize, PaymentFlowData, PaymentsAuthorizeData<T>, PaymentsResponseData>,
         ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
             // Use JSON content type for authorize (matches Hyperswitch)
-            self.build_headers(req)
+            let mut header = self.build_headers(req)?;
+            // Shift4 executes a repeated POST /charges with the same
+            // `Idempotency-Key` once and replays the cached response, so a retry
+            // after a client timeout cannot double-charge. The key must therefore
+            // be stable for one logical attempt: it is taken from the caller's own
+            // request id, never freshly generated per call.
+            let idempotency_key = req
+                .resource_common_data
+                .merchant_request_id
+                .clone()
+                .unwrap_or_else(|| {
+                    req.resource_common_data
+                        .connector_request_reference_id
+                        .clone()
+                });
+            header.push((headers::IDEMPOTENCY_KEY.to_string(), idempotency_key.into()));
+            Ok(header)
         }
 
         fn get_url(

--- a/crates/integrations/connector-integration/src/connectors/shift4.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4.rs
@@ -8,11 +8,11 @@ use common_utils::{errors::CustomResult, events, ext_traits::ByteSliceExt};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, CreateConnectorCustomer,
-        IncrementalAuthorization, PSync, RSync, Refund, RepeatPayment, SetupMandate,
+        IncrementalAuthorization, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         ClientAuthenticationTokenRequestData, ConnectorCustomerData, ConnectorCustomerResponse,
-        PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
+        PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
         PaymentsIncrementalAuthorizationData, PaymentsResponseData, PaymentsSyncData,
         RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
         SetupMandateRequestData,
@@ -45,6 +45,7 @@ use self::transformers::{
     Shift4PaymentsResponse as Shift4PSyncResponse, Shift4RSyncRequest, Shift4RefundRequest,
     Shift4RefundResponse, Shift4RefundResponse as Shift4RSyncResponse, Shift4RepeatPaymentRequest,
     Shift4RepeatPaymentResponse, Shift4SetupMandateRequest, Shift4SetupMandateResponse,
+    Shift4VoidRequest, Shift4VoidResponse,
 };
 use crate::{connectors::macros, types::ResponseRouterData, with_error_response_body};
 use domain_types::errors::ConnectorError;
@@ -177,6 +178,12 @@ macros::create_all_prerequisites!(
             request_body: Shift4CaptureRequest,
             response_body: Shift4CaptureResponse,
             router_data: RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>,
+        ),
+        (
+            flow: Void,
+            request_body: Shift4VoidRequest,
+            response_body: Shift4VoidResponse,
+            router_data: RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
         ),
         (
             flow: Refund,
@@ -383,6 +390,50 @@ macros::macro_connector_implementation!(
     }
 );
 
+// Void Flow — POST /refunds
+//
+// Shift4 has NO cancel / void / reverse / release endpoint: `POST
+// /charges/{id}/{cancel,void,reverse,release}` and `POST /voids` all return 404,
+// and `DELETE /charges/{id}` returns 405 (probed against the live sandbox on
+// 2026-09-10). The documented release mechanism is to refund the *uncaptured*
+// charge — `POST /refunds` with only `chargeId`, amount omitted so Shift4
+// releases the full authorization (https://dev.shift4.com/docs/api#refunds).
+// Verified working against api.shift4.com: the charge then reads
+// `captured: false, refunded: true`, which is exactly what the PSync mapping in
+// `get_shift4_attempt_status` reads back as `Voided`.
+//
+// The URL therefore comes from the payments base-url helper (this flow carries
+// `PaymentFlowData`, not `RefundFlowData`) even though the path is `/refunds`.
+macros::macro_connector_implementation!(
+    connector_default_implementations: [get_content_type, get_error_response_v2],
+    connector: Shift4,
+    curl_request: Json(Shift4VoidRequest),
+    curl_response: Shift4VoidResponse,
+    flow_name: Void,
+    resource_common_data: PaymentFlowData,
+    flow_request: PaymentVoidData,
+    flow_response: PaymentsResponseData,
+    http_method: Post,
+    generic_type: T,
+    [PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize],
+    other_functions: {
+        fn get_headers(
+            &self,
+            req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ) -> CustomResult<Vec<(String, Maskable<String>)>, IntegrationError> {
+            self.build_headers(req)
+        }
+
+        fn get_url(
+            &self,
+            req: &RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+        ) -> CustomResult<String, IntegrationError> {
+            let base_url = self.connector_base_url_payments(req);
+            Ok(format!("{base_url}/refunds"))
+        }
+    }
+);
+
 // Refund Flow
 macros::macro_connector_implementation!(
     connector_default_implementations: [get_headers, get_content_type, get_error_response_v2],
@@ -564,7 +615,12 @@ impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
 
 // ===== EMPTY IMPLEMENTATIONS FOR UNSUPPORTED FLOWS =====
 
-// Void (Not supported by Shift4)
+// Void — implemented via POST /refunds on an uncaptured charge (see the flow
+// block above); Shift4 has no dedicated cancel endpoint.
+impl<T: PaymentMethodDataTypes + Debug + Sync + Send + 'static + Serialize>
+    connector_types::PaymentVoidV2 for Shift4<T>
+{
+}
 
 // Order Create
 
@@ -731,7 +787,6 @@ macros::macro_connector_flow_status_impls!(
     ],
     not_supported: [
         VoidPostRefund,
-        Void,
         ServerSessionAuthenticationToken,
         ServerAuthenticationToken,
         VoidPC,

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -16,15 +16,19 @@ use domain_types::{
         Shift4ClientAuthenticationResponse as Shift4ClientAuthenticationResponseDomain,
     },
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
+    payment_address,
     payment_method_data::{
         BankRedirectData, PaymentMethodData, PaymentMethodDataTypes, RawCardNumber,
     },
-    router_data::{ConnectorSpecificConfig, FlowStatus},
+    router_data::{
+        AdditionalPaymentMethodConnectorResponse, ConnectorResponseData, ConnectorSpecificConfig,
+        FlowStatus,
+    },
     router_data_v2::RouterDataV2,
     router_response_types::RedirectForm,
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeOptionInterface, Secret};
+use hyperswitch_masking::{ExposeOptionInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -59,10 +63,51 @@ pub struct Shift4ErrorResponse {
     pub error: ApiErrorResponse,
 }
 
+/// Class of the Shift4 error envelope (`error.type`).
+///
+/// Shift4 documents exactly four values. `Unknown` keeps an unrecognised value
+/// from failing the whole error-body parse — an unparsable error body would
+/// otherwise surface as a deserialization failure instead of the decline the
+/// merchant needs to see.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Shift4ErrorType {
+    InvalidRequest,
+    CardError,
+    GatewayError,
+    RateLimitError,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Shift4's declined/failed error envelope (`HTTP 402` for card declines, `4xx`
+/// otherwise): `{ "error": { type, code, message, issuerDeclineCode, adviceCode,
+/// networkAdviceCode, chargeId, ... } }`.
+///
+/// **The wire encoding is camelCase**, so `rename_all = "camelCase"` is load
+/// bearing: the reference Hyperswitch struct carries `#[serde(rename = "camelCase")]`,
+/// which is a no-op (`rename`, not `rename_all`) and silently deserializes every
+/// network field as `None`. Do not "simplify" this attribute back.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiErrorResponse {
+    #[serde(rename = "type")]
+    pub error_type: Option<Shift4ErrorType>,
     pub code: Option<String>,
     pub message: String,
+    /// Decline code supplied by the card issuer. Declined charges only.
+    /// Maps to `ErrorResponse::network_decline_code`.
+    pub issuer_decline_code: Option<String>,
+    /// Merchant advice code (MAC). Shift4 documents exactly two states:
+    /// absent/`null`, or `do_not_try_again` (a hard stop for smart retry).
+    /// Maps to `ErrorResponse::network_error_message`.
+    pub advice_code: Option<String>,
+    /// Raw advice code from the issuer / card network. Shift4 publishes no
+    /// value table for it — it is pass-through.
+    /// Maps to `ErrorResponse::network_advice_code`.
+    pub network_advice_code: Option<String>,
+    /// Charge the decline belongs to. Maps to `ErrorResponse::connector_transaction_id`.
+    pub charge_id: Option<String>,
 }
 
 // ===== CREATE CUSTOMER FLOW STRUCTURES =====
@@ -153,6 +198,26 @@ pub struct Shift4PaymentsRequest<T: PaymentMethodDataTypes> {
     /// calls. Shift4 requires BOTH `captured=false` AND `options.authorizationType=pre`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Shift4ChargeOptions>,
+    /// Transaction initiation class. Shift4 documents no default, so an untyped
+    /// charge is classified by the scheme rather than by us. A one-off sale is
+    /// `customer_initiated`; a charge that is also storing the card on file for
+    /// later merchant-initiated use is `first_recurring`.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub transaction_type: Option<Shift4TransactionType>,
+    /// Charge-level billed-party details. Distinct from the flat `card.address*`
+    /// fields (which take precedence for AVS): this is what Shift4 echoes on the
+    /// charge object and shows in the dashboard. Note `billing.address.country`
+    /// is **two-letter** ISO while `card.addressCountry` is three-letter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub billing: Option<Shift4Billing>,
+    /// Recipient and delivery address.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shipping: Option<Shift4Shipping>,
+    /// Carries the merchant reference. `external.vendorReference` is the only
+    /// merchant-controlled reference identifier on `POST /charges` — Shift4 has
+    /// no `orderId` / `invoice` / `merchantReference` field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external: Option<Shift4External>,
     #[serde(flatten)]
     pub payment_method: Shift4PaymentMethod<T>,
 }
@@ -197,7 +262,58 @@ pub struct Shift4CardData<T: PaymentMethodDataTypes> {
     pub number: RawCardNumber<T>,
     pub exp_month: Secret<String>,
     pub exp_year: Secret<String>,
-    pub cardholder_name: Secret<String>,
+    /// Card security code. Shift4 only runs the CVV check when this is present —
+    /// omitting it forces `cvvCheck.result` to `not_provided` on every sale.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cvc: Option<Secret<String>>,
+    /// Optional for a normal charge; **required** for the zero-amount Account
+    /// Name Inquiry (ANI) path, which is enforced in the request builder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cardholder_name: Option<Secret<String>>,
+    /// Flat card-level address. This is the highest-precedence AVS source in
+    /// Shift4's documented lookup order (card address -> charge `billing`
+    /// address -> customer address -> payment-method billing address).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_city: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_state: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_zip: Option<Secret<String>>,
+    /// **Three-letter** ISO country code — deliberately different from
+    /// `billing.address.country`, which Shift4 documents as two-letter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_country: Option<common_enums::CountryAlpha3>,
+}
+
+impl<T: PaymentMethodDataTypes> Shift4CardData<T> {
+    /// Build the inline `card` object from UCS card data plus the billing
+    /// address that drives AVS. `cardholder_name` is passed in because its
+    /// requiredness is amount-dependent (see the ANI rules on `amount == 0`).
+    fn new(
+        card_data: &domain_types::payment_method_data::Card<T>,
+        cardholder_name: Option<Secret<String>>,
+        billing_address: Option<&payment_address::AddressDetails>,
+    ) -> Self {
+        Self {
+            number: card_data.card_number.clone(),
+            exp_month: card_data.card_exp_month.clone(),
+            exp_year: card_data.card_exp_year.clone(),
+            cvc: Some(card_data.card_cvc.clone()),
+            cardholder_name,
+            address_line1: billing_address.and_then(|addr| addr.line1.clone()),
+            address_line2: billing_address.and_then(|addr| addr.line2.clone()),
+            address_city: billing_address.and_then(|addr| addr.city.clone()),
+            address_state: billing_address.and_then(|addr| addr.state.clone()),
+            address_zip: billing_address.and_then(|addr| addr.zip.clone()),
+            address_country: billing_address
+                .and_then(|addr| addr.country)
+                .map(common_enums::CountryAlpha2::from_alpha2_to_alpha3),
+        }
+    }
 }
 
 // BankRedirect Payment Structures
@@ -224,19 +340,168 @@ pub struct Shift4BankRedirectMethod {
 
 #[derive(Debug, Serialize)]
 pub struct Shift4Billing {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<pii::Email>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<Secret<String>>,
+    /// Tax identification number. Shift4 documents this as the billed party's
+    /// VAT id; the Boleto APM repurposes it for the payer's social security
+    /// number, which is why it is not restricted to bank-redirect payloads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vat: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<Shift4Address>,
+}
+
+/// Recipient and delivery address on `POST /charges`. Shares `Shift4Address`
+/// with `billing` — Shift4 documents the same six sub-fields for both.
+#[derive(Debug, Serialize)]
+pub struct Shift4Shipping {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<Shift4Address>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct Shift4Address {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub line1: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub line2: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub city: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zip: Option<Secret<String>>,
-    pub country: Option<String>,
+    /// **Two-letter** ISO country code (contrast `card.addressCountry`, which
+    /// Shift4 documents as three-letter).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<common_enums::CountryAlpha2>,
+}
+
+impl Shift4Address {
+    /// `None` when the address carries no field Shift4 accepts, so an empty
+    /// `{}` object is never serialized onto the charge.
+    fn from_address_details(address: Option<&payment_address::AddressDetails>) -> Option<Self> {
+        let address = address?;
+        let built = Self {
+            line1: address.line1.clone(),
+            line2: address.line2.clone(),
+            city: address.city.clone(),
+            state: address.state.clone(),
+            zip: address.zip.clone(),
+            country: address.country,
+        };
+        (built.line1.is_some()
+            || built.line2.is_some()
+            || built.city.is_some()
+            || built.state.is_some()
+            || built.zip.is_some()
+            || built.country.is_some())
+        .then_some(built)
+    }
+}
+
+/// `external` object on `POST /charges`.
+///
+/// `vendorReference` is Shift4's only merchant-controlled reference identifier —
+/// there is no `orderId`, `invoice`, `merchantReference` or `referenceId` field
+/// anywhere in the api.shift4.com reference, so do not invent one.
+/// `schemeTransactionId` is an inbound-from-scheme value used for MIT continuity,
+/// not a merchant order id.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Shift4External {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vendor_reference: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme_transaction_id: Option<String>,
+}
+
+/// Wrapper for Shift4's three verification-check objects on the charge:
+/// `avsCheck`, `cvvCheck` and `aniCheck`, each `{ "result": "<value>" }`.
+///
+/// `result` is deliberately a `String` rather than an enum: it is a
+/// pass-through diagnostic that is copied verbatim into `payment_checks` for
+/// the merchant and never drives payment status, so a value Shift4 adds later
+/// must survive intact rather than collapse onto a catch-all variant.
+/// Documented values today — AVS: `full_match`, `partial_match`, `no_match`,
+/// `not_provided`, `unavailable`; CVV: `match`, `no_match`, `not_verified`,
+/// `not_provided`, `not_supported`; ANI: `full_match`, `partial_match`,
+/// `no_match`, `not_verified`, `not_supported`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Shift4CheckResult {
+    pub result: Option<String>,
+}
+
+/// Shift4 documents `billing.phone` / `shipping.phone` with the pattern
+/// `+12 345678901`, i.e. dialling code, a space, then the subscriber number.
+/// UCS keeps the two apart, so they are rejoined here; a number with no dialling
+/// code is sent as-is rather than guessed at.
+fn build_shift4_phone(address: Option<&payment_address::Address>) -> Option<Secret<String>> {
+    let number = address.and_then(|a| a.get_optional_phone_number())?;
+    match address.and_then(|a| a.get_optional_phone_country_code()) {
+        Some(country_code) => Some(Secret::new(format!(
+            "{} {}",
+            country_code,
+            number.peek().trim()
+        ))),
+        None => Some(number),
+    }
+}
+
+/// Build the charge-level `billing` object.
+///
+/// Returns `None` when nothing billable is known, so an empty `billing: {}` is
+/// never put on the wire. `email` prefers the request-level email and falls back
+/// to the address-level one, which is how the bank-redirect path already behaved.
+/// `vat` is left unset: Shift4 documents it as a tax identification number and
+/// UCS has no generic carrier for one on the Authorize contract (the Boleto APM,
+/// which repurposes it, is not supported by this connector).
+fn build_shift4_billing(
+    billing: Option<&payment_address::Address>,
+    request_email: Option<&pii::Email>,
+) -> Option<Shift4Billing> {
+    let name = billing.and_then(|b| b.get_optional_full_name());
+    let email = request_email
+        .cloned()
+        .or_else(|| billing.and_then(|b| b.email.clone()));
+    let phone = build_shift4_phone(billing);
+    let address = Shift4Address::from_address_details(billing.and_then(|b| b.address.as_ref()));
+
+    if name.is_none() && email.is_none() && phone.is_none() && address.is_none() {
+        return None;
+    }
+    Some(Shift4Billing {
+        name,
+        email,
+        phone,
+        vat: None,
+        address,
+    })
+}
+
+/// Build the charge-level `shipping` object from the UCS shipping address.
+/// `None` when no shipping detail is present, so no empty object is serialized.
+fn build_shift4_shipping(shipping: Option<&payment_address::Address>) -> Option<Shift4Shipping> {
+    let name = shipping.and_then(|s| s.get_optional_full_name());
+    let phone = build_shift4_phone(shipping);
+    let address = Shift4Address::from_address_details(shipping.and_then(|s| s.address.as_ref()));
+
+    if name.is_none() && phone.is_none() && address.is_none() {
+        return None;
+    }
+    Some(Shift4Shipping {
+        name,
+        phone,
+        address,
+    })
 }
 
 // BankRedirect Data Transformation
@@ -279,38 +544,20 @@ impl<T: PaymentMethodDataTypes>
             }
         };
 
-        // Extract billing information
-        let billing = router_data
-            .resource_common_data
-            .address
-            .get_payment_method_billing();
-        let name = billing.as_ref().and_then(|b| b.get_optional_full_name());
-
-        // Extract email from request - prioritize from payment data, fallback to address
-        let email = router_data
-            .request
-            .email
-            .as_ref()
-            .cloned()
-            .or_else(|| billing.as_ref().and_then(|b| b.email.as_ref()).cloned());
-
-        let address = billing
-            .as_ref()
-            .and_then(|b| b.address.as_ref())
-            .map(|addr| Shift4Address {
-                line1: addr.line1.clone(),
-                line2: addr.line2.clone(),
-                city: addr.city.clone(),
-                state: addr.state.clone(),
-                zip: addr.zip.clone(),
-                country: addr.country.as_ref().map(|c| c.to_string()),
-            });
-
-        let billing_info = Shift4Billing {
-            name,
-            email,
-            address,
-        };
+        let billing_info = build_shift4_billing(
+            router_data
+                .resource_common_data
+                .address
+                .get_payment_method_billing(),
+            router_data.request.email.as_ref(),
+        )
+        .unwrap_or(Shift4Billing {
+            name: None,
+            email: None,
+            phone: None,
+            vat: None,
+            address: None,
+        });
 
         Ok(Self {
             payment_type: payment_type.to_string(),
@@ -334,36 +581,66 @@ impl<T: PaymentMethodDataTypes>
             PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        let captured = item.request.is_auto_capture();
+        let is_zero_amount = item.request.minor_amount == MinorUnit::new(0);
+        // Shift4 rejects a zero-amount charge that asks to be captured with
+        // HTTP 400 `{"type":"invalid_request","message":"Zero amount charge cannot
+        // be captured"}` (verified against api.shift4.com). A zero-amount charge is
+        // an Account Name Inquiry — no funds move either way, so `captured` carries
+        // no merchant intent here, and honouring AUTOMATIC would make the documented
+        // verification path fail outright instead of returning `aniCheck`.
+        let captured = !is_zero_amount && item.request.is_auto_capture();
+        let billing_details = item
+            .resource_common_data
+            .address
+            .get_payment_method_billing();
 
         let payment_method = match &item.request.payment_method_data {
             PaymentMethodData::Card(card_data) => {
-                // Get cardholder name from address/billing info if available
-                let cardholder_name = item
-                    .resource_common_data
-                    .address
-                    .get_payment_method_billing()
+                // Shift4 documents `cardholderName` as OPTIONAL for a normal charge,
+                // so a card without a billing name must not fail locally. The one
+                // exception is the zero-amount Account Name Inquiry path, where the
+                // name IS the thing being verified.
+                let cardholder_name = billing_details
                     .and_then(|billing| billing.get_optional_full_name())
                     .or_else(|| {
                         item.request
                             .customer_name
                             .as_ref()
                             .map(|name| Secret::new(name.clone()))
-                    })
-                    .ok_or_else(|| {
-                        error_stack::report!(IntegrationError::MissingRequiredField {
-                            field_name: "billing_address.first_name",
-                            context: Default::default()
-                        })
-                    })?;
+                    });
+
+                if is_zero_amount && cardholder_name.is_none() {
+                    return Err(error_stack::report!(
+                        IntegrationError::MissingRequiredField {
+                            field_name: "card.cardholderName",
+                            context: IntegrationErrorContext {
+                                additional_context: Some(
+                                    "A zero-amount Shift4 charge is an Account Name Inquiry (ANI): \
+                                     Shift4 verifies `card.cardholderName` against the name on the \
+                                     account and returns the outcome in `aniCheck.result`. Without \
+                                     a name there is nothing to verify and Shift4 rejects the charge."
+                                        .to_string(),
+                                ),
+                                suggested_action: Some(
+                                    "Send a billing first/last name (or a customer name) with the \
+                                     zero-amount request, or use a non-zero amount."
+                                        .to_string(),
+                                ),
+                                doc_url: Some(
+                                    "https://dev.shift4.com/docs/fraud-prevention/verification-checks"
+                                        .to_string(),
+                                ),
+                            },
+                        }
+                    ));
+                }
 
                 Shift4PaymentMethod::Card(Shift4CardPayment {
-                    card: Shift4CardData {
-                        number: card_data.card_number.clone(),
-                        exp_month: card_data.card_exp_month.clone(),
-                        exp_year: card_data.card_exp_year.clone(),
+                    card: Shift4CardData::new(
+                        card_data,
                         cardholder_name,
-                    },
+                        billing_details.and_then(|billing| billing.address.as_ref()),
+                    ),
                 })
             }
             PaymentMethodData::PaymentMethodToken(pmt) => {
@@ -437,6 +714,28 @@ impl<T: PaymentMethodDataTypes>
             None
         };
 
+        // Shift4 documents no default for `type`, so classify explicitly: a charge
+        // that is also storing the card on file for later merchant-initiated use is
+        // `first_recurring`; every other Authorize is a plain `customer_initiated`
+        // sale. (`merchant_initiated` / `subsequent_recurring` belong to
+        // `Shift4RepeatPaymentRequest` and are set there.)
+        let transaction_type = if item.request.is_customer_initiated_mandate_payment() {
+            Shift4TransactionType::FirstRecurring
+        } else {
+            Shift4TransactionType::CustomerInitiated
+        };
+
+        // NOT SUPPORTED BY SHIFT4, deliberately dropped rather than approximated:
+        // * `PaymentFlowData::l2_l3_data` — api.shift4.com publishes no Level 2 /
+        //   Level 3 fields at all (no purchase order number, tax amount, duty,
+        //   freight, line items or commodity codes). The Level-2 capability on
+        //   docs.shift4.com belongs to a different product with a different wire
+        //   format and is not reachable through this API.
+        // * `PaymentsAuthorizeData::billing_descriptor` — there is no
+        //   `statementDescriptor` / `dynamicDescriptor` / `softDescriptor` field.
+        //   `description` is an internal charge description that never reaches the
+        //   cardholder's statement, so aliasing the descriptor onto it would
+        //   silently change its meaning.
         Ok(Self {
             amount: item.request.minor_amount,
             currency: item.request.currency,
@@ -445,12 +744,26 @@ impl<T: PaymentMethodDataTypes>
             metadata: item.request.metadata.clone().expose_option(),
             customer_id,
             options,
+            transaction_type: Some(transaction_type),
+            billing: build_shift4_billing(billing_details, item.request.email.as_ref()),
+            shipping: build_shift4_shipping(item.resource_common_data.address.get_shipping()),
+            external: Some(Shift4External {
+                vendor_reference: Some(
+                    item.resource_common_data
+                        .connector_request_reference_id
+                        .clone(),
+                ),
+                // Inbound-from-scheme continuity value; only meaningful on a
+                // follow-up MIT, which is `Shift4RepeatPaymentRequest`, not here.
+                scheme_transaction_id: None,
+            }),
             payment_method,
         })
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Shift4PaymentsResponse {
     pub id: String,
     pub currency: Currency,
@@ -459,6 +772,23 @@ pub struct Shift4PaymentsResponse {
     pub captured: bool,
     pub refunded: bool,
     pub flow: Option<FlowResponse>,
+    /// Alphanumeric authorization code from the issuing bank.
+    pub auth_code: Option<String>,
+    /// Unique reference for this transaction within the card network. This is
+    /// the value a subsequent MIT / recurring charge must quote, so it is
+    /// surfaced as `network_txn_id`.
+    pub scheme_transaction_id: Option<String>,
+    /// Address Verification Service outcome. Absent unless Shift4 has activated
+    /// AVS on the merchant account — absence means "check not performed", never
+    /// a failure.
+    pub avs_check: Option<Shift4CheckResult>,
+    /// Card security code check outcome. Only ever populated when `card.cvc` was
+    /// sent on the request. A charge may succeed even when this is `no_match`,
+    /// so it must never be used to derive payment status.
+    pub cvv_check: Option<Shift4CheckResult>,
+    /// Account Name Inquiry outcome. Shift4 documents ANI as working only on a
+    /// zero-amount charge and only on an account where it has been activated.
+    pub ani_check: Option<Shift4CheckResult>,
     /// Nested stored-card object — Shift4 returns this on any /charges
     /// success. Its `id` (e.g., `card_xxx`) is the token used for
     /// subsequent RepeatPayment / MIT calls.
@@ -469,13 +799,142 @@ pub struct Shift4PaymentsResponse {
     pub customer: Option<Shift4ResponseCustomer>,
     /// Populated by Shift4 on declined / failed charges (e.g.,
     /// `"card_declined"`). Surfaced as the ErrorResponse `code`.
-    #[serde(rename = "failureCode")]
     pub failure_code: Option<String>,
     /// Populated by Shift4 on declined / failed charges (e.g.,
     /// `"Your card was declined."`). Surfaced as the ErrorResponse
     /// `message` and `reason`.
-    #[serde(rename = "failureMessage")]
     pub failure_message: Option<String>,
+    /// Charge-object twin of the error envelope's `issuerDeclineCode`. Shift4
+    /// exposes the same decline data under two different names depending on
+    /// whether the decline arrives as an HTTP 402 envelope or as an HTTP 200
+    /// charge with `status: "failed"`. Maps to `network_decline_code`.
+    pub failure_issuer_decline_code: Option<String>,
+    /// Merchant advice code (MAC) — `null` or `do_not_try_again`. Charge-object
+    /// twin of `error.adviceCode`. Maps to `network_error_message`.
+    pub advice_code: Option<String>,
+    /// Raw scheme advice code, pass-through with no published value table.
+    /// Charge-object twin of `error.networkAdviceCode`. Maps to `network_advice_code`.
+    pub network_advice_code: Option<String>,
+}
+
+/// The single Shift4 charge-status table, shared by every flow that reads a
+/// charge object (Authorize, PSync, Capture, RepeatPayment, SetupMandate).
+///
+/// Shift4 reports only three charge states, so terminality has to come from
+/// `captured` and, for `pending`, from `flow.nextAction`:
+/// a settled sale is `Charged`, an uncaptured authorization is `Authorized`, and
+/// a `pending` charge awaiting a shopper redirect is `AuthenticationPending`
+/// rather than plain `Pending`.
+fn get_shift4_attempt_status(response: &Shift4PaymentsResponse) -> AttemptStatus {
+    match response.status {
+        Shift4PaymentStatus::Successful => {
+            if response.captured {
+                AttemptStatus::Charged
+            } else {
+                AttemptStatus::Authorized
+            }
+        }
+        Shift4PaymentStatus::Failed => AttemptStatus::Failure,
+        Shift4PaymentStatus::Pending => match response
+            .flow
+            .as_ref()
+            .and_then(|flow| flow.next_action.as_ref())
+        {
+            Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
+            Some(NextAction::Wait) | Some(NextAction::None) | None => AttemptStatus::Pending,
+        },
+        Shift4PaymentStatus::Unknown => AttemptStatus::Unresolved,
+    }
+}
+
+/// Redirect target Shift4 hands back for APM / redirect flows, if any.
+fn get_shift4_redirection_data(response: &Shift4PaymentsResponse) -> Option<Box<RedirectForm>> {
+    response
+        .flow
+        .as_ref()
+        .and_then(|flow| flow.redirect.as_ref())
+        .and_then(|redirect| {
+            Url::parse(&redirect.redirect_url)
+                .ok()
+                .map(|url| Box::new(RedirectForm::from((url, Method::Get))))
+        })
+}
+
+/// Fold Shift4's three verification checks and the issuer auth code into the
+/// only UCS carrier that exists for them: `payment_checks` on
+/// `AdditionalPaymentMethodConnectorResponse::Card`, which reaches callers as
+/// `CardConnectorResponse.payment_checks`. There is no dedicated `avs_result`
+/// field on the UCS response types.
+///
+/// AVS and ANI both require Shift4 to activate them on the merchant account; on
+/// an account without them the objects are simply absent, which is reported as
+/// "check not performed" (the key is omitted) rather than as a failure.
+fn build_shift4_connector_response(
+    response: &Shift4PaymentsResponse,
+) -> Option<ConnectorResponseData> {
+    let mut payment_checks = serde_json::Map::new();
+    if let Some(result) = response.avs_check.as_ref().and_then(|c| c.result.as_ref()) {
+        payment_checks.insert("avs_result".to_string(), serde_json::json!(result));
+    }
+    if let Some(result) = response.cvv_check.as_ref().and_then(|c| c.result.as_ref()) {
+        payment_checks.insert(
+            "card_validation_result".to_string(),
+            serde_json::json!(result),
+        );
+    }
+    if let Some(result) = response.ani_check.as_ref().and_then(|c| c.result.as_ref()) {
+        payment_checks.insert("ani_result".to_string(), serde_json::json!(result));
+    }
+
+    if payment_checks.is_empty() && response.auth_code.is_none() {
+        return None;
+    }
+
+    Some(ConnectorResponseData::with_additional_payment_method_data(
+        AdditionalPaymentMethodConnectorResponse::Card {
+            authentication_data: None,
+            payment_checks: (!payment_checks.is_empty())
+                .then(|| serde_json::Value::Object(payment_checks)),
+            card_network: None,
+            domestic_network: None,
+            auth_code: response.auth_code.clone(),
+        },
+    ))
+}
+
+/// Build the `ErrorResponse` for an HTTP-200 charge body carrying
+/// `status: "failed"` — Shift4's "soft decline" shape.
+///
+/// The decline data lives under charge-object names (`failureCode`,
+/// `failureIssuerDeclineCode`, `adviceCode`, `networkAdviceCode`) rather than
+/// the error-envelope names, but maps onto the same UCS fields, so smart retry
+/// and the GSM tables see the same values on both decline paths.
+///
+/// `flow_status` is passed in because terminality is flow-specific: an Authorize
+/// decline is `Failure`, a Capture decline is `CaptureFailed`.
+fn build_shift4_failure_response(
+    response: &Shift4PaymentsResponse,
+    http_code: u16,
+    flow_status: FlowStatus,
+) -> domain_types::router_data::ErrorResponse {
+    domain_types::router_data::ErrorResponse {
+        status_code: http_code,
+        code: response
+            .failure_code
+            .clone()
+            .unwrap_or_else(|| common_utils::consts::NO_ERROR_CODE.to_string()),
+        message: response
+            .failure_message
+            .clone()
+            .unwrap_or_else(|| common_utils::consts::NO_ERROR_MESSAGE.to_string()),
+        reason: response.failure_message.clone(),
+        attempt_status: Some(flow_status),
+        connector_transaction_id: Some(response.id.clone()),
+        network_decline_code: response.failure_issuer_decline_code.clone(),
+        network_advice_code: response.network_advice_code.clone(),
+        network_error_message: response.advice_code.clone(),
+        ..Default::default()
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -517,6 +976,10 @@ pub struct RedirectResponse {
 pub enum NextAction {
     Redirect,
     Wait,
+    /// Also the landing spot for any `nextAction` Shift4 adds later: an
+    /// unrecognised next action means "we do not know of an action to take",
+    /// which is exactly `none`, and must not fail the response parse.
+    #[serde(other)]
     None,
 }
 
@@ -526,6 +989,12 @@ pub enum Shift4PaymentStatus {
     Successful,
     Pending,
     Failed,
+    /// A charge status Shift4 has added since this integration was written.
+    /// Parsing it instead of failing keeps the charge id recoverable; it is
+    /// mapped to `Unresolved`, never to `Failure`, because an unknown state is
+    /// not evidence that the money did not move.
+    #[serde(other)]
+    Unknown,
 }
 
 impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4PaymentsResponse, Self>>
@@ -536,59 +1005,44 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4PaymentsRespons
     fn try_from(
         item: ResponseRouterData<Shift4PaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Match Hyperswitch status mapping logic exactly
-        let status = match item.response.status {
-            Shift4PaymentStatus::Successful => {
-                if item.response.captured {
-                    AttemptStatus::Charged
-                } else {
-                    AttemptStatus::Authorized
-                }
-            }
-            Shift4PaymentStatus::Failed => AttemptStatus::Failure,
-            Shift4PaymentStatus::Pending => {
-                match item
-                    .response
-                    .flow
-                    .as_ref()
-                    .and_then(|flow| flow.next_action.as_ref())
-                {
-                    Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
-                    Some(NextAction::Wait) | Some(NextAction::None) | None => {
-                        AttemptStatus::Pending
-                    }
-                }
-            }
-        };
+        let status = get_shift4_attempt_status(&item.response);
+        let connector_response = build_shift4_connector_response(&item.response);
 
-        // Extract redirect URL from flow if present
-        let redirection_data = item
-            .response
-            .flow
-            .as_ref()
-            .and_then(|flow| flow.redirect.as_ref())
-            .and_then(|redirect| {
-                Url::parse(&redirect.redirect_url)
-                    .ok()
-                    .map(|url| Box::new(RedirectForm::from((url, Method::Get))))
-            });
-
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
+        // A Shift4 decline can arrive as an HTTP 200 whose charge body says
+        // `status: "failed"`. Returning `Ok` there would strand the decline —
+        // `failureCode`, `failureMessage` and the three network codes would never
+        // reach the caller — so route it through the error channel, exactly as the
+        // SetupMandate and IncrementalAuthorization mappers already do.
+        let response = if matches!(item.response.status, Shift4PaymentStatus::Failed) {
+            Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(status),
+            ))
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
-                redirection_data,
+                redirection_data: get_shift4_redirection_data(&item.response),
                 mandate_reference: None,
                 connector_metadata: None,
-                network_txn_id: None,
+                network_txn_id: item.response.scheme_transaction_id.clone(),
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(item.response.id),
+                connector_response_reference_id: Some(item.response.id.clone()),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,
                 payment_account_reference: None,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response,
             resource_common_data: PaymentFlowData {
                 status,
+                // AVS / CVV / ANI results are reported on both the success and the
+                // decline path — a declined charge is precisely when the merchant
+                // needs to know the AVS or CVV verdict.
+                connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -605,47 +1059,36 @@ impl TryFrom<ResponseRouterData<Shift4PaymentsResponse, Self>>
     fn try_from(
         item: ResponseRouterData<Shift4PaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Match Hyperswitch status mapping logic exactly
-        let status = match item.response.status {
-            Shift4PaymentStatus::Successful => {
-                if item.response.captured {
-                    AttemptStatus::Charged
-                } else {
-                    AttemptStatus::Authorized
-                }
-            }
-            Shift4PaymentStatus::Failed => AttemptStatus::Failure,
-            Shift4PaymentStatus::Pending => {
-                match item
-                    .response
-                    .flow
-                    .as_ref()
-                    .and_then(|flow| flow.next_action.as_ref())
-                {
-                    Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
-                    Some(NextAction::Wait) | Some(NextAction::None) | None => {
-                        AttemptStatus::Pending
-                    }
-                }
-            }
-        };
+        let status = get_shift4_attempt_status(&item.response);
+        let connector_response = build_shift4_connector_response(&item.response);
 
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
+        let response = if matches!(item.response.status, Shift4PaymentStatus::Failed) {
+            Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(status),
+            ))
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
-                network_txn_id: None,
+                network_txn_id: item.response.scheme_transaction_id.clone(),
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(item.response.id),
+                connector_response_reference_id: Some(item.response.id.clone()),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,
                 payment_account_reference: None,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response,
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -662,47 +1105,45 @@ impl TryFrom<ResponseRouterData<Shift4PaymentsResponse, Self>>
     fn try_from(
         item: ResponseRouterData<Shift4PaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Match Hyperswitch status mapping logic exactly
-        let status = match item.response.status {
-            Shift4PaymentStatus::Successful => {
-                if item.response.captured {
-                    AttemptStatus::Charged
-                } else {
-                    AttemptStatus::Authorized
-                }
-            }
-            Shift4PaymentStatus::Failed => AttemptStatus::Failure,
-            Shift4PaymentStatus::Pending => {
-                match item
-                    .response
-                    .flow
-                    .as_ref()
-                    .and_then(|flow| flow.next_action.as_ref())
-                {
-                    Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
-                    Some(NextAction::Wait) | Some(NextAction::None) | None => {
-                        AttemptStatus::Pending
-                    }
-                }
-            }
-        };
+        let status = get_shift4_attempt_status(&item.response);
+        let connector_response = build_shift4_connector_response(&item.response);
 
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
+        // A capture that Shift4 reports as `failed` is terminal for the capture
+        // leg specifically, so the flow status is `CaptureFailed`, not the
+        // Authorize-level `Failure`.
+        let response = if matches!(item.response.status, Shift4PaymentStatus::Failed) {
+            Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(AttemptStatus::CaptureFailed),
+            ))
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata: None,
-                network_txn_id: None,
+                network_txn_id: item.response.scheme_transaction_id.clone(),
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(item.response.id),
+                connector_response_reference_id: Some(item.response.id.clone()),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,
                 payment_account_reference: None,
-            }),
+            })
+        };
+
+        let status = if matches!(item.response.status, Shift4PaymentStatus::Failed) {
+            AttemptStatus::CaptureFailed
+        } else {
+            status
+        };
+
+        Ok(Self {
+            response,
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -908,11 +1349,68 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     type Error = error_stack::Report<IntegrationError>;
 
     fn try_from(
-        _item: Shift4RouterData<
+        item: Shift4RouterData<
             RouterDataV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>,
             T,
         >,
     ) -> Result<Self, Self::Error> {
+        let router_data = &item.router_data;
+        let request = &router_data.request;
+
+        // `POST /charges/{id}/capture` documents no request body, so Shift4 always
+        // settles the full authorisation — a partial-capture intent cannot be
+        // expressed on the wire. Reject it here instead of silently settling more
+        // money than the caller asked for.
+        let reject_partial = |detail: String| {
+            error_stack::report!(IntegrationError::NotSupported {
+                message: "Partial capture".to_string(),
+                connector: "Shift4",
+                context: IntegrationErrorContext {
+                    additional_context: Some(detail),
+                    suggested_action: Some(
+                        "Capture the full authorised amount, then issue a refund for the \
+                         difference via POST /refunds."
+                            .to_string(),
+                    ),
+                    doc_url: Some("https://dev.shift4.com/docs/api#capture-a-charge".to_string()),
+                },
+            })
+        };
+
+        if request.is_multiple_capture() {
+            return Err(reject_partial(
+                "Shift4's capture endpoint takes no body and settles the whole charge, so a \
+                 multiple-capture request cannot be honoured."
+                    .to_string(),
+            ));
+        }
+        if let Some(
+            method @ (common_enums::CaptureMethod::ManualMultiple
+            | common_enums::CaptureMethod::Scheduled),
+        ) = &request.capture_method
+        {
+            return Err(reject_partial(format!(
+                "Shift4 supports only AUTOMATIC and MANUAL capture; {method} capture would settle \
+                 the whole charge on the first call."
+            )));
+        }
+        // `minor_amount_authorized` is a response-reporting field that request-path
+        // constructors leave as `None`, so this fires only when the caller actually
+        // knows the authorised amount. A lone partial capture with no authorised
+        // amount on the request is still indistinguishable from a full one at this
+        // layer — closing that gap needs the authorised amount added to the capture
+        // contract, mirroring the same known gap documented in `citigate`.
+        if let Some(authorized) = router_data.resource_common_data.minor_amount_authorized {
+            if request.minor_amount_to_capture != authorized {
+                return Err(reject_partial(format!(
+                    "amount_to_capture ({}) differs from the authorised amount ({}), but Shift4's \
+                     capture endpoint takes no amount and would settle the full authorisation.",
+                    request.minor_amount_to_capture.get_amount_as_i64(),
+                    authorized.get_amount_as_i64(),
+                )));
+            }
+        }
+
         Ok(Self {})
     }
 }
@@ -969,10 +1467,15 @@ pub enum Shift4RepeatPaymentCard<T: PaymentMethodDataTypes> {
     RawCard(Shift4CardData<T>),
 }
 
-/// Shift4 transaction type for MIT/recurring classification
+/// Shift4's `type` field on `POST /charges` — how the charge was initiated.
+/// The enum is exactly these four values; Shift4 documents no default.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Shift4TransactionType {
+    /// A one-off sale the cardholder is present for.
+    CustomerInitiated,
+    /// The cardholder-present charge that establishes a card on file.
+    FirstRecurring,
     MerchantInitiated,
     SubsequentRecurring,
 }
@@ -1001,19 +1504,19 @@ impl<T: PaymentMethodDataTypes>
         let (card, customer_id) = if let PaymentMethodData::Card(card_data) =
             &item.request.payment_method_data
         {
-            // Approach 3: Raw card details for MIT (no customer needed)
-            let cardholder_name = item
+            // Approach 3: Raw card details for MIT (no customer needed).
+            // `cardholderName` is optional on a normal Shift4 charge, so an
+            // absent billing name is simply omitted rather than sent as `""`.
+            let billing = item
                 .resource_common_data
-                .get_optional_billing_full_name()
-                .unwrap_or_else(|| Secret::new("".to_string()));
-
+                .address
+                .get_payment_method_billing();
             (
-                Shift4RepeatPaymentCard::RawCard(Shift4CardData {
-                    number: card_data.card_number.clone(),
-                    exp_month: card_data.card_exp_month.clone(),
-                    exp_year: card_data.card_exp_year.clone(),
-                    cardholder_name,
-                }),
+                Shift4RepeatPaymentCard::RawCard(Shift4CardData::new(
+                    card_data,
+                    billing.and_then(|b| b.get_optional_full_name()),
+                    billing.and_then(|b| b.address.as_ref()),
+                )),
                 None, // No customer needed for raw card
             )
         } else {
@@ -1132,59 +1635,36 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4RepeatPaymentRe
     fn try_from(
         item: ResponseRouterData<Shift4RepeatPaymentResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Reuse the same status mapping logic as Authorize flow
-        let status = match item.response.status {
-            Shift4PaymentStatus::Successful => {
-                if item.response.captured {
-                    AttemptStatus::Charged
-                } else {
-                    AttemptStatus::Authorized
-                }
-            }
-            Shift4PaymentStatus::Failed => AttemptStatus::Failure,
-            Shift4PaymentStatus::Pending => {
-                match item
-                    .response
-                    .flow
-                    .as_ref()
-                    .and_then(|flow| flow.next_action.as_ref())
-                {
-                    Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
-                    Some(NextAction::Wait) | Some(NextAction::None) | None => {
-                        AttemptStatus::Pending
-                    }
-                }
-            }
-        };
+        let status = get_shift4_attempt_status(&item.response);
+        let connector_response = build_shift4_connector_response(&item.response);
 
-        // Extract redirect URL from flow if present
-        let redirection_data = item
-            .response
-            .flow
-            .as_ref()
-            .and_then(|flow| flow.redirect.as_ref())
-            .and_then(|redirect| {
-                Url::parse(&redirect.redirect_url)
-                    .ok()
-                    .map(|url| Box::new(RedirectForm::from((url, Method::Get))))
-            });
-
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
+        let response = if matches!(item.response.status, Shift4PaymentStatus::Failed) {
+            Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(status),
+            ))
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
-                redirection_data,
+                redirection_data: get_shift4_redirection_data(&item.response),
                 mandate_reference: None,
                 connector_metadata: None,
-                network_txn_id: None,
+                network_txn_id: item.response.scheme_transaction_id.clone(),
                 network_txn_link_id: None,
-                connector_response_reference_id: Some(item.response.id),
+                connector_response_reference_id: Some(item.response.id.clone()),
                 incremental_authorization_allowed: None,
                 status_code: item.http_code,
                 splits: None,
                 payment_account_reference: None,
-            }),
+            })
+        };
+
+        Ok(Self {
+            response,
             resource_common_data: PaymentFlowData {
                 status,
+                connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data
@@ -1336,29 +1816,15 @@ impl TryFrom<ResponseRouterData<Shift4PaymentsResponse, Self>>
         item: ResponseRouterData<Shift4PaymentsResponse, Self>,
     ) -> Result<Self, Self::Error> {
         let response = match item.response.status {
-            Shift4PaymentStatus::Failed => Err(domain_types::router_data::ErrorResponse {
-                status_code: item.http_code,
-                code: item
-                    .response
-                    .failure_code
-                    .clone()
-                    .unwrap_or_else(|| common_utils::consts::NO_ERROR_CODE.to_string()),
-                message: item
-                    .response
-                    .failure_message
-                    .clone()
-                    .unwrap_or_else(|| common_utils::consts::NO_ERROR_MESSAGE.to_string()),
-                reason: item.response.failure_message.clone(),
-                attempt_status: Some(FlowStatus::Payment(AttemptStatus::AuthorizationFailed)),
-                connector_transaction_id: Some(item.response.id.clone()),
-                network_decline_code: None,
-                network_advice_code: None,
-                network_error_message: None,
-                typed_connector_response: None,
-                raw_connector_response: None,
-                raw_connector_request: None,
-                typed_connector_request: None,
-            }),
+            // Same decline shape as every other charge-object failure, so it goes
+            // through the shared builder: an incremental-authorization decline
+            // carries `issuerDeclineCode` / `adviceCode` / `networkAdviceCode` too,
+            // and smart retry needs them here just as much as on Authorize.
+            Shift4PaymentStatus::Failed => Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(AttemptStatus::AuthorizationFailed),
+            )),
             Shift4PaymentStatus::Successful => {
                 Ok(PaymentsResponseData::IncrementalAuthorizationResponse {
                     status: AuthorizationStatus::Success,
@@ -1369,6 +1835,16 @@ impl TryFrom<ResponseRouterData<Shift4PaymentsResponse, Self>>
             Shift4PaymentStatus::Pending => {
                 Ok(PaymentsResponseData::IncrementalAuthorizationResponse {
                     status: AuthorizationStatus::Processing,
+                    connector_authorization_id: Some(item.response.id.clone()),
+                    status_code: item.http_code,
+                })
+            }
+            // A charge status Shift4 has added since this was written. It is not
+            // evidence the increment was declined, so it must not become
+            // `Failure` — surface it as requiring merchant action instead.
+            Shift4PaymentStatus::Unknown => {
+                Ok(PaymentsResponseData::IncrementalAuthorizationResponse {
+                    status: AuthorizationStatus::Unresolved,
                     connector_authorization_id: Some(item.response.id.clone()),
                     status_code: item.http_code,
                 })
@@ -1519,30 +1995,65 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
     ) -> Result<Self, Self::Error> {
         let item = &wrapper.router_data;
 
+        // Require the caller to specify an amount. Shift4 accepts 0 for
+        // card-on-file verification, but we don't silently default to it —
+        // the caller must pass 0 explicitly if that's what they mean, so a
+        // missing amount is always a client error rather than an implicit
+        // zero-dollar auth.
+        let amount = item.request.minor_amount.ok_or_else(|| {
+            error_stack::report!(IntegrationError::MissingRequiredField {
+                field_name: "amount",
+                context: Default::default(),
+            })
+        })?;
+        let billing_details = item
+            .resource_common_data
+            .address
+            .get_payment_method_billing();
+
         let payment_method = match &item.request.payment_method_data {
             PaymentMethodData::Card(card_data) => {
                 // Cardholder name comes from the billing address — the
                 // cardholder and customer may be different entities, so
-                // never fall back to the customer-level name.
-                let cardholder_name = item
-                    .resource_common_data
-                    .address
-                    .get_payment_method_billing()
-                    .and_then(|billing| billing.get_optional_full_name())
-                    .ok_or_else(|| {
-                        error_stack::report!(IntegrationError::MissingRequiredField {
-                            field_name: "billing_address.first_name",
-                            context: Default::default(),
-                        })
-                    })?;
+                // never fall back to the customer-level name. Shift4 documents
+                // it as optional on a normal charge, so it is only enforced on
+                // the zero-amount Account Name Inquiry path, where the name is
+                // the thing being verified.
+                let cardholder_name =
+                    billing_details.and_then(|billing| billing.get_optional_full_name());
+
+                if amount == MinorUnit::new(0) && cardholder_name.is_none() {
+                    return Err(error_stack::report!(
+                        IntegrationError::MissingRequiredField {
+                            field_name: "card.cardholderName",
+                            context: IntegrationErrorContext {
+                                additional_context: Some(
+                                    "A zero-amount Shift4 charge is an Account Name Inquiry (ANI): \
+                                     Shift4 verifies `card.cardholderName` against the name on the \
+                                     account and returns the outcome in `aniCheck.result`. Without \
+                                     a name there is nothing to verify and Shift4 rejects the charge."
+                                        .to_string(),
+                                ),
+                                suggested_action: Some(
+                                    "Send a billing first/last name with the zero-amount setup \
+                                     request, or set a non-zero verification amount."
+                                        .to_string(),
+                                ),
+                                doc_url: Some(
+                                    "https://dev.shift4.com/docs/fraud-prevention/verification-checks"
+                                        .to_string(),
+                                ),
+                            },
+                        }
+                    ));
+                }
 
                 Shift4PaymentMethod::Card(Shift4CardPayment {
-                    card: Shift4CardData {
-                        number: card_data.card_number.clone(),
-                        exp_month: card_data.card_exp_month.clone(),
-                        exp_year: card_data.card_exp_year.clone(),
+                    card: Shift4CardData::new(
+                        card_data,
                         cardholder_name,
-                    },
+                        billing_details.and_then(|billing| billing.address.as_ref()),
+                    ),
                 })
             }
             PaymentMethodData::PaymentMethodToken(pmt) => {
@@ -1558,18 +2069,6 @@ impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Seria
                 }))
             }
         };
-
-        // Require the caller to specify an amount. Shift4 accepts 0 for
-        // card-on-file verification, but we don't silently default to it —
-        // the caller must pass 0 explicitly if that's what they mean, so a
-        // missing amount is always a client error rather than an implicit
-        // zero-dollar auth.
-        let amount = item.request.minor_amount.ok_or_else(|| {
-            error_stack::report!(IntegrationError::MissingRequiredField {
-                field_name: "amount",
-                context: Default::default(),
-            })
-        })?;
 
         // captured=false for SetupMandate; we only authorize (or
         // verify) to store the card-on-file. `customer_id` is the
@@ -1610,30 +2109,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4SetupMandateRes
     fn try_from(
         item: ResponseRouterData<Shift4SetupMandateResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        // Reuse the same status mapping logic as Authorize flow
-        let mut status = match item.response.status {
-            Shift4PaymentStatus::Successful => {
-                if item.response.captured {
-                    AttemptStatus::Charged
-                } else {
-                    AttemptStatus::Authorized
-                }
-            }
-            Shift4PaymentStatus::Failed => AttemptStatus::Failure,
-            Shift4PaymentStatus::Pending => {
-                match item
-                    .response
-                    .flow
-                    .as_ref()
-                    .and_then(|flow| flow.next_action.as_ref())
-                {
-                    Some(NextAction::Redirect) => AttemptStatus::AuthenticationPending,
-                    Some(NextAction::Wait) | Some(NextAction::None) | None => {
-                        AttemptStatus::Pending
-                    }
-                }
-            }
-        };
+        let mut status = get_shift4_attempt_status(&item.response);
 
         // For zero-amount mandate setup, treat Authorized as Charged so
         // the attempt reaches a terminal state for downstream consumers.
@@ -1642,45 +2118,18 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4SetupMandateRes
         }
 
         // Extract redirect URL if present (BankRedirect setups).
-        let redirection_data = item
-            .response
-            .flow
-            .as_ref()
-            .and_then(|flow| flow.redirect.as_ref())
-            .and_then(|redirect| {
-                Url::parse(&redirect.redirect_url)
-                    .ok()
-                    .map(|url| Box::new(RedirectForm::from((url, Method::Get))))
-            });
+        let redirection_data = get_shift4_redirection_data(&item.response);
+        let connector_response = build_shift4_connector_response(&item.response);
 
         let response = match status {
-            AttemptStatus::Failure => Err(domain_types::router_data::ErrorResponse {
-                status_code: item.http_code,
-                // Shift4 sets `failureCode` / `failureMessage` on declined
-                // charges (e.g. `card_declined`). Prefer those over a
-                // static "SHIFT4_MANDATE_SETUP_FAILED" so the merchant
-                // sees the actual decline reason.
-                code: item
-                    .response
-                    .failure_code
-                    .clone()
-                    .unwrap_or_else(|| common_utils::consts::NO_ERROR_CODE.to_string()),
-                message: item
-                    .response
-                    .failure_message
-                    .clone()
-                    .unwrap_or_else(|| common_utils::consts::NO_ERROR_MESSAGE.to_string()),
-                reason: item.response.failure_message.clone(),
-                attempt_status: Some(FlowStatus::Payment(status)),
-                connector_transaction_id: Some(item.response.id.clone()),
-                network_decline_code: None,
-                network_advice_code: None,
-                network_error_message: None,
-                typed_connector_response: None,
-                raw_connector_response: None,
-                raw_connector_request: None,
-                typed_connector_request: None,
-            }),
+            // Shift4 sets `failureCode` / `failureMessage` (and the three
+            // network codes) on declined charges, so the merchant sees the
+            // actual decline reason rather than a static sentinel.
+            AttemptStatus::Failure => Err(build_shift4_failure_response(
+                &item.response,
+                item.http_code,
+                FlowStatus::Payment(status),
+            )),
             _ => {
                 // For MIT/RepeatPayment, Shift4 requires the stored-card
                 // token (`card_xxx`) returned inside `response.card`. The
@@ -1736,6 +2185,7 @@ impl<T: PaymentMethodDataTypes> TryFrom<ResponseRouterData<Shift4SetupMandateRes
             resource_common_data: PaymentFlowData {
                 status,
                 connector_customer,
+                connector_response,
                 ..item.router_data.resource_common_data
             },
             ..item.router_data

--- a/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
+++ b/crates/integrations/connector-integration/src/connectors/shift4/transformers.rs
@@ -4,15 +4,15 @@ use common_utils::{pii, request::Method, types::MinorUnit};
 use domain_types::{
     connector_flow::{
         Authorize, Capture, ClientAuthenticationToken, CreateConnectorCustomer,
-        IncrementalAuthorization, PSync, RSync, Refund, RepeatPayment, SetupMandate,
+        IncrementalAuthorization, PSync, RSync, Refund, RepeatPayment, SetupMandate, Void,
     },
     connector_types::{
         ClientAuthenticationTokenData, ClientAuthenticationTokenRequestData, ConnectorCustomerData,
         ConnectorCustomerResponse, ConnectorSpecificClientAuthenticationResponse, MandateReference,
-        MandateReferenceId, PaymentFlowData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsIncrementalAuthorizationData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData, RepeatPaymentData,
-        ResponseId, SetupMandateRequestData,
+        MandateReferenceId, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
+        PaymentsCaptureData, PaymentsIncrementalAuthorizationData, PaymentsResponseData,
+        PaymentsSyncData, RefundFlowData, RefundSyncData, RefundsData, RefundsResponseData,
+        RepeatPaymentData, ResponseId, SetupMandateRequestData,
         Shift4ClientAuthenticationResponse as Shift4ClientAuthenticationResponseDomain,
     },
     merchant_authentication_flow_data::MerchantAuthenticationFlowData,
@@ -35,6 +35,12 @@ use url::Url;
 // Import the connector's RouterData wrapper type created by the macro
 use super::Shift4RouterData;
 use domain_types::errors::{ConnectorError, IntegrationError, IntegrationErrorContext};
+
+/// Shift4's refund object has no failure fields, so a declined authorization
+/// release surfaces only as `status: "failed"`. This spells out what actually
+/// happened instead of letting the caller see a bare "declined by shift4".
+const SHIFT4_VOID_DECLINED: &str =
+    "Shift4 declined the authorization release (refund of the uncaptured charge reported `failed`)";
 
 #[derive(Debug, Clone)]
 pub struct Shift4AuthType {
@@ -822,7 +828,8 @@ pub struct Shift4PaymentsResponse {
 ///
 /// Shift4 reports only three charge states, so terminality has to come from
 /// `captured` and, for `pending`, from `flow.nextAction`:
-/// a settled sale is `Charged`, an uncaptured authorization is `Authorized`, and
+/// a settled sale is `Charged`, an uncaptured authorization is `Authorized`, an
+/// uncaptured-but-refunded charge is a released authorization (`Voided`), and
 /// a `pending` charge awaiting a shopper redirect is `AuthenticationPending`
 /// rather than plain `Pending`.
 fn get_shift4_attempt_status(response: &Shift4PaymentsResponse) -> AttemptStatus {
@@ -830,6 +837,12 @@ fn get_shift4_attempt_status(response: &Shift4PaymentsResponse) -> AttemptStatus
         Shift4PaymentStatus::Successful => {
             if response.captured {
                 AttemptStatus::Charged
+            } else if response.refunded {
+                // Shift4 has no cancel endpoint: an authorization is released by
+                // refunding the uncaptured charge, so `!captured && refunded` is
+                // a completed VOID. Without this arm a voided charge keeps
+                // reporting `Authorized` and the caller polls it forever.
+                AttemptStatus::Voided
             } else {
                 AttemptStatus::Authorized
             }
@@ -1184,12 +1197,27 @@ pub struct Shift4RefundResponse {
     pub status: Shift4RefundStatus,
 }
 
+/// Shift4's refund-object status, shared by Refund, RSync and Void (Shift4
+/// releases an authorization by refunding the uncaptured charge, so a void
+/// response *is* a refund object).
+///
+/// The public API reference documents only `successful` and `failed`, but the
+/// official Shift4 SDKs also emit `pending` for an in-flight refund, and
+/// `processing` is the spelling this connector was originally written against.
+/// Both in-flight spellings are accepted so neither can fail deserialization,
+/// and anything Shift4 adds later lands on `Unknown` instead of failing the
+/// whole response parse.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Shift4RefundStatus {
     Successful,
     Failed,
+    /// In flight. `pending` is what the SDKs emit; `processing` is kept as the
+    /// variant name for compatibility and `pending` is accepted as an alias.
+    #[serde(alias = "pending")]
     Processing,
+    #[serde(other)]
+    Unknown,
 }
 
 impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
@@ -1204,6 +1232,12 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
             Shift4RefundStatus::Successful => RefundStatus::Success,
             Shift4RefundStatus::Failed => RefundStatus::Failure,
             Shift4RefundStatus::Processing => RefundStatus::Pending,
+            // Never invent a terminal state for a status Shift4 has not
+            // documented. NOT `RefundStatus::Unknown` — that serializes to the
+            // proto's Unspecified, on which the caller falls back to the
+            // previously stored status, which is silently misleading. `Pending`
+            // keeps RSync polling until Shift4 reports something we understand.
+            Shift4RefundStatus::Unknown => RefundStatus::Pending,
         };
 
         Ok(Self {
@@ -1231,6 +1265,12 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
             Shift4RefundStatus::Successful => RefundStatus::Success,
             Shift4RefundStatus::Failed => RefundStatus::Failure,
             Shift4RefundStatus::Processing => RefundStatus::Pending,
+            // Never invent a terminal state for a status Shift4 has not
+            // documented. NOT `RefundStatus::Unknown` — that serializes to the
+            // proto's Unspecified, on which the caller falls back to the
+            // previously stored status, which is silently misleading. `Pending`
+            // keeps RSync polling until Shift4 reports something we understand.
+            Shift4RefundStatus::Unknown => RefundStatus::Pending,
         };
 
         Ok(Self {
@@ -1240,6 +1280,127 @@ impl TryFrom<ResponseRouterData<Shift4RefundResponse, Self>>
                 status_code: item.http_code,
                 acquirer_reference_number: None,
             }),
+            ..item.router_data
+        })
+    }
+}
+
+// ===== VOID FLOW STRUCTURES =====
+
+/// Shift4 exposes **no** cancel / void / reverse / release endpoint — every such
+/// URL 404s (verified against the live sandbox, 2026-09-10). The documented and
+/// only way to release an open authorization is to refund the uncaptured charge:
+/// `POST /refunds` with just `chargeId`, and **no** `amount`, so Shift4 releases
+/// the full authorized amount (<https://dev.shift4.com/docs/api#refunds>).
+///
+/// `amount` is deliberately absent from this struct: a void always releases the
+/// whole authorization, and sending a partial amount would leave the remainder
+/// authorized while the caller believes the payment was cancelled. Shift4's own
+/// documentation agrees — "Partial refunds are only possible for captured
+/// charge" — so a full release is the only permitted operation here.
+///
+/// `PaymentVoidData::cancellation_reason` is deliberately NOT forwarded either:
+/// `POST /refunds` accepts a `reason`, but only the two literals `fraudulent`
+/// and `expired`. UCS cancellation reasons (e.g. `requested_by_customer`) are
+/// outside that set and Shift4 rejects them, so the field is dropped rather
+/// than mapped onto a wrong value.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Shift4VoidRequest {
+    pub charge_id: String,
+}
+
+impl<T: PaymentMethodDataTypes + std::fmt::Debug + Sync + Send + 'static + Serialize>
+    TryFrom<
+        Shift4RouterData<
+            RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+            T,
+        >,
+    > for Shift4VoidRequest
+{
+    type Error = error_stack::Report<IntegrationError>;
+
+    fn try_from(
+        item: Shift4RouterData<
+            RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>,
+            T,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            charge_id: item.router_data.request.connector_transaction_id.clone(),
+        })
+    }
+}
+
+/// Releasing an authorization returns an ordinary Shift4 *refund* object, byte
+/// for byte the same shape as an ordinary refund — `{id, amount, currency,
+/// charge, status}` — so the void response is that same type. Nothing on the
+/// refund object marks it as a released authorization; the discriminator lives
+/// on the charge (`captured == false && refunded == true`), which is what
+/// `get_shift4_attempt_status` reads on the PSync leg.
+pub type Shift4VoidResponse = Shift4RefundResponse;
+
+impl TryFrom<ResponseRouterData<Shift4VoidResponse, Self>>
+    for RouterDataV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+
+    fn try_from(item: ResponseRouterData<Shift4VoidResponse, Self>) -> Result<Self, Self::Error> {
+        // Terminality matters more here than anywhere else: a void that Shift4
+        // explicitly declined is finished, so it maps to `VoidFailed` and never
+        // to `Pending` — a `Pending` void is polled forever by the caller.
+        let status = match item.response.status {
+            Shift4RefundStatus::Successful => AttemptStatus::Voided,
+            Shift4RefundStatus::Failed => AttemptStatus::VoidFailed,
+            Shift4RefundStatus::Processing => AttemptStatus::VoidInitiated,
+            // An undocumented status is "we could not read the outcome", not a
+            // failure — `Unresolved`, never `VoidFailed` and never `Pending`.
+            Shift4RefundStatus::Unknown => AttemptStatus::Unresolved,
+        };
+
+        // The caller's transaction id must stay the CHARGE, not the refund that
+        // released it: a later PSync is `GET /charges/{id}`, and the refund id
+        // (`item.response.id`) addresses a different resource entirely.
+        let charge_id = item.response.charge.clone();
+
+        let response = if matches!(item.response.status, Shift4RefundStatus::Failed) {
+            // A Shift4 refund object carries no failureCode / failureMessage —
+            // `status: "failed"` is the whole signal — so the message is built
+            // here rather than read off the response.
+            Err(domain_types::router_data::ErrorResponse {
+                status_code: item.http_code,
+                code: common_utils::consts::NO_ERROR_CODE.to_string(),
+                message: SHIFT4_VOID_DECLINED.to_string(),
+                reason: Some(format!(
+                    "{SHIFT4_VOID_DECLINED} (charge {charge_id}, refund {})",
+                    item.response.id
+                )),
+                attempt_status: Some(FlowStatus::Payment(AttemptStatus::VoidFailed)),
+                connector_transaction_id: Some(charge_id.clone()),
+                ..Default::default()
+            })
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(charge_id.clone()),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                network_txn_link_id: None,
+                connector_response_reference_id: Some(charge_id),
+                incremental_authorization_allowed: None,
+                status_code: item.http_code,
+                splits: None,
+                payment_account_reference: None,
+            })
+        };
+
+        Ok(Self {
+            response,
+            resource_common_data: PaymentFlowData {
+                status,
+                ..item.router_data.resource_common_data
+            },
             ..item.router_data
         })
     }

--- a/crates/internal/integration-tests/src/connector_specs/shift4/specs.json
+++ b/crates/internal/integration-tests/src/connector_specs/shift4/specs.json
@@ -9,6 +9,7 @@
     "PaymentService/IncrementalAuthorization",
     "RecurringPaymentService/Charge",
     "PaymentService/Refund",
+    "PaymentService/Void",
     "RefundService/Get",
     "PaymentService/SetupRecurring"
   ]

--- a/data/field_probe/shift4.json
+++ b/data/field_probe/shift4.json
@@ -962,8 +962,21 @@
     },
     "void": {
       "default": {
-        "status": "not_supported",
-        "error": "void flow not supported by shift4 connector"
+        "status": "supported",
+        "proto_request": {
+          "merchant_void_id": "probe_void_001",
+          "connector_transaction_id": "probe_connector_txn_001"
+        },
+        "sample": {
+          "url": "https://api.shift4.com/refunds",
+          "method": "Post",
+          "headers": {
+            "authorization": "Basic cHJvYmVfa2V5Og==",
+            "content-type": "application/json",
+            "via": "HyperSwitch"
+          },
+          "body": "{\"chargeId\":\"probe_connector_txn_001\"}"
+        }
       }
     }
   }

--- a/data/field_probe/shift4.json
+++ b/data/field_probe/shift4.json
@@ -115,9 +115,7 @@
           },
           "capture_method": "AUTOMATIC",
           "address": {
-            "billing_address": {
-              "first_name": "John"
-            }
+            "billing_address": {}
           },
           "auth_type": "NO_THREE_DS",
           "return_url": "https://example.com/return"
@@ -128,9 +126,10 @@
           "headers": {
             "authorization": "Basic cHJvYmVfa2V5Og==",
             "content-type": "application/json",
+            "idempotency-key": "HS_probe00000000000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"card\":{\"number\":\"4111111111111111\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cardholderName\":\"John\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"type\":\"customer_initiated\",\"external\":{\"vendorReference\":\"probe_txn_001\"},\"card\":{\"number\":\"4111111111111111\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cvc\":\"737\"}}"
         }
       },
       "CashappQr": {
@@ -205,9 +204,10 @@
           "headers": {
             "authorization": "Basic cHJvYmVfa2V5Og==",
             "content-type": "application/json",
+            "idempotency-key": "HS_probe00000000000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"paymentMethod\":{\"type\":\"eps\",\"billing\":{\"name\":null,\"email\":null,\"address\":{\"line1\":null,\"line2\":null,\"city\":null,\"state\":null,\"zip\":null,\"country\":null}}},\"flow\":{\"returnUrl\":\"https://example.com/return\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"type\":\"customer_initiated\",\"external\":{\"vendorReference\":\"probe_txn_001\"},\"paymentMethod\":{\"type\":\"eps\",\"billing\":{}},\"flow\":{\"returnUrl\":\"https://example.com/return\"}}"
         }
       },
       "FamilyMart": {
@@ -266,9 +266,10 @@
           "headers": {
             "authorization": "Basic cHJvYmVfa2V5Og==",
             "content-type": "application/json",
+            "idempotency-key": "HS_probe00000000000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"paymentMethod\":{\"type\":\"ideal\",\"billing\":{\"name\":null,\"email\":null,\"address\":{\"line1\":null,\"line2\":null,\"city\":null,\"state\":null,\"zip\":null,\"country\":null}}},\"flow\":{\"returnUrl\":\"https://example.com/return\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"type\":\"customer_initiated\",\"external\":{\"vendorReference\":\"probe_txn_001\"},\"paymentMethod\":{\"type\":\"ideal\",\"billing\":{}},\"flow\":{\"returnUrl\":\"https://example.com/return\"}}"
         }
       },
       "Indomaret": {
@@ -749,9 +750,7 @@
             "card_network": "VISA"
           },
           "address": {
-            "billing_address": {
-              "first_name": "John"
-            }
+            "billing_address": {}
           },
           "capture_method": "AUTOMATIC",
           "auth_type": "NO_THREE_DS",
@@ -763,51 +762,17 @@
           "headers": {
             "authorization": "Basic cHJvYmVfa2V5Og==",
             "content-type": "application/json",
+            "idempotency-key": "HS_probe00000000000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"card\":{\"number\":\"{{$card_number}}\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cardholderName\":\"John\"}}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"type\":\"customer_initiated\",\"external\":{\"vendorReference\":\"probe_proxy_txn_001\"},\"card\":{\"number\":\"{{$card_number}}\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cvc\":\"{{$card_cvc}}\"}}"
         }
       }
     },
     "proxy_setup_recurring": {
       "default": {
-        "status": "supported",
-        "proto_request": {
-          "merchant_recurring_payment_id": "probe_proxy_mandate_001",
-          "amount": {
-            "minor_amount": 0,
-            "currency": "USD"
-          },
-          "card_proxy": {
-            "card_number": "4111111111111111",
-            "card_exp_month": "03",
-            "card_exp_year": "2030",
-            "card_cvc": "123",
-            "card_holder_name": "John Doe",
-            "card_network": "VISA"
-          },
-          "address": {
-            "billing_address": {
-              "first_name": "John"
-            }
-          },
-          "customer_acceptance": {
-            "acceptance_type": "OFFLINE",
-            "accepted_at": 0
-          },
-          "auth_type": "NO_THREE_DS",
-          "setup_future_usage": "OFF_SESSION"
-        },
-        "sample": {
-          "url": "https://api.shift4.com/charges",
-          "method": "Post",
-          "headers": {
-            "authorization": "Basic cHJvYmVfa2V5Og==",
-            "content-type": "application/json",
-            "via": "HyperSwitch"
-          },
-          "body": "{\"amount\":0,\"currency\":\"USD\",\"captured\":false,\"card\":{\"number\":\"{{$card_number}}\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cardholderName\":\"John\"}}"
-        }
+        "status": "error",
+        "error": "Stuck on field: card.cardholderName. A zero-amount Shift4 charge is an Account Name Inquiry — Missing required field: card.cardholderName. A zero-amount Shift4 charge is an Account Name Inquiry (ANI): Shift4 verifies `card.cardholderName` against the name on the account and returns the outcome in `aniCheck.result`. Without a name there is nothing to verify and Shift4 rejects the charge."
       }
     },
     "recurring_charge": {
@@ -910,47 +875,8 @@
     },
     "setup_recurring": {
       "default": {
-        "status": "supported",
-        "proto_request": {
-          "merchant_recurring_payment_id": "probe_mandate_001",
-          "amount": {
-            "minor_amount": 0,
-            "currency": "USD"
-          },
-          "payment_method": {
-            "card": {
-              "card_number": "4111111111111111",
-              "card_exp_month": "03",
-              "card_exp_year": "2030",
-              "card_cvc": "737",
-              "card_holder_name": "John Doe"
-            }
-          },
-          "address": {
-            "billing_address": {
-              "first_name": "John"
-            }
-          },
-          "auth_type": "NO_THREE_DS",
-          "enrolled_for_3ds": false,
-          "return_url": "https://example.com/mandate-return",
-          "setup_future_usage": "OFF_SESSION",
-          "request_incremental_authorization": false,
-          "customer_acceptance": {
-            "acceptance_type": "OFFLINE",
-            "accepted_at": 0
-          }
-        },
-        "sample": {
-          "url": "https://api.shift4.com/charges",
-          "method": "Post",
-          "headers": {
-            "authorization": "Basic cHJvYmVfa2V5Og==",
-            "content-type": "application/json",
-            "via": "HyperSwitch"
-          },
-          "body": "{\"amount\":0,\"currency\":\"USD\",\"captured\":false,\"card\":{\"number\":\"4111111111111111\",\"expMonth\":\"03\",\"expYear\":\"2030\",\"cardholderName\":\"John\"}}"
-        }
+        "status": "error",
+        "error": "Stuck on field: card.cardholderName. A zero-amount Shift4 charge is an Account Name Inquiry — Missing required field: card.cardholderName. A zero-amount Shift4 charge is an Account Name Inquiry (ANI): Shift4 verifies `card.cardholderName` against the name on the account and returns the outcome in `aniCheck.result`. Without a name there is nothing to verify and Shift4 rejects the charge."
       }
     },
     "token_authorize": {
@@ -975,9 +901,10 @@
           "headers": {
             "authorization": "Basic cHJvYmVfa2V5Og==",
             "content-type": "application/json",
+            "idempotency-key": "HS_probe00000000000000000",
             "via": "HyperSwitch"
           },
-          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"card\":\"pm_1AbcXyzStripeTestToken\"}"
+          "body": "{\"amount\":1000,\"currency\":\"USD\",\"captured\":true,\"type\":\"customer_initiated\",\"external\":{\"vendorReference\":\"probe_tokenized_txn_001\"},\"card\":\"pm_1AbcXyzStripeTestToken\"}"
         }
       }
     },

--- a/data/integration-source-links.json
+++ b/data/integration-source-links.json
@@ -221,5 +221,22 @@
     "https://apiref.pay.com/reference/retrieve-a-payment-method",
     "https://apiref.pay.com/reference/mastercard-merchant-advice-codes",
     "https://apiref.pay.com/reference/simulating-clearing-while-in-integration"
+  ],
+  "Shift4": [
+    "https://dev.shift4.com/docs/api",
+    "https://dev.shift4.com/docs/api#authentication",
+    "https://dev.shift4.com/docs/api#idempotency",
+    "https://dev.shift4.com/docs/api#errors",
+    "https://dev.shift4.com/docs/api#charges",
+    "https://dev.shift4.com/docs/api#charge-object",
+    "https://dev.shift4.com/docs/api#cards",
+    "https://dev.shift4.com/docs/api#card-object",
+    "https://dev.shift4.com/docs/api#customers",
+    "https://dev.shift4.com/docs/api#tokens",
+    "https://dev.shift4.com/docs/fraud-prevention/verification-checks",
+    "https://dev.shift4.com/docs/testing",
+    "https://dev.shift4.com/docs/webhooks",
+    "https://dev.shift4.com/docs/payments-optimization/",
+    "https://dev.shift4.com/docs/tutorials/charging-cards/"
   ]
 }

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -239,7 +239,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Revolut](connectors/revolut.md) | ✓ | ⚠ | x | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
 | [Revolv3](connectors/revolv3.md) | x | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Saferpay](connectors/saferpay.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
-| [Shift4](connectors/shift4.md) | ✓ | x | x | ✓ | ⚠ | ✓ | ✓ | ⚠ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ⚠ | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
+| [Shift4](connectors/shift4.md) | ✓ | x | x | ✓ | ⚠ | ✓ | ✓ | ⚠ | ? | ✓ | ✓ | ✓ | ? | ✓ | ⚠ | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Silverflow](connectors/silverflow.md) | ✓ | ✓ | x | ✓ | x | ✓ | ⚠ | ⚠ | ⚠ | x | ⚠ | ✓ | ⚠ | ⚠ | x | ✓ | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Stax](connectors/stax.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ? | ✓ | ✓ | ? | ? | ✓ | x | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Stripe](connectors/stripe.md) | ✓ | ✓ | x | ✓ | x | ✓ | ✓ | ⚠ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | x | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |

--- a/docs-generated/all_connector.md
+++ b/docs-generated/all_connector.md
@@ -239,7 +239,7 @@ Consolidated view of Get, Void, Refund, Capture, Reverse, CreateOrder, and other
 | [Revolut](connectors/revolut.md) | ✓ | ⚠ | x | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |
 | [Revolv3](connectors/revolv3.md) | x | ✓ | ⚠ | ✓ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ✓ | ✓ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | x | x | x | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Saferpay](connectors/saferpay.md) | ✓ | ✓ | ⚠ | ✓ | ⚠ | ? | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | ✓ | x | ⚠ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
-| [Shift4](connectors/shift4.md) | ✓ | x | x | ✓ | ⚠ | ✓ | ✓ | ⚠ | ? | ✓ | ✓ | ✓ | ? | ✓ | ⚠ | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
+| [Shift4](connectors/shift4.md) | ✓ | ✓ | x | ✓ | ⚠ | ✓ | ✓ | ⚠ | ? | ✓ | ✓ | ✓ | ? | ✓ | ⚠ | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | x | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Silverflow](connectors/silverflow.md) | ✓ | ✓ | x | ✓ | x | ✓ | ⚠ | ⚠ | ⚠ | x | ⚠ | ✓ | ⚠ | ⚠ | x | ✓ | x | x | x | x | x | x | x | x | x | ⚠ | ⚠ | x | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | x |
 | [Stax](connectors/stax.md) | ✓ | ✓ | x | ✓ | x | ✓ | x | ⚠ | ? | ✓ | ✓ | ? | ? | ✓ | x | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | ⚠ | ⚠ | ⚠ | x | x | x | x | ⚠ | x | x | ⚠ | ⚠ | x |
 | [Stripe](connectors/stripe.md) | ✓ | ✓ | x | ✓ | x | ✓ | ✓ | ⚠ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | x | ✓ | x | ✓ | ⚠ | x | x | x | x | x | x | x | ⚠ | ✓ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✓ | ✓ | x |

--- a/docs-generated/connectors/shift4.md
+++ b/docs-generated/connectors/shift4.md
@@ -123,7 +123,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L218) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L111) · [Rust](../../examples/shift4/shift4.rs#L264)
+**Examples:** [Python](../../examples/shift4/shift4.py#L224) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L118) · [Rust](../../examples/shift4/shift4.rs#L272)
 
 ### Card Payment (Authorize + Capture)
 
@@ -137,19 +137,25 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L237) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L127) · [Rust](../../examples/shift4/shift4.rs#L280)
+**Examples:** [Python](../../examples/shift4/shift4.py#L243) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L134) · [Rust](../../examples/shift4/shift4.rs#L288)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L262) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L149) · [Rust](../../examples/shift4/shift4.rs#L303)
+**Examples:** [Python](../../examples/shift4/shift4.py#L268) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L156) · [Rust](../../examples/shift4/shift4.rs#L311)
+
+### Void Payment
+
+Cancel an authorized but not-yet-captured payment.
+
+**Examples:** [Python](../../examples/shift4/shift4.py#L293) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L178) · [Rust](../../examples/shift4/shift4.rs#L334)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L287) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L171) · [Rust](../../examples/shift4/shift4.rs#L326)
+**Examples:** [Python](../../examples/shift4/shift4.py#L315) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L197) · [Rust](../../examples/shift4/shift4.rs#L353)
 
 ## API Reference
 
@@ -167,6 +173,7 @@ Retrieve current payment status from the connector.
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
 | [PaymentService.TokenAuthorize](#paymentservicetokenauthorize) | Payments | `PaymentServiceTokenAuthorizeRequest` |
 | [PaymentService.TokenSetupRecurring](#paymentservicetokensetuprecurring) | Payments | `PaymentServiceTokenSetupRecurringRequest` |
+| [PaymentService.Void](#paymentservicevoid) | Payments | `PaymentServiceVoidRequest` |
 
 ### Payments
 
@@ -309,7 +316,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L321) · [Kotlin](../../examples/shift4/shift4.kt#L189) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L350) · [Kotlin](../../examples/shift4/shift4.kt#L215) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Capture
 
@@ -320,7 +327,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L330) · [Kotlin](../../examples/shift4/shift4.kt#L201) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L359) · [Kotlin](../../examples/shift4/shift4.kt#L227) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Get
 
@@ -331,7 +338,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L357) · [Kotlin](../../examples/shift4/shift4.kt#L240) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L386) · [Kotlin](../../examples/shift4/shift4.kt#L266) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.IncrementalAuthorization
 
@@ -342,7 +349,7 @@ Increase the authorized amount for an existing payment. Enables you to capture a
 | **Request** | `PaymentServiceIncrementalAuthorizationRequest` |
 | **Response** | `PaymentServiceIncrementalAuthorizationResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L366) · [Kotlin](../../examples/shift4/shift4.kt#L248) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L395) · [Kotlin](../../examples/shift4/shift4.kt#L274) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -353,7 +360,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L375) · [Kotlin](../../examples/shift4/shift4.kt#L264) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L404) · [Kotlin](../../examples/shift4/shift4.kt#L290) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Refund
 
@@ -364,7 +371,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L393) · [Kotlin](../../examples/shift4/shift4.kt#L324) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L422) · [Kotlin](../../examples/shift4/shift4.kt#L350) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -375,7 +382,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L411) · [Kotlin](../../examples/shift4/shift4.kt#L346) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L440) · [Kotlin](../../examples/shift4/shift4.kt#L372) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenSetupRecurring
 
@@ -386,7 +393,18 @@ Setup a recurring mandate using a connector token.
 | **Request** | `PaymentServiceTokenSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L420) · [Kotlin](../../examples/shift4/shift4.kt#L367) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L449) · [Kotlin](../../examples/shift4/shift4.kt#L393) · [Rust](../../examples/shift4/shift4.rs)
+
+#### PaymentService.Void
+
+Cancel an authorized payment that has not been captured. Releases held funds back to the customer's payment method when a transaction cannot be completed.
+
+| | Message |
+|---|---------|
+| **Request** | `PaymentServiceVoidRequest` |
+| **Response** | `PaymentServiceVoidResponse` |
+
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts) · [Kotlin](../../examples/shift4/shift4.kt#L433) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Refunds
 
@@ -399,7 +417,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L402) · [Kotlin](../../examples/shift4/shift4.kt#L334) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L431) · [Kotlin](../../examples/shift4/shift4.kt#L360) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Mandates
 
@@ -412,7 +430,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L384) · [Kotlin](../../examples/shift4/shift4.kt#L293) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L413) · [Kotlin](../../examples/shift4/shift4.kt#L319) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Customers
 
@@ -425,7 +443,7 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L348) · [Kotlin](../../examples/shift4/shift4.kt#L227) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L377) · [Kotlin](../../examples/shift4/shift4.kt#L253) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Authentication
 
@@ -438,4 +456,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L339) · [Kotlin](../../examples/shift4/shift4.kt#L211) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L368) · [Kotlin](../../examples/shift4/shift4.kt#L237) · [Rust](../../examples/shift4/shift4.rs)

--- a/docs-generated/connectors/shift4.md
+++ b/docs-generated/connectors/shift4.md
@@ -123,7 +123,7 @@ Simple payment that authorizes and captures in one call. Use for immediate charg
 | `PENDING` | Payment processing — await webhook for final status before fulfilling |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L282) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L112) · [Rust](../../examples/shift4/shift4.rs#L339)
+**Examples:** [Python](../../examples/shift4/shift4.py#L218) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L111) · [Rust](../../examples/shift4/shift4.rs#L264)
 
 ### Card Payment (Authorize + Capture)
 
@@ -137,19 +137,19 @@ Two-step card payment. First authorize, then capture. Use when you need to verif
 | `PENDING` | Awaiting async confirmation — wait for webhook before capturing |
 | `FAILED` | Payment declined — surface error to customer, do not retry without new details |
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L301) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L128) · [Rust](../../examples/shift4/shift4.rs#L355)
+**Examples:** [Python](../../examples/shift4/shift4.py#L237) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L127) · [Rust](../../examples/shift4/shift4.rs#L280)
 
 ### Refund
 
 Return funds to the customer for a completed payment.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L326) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L150) · [Rust](../../examples/shift4/shift4.rs#L378)
+**Examples:** [Python](../../examples/shift4/shift4.py#L262) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L149) · [Rust](../../examples/shift4/shift4.rs#L303)
 
 ### Get Payment Status
 
 Retrieve current payment status from the connector.
 
-**Examples:** [Python](../../examples/shift4/shift4.py#L351) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L172) · [Rust](../../examples/shift4/shift4.rs#L401)
+**Examples:** [Python](../../examples/shift4/shift4.py#L287) · [JavaScript](../../examples/shift4/shift4.js) · [Kotlin](../../examples/shift4/shift4.kt#L171) · [Rust](../../examples/shift4/shift4.rs#L326)
 
 ## API Reference
 
@@ -162,11 +162,9 @@ Retrieve current payment status from the connector.
 | [PaymentService.Get](#paymentserviceget) | Payments | `PaymentServiceGetRequest` |
 | [PaymentService.IncrementalAuthorization](#paymentserviceincrementalauthorization) | Payments | `PaymentServiceIncrementalAuthorizationRequest` |
 | [PaymentService.ProxyAuthorize](#paymentserviceproxyauthorize) | Payments | `PaymentServiceProxyAuthorizeRequest` |
-| [PaymentService.ProxySetupRecurring](#paymentserviceproxysetuprecurring) | Payments | `PaymentServiceProxySetupRecurringRequest` |
 | [RecurringPaymentService.Charge](#recurringpaymentservicecharge) | Mandates | `RecurringPaymentServiceChargeRequest` |
 | [PaymentService.Refund](#paymentservicerefund) | Payments | `PaymentServiceRefundRequest` |
 | [RefundService.Get](#refundserviceget) | Refunds | `RefundServiceGetRequest` |
-| [PaymentService.SetupRecurring](#paymentservicesetuprecurring) | Payments | `PaymentServiceSetupRecurringRequest` |
 | [PaymentService.TokenAuthorize](#paymentservicetokenauthorize) | Payments | `PaymentServiceTokenAuthorizeRequest` |
 | [PaymentService.TokenSetupRecurring](#paymentservicetokensetuprecurring) | Payments | `PaymentServiceTokenSetupRecurringRequest` |
 
@@ -311,7 +309,7 @@ Authorize a payment amount on a payment method. This reserves funds without capt
 }
 ```
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L385) · [Kotlin](../../examples/shift4/shift4.kt#L190) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L321) · [Kotlin](../../examples/shift4/shift4.kt#L189) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Capture
 
@@ -322,7 +320,7 @@ Finalize an authorized payment by transferring funds. Captures the authorized am
 | **Request** | `PaymentServiceCaptureRequest` |
 | **Response** | `PaymentServiceCaptureResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L394) · [Kotlin](../../examples/shift4/shift4.kt#L202) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L330) · [Kotlin](../../examples/shift4/shift4.kt#L201) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Get
 
@@ -333,7 +331,7 @@ Retrieve current payment status from the payment processor. Enables synchronizat
 | **Request** | `PaymentServiceGetRequest` |
 | **Response** | `PaymentServiceGetResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L421) · [Kotlin](../../examples/shift4/shift4.kt#L241) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L357) · [Kotlin](../../examples/shift4/shift4.kt#L240) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.IncrementalAuthorization
 
@@ -344,7 +342,7 @@ Increase the authorized amount for an existing payment. Enables you to capture a
 | **Request** | `PaymentServiceIncrementalAuthorizationRequest` |
 | **Response** | `PaymentServiceIncrementalAuthorizationResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L430) · [Kotlin](../../examples/shift4/shift4.kt#L249) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L366) · [Kotlin](../../examples/shift4/shift4.kt#L248) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.ProxyAuthorize
 
@@ -355,18 +353,7 @@ Authorize using vault-aliased card data. Proxy substitutes before connector.
 | **Request** | `PaymentServiceProxyAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L439) · [Kotlin](../../examples/shift4/shift4.kt#L265) · [Rust](../../examples/shift4/shift4.rs)
-
-#### PaymentService.ProxySetupRecurring
-
-Setup recurring mandate using vault-aliased card data.
-
-| | Message |
-|---|---------|
-| **Request** | `PaymentServiceProxySetupRecurringRequest` |
-| **Response** | `PaymentServiceSetupRecurringResponse` |
-
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L448) · [Kotlin](../../examples/shift4/shift4.kt#L295) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L375) · [Kotlin](../../examples/shift4/shift4.kt#L264) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.Refund
 
@@ -377,18 +364,7 @@ Process a partial or full refund for a captured payment. Returns funds to the cu
 | **Request** | `PaymentServiceRefundRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L466) · [Kotlin](../../examples/shift4/shift4.kt#L359) · [Rust](../../examples/shift4/shift4.rs)
-
-#### PaymentService.SetupRecurring
-
-Configure a payment method for recurring billing. Sets up the mandate and payment details needed for future automated charges.
-
-| | Message |
-|---|---------|
-| **Request** | `PaymentServiceSetupRecurringRequest` |
-| **Response** | `PaymentServiceSetupRecurringResponse` |
-
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L484) · [Kotlin](../../examples/shift4/shift4.kt#L381) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L393) · [Kotlin](../../examples/shift4/shift4.kt#L324) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenAuthorize
 
@@ -399,7 +375,7 @@ Authorize using a connector-issued payment method token.
 | **Request** | `PaymentServiceTokenAuthorizeRequest` |
 | **Response** | `PaymentServiceAuthorizeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L493) · [Kotlin](../../examples/shift4/shift4.kt#L421) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L411) · [Kotlin](../../examples/shift4/shift4.kt#L346) · [Rust](../../examples/shift4/shift4.rs)
 
 #### PaymentService.TokenSetupRecurring
 
@@ -410,7 +386,7 @@ Setup a recurring mandate using a connector token.
 | **Request** | `PaymentServiceTokenSetupRecurringRequest` |
 | **Response** | `PaymentServiceSetupRecurringResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L502) · [Kotlin](../../examples/shift4/shift4.kt#L442) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L420) · [Kotlin](../../examples/shift4/shift4.kt#L367) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Refunds
 
@@ -423,7 +399,7 @@ Retrieve refund status from the payment processor. Tracks refund progress throug
 | **Request** | `RefundServiceGetRequest` |
 | **Response** | `RefundResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L475) · [Kotlin](../../examples/shift4/shift4.kt#L369) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L402) · [Kotlin](../../examples/shift4/shift4.kt#L334) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Mandates
 
@@ -436,7 +412,7 @@ Charge using an existing stored recurring payment instruction. Processes repeat 
 | **Request** | `RecurringPaymentServiceChargeRequest` |
 | **Response** | `RecurringPaymentServiceChargeResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L457) · [Kotlin](../../examples/shift4/shift4.kt#L328) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L384) · [Kotlin](../../examples/shift4/shift4.kt#L293) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Customers
 
@@ -449,7 +425,7 @@ Create customer record in the payment processor system. Stores customer details 
 | **Request** | `CustomerServiceCreateRequest` |
 | **Response** | `CustomerServiceCreateResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L412) · [Kotlin](../../examples/shift4/shift4.kt#L228) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L348) · [Kotlin](../../examples/shift4/shift4.kt#L227) · [Rust](../../examples/shift4/shift4.rs)
 
 ### Authentication
 
@@ -462,4 +438,4 @@ Initialize client-facing SDK sessions for wallets, device fingerprinting, etc. R
 | **Request** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest` |
 | **Response** | `MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse` |
 
-**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L403) · [Kotlin](../../examples/shift4/shift4.kt#L212) · [Rust](../../examples/shift4/shift4.rs)
+**Examples:** [Python](../../examples/shift4/shift4.py) · [TypeScript](../../examples/shift4/shift4.ts#L339) · [Kotlin](../../examples/shift4/shift4.kt#L211) · [Rust](../../examples/shift4/shift4.rs)

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -763,7 +763,7 @@ connector_id: shift4
 doc: docs/connectors/shift4.md
 scenarios: checkout_autocapture, checkout_card, refund, get_payment
 payment_methods: Card, Eps, Ideal
-flows: authorize, capture, create_client_authentication_token, customer_create, get, incremental_authorization, proxy_authorize, proxy_setup_recurring, recurring_charge, refund, refund_get, setup_recurring, token_authorize, token_setup_recurring
+flows: authorize, capture, create_client_authentication_token, customer_create, get, incremental_authorization, proxy_authorize, recurring_charge, refund, refund_get, token_authorize, token_setup_recurring
 examples_python: examples/shift4/shift4.py
 
 ## Silverflow

--- a/docs-generated/llms.txt
+++ b/docs-generated/llms.txt
@@ -761,9 +761,9 @@ examples_python: none
 ## Shift4
 connector_id: shift4
 doc: docs/connectors/shift4.md
-scenarios: checkout_autocapture, checkout_card, refund, get_payment
+scenarios: checkout_autocapture, checkout_card, refund, void_payment, get_payment
 payment_methods: Card, Eps, Ideal
-flows: authorize, capture, create_client_authentication_token, customer_create, get, incremental_authorization, proxy_authorize, recurring_charge, refund, refund_get, token_authorize, token_setup_recurring
+flows: authorize, capture, create_client_authentication_token, customer_create, get, incremental_authorization, proxy_authorize, recurring_charge, refund, refund_get, token_authorize, token_setup_recurring, void
 examples_python: examples/shift4/shift4.py
 
 ## Silverflow

--- a/examples/shift4/shift4.kt
+++ b/examples/shift4/shift4.kt
@@ -29,7 +29,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.Shift4Config
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring", "void")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -106,6 +106,13 @@ private fun buildRefundRequest(connectorTransactionIdStr: String): PaymentServic
     }.build()
 }
 
+private fun buildVoidRequest(connectorTransactionIdStr: String): PaymentServiceVoidRequest {
+    return PaymentServiceVoidRequest.newBuilder().apply {
+        merchantVoidId = "probe_void_001"  // Identification.
+        connectorTransactionId = connectorTransactionIdStr
+    }.build()
+}
+
 // Scenario: One-step Payment (Authorize + Capture)
 // Simple payment that authorizes and captures in one call. Use for immediate charges.
 fun processCheckoutAutocapture(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
@@ -164,6 +171,25 @@ fun processRefund(txnId: String, config: ConnectorConfig = _defaultConfig): Map<
         throw RuntimeException("Refund failed: ${refundResponse.error.unifiedDetails.message}")
 
     return mapOf("status" to refundResponse.status.name, "error" to refundResponse.error)
+}
+
+// Scenario: Void Payment
+// Cancel an authorized but not-yet-captured payment.
+fun processVoidPayment(txnId: String, config: ConnectorConfig = _defaultConfig): Map<String, Any?> {
+    val paymentClient = PaymentClient(config)
+
+    // Step 1: Authorize — reserve funds on the payment method
+    val authorizeResponse = paymentClient.authorize(buildAuthorizeRequest("MANUAL"))
+
+    when (authorizeResponse.status.name) {
+        "FAILED"  -> throw RuntimeException("Payment failed: ${authorizeResponse.error.unifiedDetails.message}")
+        "PENDING" -> return mapOf("status" to "PENDING")  // await webhook before proceeding
+    }
+
+    // Step 2: Void — release reserved funds (cancel authorization)
+    val voidResponse = paymentClient.void(buildVoidRequest(authorizeResponse.connectorTransactionId ?: ""))
+
+    return mapOf("status" to voidResponse.status.name, "transactionId" to authorizeResponse.connectorTransactionId, "error" to voidResponse.error)
 }
 
 // Scenario: Get Payment Status
@@ -403,6 +429,16 @@ fun tokenSetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig)
     println("Status: ${response.status.name}")
 }
 
+// Flow: PaymentService.Void
+fun void(txnId: String, config: ConnectorConfig = _defaultConfig) {
+    val client = PaymentClient(config)
+    val request = buildVoidRequest("probe_connector_txn_001")
+    val response = client.void(request)
+    if (response.status.name == "FAILED")
+        throw RuntimeException("Void failed: ${response.error.unifiedDetails.message}")
+    println("Done: ${response.status.name}")
+}
+
 
 fun main(args: Array<String>) {
     val txnId = "order_001"
@@ -411,6 +447,7 @@ fun main(args: Array<String>) {
         "processCheckoutAutocapture" -> processCheckoutAutocapture(txnId)
         "processCheckoutCard" -> processCheckoutCard(txnId)
         "processRefund" -> processRefund(txnId)
+        "processVoidPayment" -> processVoidPayment(txnId)
         "processGetPayment" -> processGetPayment(txnId)
         "authorize" -> authorize(txnId)
         "capture" -> capture(txnId)
@@ -424,6 +461,7 @@ fun main(args: Array<String>) {
         "refundGet" -> refundGet(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "tokenSetupRecurring" -> tokenSetupRecurring(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring")
+        "void" -> void(txnId)
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring, void")
     }
 }

--- a/examples/shift4/shift4.kt
+++ b/examples/shift4/shift4.kt
@@ -29,7 +29,7 @@ import payments.ConnectorSpecificConfig
 import types.Payment.Shift4Config
 import payments.SecretString
 
-val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "refund_get", "setup_recurring", "token_authorize", "token_setup_recurring")
+val SUPPORTED_FLOWS = listOf<String>("authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring")
 
 val _defaultConfig: ConnectorConfig = ConnectorConfig.newBuilder()
     .setOptions(SdkOptions.newBuilder().setEnvironment(Environment.SANDBOX).build())
@@ -64,7 +64,6 @@ private fun buildAuthorizeRequest(captureMethodStr: String): PaymentServiceAutho
         captureMethod = CaptureMethod.valueOf(captureMethodStr)  // Method for capturing the payment.
         addressBuilder.apply {  // Address Information.
             billingAddressBuilder.apply {
-                firstNameBuilder.value = "John"  // Personal Information.
             }
         }
         authType = AuthenticationType.NO_THREE_DS  // Authentication Details.
@@ -280,7 +279,6 @@ fun proxyAuthorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
         }
         addressBuilder.apply {
             billingAddressBuilder.apply {
-                firstNameBuilder.value = "John"  // Personal Information.
             }
         }
         captureMethod = CaptureMethod.AUTOMATIC
@@ -288,39 +286,6 @@ fun proxyAuthorize(txnId: String, config: ConnectorConfig = _defaultConfig) {
         returnUrl = "https://example.com/return"
     }.build()
     val response = client.proxy_authorize(request)
-    println("Status: ${response.status.name}")
-}
-
-// Flow: PaymentService.ProxySetupRecurring
-fun proxySetupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig) {
-    val client = PaymentClient(config)
-    val request = PaymentServiceProxySetupRecurringRequest.newBuilder().apply {
-        merchantRecurringPaymentId = "probe_proxy_mandate_001"
-        amountBuilder.apply {
-            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
-            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
-        cardProxyBuilder.apply {  // Card proxy for vault-aliased payments.
-            cardNumberBuilder.value = "4111111111111111"  // Card Identification.
-            cardExpMonthBuilder.value = "03"
-            cardExpYearBuilder.value = "2030"
-            cardCvcBuilder.value = "123"
-            cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
-            cardNetwork = CardNetwork.VISA
-        }
-        addressBuilder.apply {
-            billingAddressBuilder.apply {
-                firstNameBuilder.value = "John"  // Personal Information.
-            }
-        }
-        customerAcceptanceBuilder.apply {
-            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
-            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        }
-        authType = AuthenticationType.NO_THREE_DS
-        setupFutureUsage = FutureUsage.OFF_SESSION
-    }.build()
-    val response = client.proxy_setup_recurring(request)
     println("Status: ${response.status.name}")
 }
 
@@ -375,46 +340,6 @@ fun refundGet(txnId: String, config: ConnectorConfig = _defaultConfig) {
     }.build()
     val response = client.refund_get(request)
     println("Status: ${response.status.name}")
-}
-
-// Flow: PaymentService.SetupRecurring
-fun setupRecurring(txnId: String, config: ConnectorConfig = _defaultConfig) {
-    val client = PaymentClient(config)
-    val request = PaymentServiceSetupRecurringRequest.newBuilder().apply {
-        merchantRecurringPaymentId = "probe_mandate_001"  // Identification.
-        amountBuilder.apply {  // Mandate Details.
-            minorAmount = 0L  // Amount in minor units (e.g., 1000 = $10.00).
-            currency = Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        }
-        paymentMethodBuilder.apply {
-            cardBuilder.apply {  // Generic card payment.
-                cardNumberBuilder.value = "4111111111111111"  // Card Identification.
-                cardExpMonthBuilder.value = "03"
-                cardExpYearBuilder.value = "2030"
-                cardCvcBuilder.value = "737"
-                cardHolderNameBuilder.value = "John Doe"  // Cardholder Information.
-            }
-        }
-        addressBuilder.apply {  // Address Information.
-            billingAddressBuilder.apply {
-                firstNameBuilder.value = "John"  // Personal Information.
-            }
-        }
-        authType = AuthenticationType.NO_THREE_DS  // Type of authentication to be used.
-        enrolledFor3Ds = false  // Indicates if the customer is enrolled for 3D Secure.
-        returnUrl = "https://example.com/mandate-return"  // URL to redirect after setup.
-        setupFutureUsage = FutureUsage.OFF_SESSION  // Indicates future usage intention.
-        requestIncrementalAuthorization = false  // Indicates if incremental authorization is requested.
-        customerAcceptanceBuilder.apply {  // Details of customer acceptance.
-            acceptanceType = AcceptanceType.OFFLINE  // Type of acceptance (e.g., online, offline).
-            acceptedAt = 0L  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        }
-    }.build()
-    val response = client.setup_recurring(request)
-    when (response.status.name) {
-        "FAILED" -> throw RuntimeException("Setup failed: ${response.error.unifiedDetails.message}")
-        else     -> println("Mandate stored: ${response.connectorRecurringPaymentId}")
-    }
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -494,13 +419,11 @@ fun main(args: Array<String>) {
         "get" -> get(txnId)
         "incrementalAuthorization" -> incrementalAuthorization(txnId)
         "proxyAuthorize" -> proxyAuthorize(txnId)
-        "proxySetupRecurring" -> proxySetupRecurring(txnId)
         "recurringCharge" -> recurringCharge(txnId)
         "refund" -> refund(txnId)
         "refundGet" -> refundGet(txnId)
-        "setupRecurring" -> setupRecurring(txnId)
         "tokenAuthorize" -> tokenAuthorize(txnId)
         "tokenSetupRecurring" -> tokenSetupRecurring(txnId)
-        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, tokenSetupRecurring")
+        else -> System.err.println("Unknown flow: $flow. Available: processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring")
     }
 }

--- a/examples/shift4/shift4.py
+++ b/examples/shift4/shift4.py
@@ -14,7 +14,7 @@ from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, events_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring"]
+SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring", "void"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -215,6 +215,12 @@ def _build_token_setup_recurring_request():
         ),
         setup_future_usage=payment_pb2.FutureUsage.Value("OFF_SESSION"),
     )
+
+def _build_void_request(connector_transaction_id: str):
+    return payment_pb2.PaymentServiceVoidRequest(
+        merchant_void_id="probe_void_001",  # Identification.
+        connector_transaction_id=connector_transaction_id,
+    )
 async def process_checkout_autocapture(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """One-step Payment (Authorize + Capture)
 
@@ -282,6 +288,28 @@ async def process_refund(merchant_transaction_id: str, config: sdk_config_pb2.Co
         raise RuntimeError(f"Refund failed: {refund_response.error}")
 
     return {"status": getattr(refund_response, "status", ""), "error": getattr(refund_response, "error", None)}
+
+
+async def process_void_payment(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Void Payment
+
+    Cancel an authorized but not-yet-captured payment.
+    """
+    payment_client = PaymentClient(config)
+
+    # Step 1: Authorize — reserve funds on the payment method
+    authorize_response = await payment_client.authorize(_build_authorize_request("MANUAL"))
+
+    if authorize_response.status == "FAILED":
+        raise RuntimeError(f"Payment failed: {authorize_response.error}")
+    if authorize_response.status == "PENDING":
+        # Awaiting async confirmation — handle via webhook
+        return {"status": "pending", "transaction_id": authorize_response.connector_transaction_id}
+
+    # Step 2: Void — release reserved funds (cancel authorization)
+    void_response = await payment_client.void(_build_void_request(authorize_response.connector_transaction_id))
+
+    return {"status": getattr(void_response, "status", ""), "transaction_id": getattr(authorize_response, "connector_transaction_id", ""), "error": getattr(void_response, "error", None)}
 
 
 async def process_get_payment(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
@@ -403,6 +431,15 @@ async def process_token_setup_recurring(merchant_transaction_id: str, config: sd
     token_response = await payment_client.token_setup_recurring(_build_token_setup_recurring_request())
 
     return {"status": token_response.status}
+
+
+async def process_void(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
+    """Flow: PaymentService.Void"""
+    payment_client = PaymentClient(config)
+
+    void_response = await payment_client.void(_build_void_request("probe_connector_txn_001"))
+
+    return {"status": void_response.status}
 
 if __name__ == "__main__":
     scenario = sys.argv[1] if len(sys.argv) > 1 else "checkout_autocapture"

--- a/examples/shift4/shift4.py
+++ b/examples/shift4/shift4.py
@@ -14,7 +14,7 @@ from payments import RecurringPaymentClient
 from payments import RefundClient
 from payments.generated import sdk_config_pb2, payment_pb2, events_pb2, payment_methods_pb2
 
-SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "refund_get", "setup_recurring", "token_authorize", "token_setup_recurring"]
+SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring"]
 
 _default_config = sdk_config_pb2.ConnectorConfig(
     options=sdk_config_pb2.SdkOptions(environment=sdk_config_pb2.Environment.SANDBOX),
@@ -47,9 +47,7 @@ def _build_authorize_request(capture_method: str):
         ),
         capture_method=payment_pb2.CaptureMethod.Value(capture_method),  # Method for capturing the payment.
         address=payment_pb2.PaymentAddress(  # Address Information.
-            billing_address=payment_pb2.Address(
-                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
-            ),
+            billing_address=payment_pb2.Address(),
         ),
         auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),  # Authentication Details.
         return_url="https://example.com/return",  # URLs for Redirection and Webhooks.
@@ -121,41 +119,11 @@ def _build_proxy_authorize_request():
             card_network=payment_methods_pb2.CardNetwork.Value("VISA"),
         ),
         address=payment_pb2.PaymentAddress(
-            billing_address=payment_pb2.Address(
-                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
-            ),
+            billing_address=payment_pb2.Address(),
         ),
         capture_method=payment_pb2.CaptureMethod.Value("AUTOMATIC"),
         auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),
         return_url="https://example.com/return",
-    )
-
-def _build_proxy_setup_recurring_request():
-    return payment_pb2.PaymentServiceProxySetupRecurringRequest(
-        merchant_recurring_payment_id="probe_proxy_mandate_001",
-        amount=payment_pb2.Money(
-            minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
-            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
-        ),
-        card_proxy=payment_methods_pb2.ProxyCardDetails(  # Card proxy for vault-aliased payments.
-            card_number=payment_methods_pb2.SecretString(value="4111111111111111"),  # Card Identification.
-            card_exp_month=payment_methods_pb2.SecretString(value="03"),
-            card_exp_year=payment_methods_pb2.SecretString(value="2030"),
-            card_cvc=payment_methods_pb2.SecretString(value="123"),
-            card_holder_name=payment_methods_pb2.SecretString(value="John Doe"),  # Cardholder Information.
-            card_network=payment_methods_pb2.CardNetwork.Value("VISA"),
-        ),
-        address=payment_pb2.PaymentAddress(
-            billing_address=payment_pb2.Address(
-                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
-            ),
-        ),
-        customer_acceptance=payment_pb2.CustomerAcceptance(
-            acceptance_type=payment_pb2.AcceptanceType.Value("OFFLINE"),  # Type of acceptance (e.g., online, offline).
-            accepted_at=0,  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        ),
-        auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),
-        setup_future_usage=payment_pb2.FutureUsage.Value("OFF_SESSION"),
     )
 
 def _build_recurring_charge_request():
@@ -197,38 +165,6 @@ def _build_refund_get_request():
         merchant_refund_id="probe_refund_001",  # Identification.
         connector_transaction_id="probe_connector_txn_001",
         refund_id="probe_refund_id_001",  # Deprecated.
-    )
-
-def _build_setup_recurring_request():
-    return payment_pb2.PaymentServiceSetupRecurringRequest(
-        merchant_recurring_payment_id="probe_mandate_001",  # Identification.
-        amount=payment_pb2.Money(  # Mandate Details.
-            minor_amount=0,  # Amount in minor units (e.g., 1000 = $10.00).
-            currency=payment_pb2.Currency.Value("USD"),  # ISO 4217 currency code (e.g., "USD", "EUR").
-        ),
-        payment_method=payment_methods_pb2.PaymentMethod(
-            card=payment_methods_pb2.CardDetails(
-                card_number=payment_methods_pb2.CardNumberType(value="4111111111111111"),  # Card Identification.
-                card_exp_month=payment_methods_pb2.SecretString(value="03"),
-                card_exp_year=payment_methods_pb2.SecretString(value="2030"),
-                card_cvc=payment_methods_pb2.SecretString(value="737"),
-                card_holder_name=payment_methods_pb2.SecretString(value="John Doe"),  # Cardholder Information.
-            ),
-        ),
-        address=payment_pb2.PaymentAddress(  # Address Information.
-            billing_address=payment_pb2.Address(
-                first_name=payment_methods_pb2.SecretString(value="John"),  # Personal Information.
-            ),
-        ),
-        auth_type=payment_pb2.AuthenticationType.Value("NO_THREE_DS"),  # Type of authentication to be used.
-        enrolled_for_3ds=False,  # Indicates if the customer is enrolled for 3D Secure.
-        return_url="https://example.com/mandate-return",  # URL to redirect after setup.
-        setup_future_usage=payment_pb2.FutureUsage.Value("OFF_SESSION"),  # Indicates future usage intention.
-        request_incremental_authorization=False,  # Indicates if incremental authorization is requested.
-        customer_acceptance=payment_pb2.CustomerAcceptance(  # Details of customer acceptance.
-            acceptance_type=payment_pb2.AcceptanceType.Value("OFFLINE"),  # Type of acceptance (e.g., online, offline).
-            accepted_at=0,  # Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        ),
     )
 
 def _build_token_authorize_request():
@@ -433,15 +369,6 @@ async def process_proxy_authorize(merchant_transaction_id: str, config: sdk_conf
     return {"status": proxy_response.status}
 
 
-async def process_proxy_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Flow: PaymentService.ProxySetupRecurring"""
-    payment_client = PaymentClient(config)
-
-    proxy_response = await payment_client.proxy_setup_recurring(_build_proxy_setup_recurring_request())
-
-    return {"status": proxy_response.status}
-
-
 async def process_recurring_charge(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
     """Flow: RecurringPaymentService.Charge"""
     recurringpayment_client = RecurringPaymentClient(config)
@@ -458,15 +385,6 @@ async def process_refund_get(merchant_transaction_id: str, config: sdk_config_pb
     refund_response = await refund_client.refund_get(_build_refund_get_request())
 
     return {"status": refund_response.status}
-
-
-async def process_setup_recurring(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):
-    """Flow: PaymentService.SetupRecurring"""
-    payment_client = PaymentClient(config)
-
-    setup_response = await payment_client.setup_recurring(_build_setup_recurring_request())
-
-    return {"status": setup_response.status, "mandate_id": setup_response.connector_recurring_payment_id}
 
 
 async def process_token_authorize(merchant_transaction_id: str, config: sdk_config_pb2.ConnectorConfig = _default_config):

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -27,6 +27,7 @@ pub const SUPPORTED_FLOWS: &[&str] = &[
     "refund_get",
     "token_authorize",
     "token_setup_recurring",
+    "void",
 ];
 
 #[allow(dead_code)]
@@ -290,6 +291,14 @@ pub fn build_token_setup_recurring_request() -> PaymentServiceTokenSetupRecurrin
     }
 }
 
+pub fn build_void_request(connector_transaction_id: &str) -> PaymentServiceVoidRequest {
+    PaymentServiceVoidRequest {
+        merchant_void_id: Some("probe_void_001".to_string()), // Identification.
+        connector_transaction_id: connector_transaction_id.to_string(),
+        ..Default::default()
+    }
+}
+
 // Scenario: One-step Payment (Authorize + Capture)
 // Simple payment that authorizes and captures in one call. Use for immediate charges.
 #[allow(dead_code)]
@@ -406,6 +415,43 @@ pub async fn process_refund(
     }
 
     Ok(format!("Refunded: {:?}", refund_response.status()))
+}
+
+// Scenario: Void Payment
+// Cancel an authorized but not-yet-captured payment.
+#[allow(dead_code)]
+pub async fn process_void_payment(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Step 1: Authorize — reserve funds on the payment method
+    let authorize_response = client
+        .authorize(build_authorize_request("MANUAL"), &HashMap::new(), None)
+        .await?;
+
+    match authorize_response.status() {
+        PaymentStatus::Failure | PaymentStatus::AuthorizationFailed => {
+            return Err(format!("Payment failed: {:?}", authorize_response.error).into())
+        }
+        PaymentStatus::Pending => return Ok("pending — awaiting webhook".to_string()),
+        _ => {}
+    }
+
+    // Step 2: Void — release reserved funds (cancel authorization)
+    let void_response = client
+        .void(
+            build_void_request(
+                authorize_response
+                    .connector_transaction_id
+                    .as_deref()
+                    .unwrap_or(""),
+            ),
+            &HashMap::new(),
+            None,
+        )
+        .await?;
+
+    Ok(format!("Voided: {:?}", void_response.status()))
 }
 
 // Scenario: Get Payment Status
@@ -602,6 +648,22 @@ pub async fn process_token_setup_recurring(
     Ok(format!("status: {:?}", response.status()))
 }
 
+// Flow: PaymentService.Void
+#[allow(dead_code)]
+pub async fn process_void(
+    client: &ConnectorClient,
+    _merchant_transaction_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let response = client
+        .void(
+            build_void_request("probe_connector_txn_001"),
+            &HashMap::new(),
+            None,
+        )
+        .await?;
+    Ok(format!("status: {:?}", response.status()))
+}
+
 #[allow(dead_code)]
 #[tokio::main]
 async fn main() {
@@ -613,6 +675,7 @@ async fn main() {
         "process_checkout_autocapture" => process_checkout_autocapture(&client, "order_001").await,
         "process_checkout_card" => process_checkout_card(&client, "order_001").await,
         "process_refund" => process_refund(&client, "order_001").await,
+        "process_void_payment" => process_void_payment(&client, "order_001").await,
         "process_get_payment" => process_get_payment(&client, "order_001").await,
         "process_authorize" => process_authorize(&client, "txn_001").await,
         "process_capture" => process_capture(&client, "txn_001").await,
@@ -629,8 +692,9 @@ async fn main() {
         "process_refund_get" => process_refund_get(&client, "txn_001").await,
         "process_token_authorize" => process_token_authorize(&client, "txn_001").await,
         "process_token_setup_recurring" => process_token_setup_recurring(&client, "txn_001").await,
+        "process_void" => process_void(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_customer_create, process_get, process_incremental_authorization, process_proxy_authorize, process_recurring_charge, process_refund_get, process_token_authorize, process_token_setup_recurring", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_void_payment, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_customer_create, process_get, process_incremental_authorization, process_proxy_authorize, process_recurring_charge, process_refund_get, process_token_authorize, process_token_setup_recurring, process_void", flow);
             return;
         }
     };

--- a/examples/shift4/shift4.rs
+++ b/examples/shift4/shift4.rs
@@ -22,11 +22,9 @@ pub const SUPPORTED_FLOWS: &[&str] = &[
     "get",
     "incremental_authorization",
     "proxy_authorize",
-    "proxy_setup_recurring",
     "recurring_charge",
     "refund",
     "refund_get",
-    "setup_recurring",
     "token_authorize",
     "token_setup_recurring",
 ];
@@ -77,7 +75,6 @@ pub fn build_authorize_request(capture_method: &str) -> PaymentServiceAuthorizeR
         address: Some(PaymentAddress {
             // Address Information.
             billing_address: Some(Address {
-                first_name: Some(Secret::new("John".to_string())), // Personal Information.
                 ..Default::default()
             }),
             ..Default::default()
@@ -166,7 +163,6 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
         }),
         address: Some(PaymentAddress {
             billing_address: Some(Address {
-                first_name: Some(Secret::new("John".to_string())), // Personal Information.
                 ..Default::default()
             }),
             ..Default::default()
@@ -174,41 +170,6 @@ pub fn build_proxy_authorize_request() -> PaymentServiceProxyAuthorizeRequest {
         capture_method: Some(CaptureMethod::Automatic.into()),
         auth_type: AuthenticationType::NoThreeDs.into(),
         return_url: Some("https://example.com/return".to_string()),
-        ..Default::default()
-    }
-}
-
-pub fn build_proxy_setup_recurring_request() -> PaymentServiceProxySetupRecurringRequest {
-    PaymentServiceProxySetupRecurringRequest {
-        merchant_recurring_payment_id: "probe_proxy_mandate_001".to_string(),
-        amount: Some(Money {
-            minor_amount: 0,                // Amount in minor units (e.g., 1000 = $10.00).
-            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
-        }),
-        card_proxy: Some(ProxyCardDetails {
-            // Card proxy for vault-aliased payments.
-            card_number: Some(Secret::new("4111111111111111".to_string())), // Card Identification.
-            card_exp_month: Some(Secret::new("03".to_string())),
-            card_exp_year: Some(Secret::new("2030".to_string())),
-            card_cvc: Some(Secret::new("123".to_string())),
-            card_holder_name: Some(Secret::new("John Doe".to_string())), // Cardholder Information.
-            card_network: Some(CardNetwork::Visa.into()),
-            ..Default::default()
-        }),
-        address: Some(PaymentAddress {
-            billing_address: Some(Address {
-                first_name: Some(Secret::new("John".to_string())), // Personal Information.
-                ..Default::default()
-            }),
-            ..Default::default()
-        }),
-        customer_acceptance: Some(CustomerAcceptance {
-            acceptance_type: AcceptanceType::Offline.into(), // Type of acceptance (e.g., online, offline).
-            accepted_at: 0, // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-            ..Default::default()
-        }),
-        auth_type: AuthenticationType::NoThreeDs.into(),
-        setup_future_usage: Some(FutureUsage::OffSession.into()),
         ..Default::default()
     }
 }
@@ -262,48 +223,6 @@ pub fn build_refund_get_request() -> RefundServiceGetRequest {
         merchant_refund_id: Some("probe_refund_001".to_string()), // Identification.
         connector_transaction_id: "probe_connector_txn_001".to_string(),
         refund_id: "probe_refund_id_001".to_string(), // Deprecated.
-        ..Default::default()
-    }
-}
-
-pub fn build_setup_recurring_request() -> PaymentServiceSetupRecurringRequest {
-    PaymentServiceSetupRecurringRequest {
-        merchant_recurring_payment_id: "probe_mandate_001".to_string(), // Identification.
-        amount: Some(Money {
-            // Mandate Details.
-            minor_amount: 0, // Amount in minor units (e.g., 1000 = $10.00).
-            currency: Currency::Usd.into(), // ISO 4217 currency code (e.g., "USD", "EUR").
-        }),
-        payment_method: Some(PaymentMethod {
-            payment_method: Some(payment_method::PaymentMethod::Card(CardDetails {
-                card_number: Some(CardNumber::from_str("4111111111111111").unwrap()), // Card Identification.
-                card_exp_month: Some(Secret::new("03".to_string())),
-                card_exp_year: Some(Secret::new("2030".to_string())),
-                card_cvc: Some(Secret::new("737".to_string())),
-                card_holder_name: Some(Secret::new("John Doe".to_string())), // Cardholder Information.
-                ..Default::default()
-            })),
-            ..Default::default()
-        }),
-        address: Some(PaymentAddress {
-            // Address Information.
-            billing_address: Some(Address {
-                first_name: Some(Secret::new("John".to_string())), // Personal Information.
-                ..Default::default()
-            }),
-            ..Default::default()
-        }),
-        auth_type: AuthenticationType::NoThreeDs.into(), // Type of authentication to be used.
-        enrolled_for_3ds: false, // Indicates if the customer is enrolled for 3D Secure.
-        return_url: Some("https://example.com/mandate-return".to_string()), // URL to redirect after setup.
-        setup_future_usage: Some(FutureUsage::OffSession.into()), // Indicates future usage intention.
-        request_incremental_authorization: false, // Indicates if incremental authorization is requested.
-        customer_acceptance: Some(CustomerAcceptance {
-            // Details of customer acceptance.
-            acceptance_type: AcceptanceType::Offline.into(), // Type of acceptance (e.g., online, offline).
-            accepted_at: 0, // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-            ..Default::default()
-        }),
         ..Default::default()
     }
 }
@@ -635,18 +554,6 @@ pub async fn process_proxy_authorize(
     Ok(format!("status: {:?}", response.status()))
 }
 
-// Flow: PaymentService.ProxySetupRecurring
-#[allow(dead_code)]
-pub async fn process_proxy_setup_recurring(
-    client: &ConnectorClient,
-    _merchant_transaction_id: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .proxy_setup_recurring(build_proxy_setup_recurring_request(), &HashMap::new(), None)
-        .await?;
-    Ok(format!("status: {:?}", response.status()))
-}
-
 // Flow: RecurringPaymentService.Charge
 #[allow(dead_code)]
 pub async fn process_recurring_charge(
@@ -669,27 +576,6 @@ pub async fn process_refund_get(
         .refund_get(build_refund_get_request(), &HashMap::new(), None)
         .await?;
     Ok(format!("status: {:?}", response.status()))
-}
-
-// Flow: PaymentService.SetupRecurring
-#[allow(dead_code)]
-pub async fn process_setup_recurring(
-    client: &ConnectorClient,
-    _merchant_transaction_id: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let response = client
-        .setup_recurring(build_setup_recurring_request(), &HashMap::new(), None)
-        .await?;
-    if response.status() == PaymentStatus::Failure {
-        return Err(format!("Setup failed: {:?}", response.error).into());
-    }
-    Ok(format!(
-        "Mandate: {}",
-        response
-            .connector_recurring_payment_id
-            .as_deref()
-            .unwrap_or("")
-    ))
 }
 
 // Flow: PaymentService.TokenAuthorize
@@ -739,14 +625,12 @@ async fn main() {
             process_incremental_authorization(&client, "txn_001").await
         }
         "process_proxy_authorize" => process_proxy_authorize(&client, "txn_001").await,
-        "process_proxy_setup_recurring" => process_proxy_setup_recurring(&client, "txn_001").await,
         "process_recurring_charge" => process_recurring_charge(&client, "txn_001").await,
         "process_refund_get" => process_refund_get(&client, "txn_001").await,
-        "process_setup_recurring" => process_setup_recurring(&client, "txn_001").await,
         "process_token_authorize" => process_token_authorize(&client, "txn_001").await,
         "process_token_setup_recurring" => process_token_setup_recurring(&client, "txn_001").await,
         _ => {
-            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_customer_create, process_get, process_incremental_authorization, process_proxy_authorize, process_proxy_setup_recurring, process_recurring_charge, process_refund_get, process_setup_recurring, process_token_authorize, process_token_setup_recurring", flow);
+            eprintln!("Unknown flow: {}. Available: process_checkout_autocapture, process_checkout_card, process_refund, process_get_payment, process_authorize, process_capture, process_create_client_authentication_token, process_customer_create, process_get, process_incremental_authorization, process_proxy_authorize, process_recurring_charge, process_refund_get, process_token_authorize, process_token_setup_recurring", flow);
             return;
         }
     };

--- a/examples/shift4/shift4.ts
+++ b/examples/shift4/shift4.ts
@@ -7,7 +7,7 @@
 
 import { PaymentClient, MerchantAuthenticationClient, CustomerClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
 const { Environment, AcceptanceType, AuthenticationType, CaptureMethod, CardNetwork, Currency, FutureUsage, PaymentMethodType } = types;
-export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "proxy_setup_recurring", "recurring_charge", "refund", "refund_get", "setup_recurring", "token_authorize", "token_setup_recurring"];
+export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -41,7 +41,6 @@ function _buildAuthorizeRequest(captureMethod: types.CaptureMethod): types.IPaym
         "captureMethod": captureMethod,  // Method for capturing the payment.
         "address": {  // Address Information.
             "billingAddress": {
-                "firstName": {"value": "John"}  // Personal Information.
             }
         },
         "authType": AuthenticationType.NO_THREE_DS,  // Authentication Details.
@@ -121,41 +120,11 @@ function _buildProxyAuthorizeRequest(): types.IPaymentServiceProxyAuthorizeReque
         },
         "address": {
             "billingAddress": {
-                "firstName": {"value": "John"}  // Personal Information.
             }
         },
         "captureMethod": CaptureMethod.AUTOMATIC,
         "authType": AuthenticationType.NO_THREE_DS,
         "returnUrl": "https://example.com/return"
-    };
-}
-
-function _buildProxySetupRecurringRequest(): types.IPaymentServiceProxySetupRecurringRequest {
-    return {
-        "merchantRecurringPaymentId": "probe_proxy_mandate_001",
-        "amount": {
-            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
-            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        },
-        "cardProxy": {  // Card proxy for vault-aliased payments.
-            "cardNumber": {"value": "4111111111111111"},  // Card Identification.
-            "cardExpMonth": {"value": "03"},
-            "cardExpYear": {"value": "2030"},
-            "cardCvc": {"value": "123"},
-            "cardHolderName": {"value": "John Doe"},  // Cardholder Information.
-            "cardNetwork": CardNetwork.VISA
-        },
-        "address": {
-            "billingAddress": {
-                "firstName": {"value": "John"}  // Personal Information.
-            }
-        },
-        "customerAcceptance": {
-            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
-            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        },
-        "authType": AuthenticationType.NO_THREE_DS,
-        "setupFutureUsage": FutureUsage.OFF_SESSION
     };
 }
 
@@ -197,39 +166,6 @@ function _buildRefundGetRequest(): types.IRefundServiceGetRequest {
         "merchantRefundId": "probe_refund_001",  // Identification.
         "connectorTransactionId": "probe_connector_txn_001",
         "refundId": "probe_refund_id_001"  // Deprecated.
-    };
-}
-
-function _buildSetupRecurringRequest(): types.IPaymentServiceSetupRecurringRequest {
-    return {
-        "merchantRecurringPaymentId": "probe_mandate_001",  // Identification.
-        "amount": {  // Mandate Details.
-            "minorAmount": 0,  // Amount in minor units (e.g., 1000 = $10.00).
-            "currency": Currency.USD  // ISO 4217 currency code (e.g., "USD", "EUR").
-        },
-        "paymentMethod": {
-            "card": {  // Generic card payment.
-                "cardNumber": {"value": "4111111111111111"},  // Card Identification.
-                "cardExpMonth": {"value": "03"},
-                "cardExpYear": {"value": "2030"},
-                "cardCvc": {"value": "737"},
-                "cardHolderName": {"value": "John Doe"}  // Cardholder Information.
-            }
-        },
-        "address": {  // Address Information.
-            "billingAddress": {
-                "firstName": {"value": "John"}  // Personal Information.
-            }
-        },
-        "authType": AuthenticationType.NO_THREE_DS,  // Type of authentication to be used.
-        "enrolledFor_3ds": false,  // Indicates if the customer is enrolled for 3D Secure.
-        "returnUrl": "https://example.com/mandate-return",  // URL to redirect after setup.
-        "setupFutureUsage": FutureUsage.OFF_SESSION,  // Indicates future usage intention.
-        "requestIncrementalAuthorization": false,  // Indicates if incremental authorization is requested.
-        "customerAcceptance": {  // Details of customer acceptance.
-            "acceptanceType": AcceptanceType.OFFLINE,  // Type of acceptance (e.g., online, offline).
-            "acceptedAt": 0  // Timestamp when the acceptance was made (Unix timestamp, seconds since epoch).
-        }
     };
 }
 
@@ -444,15 +380,6 @@ async function proxyAuthorize(merchantTransactionId: string, config: types.IConn
     return proxyResponse;
 }
 
-// Flow: PaymentService.ProxySetupRecurring
-async function proxySetupRecurring(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    const proxyResponse = await paymentClient.proxySetupRecurring(_buildProxySetupRecurringRequest());
-
-    return proxyResponse;
-}
-
 // Flow: RecurringPaymentService.Charge
 async function recurringCharge(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const recurringPaymentClient = new RecurringPaymentClient(config);
@@ -480,15 +407,6 @@ async function refundGet(merchantTransactionId: string, config: types.IConnector
     return refundResponse;
 }
 
-// Flow: PaymentService.SetupRecurring
-async function setupRecurring(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
-    const paymentClient = new PaymentClient(config);
-
-    const setupResponse = await paymentClient.setupRecurring(_buildSetupRecurringRequest());
-
-    return setupResponse;
-}
-
 // Flow: PaymentService.TokenAuthorize
 async function tokenAuthorize(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
     const paymentClient = new PaymentClient(config);
@@ -510,7 +428,7 @@ async function tokenSetupRecurring(merchantTransactionId: string, config: types.
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, proxySetupRecurring, recurringCharge, refund, refundGet, setupRecurring, tokenAuthorize, tokenSetupRecurring, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildIncrementalAuthorizationRequest, _buildProxyAuthorizeRequest, _buildProxySetupRecurringRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildSetupRecurringRequest, _buildTokenAuthorizeRequest, _buildTokenSetupRecurringRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildIncrementalAuthorizationRequest, _buildProxyAuthorizeRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildTokenSetupRecurringRequest
 };
 
 // CLI runner

--- a/examples/shift4/shift4.ts
+++ b/examples/shift4/shift4.ts
@@ -7,7 +7,7 @@
 
 import { PaymentClient, MerchantAuthenticationClient, CustomerClient, RecurringPaymentClient, RefundClient, types } from 'hyperswitch-prism';
 const { Environment, AcceptanceType, AuthenticationType, CaptureMethod, CardNetwork, Currency, FutureUsage, PaymentMethodType } = types;
-export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring"];
+export const SUPPORTED_FLOWS = ["authorize", "capture", "create_client_authentication_token", "customer_create", "get", "incremental_authorization", "proxy_authorize", "recurring_charge", "refund", "refund_get", "token_authorize", "token_setup_recurring", "void"];
 
 const _defaultConfig: types.IConnectorConfig = {
     options: {
@@ -222,6 +222,13 @@ function _buildTokenSetupRecurringRequest(): types.IPaymentServiceTokenSetupRecu
     };
 }
 
+function _buildVoidRequest(connectorTransactionId: string): types.IPaymentServiceVoidRequest {
+    return {
+        "merchantVoidId": "probe_void_001",  // Identification.
+        "connectorTransactionId": connectorTransactionId
+    };
+}
+
 
 // ANCHOR: scenario_functions
 // One-step Payment (Authorize + Capture)
@@ -293,6 +300,28 @@ async function processRefund(merchantTransactionId: string, config: types.IConne
     }
 
     return { status: refundResponse.status, error: refundResponse.error } as any;
+}
+
+// Void Payment
+// Cancel an authorized but not-yet-captured payment.
+async function processVoidPayment(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    // Step 1: Authorize — reserve funds on the payment method
+    const authorizeResponse = await paymentClient.authorize(_buildAuthorizeRequest(CaptureMethod.MANUAL));
+
+    if (authorizeResponse.status === types.PaymentStatus.FAILURE) {
+        throw new Error(`Payment failed: ${JSON.stringify(authorizeResponse.error)}`);
+    }
+    if (authorizeResponse.status === types.PaymentStatus.PENDING) {
+        // Awaiting async confirmation — handle via webhook
+        return { status: 'pending', connectorTransactionId: authorizeResponse.connectorTransactionId };
+    }
+
+    // Step 2: Void — release reserved funds (cancel authorization)
+    const voidResponse = await paymentClient.void(_buildVoidRequest(authorizeResponse.connectorTransactionId!));
+
+    return { status: voidResponse.status, transactionId: authorizeResponse.connectorTransactionId!, error: voidResponse.error } as any;
 }
 
 // Get Payment Status
@@ -425,10 +454,19 @@ async function tokenSetupRecurring(merchantTransactionId: string, config: types.
     return tokenResponse;
 }
 
+// Flow: PaymentService.Void
+async function voidPayment(merchantTransactionId: string, config: types.IConnectorConfig = _defaultConfig) {
+    const paymentClient = new PaymentClient(config);
+
+    const voidResponse = await paymentClient.void(_buildVoidRequest('probe_connector_txn_001'));
+
+    return voidResponse;
+}
+
 
 // Export all process* functions for the smoke test
 export {
-    processCheckoutAutocapture, processCheckoutCard, processRefund, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildIncrementalAuthorizationRequest, _buildProxyAuthorizeRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildTokenSetupRecurringRequest
+    processCheckoutAutocapture, processCheckoutCard, processRefund, processVoidPayment, processGetPayment, authorize, capture, createClientAuthenticationToken, customerCreate, get, incrementalAuthorization, proxyAuthorize, recurringCharge, refund, refundGet, tokenAuthorize, tokenSetupRecurring, voidPayment, _buildAuthorizeRequest, _buildCaptureRequest, _buildCreateClientAuthenticationTokenRequest, _buildCustomerCreateRequest, _buildGetRequest, _buildIncrementalAuthorizationRequest, _buildProxyAuthorizeRequest, _buildRecurringChargeRequest, _buildRefundRequest, _buildRefundGetRequest, _buildTokenAuthorizeRequest, _buildTokenSetupRecurringRequest, _buildVoidRequest
 };
 
 // CLI runner


### PR DESCRIPTION
## Summary

Targets `main`, alongside #2279 (Shift4 **Authorize enrichment** + **Void**).

**Merge #2279 first.** The recurring code in this PR is written on top of the enrichment and Void commits, so those 4 commits ride along in this branch and show up in this diff until #2279 lands. Once #2279 merges, this PR's file diff reduces to the recurring work on its own, with no rebase needed and no conflict expected, since the content is identical. They cannot be made fully independent: replaying the recurring commits onto `main` without the enrichment conflicts on the first commit, and the recurring transformers call helpers that the enrichment introduces.

This PR adds **recurring payments** for **card**, **Apple Pay** and **Google Pay**:

- **SetupMandate** (SetupRecurring)
- **RepeatPayment** (RecurringPaymentService/Charge)
- **off-session CIT Authorize**, which returns a mandate

It also carries the **review, logic-parity and E2E fixes** found while validating the above, including:

- a **security fix**: the Shift4 `Authorization` header was logged unmasked (pre-existing on `main`)
- a **partial-capture fix**: `POST /charges/{id}/capture` now sends `amount`, so Shift4 settles the captured amount instead of the full authorization
- **captured-amount reporting**, so Hyperswitch records `amount_received`

Generated with **GRACE**, then exercised against the `api.shift4.com` sandbox by grpcurl, and end-to-end as Hyperswitch -> UCS -> Shift4 for both card and wallets.

Companion Hyperswitch PR: https://github.com/juspay/hyperswitch/pull/14210

**Per-run evidence** was posted as comments on #2279 while this work still lived on that branch:

- [SetupMandate / card](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672056983)
- [RepeatPayment / card + CIT mandate](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672450722)
- [SetupMandate / wallet](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672973323)
- [RepeatPayment / wallet + wallet Authorize](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673276858)
- [Fix run](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673818577) and [follow-up](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673935305)
- [HS -> UCS -> Shift4 final regression](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5674066016)
- [Captured-amount fix](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5674202261) and [its HS E2E](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5674245943)

> The tables below describe the Shift4 connector as a whole. Authorize enrichment and Void come from #2279; everything recurring, plus the fixes listed above, is this PR.

## What the connector does, per flow and payment method

| Flow | Card | Apple Pay / Google Pay (encrypted token) |
|---|---|---|
| **Authorize** | Inline `card`. Typed `customer_initiated`, or `first_recurring` for an off-session CIT. The CIT returns mandate `card_...`. | Inline `paymentMethod{type, token, billing}`. An off-session CIT returns mandate `pm_...`; a one-off sale returns no mandate. |
| **SetupMandate** (SetupRecurring) | `POST /charges` typed `first_recurring` under a Shift4 customer. Returns `card_...` and the customer. | Same shape, as `paymentMethod`. Returns `pm_...` and the customer. |
| **RepeatPayment** (RecurringPaymentService/Charge) | `card: "card_..."` + `customerId`. A NetworkMandateId sends the raw card + `external.schemeTransactionId`. | `paymentMethod: "pm_..."` + `customerId`. No charge-level billing. |
| **Capture** | `POST /charges/{id}/capture {amount}`, which settles exactly that amount. | Same. |
| **Void** | `POST /refunds {chargeId}` on the uncaptured charge. PSync reads `captured:false, refunded:true` as `VOIDED`. | Same. |
| **PSync / Refund / RSync / IncrementalAuthorization / CustomerService.Create / ClientAuthenticationToken** | Implemented. | PSync, Refund and RSync are shared. |

**Common behaviour**

- **Customer:** `customerId` always comes from `connector_customer_id`, never from the merchant customer id.
- **Mandate discriminator:** the `pm_` prefix of the Shift4 `connector_mandate_id`, defined once.
  - Hyperswitch payment method ids also start with `pm_`. The prefix is therefore only ever tested on `connector_mandate_id`.
- **Mandates returned:**
  - A `pm_` is returned only while a customer owns it and its `status` is `chargeable`.
  - A `card_` is returned only while a customer owns it. Card and Shift4 card-token (`tok_...`) charges return `paymentMethod: null`, so they always take the `card_` branch (sandbox-verified for an off-session token CIT and a token SetupRecurring).
- **Decline mapping:**
  - A decline over HTTP 402 is `FAILURE` on Authorize, SetupMandate and RepeatPayment, with `issuerDeclineCode` / `adviceCode` / `networkAdviceCode` / `chargeId` preserved.
  - An HTTP 200 `status: failed` charge is returned as an error, with the same codes.
- **Not supported by Shift4, and deliberately not approximated:**
  - L2/L3 data
  - a dynamic statement descriptor
- **Zero-amount charges** are always sent `captured: false`. Shift4 rejects capturing a zero amount with "Zero amount charge cannot be captured".

## Behaviour changes to call out

1. **Off-session CIT without `connector_customer_id` is refused (U17).**
   - **Affects:** card, token, Apple Pay and Google Pay Authorize with `setup_future_usage=OFF_SESSION` + customer acceptance, and every SetupRecurring.
   - **Result:** refused locally with `MissingRequiredField customer.connector_customer_id` (gRPC `InvalidArgument`, Hyperswitch IR_04) before the shopper is charged.
   - **Why:** Shift4 charges a stored card or payment method only together with its owning customer. A customer-less `pm_` would be claimed by whichever customer charges it first.
   - **Companion:** the Hyperswitch PR creates the Shift4 customer for these payments.
2. **SetupRecurring capture (U4).**
   - **Zero amount:** always an uncaptured verification, reported `CHARGED`. This applies to card and wallet alike.
   - **Non-zero amount:** always **captured, and the funds settle**, reported `CHARGED`. `PaymentServiceSetupRecurringRequest` has no `capture_method` field, so there is no way to ask for an open authorization. The `cc7aadee7d` commit message says a manual non-zero setup stays `AUTHORIZED`; that branch was unreachable and was removed in the follow-up commit.
   - **Previously:** a non-zero card setup was reported `CHARGED` over an uncaptured hold that never settled, and a non-zero wallet setup was reported `AUTHORIZED`.
   - **Hyperswitch:** routes a non-zero `payment_type=setup_mandate` to SetupMandate, so this is visible there.
   - **Sandbox check:** Shift4 accepts `captured: true` with `type: first_recurring`, still stores the card / payment method under the customer, and an MIT on it succeeds.
3. **Cardholder name (U5).**
   - `card.cardholderName` is the card's own holder name only, with no fallback to the billing name or the customer name, on every flow.
   - It is no longer required on a zero-amount charge; the sandbox accepts one without it.
4. **Partial capture (U12).**
   - Capture sends `amount`, and Shift4 settles exactly that amount and releases the rest.
   - Before this, a partial capture settled the full authorization (reproduced from Hyperswitch: HS recorded 400 while Shift4 captured 1000).
   - `amount` is not in the API reference, but is sandbox-verified:
     - the 1000 charge reads back 400 after capturing 400
     - an over-capture is refused with "Invalid Capture data"
     - a second capture is refused with "Requested Charge is already captured"
   - Multiple-capture intents stay rejected.
   - The Capture response reports `CHARGED` even after a partial capture. `PartialCharged` cannot be derived: Shift4 rewrites the charge `amount` to the captured amount and returns no authorized amount, and the capture request carries none either. Hyperswitch derives `partially_captured` from its own amounts, so it is unaffected; a direct gRPC/SDK caller has to compare `amount_to_capture` with the authorized amount itself.
5. **`customerId` on Authorize.**
   - Sent only when the charge stores the credential, or charges a token.
   - A one-off card, wallet or bank-redirect sale no longer attaches the card or payment method to a known customer.
6. **Authorize 402 is `FAILURE` (U10),** consistent with SetupMandate and RepeatPayment. Other errors still carry no attempt status, so the caller decides; Hyperswitch marks non-5xx errors failed.
7. **Wallet connector response (W2).** Apple Pay / Google Pay charges report the auth code under `additionalPaymentMethodData.applePay` / `googlePay`, not `card`. AVS / CVV are not reported for wallets.
8. **Typed response (CW7).** `typedConnectorResponse` of a card charge now also contains `"paymentMethod":null`. This is additive.
9. **Empty values are omitted:**
   - `Idempotency-Key` is omitted when neither `merchant_request_id` nor the merchant reference is set.
   - `external.vendorReference` is omitted when the merchant reference is empty.
   - `card.cvc` is omitted when absent or empty.
   - The key is `merchant_request_id`, else the merchant reference (`merchant_transaction_id` / `merchant_recurring_payment_id` / `merchant_charge_id`), and is never generated per call.

## Known limitations

- **3DS (U13).** PreAuthenticate / Authenticate / PostAuthenticate are not implemented for Shift4 in UCS. A Hyperswitch 3DS card CIT routed through UCS therefore fails at pre-authentication, before Authorize. Only no-3DS card flows are supported through UCS.
- **Pre-decrypted wallets and third-party SDK tokens.** Pre-decrypted Apple Pay / Google Pay and third-party SDK wallet tokens return `NotSupported` (Hyperswitch IR_00). Shift4 has no request field for a DPAN, cryptogram or ECI. The MCA must not enable Apple Pay "simplified" / decrypt-at-Hyperswitch or `google_pay.support_predecrypted_token` for shift4.
- **Google Pay PAN_ONLY.** Only `CRYPTOGRAM_3DS` tokens work. A `PAN_ONLY` token needs browser 3DS, and Shift4 declines it with a final HTTP 402 `authentication_required`.
- **Apple Pay JSON token (CW8).** A token that decodes to a JSON `paymentData` object is sent to Shift4 as an object; the sandbox `TEST_TOKEN:<amount><CCY>` tokens are sent as a string.
  - With a structurally valid PKPaymentToken carrying fake cryptography, Shift4 answered HTTP 400 `ApplePay token is malformed`. Raw probes got the same verdict for a fake token sent as an object and as a string.
  - Acceptance of a real production token is not verified, because no real token exists in the sandbox.
- **Redirect wallets.** AliPay, WeChat Pay, Paysera and Skrill, which native Hyperswitch Shift4 supports, return `NotImplemented` through UCS. This predates this branch.
- **Network transaction id MIT.** Accepts a raw `card` only. `CardDetailsForNetworkTransactionId` returns `NotSupported`; shift4 is not in Hyperswitch's NTI connector list.
- **SetupRecurring capture method.** A non-zero setup cannot be kept as an open authorization, because the SetupRecurring proto has no `capture_method`. Adding one is a proto change and is left as a follow-up.
- **Idempotency-Key and retries.** The key is the caller's reference. If a caller reuses one reference across retry attempts of a payment within 24 h, Shift4 replays the first response. Hyperswitch sends attempt-scoped references by default.

## Hyperswitch companion and E2E

**https://github.com/juspay/hyperswitch/pull/14210:**
- creates the Shift4 customer for off-session card CITs and zero-amount setups
- adds shift4 to the mandate payment-method lists
- fixes the create-then-confirm path so `setup_future_usage` set at confirm is honoured

**E2E Hyperswitch -> UCS -> Shift4:**
- **Card:** passed on the pre-fix binary. It surfaced U12 (partial capture), U13 (3DS) and U17.
- **Wallet:** pending.
- **Regression:** a final Hyperswitch regression runs on the binary built from this head.

## Test coverage

**`crates/internal/integration-tests/src/connector_specs/shift4/specs.json`**
- It declares `supported_payment_methods` (`card`, `apple_pay_sdk`, `google_pay_sdk`, `ideal`, `eps`).
- It also marks the global Google Pay Authorize scenario unsupported. The harness swaps that scenario's token for a browser-generated one, which needs `GPAY_HOSTED_URL` and a `metadata.google_pay` block in the creds; Shift4's creds have neither.

**Apple Pay / Google Pay integration scenarios are pending two harness gaps.** Earlier comments on this PR said the harness does not load connector-specific scenario files (CW2). That is not quite right: the file is loaded, but the harness cannot run its scenarios because of these gaps (line numbers at `cc7aadee7d`):
1. **Connector-specific scenarios cannot be built.**
   - `crates/internal/integration-tests/src/harness/scenario_api.rs:65-70`: `load_effective_scenario_for_connector` only calls `load_scenario` (`scenario_loader.rs:107`), which reads the global suite file. `scenario_api.rs:4868` has the same `load_scenario` call.
   - The suite run and the schema check both merge `connector_specific_scenarios.json` in (`scenario_loader.rs:294`), but every per-scenario request is built through that function, so a private scenario fails with `scenario '<name>' not found in suite`.
2. **Apple Pay `payment_data` is not normalized.**
   - `scenario_api.rs:3325-3334`: `normalize_proto_oneof_shapes` adds the prost wrapper for Google Pay `tokenization_data`, but not for Apple Pay `payment_data`.
   - `validate_tonic_payload_shape` (`:5209`) therefore reports `apple_pay_sdk.payment_data.encrypted_data` as an `unknown/ignored request field`.

Four Apple Pay scenarios are ready: Authorize one-off and off-session CIT, and SetupRecurring 1500 and 0, on Shift4's amount-bound sandbox token. They pass the schema validator only once both gaps are fixed. They are deferred to a separate harness PR rather than changing shared test code here.

Until then, wallet coverage is the grpcurl evidence below:
- Apple Pay and Google Pay SetupRecurring, off-session CIT, MIT, one-off sale and partial capture
- negative cases

A wallet RecurringPaymentService/Charge scenario would also need that suite's SetupRecurring dependency to resolve to a wallet setup.

**Field probe.** `probe-config.toml` gives the Shift4 setup flows a probe `customer.connector_customer_id`. `setup_recurring` / `proxy_setup_recurring` / `token_setup_recurring` now report `supported` instead of `error`, and the `all_connector.md` Shift4 cells SetupRecurring, TokenSetupRecurring and ProxySetupRecurring change from `?` to `✓`.

## Validation

Run on head `6b823ff959` with `CARGO_INCREMENTAL=0`, and again on `0d9e294cb8` after the follow-up commit, with the same results:

- **`scripts/validation/pre-push.sh --fix`**
  - formatting: no changes needed
  - `cargo check --all-features --all-targets`: pass
  - `cargo clippy --all-features --all-targets -- -D warnings`: pass
  - `check_connector_specs`: `[OK] shift4 (11 flows mapped)`
  - `make generate`: pass
  - `make docs`: fails only on 7 Kotlin compile errors in the stale `examples/globalpay/globalpay.kt` and `examples/paydotcom/paydotcom.kt`, unrelated to shift4. The Shift4 docs and examples regenerated, and `all_connector.md` was regenerated with `--no-syntax-check`.
- **Schema validators:** `all_supported_scenarios_match_proto_schema_for_all_connectors` ok, `all_override_entries_match_existing_scenarios_and_proto_schema` ok.
- **Connector crate:** `cargo clippy -p connector-integration --all-targets -- -D warnings` clean; `cargo +nightly fmt --all` clean.
- **Spelling:** `typos --config ./.typos.toml` clean on the changed files.
- **Build and grpcurl:** debug `grpc-server` builds; 29 of 29 fix-run grpcurl legs and 13 of 13 follow-up legs pass against the Shift4 sandbox.
- **Credentials:** 0 occurrences of the api key (raw, `base64(key:)`, `base64(key)`) in the server log after the U18 fix.

## grpcurl evidence (fix run, redacted)

**Setup:** debug `grpc-server` built from this head, port 50061, Shift4 sandbox. The api key was sent in `x-connector-config` and redacted as `<REDACTED>` everywhere. After the U18 masking fix, the server log contained **0** occurrences of the key in raw form, as `base64(key:)` and as `base64(key)`.

| # | PM | Leg | Outcome | Result |
|---|---|---|---|---|
| 1 | Card | CustomerService/Create | cust_ returned | PASS |
| 2 | Card | Authorize AUTOMATIC (one-off) | CHARGED, no customerId | PASS |
| 3 | Card | Authorize MANUAL -> Capture 1000 | AUTHORIZED -> CHARGED | PASS |
| 4 | Card | Authorize MANUAL 1000 -> Capture 400 (U12) | CHARGED, PSync amount 400 | PASS |
| 5 | Card | Authorize MANUAL -> Void | VOIDED, PSync VOIDED | PASS |
| 6 | Card | PSync | CHARGED, PAR returned | PASS |
| 7 | Card | Refund 300 -> RSync | REFUND_SUCCESS | PASS |
| 8 | Card | SetupRecurring 0, no card holder name | CHARGED (captured:false), card_ | PASS |
| 9 | Card | SetupRecurring 1500 (U4) | CHARGED (captured:true), card_ | PASS |
| 10 | Card | Charge on SetupRecurring card_ | CHARGED | PASS |
| 11 | Card | Authorize off-session CIT -> Charge on its card_ | CHARGED | PASS |
| 12 | Card | Charge without merchant_charge_id (U1/U2) | CHARGED, no Idempotency-Key, no external | PASS |
| 13 | Card | NetworkMandateId MIT, raw card (U3) | CHARGED, external.schemeTransactionId sent | PASS |
| 14 | Card | Authorize decline 4916018475814056 (U10) | 402 card_declined, status FAILURE | PASS |
| 15 | Card | Authorize card_cvc "" (U14) | CHARGED, no cvc sent | PASS |
| 16 | Card | SetupRecurring without connector_customer_id | InvalidArgument, no request | PASS |
| 17 | Card | NetworkMandateId MIT without card | Unimplemented, no request | PASS |
| 18 | Apple Pay | SetupRecurring 1500 -> Charge | CHARGED -> CHARGED | PASS |
| 19 | Apple Pay | SetupRecurring 0 -> Charge | CHARGED -> CHARGED | PASS |
| 20 | Google Pay | SetupRecurring CRYPTOGRAM_3DS -> Charge | CHARGED -> CHARGED | PASS |
| 21 | Apple Pay | Authorize off-session CIT -> Charge | CHARGED pm_ -> CHARGED | PASS |
| 22 | Google Pay | Authorize off-session CIT -> Charge | CHARGED pm_ -> CHARGED | PASS |
| 23 | Apple Pay | Authorize one-off | CHARGED, no customerId, no mandate | PASS |
| 24 | Apple Pay | Authorize MANUAL 2000 -> Capture 500 (W-P5) | CHARGED, PSync amount 500 | PASS |
| 25 | Apple Pay | Authorize JSON PKPaymentToken (CW8) | 400 ApplePay token is malformed (expected, fake crypto) | PASS |
| 26 | Apple Pay | Authorize CIT without connector_customer_id | InvalidArgument, no request | PASS |
| 27 | Apple Pay | Charge without connector_customer_id | InvalidArgument, no request | PASS |
| 28 | Apple Pay | SetupRecurring pre-decrypted | Unimplemented (NotSupported) | PASS |
| 29 | Google Pay | Authorize pre-decrypted | Unimplemented (NotSupported) | PASS |

<details>
<summary>Partial capture (U12): card 1000 -> capture 400; Apple Pay 2000 -> capture 500</summary>

Outgoing capture bodies (server log, Authorization stripped):

```
POST /charges/char_6WvtE28LBExzXuU23V3ZiKHm/capture  {"amount":400}   -> CHARGED
GET  /charges/char_6WvtE28LBExzXuU23V3ZiKHm           -> status CHARGED, amount 400, captured true
POST /charges/char_alxJQrOz0Dmrk0mJ91DvmnjH/capture  {"amount":500}   -> CHARGED
GET  /charges/char_alxJQrOz0Dmrk0mJ91DvmnjH           -> status CHARGED, amount 500, captured true
```

</details>

<details>
<summary>Name rule (U5), one-off customerId, empty values (U1/U2/U14)</summary>

- **Card Authorize, one-off** (`card_holder_name` "Card Holder", billing name "Billing Person"):
  - The outgoing body has no `customerId`.
  - Shift4 `GET /charges/char_gLf2TahtvFlrWLVdX38SRUFn` returns `type: customer_initiated`, `customerId: null`, `card.cardholderName: "Card Holder"`, `billing.name: "Billing Person"`.
- **Card off-session CIT** (`char_QdVAuoCujG5c4EN4Qmsb8Ifd`): `customerId` and `card.customerId` set, mandate `card_GUyLTSz0f1dOL2WodqklMMyL`.
- **Apple Pay one-off** (`char_81nOvsVNmTXsxMyZg4WaAKM6`): no `customerId`, `paymentMethod.customerId: null`, no mandate.
- **Zero-amount card SetupRecurring without a card holder name:** the body has no `cardholderName`, status `CHARGED`, mandate `card_A8oiiU8i5lGmFY3YZQxx3PQD`.
- **RecurringPaymentService/Charge without `merchant_charge_id`:** headers have no `Idempotency-Key`, the body has no `external`, status `CHARGED`.
- **Authorize with `card_cvc: ""`:** the card object has keys `number, expMonth, expYear, cardholderName`, no `cvc`, status `CHARGED`.

</details>

<details>
<summary>NetworkMandateId MIT (U3) and decline (U10)</summary>

- **NTI MIT:** the outgoing body has the raw card, no `customerId`, `type: merchant_initiated`, and `external: {vendorReference, schemeTransactionId}` carrying the network transaction id of the earlier CIT. Result `CHARGED` (`char_BAdIibalS7UuXQLha7JclAmp`).
- **NetworkMandateId with no card:** `Unimplemented` "NetworkMandateId without raw card details is not supported by Shift4 ...". No request is sent.
- **Decline card `4916018475814056` on Authorize:** HTTP 402 `card_declined`, issuer code `05`, `chargeId` preserved. The error details now carry payment status `FAILURE` (21), which is absent on the pre-fix Authorize decline.

</details>

<details>
<summary>Wallet legs</summary>

- **Apple Pay SetupRecurring 1500:** `captured: true`, `CHARGED`, `pm_C3Ow1S3VUj5dD177VtUCV9mL` -> Charge 800 `CHARGED`.
- **Apple Pay SetupRecurring 0:** `captured: false`, `CHARGED`, `pm_CRzH0Nd0PXogrTSJHsHsTAhy` -> Charge 500 `CHARGED`.
- **Google Pay CRYPTOGRAM_3DS SetupRecurring 1500:** `CHARGED`, `pm_cHdzGzdpDGfuXO2KZj8z4uue` -> Charge 900 `CHARGED`.
- **Off-session Apple Pay Authorize 2000:** `CHARGED`, `pm_s9a4VhGOZoHHMNHmQwQAkWmS` -> Charge 1200 `CHARGED`.
- **Off-session Google Pay Authorize 2500:** `CHARGED`, `pm_5IMLrLDfrUKVLruHd9lpGxHh` -> Charge 1300 `CHARGED`.
- **Connector response:** wallet responses carry `connectorResponse.additionalPaymentMethodData.applePay|googlePay.authCode`.
- **Refused locally, with no request sent:**
  - Apple Pay CIT without `connector_customer_id` -> `InvalidArgument`
  - wallet Charge without `connector_customer_id` -> `InvalidArgument`
  - pre-decrypted Apple Pay SetupRecurring -> `Unimplemented`
  - pre-decrypted Google Pay Authorize -> `Unimplemented`
- **Apple Pay JSON token (CW8):** see Known limitations.

</details>

Earlier grpcurl evidence, not repeated here:
- [Authorize enrichment](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5609488006)
- [SetupMandate / card](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672056983)
- [RepeatPayment / card](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672450722)
- [SetupMandate / wallet](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5672973323)
- [RepeatPayment / wallet](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673276858)
- [This fix run](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673818577)
- [Follow-up: setup capture, partial-capture status, token mandates](https://github.com/juspay/hyperswitch-prism/pull/2279#issuecomment-5673935305)

## Files modified

- `crates/integrations/connector-integration/src/connectors/shift4.rs`
- `crates/integrations/connector-integration/src/connectors/shift4/transformers.rs`
- `crates/internal/integration-tests/src/connector_specs/shift4/specs.json`
- `crates/internal/field-probe/probe-config.toml`
- `data/integration-source-links.json`
- generated: `data/field_probe/shift4.json`, `docs-generated/`, `examples/shift4/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
